### PR TITLE
fix : issue #528

### DIFF
--- a/vendor/wheels/model/onmissingmethod.cfc
+++ b/vendor/wheels/model/onmissingmethod.cfc
@@ -245,7 +245,7 @@ component {
 				arguments.missingMethodArguments.include = local.include;
 				local.where = $keyWhereString(
 					properties = local.joinAssociation.foreignKey,
-					keys = local.componentReference.primaryKeys()
+					keys = primaryKeys()
 				);
 				if (StructKeyExists(arguments.missingMethodArguments, "where")) {
 					local.where = "(#local.where#) AND (#arguments.missingMethodArguments.where#)";


### PR DESCRIPTION
Fix: Align $keyWhereString key mapping with primary model context in shortcut association

Updated the FK–PK mapping logic inside dynamic shortcut resolution to pass the current model's primary keys (`primaryKeys()`) instead of the associated component's primary keys (`local.componentReference.primaryKeys()`).

This change ensures the `$keyWhereString()` function correctly uses values from the calling instance (`this[pk]`), matching the behavior of the new manual FK–PK mapping implementation.