### PR TITLE
Fix : Issue #910

### DIFF
--- a/docs/src/handling-requests-with-controllers/responding-with-multiple-formats.md
+++ b/docs/src/handling-requests-with-controllers/responding-with-multiple-formats.md
@@ -200,3 +200,21 @@ HTML
     </table>
 </cfdocument>
 ```
+
+### Error Handling with Multiple Formats
+
+When an error occurs in your application, Wheels will automatically respond with an error in the same format as the original request. This ensures consistent API behavior across all supported formats.
+
+For example:
+
+- If a request is made to `/products.json` and an error occurs, the error response will be returned as JSON
+- If a request is made to `/products.xml` and an error occurs, the error response will be returned as XML
+- If a request is made with an `Accept: application/json` header and an error occurs, the error response will be JSON
+
+Wheels provides default error templates for different formats that can be executed when `showErrorInformation` is set to false (like in `production` environment):
+
+- `app/events/onerror.cfm` - HTML error page (default)
+- `app/events/onerror.json.cfm` - JSON error response
+- `app/events/onerror.xml.cfm` - XML error response
+
+You can customize these templates to provide more specific error information or branding for your application. The error response will automatically include the appropriate `Content-Type` header matching the requested format.

--- a/templates/base/src/app/events/onerror.json.cfm
+++ b/templates/base/src/app/events/onerror.json.cfm
@@ -1,0 +1,10 @@
+<cfsilent>
+	<!--- Place JSON error response here that should be displayed when an error is encountered while running in "production" mode. --->
+	
+	<cfset local.errorResponse = {
+		"error": true,
+		"message": "Internal Server Error",
+		"statusCode": 500,
+		"timestamp": DateFormat(Now(), "yyyy-mm-dd") & "T" & TimeFormat(Now(), "HH:mm:ss") & "Z"
+	} />
+</cfsilent><cfoutput>#SerializeJSON(local.errorResponse)#</cfoutput>

--- a/templates/base/src/app/events/onerror.xml.cfm
+++ b/templates/base/src/app/events/onerror.xml.cfm
@@ -1,0 +1,10 @@
+<cfsilent>
+	<!--- Place XML error response here that should be displayed when an error is encountered while running in "production" mode. --->
+	
+	<cfset local.timestamp = DateFormat(Now(), "yyyy-mm-dd") & "T" & TimeFormat(Now(), "HH:mm:ss") & "Z" />
+</cfsilent><cfoutput><?xml version="1.0" encoding="UTF-8"?>
+<error>
+	<message>Internal Server Error</message>
+	<statusCode>500</statusCode>
+	<timestamp>#local.timestamp#</timestamp>
+</error></cfoutput>


### PR DESCRIPTION
feat(error): add format-specific error handling in $runOnError

- Implemented JSON and XML error serialization using $getRequestFormat.
- Applied correct content-type headers based on detected request format.
- Fallback to HTML with layout or onerror.cfm for unknown formats.