### PR TITLE
Add wheels-cli package publishing to ForgeBox

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,16 @@ jobs:
         env:
           BOXJSON_DIR: /build-cfwheels-base/cfwheels
 
+      # publish CLI package
+      - uses: pixl8/github-action-box-publish@v4
+        id: Publish-CLI-Package
+        with:
+          forgebox_user: wheels-dev
+          forgebox_pass: ${{ secrets.FORGEBOX_PASS }}
+          force: "true"
+        env:
+          BOXJSON_DIR: /build-cfwheels-cli/wheels-cli
+
       - name: Post Slack Message
         id: Post-Slack-Message
         uses: act10ns/slack@v2


### PR DESCRIPTION
## Summary
- Adds the wheels-cli package to the GitHub Actions release workflow
- Ensures the CLI commands module is published to ForgeBox alongside the core and base packages

## Changes
- Added a new publishing step in `.github/workflows/release.yml` for the wheels-cli package
- Uses the same `pixl8/github-action-box-publish@v4` action as the other packages
- Points to the correct build directory: `/build-cfwheels-cli/wheels-cli`

## Context
The build process was already creating three packages:
1. `cfwheels-{version}.zip` - Core Wheels framework
2. `cfwheels-base-template-{version}.zip` - Base application template
3. `wheels-cli-{version}.zip` - CLI commands module

However, only the first two were being published to ForgeBox. This PR adds the missing publishing step for the CLI package.

## Test plan
- [ ] Verify GitHub Actions workflow syntax is correct
- [ ] Once merged, check that the next release publishes all three packages to ForgeBox
- [ ] Confirm the wheels-cli package can be installed via `box install wheels-cli`

🤖 Generated with [Claude Code](https://claude.ai/code)