### PR TITLE
feat: Add maintenance mode and cleanup CLI commands

### DIFF
--- a/AI-CLI.md
+++ b/AI-CLI.md
@@ -16,6 +16,9 @@ This guide provides AI assistants with comprehensive CLI command reference for t
   - [Development Workflow](#development-workflow)
 - [Asset and Cache Management Commands](#asset-and-cache-management-commands)
 - [Plugin Management](#plugin-management)
+- [Maintenance Commands](#maintenance-commands)
+  - [Maintenance Mode](#maintenance-mode)
+  - [Cleanup Commands](#cleanup-commands)
 - [Analysis and Optimization Commands](#analysis-and-optimization-commands)
 - [Application Utilities](#application-utilities)
 - [Common Command Sequences](#common-command-sequences)
@@ -1565,6 +1568,200 @@ box package publish
 3. **Documentation**: Include comprehensive README.md
 4. **Testing**: Include test suite in `/tests/`
 5. **Versioning**: Follow semantic versioning (major.minor.patch)
+
+## Maintenance Commands
+
+### Maintenance Mode
+
+Control application availability during deployments or maintenance:
+
+#### Enable Maintenance Mode
+```bash
+# Basic maintenance mode
+wheels maintenance:on
+
+# With custom message
+wheels maintenance:on message="We'll be back shortly after upgrading our systems."
+
+# Allow specific IPs to bypass
+wheels maintenance:on allowedIPs="192.168.1.100,10.0.0.5"
+
+# With redirect URL
+wheels maintenance:on redirectURL="/maintenance.html"
+
+# Skip confirmation
+wheels maintenance:on --force
+
+# Combined options
+wheels maintenance:on \
+  message="Scheduled maintenance in progress" \
+  allowedIPs="192.168.1.100" \
+  --force
+```
+
+Features:
+- Creates `.maintenance` file in config directory
+- Automatically updates Application.cfc with maintenance check
+- Supports IP whitelisting for admin access
+- Custom messages and redirect URLs
+- Tracks who enabled maintenance and when
+
+#### Disable Maintenance Mode
+```bash
+# Basic disable
+wheels maintenance:off
+
+# Skip confirmation
+wheels maintenance:off --force
+
+# Remove maintenance check from Application.cfc
+wheels maintenance:off --cleanup
+```
+
+Shows:
+- Current maintenance configuration
+- Duration of maintenance window
+- Who enabled maintenance mode
+
+### Cleanup Commands
+
+Remove old files to free disk space and improve performance:
+
+#### Clean Log Files
+```bash
+# Remove logs older than 7 days (default)
+wheels cleanup:logs
+
+# Keep last 30 days of logs
+wheels cleanup:logs days=30
+
+# Clean specific directory
+wheels cleanup:logs directory="logs/custom"
+
+# Use custom pattern
+wheels cleanup:logs pattern="*.log,*.txt"
+
+# Preview without deleting
+wheels cleanup:logs --dryRun
+
+# Skip confirmation
+wheels cleanup:logs --force
+
+# Clean all logs immediately
+wheels cleanup:logs days=0 --force
+```
+
+Features:
+- Scans recursively for log files
+- Shows file age and size statistics
+- Removes empty directories after cleanup
+- Detailed reporting of freed space
+
+#### Clean Temporary Files
+```bash
+# Remove temp files older than 1 day (default)
+wheels cleanup:tmp
+
+# Keep last 3 days
+wheels cleanup:tmp days=3
+
+# Clean specific directories
+wheels cleanup:tmp directories="tmp,temp,cache,uploads/temp"
+
+# Custom file patterns
+wheels cleanup:tmp patterns="*.tmp,*.cache,~*"
+
+# Exclude patterns
+wheels cleanup:tmp excludePatterns=".gitkeep,important.tmp"
+
+# Preview cleanup
+wheels cleanup:tmp --dryRun
+
+# Force cleanup
+wheels cleanup:tmp --force
+```
+
+Features:
+- Cleans multiple temp directories
+- Flexible pattern matching
+- Preserves important files (.gitkeep, .gitignore)
+- Groups files by directory in output
+
+#### Clean Session Files
+```bash
+# Clean file-based sessions
+wheels cleanup:sessions
+
+# Clean database sessions
+wheels cleanup:sessions storage=database datasource=mydb
+
+# Custom session directory
+wheels cleanup:sessions directory="sessions/custom"
+
+# Database with custom table
+wheels cleanup:sessions \
+  storage=database \
+  datasource=mydb \
+  table=user_sessions
+
+# Delete all sessions (not just expired)
+wheels cleanup:sessions expiredOnly=false --force
+
+# Preview session cleanup
+wheels cleanup:sessions --dryRun
+```
+
+Features:
+- Supports both file and database session storage
+- Auto-detects common session directories
+- Shows active vs expired session counts
+- Configurable expiration detection
+
+### Cleanup Best Practices
+
+1. **Schedule Regular Cleanups**
+   ```bash
+   # Add to cron/scheduled task
+   0 2 * * * cd /path/to/app && wheels cleanup:logs days=7 --force
+   0 3 * * * cd /path/to/app && wheels cleanup:tmp days=1 --force
+   0 4 * * * cd /path/to/app && wheels cleanup:sessions --force
+   ```
+
+2. **Test with Dry Run First**
+   ```bash
+   wheels cleanup:logs --dryRun
+   wheels cleanup:tmp --dryRun
+   wheels cleanup:sessions --dryRun
+   ```
+
+3. **Monitor Disk Usage**
+   ```bash
+   # Check before cleanup
+   df -h
+   
+   # Run cleanup
+   wheels cleanup:logs days=30 --force
+   wheels cleanup:tmp --force
+   
+   # Check after cleanup
+   df -h
+   ```
+
+4. **Maintenance Mode Workflow**
+   ```bash
+   # Enable maintenance
+   wheels maintenance:on message="Upgrading to v2.0"
+   
+   # Perform deployment/updates
+   git pull
+   wheels dbmigrate latest
+   
+   # Clear caches
+   wheels cache:clear
+   
+   # Disable maintenance
+   wheels maintenance:off
+   ```
 
 ## Analysis and Optimization Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,3 +397,33 @@ Use the gh command via the Bash tool for ALL GitHub-related tasks including work
 - Run `wheels config check production` before deployment
 - Mask sensitive values in logs and output
 - Use environment-specific secrets
+
+## Development Workflow Commands
+
+### Initialize Existing Project
+- `wheels init` - Bootstrap existing Wheels app for CLI
+- `wheels init name=myapp` - With custom name
+- `wheels init --force` - Overwrite existing configs
+
+### Framework Upgrades
+- `wheels upgrade` - Interactive upgrade wizard
+- `wheels upgrade --check` - Check for available updates
+- `wheels upgrade --to=3.0.0` - Upgrade to specific version
+
+### Performance Testing
+- `wheels benchmark /path` - Simple load testing
+- `wheels benchmark --config=scenarios.json` - Batch benchmarking
+- `wheels profile /path` - Request profiling
+- `wheels profile --interactive` - Compare multiple endpoints
+
+### Documentation
+- `wheels docs` - Open framework documentation
+- `wheels docs:generate` - Generate API docs for your app
+- `wheels docs:generate --format=markdown` - Export as Markdown
+
+## Commit Message Guidelines
+- Use conventional commit format: `type: description`
+- Types: feat, fix, docs, style, refactor, test, chore
+- Keep subject line under 50 characters
+- Don't add Claude signature to commits
+- Don't add Claude signature to PR descriptions

--- a/cli/commands/wheels/cleanup/logs.cfc
+++ b/cli/commands/wheels/cleanup/logs.cfc
@@ -1,0 +1,198 @@
+/**
+ * Clean up old log files
+ */
+component extends="../base" {
+
+	/**
+	 * Remove old log files from the application
+	 *
+	 * @days Number of days to keep logs (default: 7)
+	 * @pattern File pattern to match (default: *.log)
+	 * @directory Custom log directory (default: logs/)
+	 * @dryRun Show what would be deleted without actually deleting
+	 * @force Skip confirmation prompt
+	 */
+	function run(
+		numeric days = 7,
+		string pattern = "*.log",
+		string directory = "logs",
+		boolean dryRun = false,
+		boolean force = false
+	) {
+		// Ensure we're in a Wheels app directory
+		if (!directoryExists(fileSystemUtil.resolvePath("vendor/wheels"))) {
+			error("This command must be run from a Wheels application root directory.");
+		}
+
+		// Resolve log directory
+		var logDir = fileSystemUtil.resolvePath(arguments.directory);
+		
+		if (!directoryExists(logDir)) {
+			print.yellowLine("Log directory '#arguments.directory#' does not exist.");
+			return;
+		}
+
+		// Calculate cutoff date
+		var cutoffDate = dateAdd("d", -arguments.days, now());
+		
+		print.line("Scanning for log files older than #arguments.days# days...");
+		print.line("Cutoff date: #dateFormat(cutoffDate, 'yyyy-mm-dd')# #timeFormat(cutoffDate, 'HH:mm:ss')#");
+		print.line("");
+
+		// Get list of log files
+		var files = directoryList(
+			path = logDir,
+			recurse = true,
+			filter = arguments.pattern,
+			type = "file",
+			listInfo = "query"
+		);
+
+		var filesToDelete = [];
+		var totalSize = 0;
+
+		// Filter files by age
+		for (var file in files) {
+			if (file.dateLastModified < cutoffDate) {
+				var fileInfo = {
+					name: file.name,
+					path: file.directory & "/" & file.name,
+					size: file.size,
+					modified: file.dateLastModified,
+					age: dateDiff("d", file.dateLastModified, now())
+				};
+				filesToDelete.append(fileInfo);
+				totalSize += file.size;
+			}
+		}
+
+		if (filesToDelete.len() == 0) {
+			print.greenLine("No log files found older than #arguments.days# days.");
+			return;
+		}
+
+		// Display files to be deleted
+		print.line("Found #filesToDelete.len()# log file(s) to clean up:");
+		print.line("");
+		
+		var table = [];
+		for (var file in filesToDelete) {
+			table.append({
+				"File": file.name,
+				"Age": "#file.age# days",
+				"Size": formatFileSize(file.size),
+				"Modified": dateFormat(file.modified, "yyyy-mm-dd HH:mm")
+			});
+		}
+		
+		print.table(
+			data = table,
+			headers = ["File", "Age", "Size", "Modified"]
+		);
+		
+		print.line("");
+		print.line("Total size to be freed: #formatFileSize(totalSize)#");
+		print.line("");
+
+		if (arguments.dryRun) {
+			print.yellowLine("DRY RUN: No files were deleted.");
+			return;
+		}
+
+		// Confirm deletion if not forced
+		if (!arguments.force) {
+			var proceed = confirm("Are you sure you want to delete these #filesToDelete.len()# log file(s)? [y/N]");
+			if (!proceed) {
+				print.line("Log cleanup cancelled.");
+				return;
+			}
+		}
+
+		// Delete files
+		var deletedCount = 0;
+		var deletedSize = 0;
+		var errors = [];
+
+		for (var file in filesToDelete) {
+			try {
+				fileDelete(file.path);
+				deletedCount++;
+				deletedSize += file.size;
+			} catch (any e) {
+				errors.append({
+					file: file.name,
+					error: e.message
+				});
+			}
+		}
+
+		// Report results
+		print.line("");
+		if (deletedCount > 0) {
+			print.greenLine("✓ Successfully deleted #deletedCount# log file(s).");
+			print.greenLine("✓ Freed #formatFileSize(deletedSize)# of disk space.");
+		}
+		
+		if (errors.len() > 0) {
+			print.line("");
+			print.redLine("Failed to delete #errors.len()# file(s):");
+			for (var error in errors) {
+				print.indentedRedLine("- #error.file#: #error.error#");
+			}
+		}
+
+		// Clean up empty directories
+		cleanEmptyDirectories(logDir);
+	}
+
+	/**
+	 * Format file size in human-readable format
+	 */
+	private function formatFileSize(numeric size) {
+		if (arguments.size < 1024) {
+			return "#arguments.size# B";
+		} else if (arguments.size < 1024 * 1024) {
+			return "#numberFormat(arguments.size / 1024, '0.0')# KB";
+		} else if (arguments.size < 1024 * 1024 * 1024) {
+			return "#numberFormat(arguments.size / (1024 * 1024), '0.0')# MB";
+		} else {
+			return "#numberFormat(arguments.size / (1024 * 1024 * 1024), '0.0')# GB";
+		}
+	}
+
+	/**
+	 * Clean up empty directories after file deletion
+	 */
+	private function cleanEmptyDirectories(required string directory) {
+		var dirs = directoryList(
+			path = arguments.directory,
+			recurse = true,
+			type = "dir",
+			listInfo = "path"
+		);
+		
+		// Sort directories by depth (deepest first)
+		dirs.sort(function(a, b) {
+			return listLen(b, "/\") - listLen(a, "/\");
+		});
+		
+		var removedCount = 0;
+		for (var dir in dirs) {
+			try {
+				var contents = directoryList(dir);
+				if (contents.len() == 0) {
+					directoryDelete(dir);
+					removedCount++;
+				}
+			} catch (any e) {
+				// Ignore errors
+			}
+		}
+		
+		if (removedCount > 0) {
+			print.line("");
+			print.greenLine("✓ Removed #removedCount# empty director#removedCount == 1 ? 'y' : 'ies'#.");
+		}
+	}
+
+}

--- a/cli/commands/wheels/cleanup/sessions.cfc
+++ b/cli/commands/wheels/cleanup/sessions.cfc
@@ -1,0 +1,383 @@
+/**
+ * Clean up expired session files
+ */
+component extends="../base" {
+
+	/**
+	 * Remove expired session files from the application
+	 *
+	 * @storage Session storage type (file or database) 
+	 * @directory Custom session directory for file storage (default: sessions/)
+	 * @datasource Datasource name for database sessions
+	 * @table Table name for database sessions (default: sessions)
+	 * @expiredOnly Only remove expired sessions (default: true)
+	 * @dryRun Show what would be deleted without actually deleting
+	 * @force Skip confirmation prompt
+	 */
+	function run(
+		string storage = "file",
+		string directory = "sessions",
+		string datasource = "",
+		string table = "sessions",
+		boolean expiredOnly = true,
+		boolean dryRun = false,
+		boolean force = false
+	) {
+		// Ensure we're in a Wheels app directory
+		if (!directoryExists(fileSystemUtil.resolvePath("vendor/wheels"))) {
+			error("This command must be run from a Wheels application root directory.");
+		}
+
+		if (arguments.storage == "file") {
+			cleanFileSessions(argumentCollection=arguments);
+		} else if (arguments.storage == "database") {
+			cleanDatabaseSessions(argumentCollection=arguments);
+		} else {
+			error("Invalid storage type. Use 'file' or 'database'.");
+		}
+	}
+
+	/**
+	 * Clean file-based sessions
+	 */
+	private function cleanFileSessions(
+		required string directory,
+		required boolean expiredOnly,
+		required boolean dryRun,
+		required boolean force
+	) {
+		// Resolve session directory
+		var sessionDir = fileSystemUtil.resolvePath(arguments.directory);
+		
+		if (!directoryExists(sessionDir)) {
+			// Try common session directories
+			var commonDirs = [
+				fileSystemUtil.resolvePath("WEB-INF/cfclasses/sessions"),
+				fileSystemUtil.resolvePath("WEB-INF/lucee/sessions"),
+				fileSystemUtil.resolvePath("sessions"),
+				getTempDirectory() & "sessions"
+			];
+			
+			var found = false;
+			for (var dir in commonDirs) {
+				if (directoryExists(dir)) {
+					sessionDir = dir;
+					found = true;
+					break;
+				}
+			}
+			
+			if (!found) {
+				print.yellowLine("Session directory '#arguments.directory#' does not exist.");
+				print.line("Tried common locations:");
+				for (var dir in commonDirs) {
+					print.indentedLine("- #dir#");
+				}
+				return;
+			}
+		}
+
+		print.line("Scanning session files in: #sessionDir#");
+		print.line("");
+
+		// Get list of session files
+		var files = [];
+		try {
+			files = directoryList(
+				path = sessionDir,
+				recurse = true,
+				filter = "*.cfm,*.tmp,*.session",
+				type = "file",
+				listInfo = "query"
+			);
+		} catch (any e) {
+			print.redLine("Error accessing session directory: #e.message#");
+			return;
+		}
+
+		var filesToDelete = [];
+		var totalSize = 0;
+		var expiredCount = 0;
+		var activeCount = 0;
+
+		// Analyze session files
+		for (var file in files) {
+			var isExpired = false;
+			
+			if (arguments.expiredOnly) {
+				// Try to determine if session is expired
+				// Most session files are updated with each access
+				var age = dateDiff("n", file.dateLastModified, now());
+				
+				// Consider sessions older than 2 hours as expired (configurable)
+				// This should match your CF/Lucee session timeout settings
+				if (age > 120) {
+					isExpired = true;
+				}
+			} else {
+				// Delete all sessions
+				isExpired = true;
+			}
+			
+			if (isExpired) {
+				var fileInfo = {
+					name: file.name,
+					path: file.directory & "/" & file.name,
+					size: file.size,
+					modified: file.dateLastModified,
+					age: dateDiff("n", file.dateLastModified, now())
+				};
+				filesToDelete.append(fileInfo);
+				totalSize += file.size;
+				expiredCount++;
+			} else {
+				activeCount++;
+			}
+		}
+
+		print.line("Session summary:");
+		print.indentedLine("Total sessions: #files.recordCount#");
+		print.indentedLine("Expired sessions: #expiredCount#");
+		print.indentedLine("Active sessions: #activeCount#");
+		print.line("");
+
+		if (filesToDelete.len() == 0) {
+			print.greenLine("No expired session files found to clean up.");
+			return;
+		}
+
+		// Display files to be deleted
+		print.line("Found #filesToDelete.len()# session file(s) to clean up:");
+		print.line("");
+		
+		// Show summary instead of listing all files if there are many
+		if (filesToDelete.len() > 20) {
+			print.line("Summary by age:");
+			var ageBuckets = {
+				"< 1 hour": 0,
+				"1-2 hours": 0,
+				"2-24 hours": 0,
+				"1-7 days": 0,
+				"> 7 days": 0
+			};
+			
+			for (var file in filesToDelete) {
+				var ageInHours = file.age / 60;
+				var ageInDays = ageInHours / 24;
+				
+				if (ageInHours < 1) {
+					ageBuckets["< 1 hour"]++;
+				} else if (ageInHours <= 2) {
+					ageBuckets["1-2 hours"]++;
+				} else if (ageInHours <= 24) {
+					ageBuckets["2-24 hours"]++;
+				} else if (ageInDays <= 7) {
+					ageBuckets["1-7 days"]++;
+				} else {
+					ageBuckets["> 7 days"]++;
+				}
+			}
+			
+			var summaryTable = [];
+			for (var bucket in ageBuckets) {
+				if (ageBuckets[bucket] > 0) {
+					summaryTable.append({
+						"Age Range": bucket,
+						"Count": ageBuckets[bucket]
+					});
+				}
+			}
+			
+			print.table(
+				data = summaryTable,
+				headers = ["Age Range", "Count"]
+			);
+		} else {
+			// Show individual files if not too many
+			var table = [];
+			for (var file in filesToDelete) {
+				table.append({
+					"File": file.name,
+					"Age": formatAge(file.age),
+					"Size": formatFileSize(file.size)
+				});
+			}
+			
+			print.table(
+				data = table,
+				headers = ["File", "Age", "Size"]
+			);
+		}
+		
+		print.line("");
+		print.line("Total size to be freed: #formatFileSize(totalSize)#");
+		print.line("");
+
+		if (arguments.dryRun) {
+			print.yellowLine("DRY RUN: No sessions were deleted.");
+			return;
+		}
+
+		// Confirm deletion if not forced
+		if (!arguments.force) {
+			var proceed = confirm("Are you sure you want to delete these #filesToDelete.len()# session file(s)? [y/N]");
+			if (!proceed) {
+				print.line("Session cleanup cancelled.");
+				return;
+			}
+		}
+
+		// Delete files
+		var deletedCount = 0;
+		var deletedSize = 0;
+		var errors = [];
+
+		for (var file in filesToDelete) {
+			try {
+				fileDelete(file.path);
+				deletedCount++;
+				deletedSize += file.size;
+			} catch (any e) {
+				errors.append({
+					file: file.name,
+					error: e.message
+				});
+			}
+		}
+
+		// Report results
+		print.line("");
+		if (deletedCount > 0) {
+			print.greenLine("✓ Successfully deleted #deletedCount# session file(s).");
+			print.greenLine("✓ Freed #formatFileSize(deletedSize)# of disk space.");
+		}
+		
+		if (errors.len() > 0) {
+			print.line("");
+			print.redLine("Failed to delete #errors.len()# file(s):");
+			for (var error in errors) {
+				print.indentedRedLine("- #error.file#: #error.error#");
+			}
+		}
+	}
+
+	/**
+	 * Clean database sessions
+	 */
+	private function cleanDatabaseSessions(
+		required string datasource,
+		required string table,
+		required boolean expiredOnly,
+		required boolean dryRun,
+		required boolean force
+	) {
+		if (!len(arguments.datasource)) {
+			error("Datasource is required for database session cleanup.");
+		}
+
+		print.line("Cleaning database sessions from datasource: #arguments.datasource#");
+		print.line("Table: #arguments.table#");
+		print.line("");
+
+		try {
+			// Check if table exists
+			var tables = queryExecute(
+				"SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = :tableName",
+				{tableName: arguments.table},
+				{datasource: arguments.datasource}
+			);
+			
+			if (tables.recordCount == 0) {
+				print.yellowLine("Session table '#arguments.table#' does not exist.");
+				return;
+			}
+
+			// Count sessions
+			var countQuery = "SELECT COUNT(*) as total FROM #arguments.table#";
+			var whereClause = "";
+			
+			if (arguments.expiredOnly) {
+				// Assume expires column exists
+				whereClause = " WHERE expires < :now";
+			}
+			
+			var counts = queryExecute(
+				countQuery & whereClause,
+				arguments.expiredOnly ? {now: now()} : {},
+				{datasource: arguments.datasource}
+			);
+			
+			var totalSessions = counts.total;
+			
+			if (totalSessions == 0) {
+				print.greenLine("No #arguments.expiredOnly ? 'expired ' : ''#sessions found to clean up.");
+				return;
+			}
+
+			print.line("Found #totalSessions# #arguments.expiredOnly ? 'expired ' : ''#session(s) to clean up.");
+			print.line("");
+
+			if (arguments.dryRun) {
+				print.yellowLine("DRY RUN: No sessions were deleted.");
+				return;
+			}
+
+			// Confirm deletion if not forced
+			if (!arguments.force) {
+				var proceed = confirm("Are you sure you want to delete these #totalSessions# session(s)? [y/N]");
+				if (!proceed) {
+					print.line("Session cleanup cancelled.");
+					return;
+				}
+			}
+
+			// Delete sessions
+			var deleteQuery = "DELETE FROM #arguments.table#" & whereClause;
+			var result = queryExecute(
+				deleteQuery,
+				arguments.expiredOnly ? {now: now()} : {},
+				{datasource: arguments.datasource, result: "result"}
+			);
+			
+			print.line("");
+			print.greenLine("✓ Successfully deleted #result.recordCount# session(s) from the database.");
+			
+		} catch (any e) {
+			print.redLine("Error cleaning database sessions: #e.message#");
+			if (structKeyExists(e, "detail")) {
+				print.redLine("Detail: #e.detail#");
+			}
+		}
+	}
+
+	/**
+	 * Format file size in human-readable format
+	 */
+	private function formatFileSize(numeric size) {
+		if (arguments.size < 1024) {
+			return "#arguments.size# B";
+		} else if (arguments.size < 1024 * 1024) {
+			return "#numberFormat(arguments.size / 1024, '0.0')# KB";
+		} else if (arguments.size < 1024 * 1024 * 1024) {
+			return "#numberFormat(arguments.size / (1024 * 1024), '0.0')# MB";
+		} else {
+			return "#numberFormat(arguments.size / (1024 * 1024 * 1024), '0.0')# GB";
+		}
+	}
+
+	/**
+	 * Format age in human-readable format
+	 */
+	private function formatAge(numeric minutes) {
+		if (arguments.minutes < 60) {
+			return "#arguments.minutes# min";
+		} else if (arguments.minutes < 1440) {
+			var hours = int(arguments.minutes / 60);
+			return "#hours# hour#hours != 1 ? 's' : ''#";
+		} else {
+			var days = int(arguments.minutes / 1440);
+			return "#days# day#days != 1 ? 's' : ''#";
+		}
+	}
+
+}

--- a/cli/commands/wheels/cleanup/tmp.cfc
+++ b/cli/commands/wheels/cleanup/tmp.cfc
@@ -1,0 +1,259 @@
+/**
+ * Clean up temporary files
+ */
+component extends="../base" {
+
+	/**
+	 * Remove old temporary files from the application
+	 *
+	 * @days Number of days to keep temporary files (default: 1)
+	 * @directories Comma-separated list of directories to clean (default: tmp,temp,cache)
+	 * @patterns Comma-separated list of file patterns to match (default: *,.*) 
+	 * @excludePatterns Comma-separated list of patterns to exclude
+	 * @dryRun Show what would be deleted without actually deleting
+	 * @force Skip confirmation prompt
+	 */
+	function run(
+		numeric days = 1,
+		string directories = "tmp,temp,cache",
+		string patterns = "*,.*",
+		string excludePatterns = ".gitkeep,.gitignore",
+		boolean dryRun = false,
+		boolean force = false
+	) {
+		// Ensure we're in a Wheels app directory
+		if (!directoryExists(fileSystemUtil.resolvePath("vendor/wheels"))) {
+			error("This command must be run from a Wheels application root directory.");
+		}
+
+		// Parse directories
+		var dirList = listToArray(arguments.directories);
+		var patternList = listToArray(arguments.patterns);
+		var excludeList = listToArray(arguments.excludePatterns);
+		
+		// Calculate cutoff date
+		var cutoffDate = dateAdd("d", -arguments.days, now());
+		
+		print.line("Scanning for temporary files older than #arguments.days# day(s)...");
+		print.line("Cutoff date: #dateFormat(cutoffDate, 'yyyy-mm-dd')# #timeFormat(cutoffDate, 'HH:mm:ss')#");
+		print.line("");
+
+		var filesToDelete = [];
+		var totalSize = 0;
+		var scannedDirs = [];
+
+		// Scan each directory
+		for (var dir in dirList) {
+			var dirPath = fileSystemUtil.resolvePath(trim(dir));
+			
+			if (!directoryExists(dirPath)) {
+				continue;
+			}
+			
+			scannedDirs.append(dir);
+			
+			// Scan for each pattern
+			for (var pattern in patternList) {
+				try {
+					var files = directoryList(
+						path = dirPath,
+						recurse = true,
+						filter = trim(pattern),
+						type = "file",
+						listInfo = "query"
+					);
+					
+					// Filter files by age and exclusions
+					for (var file in files) {
+						var fileName = file.name;
+						var shouldExclude = false;
+						
+						// Check exclusions
+						for (var exclude in excludeList) {
+							if (fileName == trim(exclude) || reFindNoCase(trim(exclude), fileName)) {
+								shouldExclude = true;
+								break;
+							}
+						}
+						
+						if (!shouldExclude && file.dateLastModified < cutoffDate) {
+							var fileInfo = {
+								name: file.name,
+								path: file.directory & "/" & file.name,
+								relativePath: replaceNoCase(file.directory & "/" & file.name, getCWD() & "/", ""),
+								size: file.size,
+								modified: file.dateLastModified,
+								age: dateDiff("d", file.dateLastModified, now()),
+								directory: dir
+							};
+							filesToDelete.append(fileInfo);
+							totalSize += file.size;
+						}
+					}
+				} catch (any e) {
+					// Continue with next pattern
+				}
+			}
+		}
+
+		if (scannedDirs.len() == 0) {
+			print.yellowLine("No temporary directories found to scan.");
+			return;
+		}
+
+		print.line("Scanned directories: #arrayToList(scannedDirs, ', ')#");
+		print.line("");
+
+		if (filesToDelete.len() == 0) {
+			print.greenLine("No temporary files found older than #arguments.days# day(s).");
+			return;
+		}
+
+		// Group files by directory for display
+		var filesByDir = {};
+		for (var file in filesToDelete) {
+			if (!structKeyExists(filesByDir, file.directory)) {
+				filesByDir[file.directory] = [];
+			}
+			filesByDir[file.directory].append(file);
+		}
+
+		// Display files to be deleted
+		print.line("Found #filesToDelete.len()# temporary file(s) to clean up:");
+		print.line("");
+		
+		for (var dir in filesByDir) {
+			print.boldLine("#dir#/ (#filesByDir[dir].len()# files):");
+			
+			var table = [];
+			for (var file in filesByDir[dir]) {
+				table.append({
+					"File": file.name,
+					"Age": "#file.age# days",
+					"Size": formatFileSize(file.size),
+					"Modified": dateFormat(file.modified, "yyyy-mm-dd HH:mm")
+				});
+			}
+			
+			print.table(
+				data = table,
+				headers = ["File", "Age", "Size", "Modified"]
+			);
+			print.line("");
+		}
+		
+		print.line("Total size to be freed: #formatFileSize(totalSize)#");
+		print.line("");
+
+		if (arguments.dryRun) {
+			print.yellowLine("DRY RUN: No files were deleted.");
+			return;
+		}
+
+		// Confirm deletion if not forced
+		if (!arguments.force) {
+			var proceed = confirm("Are you sure you want to delete these #filesToDelete.len()# temporary file(s)? [y/N]");
+			if (!proceed) {
+				print.line("Temporary file cleanup cancelled.");
+				return;
+			}
+		}
+
+		// Delete files
+		var deletedCount = 0;
+		var deletedSize = 0;
+		var errors = [];
+
+		for (var file in filesToDelete) {
+			try {
+				fileDelete(file.path);
+				deletedCount++;
+				deletedSize += file.size;
+			} catch (any e) {
+				errors.append({
+					file: file.relativePath,
+					error: e.message
+				});
+			}
+		}
+
+		// Report results
+		print.line("");
+		if (deletedCount > 0) {
+			print.greenLine("✓ Successfully deleted #deletedCount# temporary file(s).");
+			print.greenLine("✓ Freed #formatFileSize(deletedSize)# of disk space.");
+		}
+		
+		if (errors.len() > 0) {
+			print.line("");
+			print.redLine("Failed to delete #errors.len()# file(s):");
+			for (var error in errors) {
+				print.indentedRedLine("- #error.file#: #error.error#");
+			}
+		}
+
+		// Clean up empty directories
+		for (var dir in scannedDirs) {
+			cleanEmptyDirectories(fileSystemUtil.resolvePath(dir));
+		}
+	}
+
+	/**
+	 * Format file size in human-readable format
+	 */
+	private function formatFileSize(numeric size) {
+		if (arguments.size < 1024) {
+			return "#arguments.size# B";
+		} else if (arguments.size < 1024 * 1024) {
+			return "#numberFormat(arguments.size / 1024, '0.0')# KB";
+		} else if (arguments.size < 1024 * 1024 * 1024) {
+			return "#numberFormat(arguments.size / (1024 * 1024), '0.0')# MB";
+		} else {
+			return "#numberFormat(arguments.size / (1024 * 1024 * 1024), '0.0')# GB";
+		}
+	}
+
+	/**
+	 * Clean up empty directories after file deletion
+	 */
+	private function cleanEmptyDirectories(required string directory) {
+		if (!directoryExists(arguments.directory)) {
+			return;
+		}
+		
+		try {
+			var dirs = directoryList(
+				path = arguments.directory,
+				recurse = true,
+				type = "dir",
+				listInfo = "path"
+			);
+			
+			// Sort directories by depth (deepest first)
+			dirs.sort(function(a, b) {
+				return listLen(b, "/\") - listLen(a, "/\");
+			});
+			
+			var removedCount = 0;
+			for (var dir in dirs) {
+				try {
+					var contents = directoryList(dir);
+					if (contents.len() == 0) {
+						directoryDelete(dir);
+						removedCount++;
+					}
+				} catch (any e) {
+					// Ignore errors
+				}
+			}
+			
+			if (removedCount > 0) {
+				print.line("");
+				print.greenLine("✓ Removed #removedCount# empty director#removedCount == 1 ? 'y' : 'ies'#.");
+			}
+		} catch (any e) {
+			// Ignore errors
+		}
+	}
+
+}

--- a/cli/commands/wheels/maintenance/off.cfc
+++ b/cli/commands/wheels/maintenance/off.cfc
@@ -1,0 +1,144 @@
+/**
+ * Disable maintenance mode for the application
+ */
+component extends="../base" {
+
+	/**
+	 * Turn off maintenance mode
+	 *
+	 * @force Skip confirmation prompt
+	 * @cleanup Remove maintenance check from Application.cfc
+	 */
+	function run(
+		boolean force = false,
+		boolean cleanup = false
+	) {
+		// Ensure we're in a Wheels app directory
+		if (!directoryExists(fileSystemUtil.resolvePath("vendor/wheels"))) {
+			error("This command must be run from a Wheels application root directory.");
+		}
+
+		// Check if maintenance mode is enabled
+		var maintenanceFile = fileSystemUtil.resolvePath("config/.maintenance");
+		if (!fileExists(maintenanceFile)) {
+			print.yellowLine("Maintenance mode is not currently enabled.");
+			return;
+		}
+
+		// Read current configuration
+		var config = deserializeJSON(fileRead(maintenanceFile));
+		
+		// Show current configuration
+		print.line("Current maintenance mode configuration:");
+		print.indentedLine("Message: #config.message#");
+		if (structKeyExists(config, "allowedIPs") && len(config.allowedIPs)) {
+			print.indentedLine("Allowed IPs: #config.allowedIPs#");
+		}
+		if (structKeyExists(config, "redirectURL") && len(config.redirectURL)) {
+			print.indentedLine("Redirect URL: #config.redirectURL#");
+		}
+		print.indentedLine("Enabled at: #config.enabledAt#");
+		if (structKeyExists(config, "enabledBy")) {
+			print.indentedLine("Enabled by: #config.enabledBy#");
+		}
+		
+		// Calculate downtime duration
+		try {
+			var enabledDate = parseDateTime(config.enabledAt);
+			var duration = dateDiff("n", enabledDate, now());
+			var hours = int(duration / 60);
+			var minutes = duration mod 60;
+			
+			if (hours > 0) {
+				print.indentedLine("Duration: #hours# hour(s) and #minutes# minute(s)");
+			} else {
+				print.indentedLine("Duration: #minutes# minute(s)");
+			}
+		} catch (any e) {
+			// Ignore duration calculation errors
+		}
+		
+		print.line("");
+
+		// Confirm action if not forced
+		if (!arguments.force) {
+			var proceed = confirm("Are you sure you want to disable maintenance mode? [y/N]");
+			if (!proceed) {
+				print.line("Maintenance mode was not disabled.");
+				return;
+			}
+		}
+
+		// Delete maintenance file
+		fileDelete(maintenanceFile);
+
+		// Clean up Application.cfc if requested
+		if (arguments.cleanup) {
+			cleanupApplicationCFC();
+		}
+
+		print.greenLine("✓ Maintenance mode has been disabled.");
+		print.line("");
+		print.line("Your application is now accessible to all users.");
+		
+		if (!arguments.cleanup) {
+			print.line("");
+			print.line("Note: The maintenance mode check is still in Application.cfc.");
+			print.line("To remove it, run: wheels maintenance:off --cleanup");
+		}
+	}
+
+	/**
+	 * Remove maintenance mode check from Application.cfc
+	 */
+	private function cleanupApplicationCFC() {
+		var appCFCPath = fileSystemUtil.resolvePath("Application.cfc");
+		if (!fileExists(appCFCPath)) {
+			return;
+		}
+
+		var appContent = fileRead(appCFCPath);
+		
+		// Check if maintenance mode check exists
+		if (!findNoCase("checkMaintenanceMode", appContent)) {
+			return; // No maintenance mode handling to remove
+		}
+
+		// Remove checkMaintenanceMode() call from onRequestStart
+		appContent = reReplace(
+			appContent,
+			"\s*checkMaintenanceMode\(\);",
+			"",
+			"all"
+		);
+
+		// Remove the checkMaintenanceMode method
+		// This regex handles the method and its comments
+		appContent = reReplace(
+			appContent,
+			"(\s*//\s*Maintenance mode check\s*)?[\r\n\s]*private\s+function\s+checkMaintenanceMode\s*\([^)]*\)\s*\{[^}]*\}",
+			"",
+			"one"
+		);
+
+		// Clean up any empty onRequestStart methods that might remain
+		appContent = reReplace(
+			appContent,
+			"public\s+function\s+onRequestStart\s*\([^)]*\)\s*\{\s*\}",
+			"",
+			"one"
+		);
+
+		// Write updated content
+		fileWrite(appCFCPath, appContent);
+		
+		// Clean up backup if it exists
+		var backupPath = appCFCPath & ".bak";
+		if (fileExists(backupPath)) {
+			fileDelete(backupPath);
+		}
+		
+		print.line("Removed maintenance mode check from Application.cfc.");
+	}
+
+}

--- a/cli/commands/wheels/maintenance/on.cfc
+++ b/cli/commands/wheels/maintenance/on.cfc
@@ -1,0 +1,182 @@
+/**
+ * Enable maintenance mode for the application
+ */
+component extends="../base" {
+
+	/**
+	 * Turn on maintenance mode
+	 *
+	 * @message Optional custom maintenance message
+	 * @allowedIPs Comma-separated list of IP addresses that can bypass maintenance mode
+	 * @redirectURL Optional URL to redirect to during maintenance
+	 * @force Skip confirmation prompt
+	 */
+	function run(
+		string message = "The application is currently undergoing maintenance. Please check back soon.",
+		string allowedIPs = "",
+		string redirectURL = "",
+		boolean force = false
+	) {
+		// Ensure we're in a Wheels app directory
+		if (!directoryExists(fileSystemUtil.resolvePath("vendor/wheels"))) {
+			error("This command must be run from a Wheels application root directory.");
+		}
+
+		// Check if maintenance mode is already on
+		var maintenanceFile = fileSystemUtil.resolvePath("config/.maintenance");
+		if (fileExists(maintenanceFile)) {
+			print.yellowLine("Maintenance mode is already enabled.");
+			
+			// Show current configuration
+			var config = deserializeJSON(fileRead(maintenanceFile));
+			print.line("Current configuration:");
+			print.indentedLine("Message: #config.message#");
+			if (len(config.allowedIPs)) {
+				print.indentedLine("Allowed IPs: #config.allowedIPs#");
+			}
+			if (len(config.redirectURL)) {
+				print.indentedLine("Redirect URL: #config.redirectURL#");
+			}
+			print.indentedLine("Enabled at: #config.enabledAt#");
+			
+			if (!arguments.force) {
+				var overwrite = confirm("Do you want to update the maintenance configuration? [y/N]");
+				if (!overwrite) {
+					return;
+				}
+			}
+		}
+
+		// Confirm action if not forced
+		if (!arguments.force && !fileExists(maintenanceFile)) {
+			print.line("This will enable maintenance mode for your application.");
+			print.yellowLine("All requests will see the maintenance message unless their IP is in the allowed list.");
+			
+			var proceed = confirm("Are you sure you want to enable maintenance mode? [y/N]");
+			if (!proceed) {
+				print.line("Maintenance mode was not enabled.");
+				return;
+			}
+		}
+
+		// Create maintenance configuration
+		var maintenanceConfig = {
+			"enabled": true,
+			"message": arguments.message,
+			"allowedIPs": arguments.allowedIPs,
+			"redirectURL": arguments.redirectURL,
+			"enabledAt": now().toString(),
+			"enabledBy": createObject("java", "java.lang.System").getProperty("user.name")
+		};
+
+		// Ensure config directory exists
+		if (!directoryExists(fileSystemUtil.resolvePath("config"))) {
+			directoryCreate(fileSystemUtil.resolvePath("config"));
+		}
+
+		// Write maintenance file
+		fileWrite(maintenanceFile, serializeJSON(maintenanceConfig));
+
+		// Create maintenance mode handler in Application.cfc if it doesn't exist
+		updateApplicationCFC();
+
+		print.greenLine("✓ Maintenance mode has been enabled.");
+		print.line("");
+		print.line("Configuration:");
+		print.indentedLine("Message: #arguments.message#");
+		if (len(arguments.allowedIPs)) {
+			print.indentedLine("Allowed IPs: #arguments.allowedIPs#");
+		}
+		if (len(arguments.redirectURL)) {
+			print.indentedLine("Redirect URL: #arguments.redirectURL#");
+		}
+		print.line("");
+		print.line("To disable maintenance mode, run: wheels maintenance:off");
+	}
+
+	/**
+	 * Update Application.cfc to handle maintenance mode
+	 */
+	private function updateApplicationCFC() {
+		var appCFCPath = fileSystemUtil.resolvePath("Application.cfc");
+		if (!fileExists(appCFCPath)) {
+			print.yellowLine("Warning: Application.cfc not found. Maintenance mode check will not be added.");
+			return;
+		}
+
+		var appContent = fileRead(appCFCPath);
+		
+		// Check if maintenance mode check already exists
+		if (findNoCase("checkMaintenanceMode", appContent)) {
+			return; // Already has maintenance mode handling
+		}
+
+		// Add maintenance mode check to onRequestStart
+		var maintenanceCheck = '
+	// Maintenance mode check
+	private function checkMaintenanceMode() {
+		var maintenanceFile = expandPath("/config/.maintenance");
+		if (fileExists(maintenanceFile)) {
+			var config = deserializeJSON(fileRead(maintenanceFile));
+			if (config.enabled) {
+				// Check if current IP is allowed
+				var clientIP = cgi.remote_addr;
+				if (len(config.allowedIPs) && listFindNoCase(config.allowedIPs, clientIP)) {
+					return; // Allow access
+				}
+				
+				// Handle redirect
+				if (len(config.redirectURL)) {
+					location(url=config.redirectURL, addtoken=false);
+				}
+				
+				// Show maintenance message
+				writeOutput("<!DOCTYPE html><html><head><title>Maintenance Mode</title><style>body{font-family:Arial,sans-serif;text-align:center;padding:50px;}h1{color:##333;}.message{background:##f0f0f0;padding:20px;border-radius:5px;max-width:600px;margin:0 auto;}</style></head><body><h1>Maintenance Mode</h1><div class=""message"">##config.message##</div></body></html>");
+				abort;
+			}
+		}
+	}';
+
+		// Find onRequestStart or add it
+		if (findNoCase("function onRequestStart", appContent)) {
+			// Add check at the beginning of onRequestStart
+			appContent = reReplace(
+				appContent,
+				"(function\s+onRequestStart[^{]*{)",
+				"\1#chr(10)##chr(9)##chr(9)#checkMaintenanceMode();",
+				"one"
+			);
+		} else {
+			// Add onRequestStart with maintenance check
+			var onRequestStartMethod = '
+	public function onRequestStart() {
+		checkMaintenanceMode();
+	}';
+			
+			// Insert before the closing component tag
+			appContent = reReplace(
+				appContent,
+				"(<\/cfcomponent>|})(\s*)$",
+				"#onRequestStartMethod##chr(10)#\1\2",
+				"one"
+			);
+		}
+
+		// Add the checkMaintenanceMode method before the closing tag
+		appContent = reReplace(
+			appContent,
+			"(<\/cfcomponent>|})(\s*)$",
+			"#maintenanceCheck##chr(10)#\1\2",
+			"one"
+		);
+
+		// Backup original file
+		fileCopy(appCFCPath, appCFCPath & ".bak");
+		
+		// Write updated content
+		fileWrite(appCFCPath, appContent);
+		
+		print.line("Updated Application.cfc with maintenance mode check.");
+	}
+
+}

--- a/guides/command-line-tools/commands/README.md
+++ b/guides/command-line-tools/commands/README.md
@@ -221,6 +221,23 @@ Commands for generating and serving documentation.
 - `--output` - Output directory
 - `--port` - Server port
 
+## Maintenance Commands
+
+Commands for managing application maintenance mode and cleanup tasks.
+
+| Command | Description | Documentation |
+|---------|-------------|---------------|
+| `wheels maintenance:on` | Enable maintenance mode | [Details](maintenance/maintenance-mode.md#wheels-maintenanceon) |
+| `wheels maintenance:off` | Disable maintenance mode | [Details](maintenance/maintenance-mode.md#wheels-maintenanceoff) |
+| `wheels cleanup:logs` | Remove old log files | [Details](maintenance/cleanup-commands.md#wheels-cleanuplogs) |
+| `wheels cleanup:tmp` | Remove temporary files | [Details](maintenance/cleanup-commands.md#wheels-cleanuptmp) |
+| `wheels cleanup:sessions` | Remove expired sessions | [Details](maintenance/cleanup-commands.md#wheels-cleanupsessions) |
+
+### Maintenance Options
+
+- `--force` - Skip confirmation prompts
+- `--dryRun` - Preview changes without executing
+
 ## CI/CD Commands
 
 Commands for continuous integration and deployment workflows.

--- a/guides/command-line-tools/commands/maintenance/README.md
+++ b/guides/command-line-tools/commands/maintenance/README.md
@@ -1,0 +1,68 @@
+# Maintenance Commands
+
+Commands for managing application maintenance mode and cleaning up temporary files.
+
+## Available Commands
+
+### Maintenance Mode
+- [wheels maintenance:on](maintenance-mode.md#wheels-maintenanceon) - Enable maintenance mode
+- [wheels maintenance:off](maintenance-mode.md#wheels-maintenanceoff) - Disable maintenance mode
+
+### Cleanup Commands
+- [wheels cleanup:logs](cleanup-commands.md#wheels-cleanuplogs) - Remove old log files
+- [wheels cleanup:tmp](cleanup-commands.md#wheels-cleanuptmp) - Remove temporary files
+- [wheels cleanup:sessions](cleanup-commands.md#wheels-cleanupsessions) - Remove expired sessions
+
+## Quick Examples
+
+### Enable Maintenance Mode
+```bash
+# Basic maintenance
+wheels maintenance:on
+
+# With custom message
+wheels maintenance:on message="Back at 3:00 PM"
+
+# Allow admin access
+wheels maintenance:on allowedIPs="192.168.1.100"
+```
+
+### Cleanup Old Files
+```bash
+# Clean logs older than 7 days
+wheels cleanup:logs
+
+# Clean all temp files
+wheels cleanup:tmp --force
+
+# Clean expired sessions
+wheels cleanup:sessions
+```
+
+## Common Workflows
+
+### Deployment with Maintenance
+```bash
+# Enable maintenance
+wheels maintenance:on message="Upgrading..." --force
+
+# Deploy and migrate
+git pull && wheels dbmigrate latest
+
+# Clean up and disable maintenance
+wheels cleanup:tmp --force
+wheels maintenance:off --force
+```
+
+### Scheduled Cleanup
+```bash
+# Add to crontab
+0 2 * * * wheels cleanup:logs days=30 --force
+0 3 * * * wheels cleanup:tmp --force
+0 4 * * * wheels cleanup:sessions --force
+```
+
+## See Also
+- [Asset and Cache Management](../assets-cache-management.md)
+- [Server Management](../server/server.md)
+- [Database Management](../database/database-management.md)

--- a/guides/command-line-tools/commands/maintenance/cleanup-commands.md
+++ b/guides/command-line-tools/commands/maintenance/cleanup-commands.md
@@ -1,0 +1,337 @@
+# Cleanup Commands
+
+## Overview
+
+The cleanup commands help maintain your application by removing old log files, temporary files, and expired sessions. Regular cleanup improves performance, frees disk space, and keeps your application directory organized.
+
+## Commands
+
+### wheels cleanup:logs
+
+Remove old log files from your application.
+
+```bash
+wheels cleanup:logs [days] [pattern] [directory] [--dryRun] [--force]
+```
+
+#### Parameters
+
+- `days` - Number of days to keep logs (default: 7)
+- `pattern` - File pattern to match (default: *.log)
+- `directory` - Custom log directory (default: logs/)
+- `--dryRun` - Show what would be deleted without actually deleting
+- `--force` - Skip confirmation prompt
+
+#### Examples
+
+```bash
+# Remove logs older than 7 days (default)
+wheels cleanup:logs
+
+# Keep last 30 days of logs
+wheels cleanup:logs days=30
+
+# Clean specific directory
+wheels cleanup:logs directory="logs/custom"
+
+# Match multiple patterns
+wheels cleanup:logs pattern="*.log,*.txt"
+
+# Preview without deleting
+wheels cleanup:logs --dryRun
+
+# Clean all logs immediately without confirmation
+wheels cleanup:logs days=0 --force
+```
+
+#### Features
+
+- Recursively scans for log files
+- Shows file age and size statistics
+- Removes empty directories after cleanup
+- Detailed reporting of freed disk space
+
+### wheels cleanup:tmp
+
+Remove old temporary files from your application.
+
+```bash
+wheels cleanup:tmp [days] [directories] [patterns] [excludePatterns] [--dryRun] [--force]
+```
+
+#### Parameters
+
+- `days` - Number of days to keep temporary files (default: 1)
+- `directories` - Comma-separated list of directories to clean (default: tmp,temp,cache)
+- `patterns` - Comma-separated list of file patterns to match (default: *,.*) 
+- `excludePatterns` - Comma-separated list of patterns to exclude (default: .gitkeep,.gitignore)
+- `--dryRun` - Show what would be deleted without actually deleting
+- `--force` - Skip confirmation prompt
+
+#### Examples
+
+```bash
+# Remove temp files older than 1 day (default)
+wheels cleanup:tmp
+
+# Keep last 3 days
+wheels cleanup:tmp days=3
+
+# Clean specific directories
+wheels cleanup:tmp directories="tmp,temp,cache,uploads/temp"
+
+# Custom file patterns
+wheels cleanup:tmp patterns="*.tmp,*.cache,~*"
+
+# Exclude important files
+wheels cleanup:tmp excludePatterns=".gitkeep,important.tmp,*.lock"
+
+# Preview cleanup
+wheels cleanup:tmp --dryRun
+
+# Force immediate cleanup
+wheels cleanup:tmp days=0 --force
+```
+
+#### Features
+
+- Cleans multiple temp directories
+- Flexible pattern matching with exclusions
+- Preserves important files (.gitkeep, .gitignore)
+- Groups files by directory in output
+- Removes empty directories after cleanup
+
+### wheels cleanup:sessions
+
+Remove expired session files from your application.
+
+```bash
+wheels cleanup:sessions [storage] [directory] [datasource] [table] [expiredOnly] [--dryRun] [--force]
+```
+
+#### Parameters
+
+- `storage` - Session storage type: file or database (default: file)
+- `directory` - Custom session directory for file storage (default: sessions/)
+- `datasource` - Datasource name for database sessions
+- `table` - Table name for database sessions (default: sessions)
+- `expiredOnly` - Only remove expired sessions (default: true)
+- `--dryRun` - Show what would be deleted without actually deleting
+- `--force` - Skip confirmation prompt
+
+#### Examples
+
+```bash
+# Clean file-based sessions
+wheels cleanup:sessions
+
+# Clean database sessions
+wheels cleanup:sessions storage=database datasource=mydb
+
+# Custom session directory
+wheels cleanup:sessions directory="WEB-INF/lucee/sessions"
+
+# Database with custom table
+wheels cleanup:sessions \
+  storage=database \
+  datasource=mydb \
+  table=user_sessions
+
+# Delete all sessions (not just expired)
+wheels cleanup:sessions expiredOnly=false --force
+
+# Preview session cleanup
+wheels cleanup:sessions --dryRun
+```
+
+#### Features
+
+- Supports both file and database session storage
+- Auto-detects common session directories:
+  - `WEB-INF/cfclasses/sessions`
+  - `WEB-INF/lucee/sessions`
+  - `sessions/`
+  - System temp directory
+- Shows active vs expired session counts
+- Configurable expiration detection (default: 2 hours)
+
+## Best Practices
+
+### 1. Schedule Regular Cleanups
+
+Add to your cron jobs or scheduled tasks:
+
+```bash
+# Daily cleanup at 2 AM
+0 2 * * * cd /path/to/app && wheels cleanup:logs days=7 --force
+0 3 * * * cd /path/to/app && wheels cleanup:tmp days=1 --force
+0 4 * * * cd /path/to/app && wheels cleanup:sessions --force
+```
+
+### 2. Test with Dry Run First
+
+Always preview what will be deleted:
+
+```bash
+# Check what will be deleted
+wheels cleanup:logs --dryRun
+wheels cleanup:tmp --dryRun
+wheels cleanup:sessions --dryRun
+
+# If looks good, run the actual cleanup
+wheels cleanup:logs --force
+wheels cleanup:tmp --force
+wheels cleanup:sessions --force
+```
+
+### 3. Monitor Disk Usage
+
+```bash
+# Check disk usage before cleanup
+df -h
+
+# Run cleanup commands
+wheels cleanup:logs days=30 --force
+wheels cleanup:tmp --force
+wheels cleanup:sessions --force
+
+# Check disk usage after cleanup
+df -h
+```
+
+### 4. Deployment Cleanup
+
+Include in your deployment script:
+
+```bash
+#!/bin/bash
+# deployment.sh
+
+# Clean up before deployment
+wheels cleanup:tmp --force
+wheels cleanup:sessions expiredOnly=false --force
+
+# Deploy new code
+git pull
+wheels dbmigrate latest
+
+# Clean up old logs after deployment
+wheels cleanup:logs days=30 --force
+```
+
+### 5. Different Retention Policies
+
+Set different retention periods based on file type:
+
+```bash
+# Keep error logs longer
+wheels cleanup:logs pattern="error*.log" days=90
+wheels cleanup:logs pattern="access*.log" days=7
+wheels cleanup:logs pattern="debug*.log" days=1
+
+# Clean different temp directories with different policies
+wheels cleanup:tmp directories="cache" days=7
+wheels cleanup:tmp directories="uploads/temp" days=1
+wheels cleanup:tmp directories="tmp" days=0
+```
+
+## Output Examples
+
+### Log Cleanup Output
+
+```
+Scanning for log files older than 7 days...
+Cutoff date: 2024-01-08 10:30:00
+
+Found 15 log file(s) to clean up:
+
+┌─────────────────┬──────────┬──────────┬─────────────────────┐
+│ File            │ Age      │ Size     │ Modified            │
+├─────────────────┼──────────┼──────────┼─────────────────────┤
+│ app.log.1       │ 10 days  │ 2.3 MB   │ 2024-01-05 14:23    │
+│ app.log.2       │ 15 days  │ 1.8 MB   │ 2023-12-31 09:15    │
+│ error.log.old   │ 30 days  │ 512 KB   │ 2023-12-16 18:45    │
+└─────────────────┴──────────┴──────────┴─────────────────────┘
+
+Total size to be freed: 4.6 MB
+
+✓ Successfully deleted 15 log file(s).
+✓ Freed 4.6 MB of disk space.
+✓ Removed 2 empty directories.
+```
+
+### Session Cleanup Output
+
+```
+Scanning session files in: /app/WEB-INF/lucee/sessions
+
+Session summary:
+  Total sessions: 127
+  Expired sessions: 89
+  Active sessions: 38
+
+Found 89 session file(s) to clean up:
+
+Summary by age:
+┌─────────────┬───────┐
+│ Age Range   │ Count │
+├─────────────┼───────┤
+│ 2-24 hours  │ 45    │
+│ 1-7 days    │ 32    │
+│ > 7 days    │ 12    │
+└─────────────┴───────┘
+
+Total size to be freed: 1.2 MB
+
+✓ Successfully deleted 89 session file(s).
+✓ Freed 1.2 MB of disk space.
+```
+
+## Troubleshooting
+
+### Permission Errors
+
+If you get permission errors:
+
+```bash
+# Run with appropriate user
+sudo -u www-data wheels cleanup:logs --force
+
+# Or fix permissions
+chmod -R 755 logs/
+chown -R www-data:www-data logs/
+```
+
+### Files Not Being Detected
+
+1. Check the directory path is correct
+2. Verify the file pattern matches your files
+3. Use `--dryRun` to see what's being scanned
+4. Check if files are excluded by excludePatterns
+
+### Session Cleanup Issues
+
+1. For file sessions, ensure correct directory:
+   ```bash
+   # Find session files
+   find / -name "*.cfm" -path "*/sessions/*" 2>/dev/null
+   ```
+
+2. For database sessions, verify table structure:
+   ```sql
+   -- Check if expires column exists
+   DESCRIBE sessions;
+   ```
+
+## Performance Tips
+
+1. **Run during off-peak hours** to minimize impact
+2. **Clean incrementally** - don't let files accumulate for months
+3. **Monitor cleanup duration** - adjust retention if taking too long
+4. **Use specific patterns** to avoid scanning unnecessary files
+
+## Related Commands
+
+- [wheels cache:clear](../assets-cache-management.md) - Clear application caches
+- [wheels maintenance:on](./maintenance-mode.md) - Enable maintenance during cleanup
+- [wheels stats](../application-utilities/stats.md) - View application statistics

--- a/guides/command-line-tools/commands/maintenance/maintenance-mode.md
+++ b/guides/command-line-tools/commands/maintenance/maintenance-mode.md
@@ -1,0 +1,228 @@
+# Maintenance Mode Commands
+
+## Overview
+
+The maintenance mode commands allow you to control application availability during deployments, upgrades, or maintenance tasks. When maintenance mode is enabled, users see a maintenance message instead of the regular application, with options for IP whitelisting and custom redirects.
+
+## Commands
+
+### wheels maintenance:on
+
+Enable maintenance mode for your application.
+
+```bash
+wheels maintenance:on [message] [allowedIPs] [redirectURL] [--force]
+```
+
+#### Parameters
+
+- `message` - Custom maintenance message to display (default: "The application is currently undergoing maintenance. Please check back soon.")
+- `allowedIPs` - Comma-separated list of IP addresses that can bypass maintenance mode
+- `redirectURL` - Optional URL to redirect users to during maintenance
+- `--force` - Skip confirmation prompt
+
+#### Examples
+
+```bash
+# Basic maintenance mode
+wheels maintenance:on
+
+# Custom message
+wheels maintenance:on message="We'll be back at 3:00 PM EST"
+
+# Allow admin IPs to bypass
+wheels maintenance:on allowedIPs="192.168.1.100,10.0.0.5"
+
+# Redirect to status page
+wheels maintenance:on redirectURL="https://status.example.com"
+
+# Combined options without confirmation
+wheels maintenance:on \
+  message="Scheduled maintenance in progress" \
+  allowedIPs="192.168.1.100" \
+  redirectURL="/status" \
+  --force
+```
+
+#### How It Works
+
+1. Creates a `.maintenance` file in the `config/` directory containing:
+   - Enabled status
+   - Custom message
+   - Allowed IP addresses
+   - Redirect URL
+   - Timestamp when enabled
+   - Username who enabled it
+
+2. Automatically updates `Application.cfc` to add a maintenance check:
+   - Adds `checkMaintenanceMode()` private method
+   - Calls it from `onRequestStart()`
+   - Backs up original Application.cfc
+
+3. When a request is made:
+   - Checks if maintenance mode is enabled
+   - Allows whitelisted IPs through
+   - Redirects to custom URL if specified
+   - Otherwise shows maintenance page with message
+
+### wheels maintenance:off
+
+Disable maintenance mode and restore normal application access.
+
+```bash
+wheels maintenance:off [--force] [--cleanup]
+```
+
+#### Parameters
+
+- `--force` - Skip confirmation prompt
+- `--cleanup` - Remove maintenance check from Application.cfc
+
+#### Examples
+
+```bash
+# Basic disable
+wheels maintenance:off
+
+# Skip confirmation
+wheels maintenance:off --force
+
+# Clean up Application.cfc modifications
+wheels maintenance:off --cleanup
+```
+
+#### What It Shows
+
+- Current maintenance configuration
+- How long maintenance mode was active
+- Who enabled maintenance mode
+
+## Best Practices
+
+### 1. Deployment Workflow
+
+```bash
+# Enable maintenance before deployment
+wheels maintenance:on message="Upgrading to version 2.0" --force
+
+# Pull latest code
+git pull origin main
+
+# Run database migrations
+wheels dbmigrate latest
+
+# Clear caches
+wheels cache:clear
+
+# Run tests
+wheels test app
+
+# Disable maintenance
+wheels maintenance:off --force
+```
+
+### 2. Scheduled Maintenance
+
+```bash
+# Schedule maintenance with clear messaging
+wheels maintenance:on \
+  message="Scheduled maintenance: 2:00 AM - 4:00 AM EST. We apologize for any inconvenience." \
+  redirectURL="/maintenance-schedule"
+```
+
+### 3. Emergency Maintenance
+
+```bash
+# Quick emergency maintenance
+wheels maintenance:on message="Emergency maintenance in progress" --force
+
+# Allow only admin access
+wheels maintenance:on \
+  message="System maintenance" \
+  allowedIPs="192.168.1.100" \
+  --force
+```
+
+### 4. Testing Maintenance Mode
+
+```bash
+# Enable with your IP allowed
+wheels maintenance:on allowedIPs="$(curl -s ifconfig.me)"
+
+# Test from another IP or incognito window
+# Should see maintenance page
+
+# Disable when done
+wheels maintenance:off
+```
+
+## Configuration Storage
+
+The maintenance configuration is stored in `config/.maintenance` as JSON:
+
+```json
+{
+  "enabled": true,
+  "message": "The application is currently undergoing maintenance...",
+  "allowedIPs": "192.168.1.100,10.0.0.5",
+  "redirectURL": "",
+  "enabledAt": "2024-01-15 14:30:00",
+  "enabledBy": "admin"
+}
+```
+
+## Application.cfc Integration
+
+The maintenance check is automatically added to your Application.cfc:
+
+```cfml
+private function checkMaintenanceMode() {
+    var maintenanceFile = expandPath("/config/.maintenance");
+    if (fileExists(maintenanceFile)) {
+        var config = deserializeJSON(fileRead(maintenanceFile));
+        if (config.enabled) {
+            // Check if current IP is allowed
+            var clientIP = cgi.remote_addr;
+            if (len(config.allowedIPs) && listFindNoCase(config.allowedIPs, clientIP)) {
+                return; // Allow access
+            }
+            
+            // Handle redirect
+            if (len(config.redirectURL)) {
+                location(url=config.redirectURL, addtoken=false);
+            }
+            
+            // Show maintenance message
+            writeOutput("<!DOCTYPE html>...");
+            abort;
+        }
+    }
+}
+```
+
+## Troubleshooting
+
+### Maintenance Mode Not Working
+
+1. Check if `.maintenance` file exists in `config/` directory
+2. Verify Application.cfc has the maintenance check
+3. Ensure file permissions allow reading the maintenance file
+4. Check server logs for errors
+
+### Can't Disable Maintenance Mode
+
+1. Use `--force` flag to skip confirmation
+2. Manually delete `config/.maintenance` file if needed
+3. Use `--cleanup` to remove Application.cfc modifications
+
+### IP Whitelisting Not Working
+
+1. Check the actual client IP: `cgi.remote_addr`
+2. Behind a proxy? May need to check `cgi.http_x_forwarded_for`
+3. Verify IP format in allowedIPs parameter
+
+## Related Commands
+
+- [wheels cache:clear](../assets-cache-management.md) - Clear caches after maintenance
+- [wheels dbmigrate latest](../database/dbmigrate-latest.md) - Run migrations during maintenance
+- [wheels reload](../core/reload.md) - Reload application after changes


### PR DESCRIPTION
## Summary
- Implements maintenance mode commands (`wheels maintenance:on/off`)
- Implements cleanup commands (`wheels cleanup:logs/tmp/sessions`)
- Adds comprehensive documentation and guides

## Features

### Maintenance Mode
- Enable/disable maintenance mode with custom messages
- IP whitelisting for admin access during maintenance
- Optional redirect URLs
- Automatic Application.cfc integration
- Tracks who enabled maintenance and duration

### Cleanup Commands
- Clean old log files with configurable retention
- Remove temporary files with pattern matching
- Clean expired sessions (file and database support)
- Dry run mode for previewing changes
- Automatic empty directory removal

## Documentation
- Updated AI-CLI.md with all new commands
- Created detailed guides in guides/command-line-tools/commands/maintenance/
- Added examples and best practices

## Test Plan
- [x] CommandBox loads without syntax errors
- [x] Help documentation works for all commands
- [ ] Test maintenance:on command in workspace app
- [ ] Test maintenance:off command in workspace app
- [ ] Test cleanup commands with dry run mode
- [ ] Verify Application.cfc integration works correctly

Co-Authored-By: Claude <noreply@anthropic.com>