### PR TITLE
fix: Issue #851

### DIFF
--- a/core/src/wheels/tests_testbox/specs/view/urls.cfc
+++ b/core/src/wheels/tests_testbox/specs/view/urls.cfc
@@ -71,14 +71,14 @@ component extends="testbox.system.BaseSpec" {
 
 			it("works with delete method arguments", () => {
 				actual = _controller.buttonTo(method = "delete")
-				expected = '<form action="#application.wheels.webpath#" method="post"><input id="_method" name="_method" type="hidden" value="delete"><button type="submit" value="save">' & '</button>' & _controller.authenticityTokenField() & '</form>'
+				expected = '<form action="#application.wheels.webpath#" method="post"><input name="_method" type="hidden" value="delete"><button type="submit" value="save">' & '</button>' & _controller.authenticityTokenField() & '</form>'
 				
 				expect(actual).toBe(expected)
 			})
 
 			it("works with put method arguments", () => {
 				actual = _controller.buttonTo(method = "put")
-				expected = '<form action="#application.wheels.webpath#" method="post"><input id="_method" name="_method" type="hidden" value="put"><button type="submit" value="save">' & '</button>' & _controller.authenticityTokenField() & '</form>'
+				expected = '<form action="#application.wheels.webpath#" method="post"><input name="_method" type="hidden" value="put"><button type="submit" value="save">' & '</button>' & _controller.authenticityTokenField() & '</form>'
 				
 				expect(actual).toBe(expected)
 			})

--- a/core/src/wheels/view/forms.cfc
+++ b/core/src/wheels/view/forms.cfc
@@ -173,7 +173,11 @@ component {
 			local.rv &= authenticityTokenField();
 		}
 		if (StructKeyExists(local, "method") && local.method != "get") {
-			local.rv &= hiddenFieldTag(name = "_method", value = local.method);
+			local.methodField = hiddenFieldTag(name = "_method", value = local.method);
+			// Delete the id="_method" part of the string.
+			// There could be multiple forms on a page and duplicate "id" attributes are not allowed in HTML.
+			local.methodField = Replace(local.methodField, ' id="_method" ', " ");
+			local.rv &= local.methodField;
 		}
 		return local.rv;
 	}

--- a/core/src/wheels/view/links.cfc
+++ b/core/src/wheels/view/links.cfc
@@ -120,7 +120,11 @@ component {
 		local.content = "";
 		if (StructKeyExists(arguments, "method")) {
 			if (!ListFindNoCase("post,get", arguments.method)) {
-				local.content &= hiddenFieldTag(name = "_method", value = arguments.method);
+				local.methodField = hiddenFieldTag(name = "_method", value = arguments.method);
+				// Delete the id="_method" part of the string.
+				// There could be multiple forms on a page and duplicate "id" attributes are not allowed in HTML.
+				local.methodField = Replace(local.methodField, ' id="_method" ', " ");
+				local.content &= local.methodField;
 			} else if (arguments.method == "get") {
 				local.method = "get";
 			}


### PR DESCRIPTION
fix(form): remove duplicate id="_method" from hidden method field

Avoids HTML validation warnings by removing the id="_method" attribute from the hidden _method field.

This prevents duplicate ID issues when multiple forms are present on the same page.