### PR TITLE
Upgrade: Adding the Compatibility with ACF 2025

### DIFF
--- a/tests/Testbox/runner.cfm
+++ b/tests/Testbox/runner.cfm
@@ -17,9 +17,9 @@
         cfheader(name="Access-Control-Allow-Origin", value="*");
         DeJsonResult = DeserializeJSON(result);
         if (DeJsonResult.totalFail > 0 || DeJsonResult.totalError > 0) {
-            cfheader(statustext="Expectation Failed", statuscode=417);
+            cfheader(statuscode=417);
         } else {
-            cfheader(statustext="OK", statuscode=200);
+            cfheader(statuscode=200);
         }
         // Check if 'only' parameter is provided in the URL
         if (structKeyExists(url, "only") && url.only eq "failure,error") {

--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -678,13 +678,13 @@ component output="false" {
 		) {
 			if (StructKeyExists(application, "wheels")) {
 				if (StructKeyExists(application.wheels, "showErrorInformation") && !application.wheels.showErrorInformation) {
-					$header(statusCode = 404, statustext = "Not Found");
+					$header(statusCode = 404);
 				}
 				if (StructKeyExists(application.wheels, "eventPath")) {
 					$includeAndOutput(template = "#application.wheels.eventPath#/onmissingtemplate.cfm");
 				}
 			}
-			$header(statusCode = 404, statustext = "Not Found");
+			$header(statusCode = 404);
 			abort;
 		}
 	}
