### PR TITLE
Fix: Issue #928

### DIFF
--- a/core/src/wheels/migrator/adapters/MicrosoftSQLServer.cfc
+++ b/core/src/wheels/migrator/adapters/MicrosoftSQLServer.cfc
@@ -278,14 +278,22 @@ component extends="Abstract" {
 	 * prepends sql server identity_insert on to allow inserting primary key values
 	 */
 	public string function addRecordPrefix(required string table) {
-		return "SET IDENTITY_INSERT #quoteTableName(arguments.table)# ON";
+		return "
+			IF EXISTS (SELECT * FROM sys.identity_columns WHERE OBJECT_NAME(object_id) = '#objectCase(arguments.table)#') BEGIN
+				SET IDENTITY_INSERT #quoteTableName(arguments.table)# ON
+			END
+		";
 	}
 
 	/**
 	 * appends sql server identity_insert on to disallow inserting primary key values
 	 */
 	public string function addRecordSuffix(required string table) {
-		return "SET IDENTITY_INSERT #quoteTableName(arguments.table)# OFF";
+		return "
+			IF EXISTS (SELECT * FROM sys.identity_columns WHERE OBJECT_NAME(object_id) = '#objectCase(arguments.table)#') BEGIN
+				SET IDENTITY_INSERT #quoteTableName(arguments.table)# OFF
+			END
+		";
 	}
 
 }


### PR DESCRIPTION
fix : Enhance addRecordPrefix/Suffix to conditionally set IDENTITY_INSERT

- Wrapped SET IDENTITY_INSERT statements in an IF EXISTS check.
- Ensures IDENTITY_INSERT is only applied to tables with identity columns.
- Prevents SQL errors when operating on tables without identity fields.