### PR TITLE
Fix: Issue #885

### DIFF
--- a/core/src/wheels/model/create.cfc
+++ b/core/src/wheels/model/create.cfc
@@ -179,6 +179,9 @@ component {
 						&& $callback("afterSave", arguments.callbacks)
 					) {
 						$updatePersistedProperties();
+						if (arguments.reload) {
+							this.reload();
+						}
 						local.rv = true;
 					} else if (local.rollback) {
 						$resetToNew();
@@ -202,6 +205,9 @@ component {
 						&& $callback("afterSave", arguments.callbacks)
 					) {
 						$updatePersistedProperties();
+						if (arguments.reload) {
+							this.reload();
+						}
 						local.rv = true;
 					}
 				} else {
@@ -334,9 +340,6 @@ component {
 			this[primaryKeys(1)] = local.inserted.result[local.generatedKey];
 		}
 
-		if (arguments.reload) {
-			this.reload();
-		}
 		return true;
 	}
 

--- a/core/src/wheels/model/update.cfc
+++ b/core/src/wheels/model/update.cfc
@@ -333,9 +333,6 @@ component {
 				local.sql = $addKeyWhereClause(sql = local.sql);
 				variables.wheels.class.adapter.$querySetup(sql = local.sql, parameterize = arguments.parameterize);
 				$clearRequestCache();
-				if (arguments.reload) {
-					this.reload();
-				}
 			}
 		}
 


### PR DESCRIPTION
fix(model): move reload=true in save() to occur after afterSave callbacks

Previously, save(reload=true) would reload the record before afterSave ran, which could cause callbacks to operate on stale or incomplete data, especially if DB triggers set additional fields.

This change moves reload() to the end of $save(), ensuring all lifecycle callbacks (afterSave, afterCreate, etc) run before the reload.