@@ -1488,7 +1488,7 @@ component output="false" {
 	 * Otherwise show the 404 page for end users (typically in production mode).
 	 */
 	public void function $throwErrorOrShow404Page(required string type, required string message, string extendedInfo = "") {
-		$header(statusCode = 404, statustext = "Not Found");
+		$header(statusCode = 404);
 		if ($get("showErrorInformation")) {
 			Throw(type = arguments.type, message = arguments.message, extendedInfo = arguments.extendedInfo);
 		} else {
@@ -2047,7 +2047,7 @@ component output="false" {
 
 		// Set back the status code to 200 so the test suite does not use the same code that the action that was tested did.
 		// If the test suite fails it will set the status code to 500 later.
-		$header(statusCode = 200, statusText = "OK");
+		$header(statusCode = 200);
 
 		// Set the Content-Type header in case it was set to something else (e.g. application/json) during processing.
 		// It's fine to do this because we always want to return the test page as text/html.

--- a/vendor/wheels/controller/rendering.cfc
+++ b/vendor/wheels/controller/rendering.cfc
@@ -700,7 +700,7 @@ component {
 			local.statusText = local.status;
 		}
 		if (local.statusCode != $statusCode()) {
-			$header(statusCode = local.statusCode, statusText = local.statusText);
+			$header(statusCode = local.statusCode);
 		}
 	}
 

--- a/vendor/wheels/events/EventMethods.cfc
+++ b/vendor/wheels/events/EventMethods.cfc
@@ -69,7 +69,7 @@ component extends="wheels.Global" {
 					Throw(object = arguments.exception);
 				}
 			} else {
-				$header(statusCode = 500, statusText = "Internal Server Error");
+				$header(statusCode = 500);
 				local.rv = $includeAndReturnOutput(
 					$template = "#application.wheels.eventPath#/onerror.cfm",
 					eventName = arguments.eventName,
@@ -135,7 +135,7 @@ component extends="wheels.Global" {
 				}
 			}
 			if (!local.makeException) {
-				$header(statusCode = 503, statustext = "Service Unavailable");
+				$header(statusCode = 503);
 
 				// Set the content to be displayed in maintenance mode to a request variable and exit the function.
 				// This variable is then checked in the Wheels $request function (which is what sets what to render).
@@ -208,7 +208,7 @@ component extends="wheels.Global" {
 
 	public void function $runOnMissingTemplate(required targetpage) {
 		if (!application.wheels.showErrorInformation) {
-			$header(statusCode = 404, statustext = "Not Found");
+			$header(statusCode = 404);
 		}
 		$includeAndOutput(template = "#application.wheels.eventPath#/onmissingtemplate.cfm");
 		abort;

--- a/vendor/wheels/public/tests/json.cfm
+++ b/vendor/wheels/public/tests/json.cfm
@@ -1,8 +1,8 @@
 <cfsilent>
 <cfif testResults.numErrors || testResults.numFailures>
-	<cfheader statuscode="417" statustext="Expectation Failed" />
+	<cfheader statuscode="417"/>
 <cfelse>
-	<cfheader statuscode="200" statustext="OK" />
+	<cfheader statuscode="200"/>
 </cfif>
 <!---cfscript>
   content(type="text/json");

--- a/vendor/wheels/public/tests/junit.cfm
+++ b/vendor/wheels/public/tests/junit.cfm
@@ -1,8 +1,8 @@
 <!--- cfformat-ignore-start ---><cfoutput><cfsilent>
 <cfif testResults.numErrors || testResults.numFailures>
-	<cfheader statuscode="417" statustext="Expectation Failed" />
+	<cfheader statuscode="417"/>
 <cfelse>
-	<cfheader statuscode="200" statustext="OK" />
+	<cfheader statuscode="200"/>
 </cfif>
 <cfsetting showdebugoutput="false">
 <cfset request.wheels.showDebugInformation = false>

--- a/vendor/wheels/public/tests/txt.cfm
+++ b/vendor/wheels/public/tests/txt.cfm
@@ -1,9 +1,9 @@
 <cfsilent>
 	<cfscript>
 	if (testResults.numErrors || testResults.numFailures) {
-		cfheader(statustext="Expectation Failed", statuscode=417);
+		cfheader(statuscode=417);
 	} else {
-		cfheader(statustext="OK", statuscode=200);
+		cfheader(statuscode=200);
 	}
 	cfsetting(showdebugoutput=false);
 	request.wheels.showDebugInformation = false;

--- a/vendor/wheels/tests/controller/rendering/rendertext.cfc
+++ b/vendor/wheels/tests/controller/rendering/rendertext.cfc
@@ -23,7 +23,7 @@ component extends="wheels.tests.Test" {
 	}
 
 	function test_render_text_with_doesnt_hijack_status() {
-		cfheader(statustext="Leave me be", statuscode=403);
+		cfheader(statuscode=403);
 		_controller.renderText(text = "OMG!");
 		actual = $statusCode();
 		expected = 403;

--- a/vendor/wheels/tests/controller/rendering/renderwith.cfc
+++ b/vendor/wheels/tests/controller/rendering/renderwith.cfc
@@ -3,7 +3,7 @@ component extends="wheels.tests.Test" {
 	function setup() {
 		include "setup.cfm";
 		params = {controller = "test", action = "test"};
-		cfheader(statustext="OK", statuscode=200); // start with a fresh status code
+		cfheader(statuscode=200); // start with a fresh status code
 	}
 
 	function teardown() {

--- a/vendor/wheels/tests_testbox/runner.cfm
+++ b/vendor/wheels/tests_testbox/runner.cfm
@@ -21,9 +21,9 @@
         cfheader(name="Access-Control-Allow-Origin", value="*");
         DeJsonResult = DeserializeJSON(result);
         if (DeJsonResult.totalFail > 0 || DeJsonResult.totalError > 0) {
-            cfheader(statustext="Expectation Failed", statuscode=417);
+            cfheader(statuscode=417);
         } else {
-            cfheader(statustext="OK", statuscode=200);
+            cfheader(statuscode=200);
         }
         // Check if 'only' parameter is provided in the URL
         if (structKeyExists(url, "only") && url.only eq "failure,error") {

--- a/vendor/wheels/tests_testbox/specs/controller/rendering.cfc
+++ b/vendor/wheels/tests_testbox/specs/controller/rendering.cfc
@@ -238,7 +238,7 @@ component extends="testbox.system.BaseSpec" {
 			})
 
 			it("is rendering text with doesnt hijack status", () => {
-				cfheader(statustext = "Leave me be", statuscode = 403)
+				cfheader(statuscode = 403)
 				_controller.renderText(text = "OMG!")
 
 				expect(application.wo.$statusCode()).toBe(403)
@@ -294,7 +294,7 @@ component extends="testbox.system.BaseSpec" {
 
 			beforeEach(() => {
 				params = {controller = "test", action = "test"}
-				cfheader(statustext = "OK", statuscode = 200);
+				cfheader(statuscode = 200);
 			})
 
 			afterEach(() => {


### PR DESCRIPTION
refactor: remove deprecated cfheader statustext attribute for CF 2025 compatibility

- Removed all usage of the `statustext` attribute from <cfheader> tags.