### PR TITLE
Fix/wheels cli commands

### DIFF
--- a/cli/src/commands/wheels/about.cfc
+++ b/cli/src/commands/wheels/about.cfc
@@ -34,7 +34,7 @@ component extends="base" {
 		// CLI Version
 		print.boldGreenLine("Wheels CLI");
 		print.greenLine("  Version: " & getWheelsCliVersion());
-		print.greenLine("  Location: " & expandPath("/cfwheels-cli/"));
+		print.greenLine("  Location: " & expandPath("/wheels-cli/"));
 		print.line();
 		
 		// Application Info
@@ -90,10 +90,10 @@ component extends="base" {
 		
 		// Helpful Links
 		print.boldGreenLine("Resources");
-		print.cyanLine("  Documentation: https://guides.wheels.dev");
-		print.cyanLine("  API Reference: https://api.wheels.dev");
-		print.cyanLine("  GitHub: https://github.com/cfwheels/cfwheels");
-		print.cyanLine("  Community: https://community.wheels.dev");
+		print.cyanLine("  Documentation: https://wheels.dev/docs");
+		print.cyanLine("  API Reference: https://wheels.dev/api");
+		print.cyanLine("  GitHub: https://github.com/wheels-dev/wheels");
+		print.cyanLine("  Community: https://wheels.dev/community");
 		print.line();
 	}
 

--- a/cli/src/commands/wheels/base.cfc
+++ b/cli/src/commands/wheels/base.cfc
@@ -75,29 +75,35 @@ component excludeFromHelp=true {
 		return true;
 	}
 
-	// Compare against current wheels version
-	// scope can be one of major/minor/patch
-	boolean function $isWheelsVersion(required any version, string scope="major"){
-		// Assume a string like 2, or 2.0, or 2.0.1, or 1.x
-		var currentversion=listToArray($getWheelsVersion(), ".");
-		var compareversion=listToArray(arguments.version, ".");
-		if(arguments.scope == "major"){
-			if(compareversion[1] == currentversion[1]){
-				return true;
-			}
+	/**
+	* Checks whether the current Wheels version matches the provided version.
+	* @version The version to compare against. Accepts "2", "2.0", "2.0.1", etc.
+	* @scope One of "major", "minor", or "patch"
+	*/
+	boolean function $isWheelsVersion(required any version, string scope="major") {
+		var current = listToArray($getWheelsVersion(), ".");
+		var compare = listToArray(arguments.version, ".");
+
+		// Fill missing parts with 0s
+		while (arrayLen(current) < 3) {
+			arrayAppend(current, "0");
 		}
-		if(arguments.scope == "minor"){
-			if(compareversion[2] == currentversion[2]){
-				return true;
-			}
+		while (arrayLen(compare) < 3) {
+			arrayAppend(compare, "0");
 		}
-		if(arguments.scope == "patch"){
-			if(compareversion[3] == currentversion[3]){
-				return true;
-			}
+
+		switch (scope) {
+			case "major":
+				return compare[1] == current[1];
+			case "minor":
+				return compare[1] == current[1] && compare[2] == current[2];
+			case "patch":
+				return compare[1] == current[1] && compare[2] == current[2] && compare[3] == current[3];
+			default:
+				return false;
 		}
-		return false;
 	}
+
 
 	/**
 	 * Prompt user for confirmation

--- a/cli/src/commands/wheels/db/create.cfc
+++ b/cli/src/commands/wheels/db/create.cfc
@@ -371,10 +371,18 @@ component extends="../base" {
 	}
 
 	private string function extractDataSourceName(required string content) {
-		local.pattern = 'set\s*\(\s*dataSourceName\s*=\s*["'']([^"'']+)["'']';
-		local.match = REFind(local.pattern, arguments.content, 1, true);
-		if (local.match.pos[1] > 0) {
-			return Mid(arguments.content, local.match.pos[2], local.match.len[2]);
+		// Step 1: Remove multi-line block comments: /* ... */
+		local.cleaned = REReplace(arguments.content, "/\*[\s\S]*?\*/", "", "all");
+
+		// Step 2: Remove single-line comments: // ... until end of line
+		local.cleaned = REReplace(local.cleaned, "//.*", "", "all");
+
+		// Step 3: Match set(dataSourceName="...")
+		local.pattern = "set\s*\(\s*dataSourceName\s*=\s*[""']([^""']+)[""']";
+		local.match = REFind(local.pattern, local.cleaned, 1, true);
+
+		if (arrayLen(local.match.pos) >= 2 && local.match.pos[2] > 0) {
+			return Mid(local.cleaned, local.match.pos[2], local.match.len[2]);
 		}
 		return "";
 	}

--- a/cli/src/commands/wheels/db/drop.cfc
+++ b/cli/src/commands/wheels/db/drop.cfc
@@ -338,10 +338,18 @@ component extends="../base" {
 	}
 
 	private string function extractDataSourceName(required string content) {
-		local.pattern = 'set\s*\(\s*dataSourceName\s*=\s*["'']([^"'']+)["'']';
-		local.match = REFind(local.pattern, arguments.content, 1, true);
-		if (local.match.pos[1] > 0) {
-			return Mid(arguments.content, local.match.pos[2], local.match.len[2]);
+		// Step 1: Remove multi-line block comments: /* ... */
+		local.cleaned = REReplace(arguments.content, "/\*[\s\S]*?\*/", "", "all");
+
+		// Step 2: Remove single-line comments: // ... until end of line
+		local.cleaned = REReplace(local.cleaned, "//.*", "", "all");
+
+		// Step 3: Match set(dataSourceName="...")
+		local.pattern = "set\s*\(\s*dataSourceName\s*=\s*[""']([^""']+)[""']";
+		local.match = REFind(local.pattern, local.cleaned, 1, true);
+
+		if (arrayLen(local.match.pos) >= 2 && local.match.pos[2] > 0) {
+			return Mid(local.cleaned, local.match.pos[2], local.match.len[2]);
 		}
 		return "";
 	}

--- a/cli/src/commands/wheels/db/dump.cfc
+++ b/cli/src/commands/wheels/db/dump.cfc
@@ -343,8 +343,82 @@ component extends="../base" {
 	}
 
 	private struct function getDatasourceInfo(required string datasourceName) {
-		// Placeholder implementation
-		return {};
+		try {
+			// Try to get datasource info from application.cfc
+			local.appPath = getCWD();
+			local.appCfcPath = local.appPath & "/config/app.cfm";
+			
+			if (fileExists(local.appCfcPath)) {
+				local.content = fileRead(local.appCfcPath);
+				
+				// Look for datasource definition in this.datasources['name']
+				local.pattern = "this\.datasources\['#arguments.datasourceName#'\]\s*=\s*\{([^}]+)\}";
+				local.match = reFindNoCase(local.pattern, local.content, 1, true);
+				
+				if (local.match.pos[1] > 0) {
+					local.dsDefinition = mid(local.content, local.match.pos[1], local.match.len[1]);
+					local.dsInfo = {
+						"datasource": arguments.datasourceName,
+						"database": "",
+						"driver": "",
+						"host": "localhost",
+						"port": "",
+						"username": "",
+						"password": ""
+					};
+					
+					// Extract driver class
+					local.classMatch = reFindNoCase("class\s*:\s*'([^']+)'", local.dsDefinition, 1, true);
+					if (local.classMatch.pos[2] > 0) {
+						local.className = mid(local.dsDefinition, local.classMatch.pos[2], local.classMatch.len[2]);
+						switch(local.className) {
+							case "org.h2.Driver":
+								local.dsInfo.driver = "H2";
+								break;
+							case "com.mysql.cj.jdbc.Driver":
+							case "com.mysql.jdbc.Driver":
+								local.dsInfo.driver = "MySQL";
+								break;
+							case "org.postgresql.Driver":
+								local.dsInfo.driver = "PostgreSQL";
+								break;
+							case "com.microsoft.sqlserver.jdbc.SQLServerDriver":
+								local.dsInfo.driver = "MSSQL";
+								break;
+						}
+					}
+					
+					// Extract connection string
+					local.connMatch = reFindNoCase("connectionString\s*:\s*'([^']+)'", local.dsDefinition, 1, true);
+					if (local.connMatch.pos[2] > 0) {
+						local.connString = mid(local.dsDefinition, local.connMatch.pos[2], local.connMatch.len[2]);
+						
+						// Parse H2 database path
+						if (local.dsInfo.driver == "H2") {
+							if (find("jdbc:h2:file:", local.connString)) {
+								local.dbPath = replaceNoCase(local.connString, "jdbc:h2:file:", "");
+								local.dbPath = listFirst(local.dbPath, ";");
+								local.dsInfo.database = local.dbPath;
+							}
+						}
+					}
+					
+					// Extract username
+					local.userMatch = reFindNoCase("username\s*[=:]\s*'([^']*)'", local.dsDefinition, 1, true);
+					if (local.userMatch.pos[2] > 0) {
+						local.dsInfo.username = mid(local.dsDefinition, local.userMatch.pos[2], local.userMatch.len[2]);
+					}
+					
+					return local.dsInfo;
+				}
+			}
+			
+			// If not found in app.cfm, return empty struct
+			return {};
+		} catch (any e) {
+			// Server might not be running or file read error
+			return {};
+		}
 	}
 
 	private string function getEnvironment(required string appPath) {
@@ -397,10 +471,18 @@ component extends="../base" {
 	}
 
 	private string function extractDataSourceName(required string content) {
-		local.pattern = 'set\s*\(\s*dataSourceName\s*=\s*["'']([^"'']+)["'']';
-		local.match = REFind(local.pattern, arguments.content, 1, true);
-		if (local.match.pos[1] > 0) {
-			return Mid(arguments.content, local.match.pos[2], local.match.len[2]);
+		// Step 1: Remove multi-line block comments: /* ... */
+		local.cleaned = REReplace(arguments.content, "/\*[\s\S]*?\*/", "", "all");
+
+		// Step 2: Remove single-line comments: // ... until end of line
+		local.cleaned = REReplace(local.cleaned, "//.*", "", "all");
+
+		// Step 3: Match set(dataSourceName="...")
+		local.pattern = "set\s*\(\s*dataSourceName\s*=\s*[""']([^""']+)[""']";
+		local.match = REFind(local.pattern, local.cleaned, 1, true);
+
+		if (arrayLen(local.match.pos) >= 2 && local.match.pos[2] > 0) {
+			return Mid(local.cleaned, local.match.pos[2], local.match.len[2]);
 		}
 		return "";
 	}

--- a/cli/src/commands/wheels/db/restore.cfc
+++ b/cli/src/commands/wheels/db/restore.cfc
@@ -368,10 +368,18 @@ component extends="../base" {
 	}
 
 	private string function extractDataSourceName(required string content) {
-		local.pattern = 'set\s*\(\s*dataSourceName\s*=\s*["'']([^"'']+)["'']';
-		local.match = REFind(local.pattern, arguments.content, 1, true);
-		if (local.match.pos[1] > 0) {
-			return Mid(arguments.content, local.match.pos[2], local.match.len[2]);
+		// Step 1: Remove multi-line block comments: /* ... */
+		local.cleaned = REReplace(arguments.content, "/\*[\s\S]*?\*/", "", "all");
+
+		// Step 2: Remove single-line comments: // ... until end of line
+		local.cleaned = REReplace(local.cleaned, "//.*", "", "all");
+
+		// Step 3: Match set(dataSourceName="...")
+		local.pattern = "set\s*\(\s*dataSourceName\s*=\s*[""']([^""']+)[""']";
+		local.match = REFind(local.pattern, local.cleaned, 1, true);
+
+		if (arrayLen(local.match.pos) >= 2 && local.match.pos[2] > 0) {
+			return Mid(local.cleaned, local.match.pos[2], local.match.len[2]);
 		}
 		return "";
 	}

--- a/cli/src/commands/wheels/db/shell.cfc
+++ b/cli/src/commands/wheels/db/shell.cfc
@@ -591,10 +591,18 @@ component extends="../base" {
 	}
 
 	private string function extractDataSourceName(required string content) {
-		local.pattern = 'set\s*\(\s*dataSourceName\s*=\s*["'']([^"'']+)["'']';
-		local.match = REFind(local.pattern, arguments.content, 1, true);
-		if (local.match.pos[1] > 0) {
-			return Mid(arguments.content, local.match.pos[2], local.match.len[2]);
+		// Step 1: Remove multi-line block comments: /* ... */
+		local.cleaned = REReplace(arguments.content, "/\*[\s\S]*?\*/", "", "all");
+
+		// Step 2: Remove single-line comments: // ... until end of line
+		local.cleaned = REReplace(local.cleaned, "//.*", "", "all");
+
+		// Step 3: Match set(dataSourceName="...")
+		local.pattern = "set\s*\(\s*dataSourceName\s*=\s*[""']([^""']+)[""']";
+		local.match = REFind(local.pattern, local.cleaned, 1, true);
+
+		if (arrayLen(local.match.pos) >= 2 && local.match.pos[2] > 0) {
+			return Mid(local.cleaned, local.match.pos[2], local.match.len[2]);
 		}
 		return "";
 	}

--- a/cli/src/commands/wheels/deps.cfc
+++ b/cli/src/commands/wheels/deps.cfc
@@ -353,14 +353,16 @@ component extends="base" {
                 }
             }
             
-            // Get Wheels version
-            try {
-                local.versionInfo = $sendToCliCommand(urlstring="&command=info");
-                if (structKeyExists(local.versionInfo, "wheelsVersion")) {
-                    local.report.wheelsVersion = local.versionInfo.wheelsVersion;
-                }
-            } catch (any e) {
-                // Ignore
+            // Try to get Wheels version from vendor/wheels/box.json
+            local.wheelsBoxPath = fileSystemUtil.resolvePath("vendor/wheels/box.json");
+            if (fileExists(local.wheelsBoxPath)) {
+                try {
+                    local.wheelsBox = deserializeJSON(fileRead(local.wheelsBoxPath));
+                    if (structKeyExists(local.wheelsBox, "version")) {
+                        local.report.wheelsVersion = local.wheelsBox.version;
+                    }
+                } catch (any e) {
+                    // Ignore errors
             }
             
             // Check installed modules
@@ -488,7 +490,7 @@ component extends="base" {
      */
     private boolean function checkIfInstalled(required string packageName) {
         // Check modules directory
-        local.modulesPath = fileSystemUtil.resolvePath("modules");
+        local.modulesPath = fileSystemUtil.resolvePath("vendor");
         if (directoryExists(local.modulesPath)) {
             // Simple name check
             local.simpleName = listLast(arguments.packageName, ":");

--- a/cli/src/commands/wheels/info.cfc
+++ b/cli/src/commands/wheels/info.cfc
@@ -14,7 +14,7 @@ component  extends="base"  {
 	function run(  ) {
 		var current={
 			directory		= getCWD(),
-			moduleRoot		= expandPath("/cfwheels-cli/"),
+			moduleRoot		= expandPath("/wheels-cli/"),
 			wheelsVersion	= $getWheelsVersion()
 		};
 		print.redLine(",--.   ,--.,--.                   ,--.            ,-----.,--.   ,--. ")

--- a/templates/base/src/box.json
+++ b/templates/base/src/box.json
@@ -7,7 +7,8 @@
         "testbox": "^5.0.0"
     },
     "installPaths": {
-        "wirebox": "core/wirebox/",
-        "testbox": "core/testbox/"
+        "wheels-core": "vendor/wheels/",
+        "wirebox": "vendor/wirebox/",
+        "testbox": "vendor/testbox/"
     }
 }

--- a/templates/base/src/box.json
+++ b/templates/base/src/box.json
@@ -2,6 +2,7 @@
     "name": "cfwheels-test-suite",
     "version": "1.0.0",
     "dependencies": {
+        "wheels-core": "^3.0.0-SNAPSHOT+824",
         "wirebox": "^7.0.0",
         "testbox": "^5.0.0"
     },

--- a/templates/base/src/config/settings.cfm
+++ b/templates/base/src/config/settings.cfm
@@ -12,8 +12,8 @@
 		You can also change the value for the "coreTestDataSourceName" to set your testing datasource.
 		You can also uncomment the 2 "set" functions below them to set the username and password for the datasource.
 	*/
-	set(coreTestDataSourceName="wheels.dev");
-	set(dataSourceName="wheels.dev");
+	set(coreTestDataSourceName="wheels-dev");
+	set(dataSourceName="wheels-dev");
 	// set(dataSourceUserName="");
 	// set(dataSourcePassword="");
 


### PR DESCRIPTION
### Wheels CLI Commands Fixed

This PR includes fixes and implementations for several core Wheels CLI commands. The following commands are now working as expected and have been tested in the development environment:

#### General CLI Commands

* `wheels about` – Display comprehensive information about the Wheels application and environment.
* `wheels info` – Provides information about the CLI module, and also any identified wheels version.

####  Dependency Management (`wheels deps`)

* `list` – Lists installed and available dependencies.
* `install` – Installs specified dependencies into the modules directory.
* `update` – Updates existing dependencies to the latest versions.
* `remove` – Removes specified dependencies from the modules directory.
* `report` – Generates a status report of current dependencies.

#### Database Commands (`wheels db`)

* `create` – Creates the development database.
* `drop` – Drops the development database.
* `dump` – Dumps the current database schema and data.
* `restore` – Restores the database from a previously dumped file.
* `status` – Shows the status of the database and migrations.
* `info` – Displays database-specific configuration and environment info.

> All commands have been tested and verified for functionality. Tests have been performed using the H2 database engine. Test for other database engines is currently in progress.
