### PR TITLE
feat : boxlang compatibility with 1.4.x and postgresql

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,8 @@ jobs:
             dbengine: mysql
           - cfengine: boxlang
             dbengine: sqlserver
+          - cfengine: boxlang
+            dbengine: postgres
         exclude:
           - cfengine: adobe2018
             dbengine: h2
@@ -91,8 +93,6 @@ jobs:
             dbengine: h2
           - cfengine: boxlang
             dbengine: h2
-          - cfengine: boxlang
-            dbengine: postgres
           - cfengine: boxlang
             dbengine: oracle
           - cfengine: adobe2025

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,7 +213,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### Testing with BoxLang
 - Local Docker testing: `docker compose up boxlang -d`
 - Access BoxLang instance: http://localhost:60001
-- BoxLang version support: 1.3.x
+- BoxLang version support: 1
 
 ## Repository Structure
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In this [Beginner Tutorial: Hello World][2], we'll be writing a simple applicati
 
 - Adobe ColdFusion 2018/2021/2023
 - Lucee 5/6/7
-- Boxlang 1.1 - 1.4
+- Boxlang 1
 
 **Supported Databases:**
 
@@ -120,7 +120,7 @@ Please report any errors you encounter on our [issue tracker][4]. When reporting
 CFWheels supports the following CFML engines:
 - **Adobe ColdFusion**: 2018, 2021, 2023
 - **Lucee**: 5.x, 6.x, 7.x
-- **BoxLang**: 1.1.x - 1.4.x
+- **BoxLang**: 1
 
 ## License
 

--- a/core/src/wheels/Global.cfc
+++ b/core/src/wheels/Global.cfc
@@ -1340,7 +1340,7 @@ component output="false" {
 			local.minimumMinor = "0";
 			local.minimumPatch = "0";
 			local.maximumMajor = "1";
-			local.maximumMinor = "3";
+			local.maximumMinor = "4";
 			local.maximumPatch = "999";
 			
 			// Check minimum version

--- a/core/src/wheels/controller/rendering.cfc
+++ b/core/src/wheels/controller/rendering.cfc
@@ -507,7 +507,26 @@ component {
 			local.fileName = Replace("_" & local.fileName, "__", "_", "one");
 		}
 
-		local.folderName = Reverse(ListRest(Reverse(arguments.$name), "/"));
+		// BoxLang compatibility: Extract folder name more reliably
+		if (structKeyExists(server, "boxlang")) {
+			// For BoxLang, extract folder path manually to handle version differences
+			local.tempName = arguments.$name;
+			if (Find("/", local.tempName)) {
+				local.folderName = Left(local.tempName, Len(local.tempName) - Len(ListLast(local.tempName, "/")));
+				// Remove trailing slash if present, but only if there's more than just "/"
+				if (Right(local.folderName, 1) == "/" AND Len(local.folderName) > 1) {
+					local.folderName = Left(local.folderName, Len(local.folderName) - 1);
+				}
+				// If we end up with just "/", it means the file is at root level
+				if (local.folderName == "/") {
+					local.folderName = "";
+				}
+			} else {
+				local.folderName = "";
+			}
+		} else {
+			local.folderName = Reverse(ListRest(Reverse(arguments.$name), "/"));
+		}
 
 		if (Left(arguments.$name, 1) == "/") {
 			// Include a file in a sub folder to views.

--- a/core/src/wheels/model/adapters/PostgreSQL.cfc
+++ b/core/src/wheels/model/adapters/PostgreSQL.cfc
@@ -133,11 +133,22 @@ component extends="Base" output=false {
 			local.endPar = Find(")", local.sql);
 			local.columnList = "";
 			if (local.endPar) {
-				local.columnList = ReplaceList(
-					Mid(local.sql, local.startPar, (local.endPar - local.startPar)),
-					"#Chr(10)#,#Chr(13)#, ",
-					",,"
-				);
+				local.rawColumns = Mid(local.sql, local.startPar, (local.endPar - local.startPar));
+
+				// BoxLang compatibility fix - ReplaceList behaves differently
+				if (StructKeyExists(server, "boxlang")) {
+					// For BoxLang, use regex to properly parse column names
+					local.columnList = REReplace(local.rawColumns, "\s*,\s*", ",", "all");
+					local.columnList = REReplace(local.columnList, "[\r\n]", "", "all");
+					local.columnList = Trim(local.columnList);
+				} else {
+					// Original Lucee/ACF behavior
+					local.columnList = ReplaceList(
+						local.rawColumns,
+						"#Chr(10)#,#Chr(13)#, ",
+						",,"
+					);
+				}
 			}
 
 			// Lucee/ACF doesn't support PostgreSQL natively when it comes to returning the primary key value of the last inserted record so we have to do it manually by using the sequence.

--- a/core/src/wheels/model/miscellaneous.cfc
+++ b/core/src/wheels/model/miscellaneous.cfc
@@ -269,6 +269,25 @@ component {
 		local.rv.dataType = variables.wheels.class.properties[arguments.property].dataType;
 		local.rv.scale = variables.wheels.class.properties[arguments.property].scale;
 		local.rv.null = (!Len(this[arguments.property]) && variables.wheels.class.properties[arguments.property].nullable);
+
+		// BoxLang/JDK compatibility: Convert date strings to proper date for datetime types
+		if (structKeyExists(server, "boxlang") && (Len(local.rv.value) && !local.rv.null && 
+		    (local.rv.type == "CF_SQL_DATE" || local.rv.type == "CF_SQL_TIME" || local.rv.type == "CF_SQL_TIMESTAMP") &&
+		    IsSimpleValue(local.rv.value) && !IsDate(local.rv.value))) {
+
+			// Handle DD/MM/YYYY and DD-MM-YYYY formats common in European locales
+			if (REFind("^\d{1,2}[\/\-]\d{1,2}[\/\-]\d{4}$", local.rv.value)) {
+				local.parts = ListToArray(local.rv.value, "/-");
+				if (ArrayLen(local.parts) == 3 && IsNumeric(local.parts[1]) && IsNumeric(local.parts[2]) && IsNumeric(local.parts[3])) {
+					try {
+						local.rv.value = CreateDate(local.parts[3], local.parts[2], local.parts[1]);
+					} catch (any e) {
+						local.rv.value = CreateDate(local.parts[3], local.parts[1], local.parts[2]);
+					}
+				}
+			}
+		}
+		
 		if(local.rv.datatype eq 'geography'){
 			local.sqlQuery = "select type from geography_columns where f_table_name = '#tableName()#' and f_geography_column = '#arguments.property#'";
 			local.result = queryExecute(local.sqlQuery,[],{datasource: "#variables.wheels.class.datasource#"});

--- a/docs/src/introduction/readme/boxlang-support.md
+++ b/docs/src/introduction/readme/boxlang-support.md
@@ -143,7 +143,7 @@ curl -LO https://downloads.ortussolutions.com/ortussolutions/boxlang-runtimes/bo
 
    ```bash
    # Download complete package with additional files
-   curl -LO https://github.com/ortus-solutions/boxlang/releases/latest/download/boxlang-miniserver.zip
+   curl -LO https://downloads.ortussolutions.com/ortussolutions/boxlang-runtimes/boxlang-miniserver/boxlang-miniserver-latest.zip
    unzip boxlang-miniserver.zip
    ```
 

--- a/docs/src/introduction/readme/boxlang-support.md
+++ b/docs/src/introduction/readme/boxlang-support.md
@@ -1,6 +1,6 @@
 # BoxLang Server Setup
 
-CFWheels supports BoxLang 1.3.x, providing developers with a modern, high-performance CFML runtime. You can run BoxLang applications using either CommandBox or BoxLang Mini-Server.
+CFWheels supports BoxLang 1.x, providing developers with a modern, high-performance CFML runtime. You can run BoxLang applications using either CommandBox or BoxLang Mini-Server.
 
 ## Prerequisites
 
@@ -21,13 +21,13 @@ box install boxlang
 # Start server with BoxLang
 box server start cfengine=boxlang
 
-# Or specify specific BoxLang version
-box server start cfengine=boxlang@1.3.0
+# Or specify specific BoxLang version (optional)
+box server start cfengine=boxlang@1.4.0+40
 ```
 
 ### BoxLang Module Dependencies
 
-BoxLang requires specific modules for full CFWheels compatibility. These dependencies should be added to your `box.json` file:
+BoxLang requires specific modules for full CFWheels compatibility. These core dependencies should be added to your `box.json` file:
 
 ```json
 {
@@ -36,7 +36,6 @@ BoxLang requires specific modules for full CFWheels compatibility. These depende
     "bx-csrf": "^1.2.0+3", 
     "bx-esapi": "^1.6.0+9",
     "bx-image": "^1.0.1",
-    "bx-mssql": "^1.4.0+11",
     "bx-mysql": "^1.0.1+7"
   }
 }
@@ -53,7 +52,6 @@ box install bx-compat-cfml
 box install bx-csrf
 box install bx-esapi
 box install bx-image
-box install bx-mssql
 box install bx-mysql
 ```
 
@@ -63,15 +61,24 @@ box install bx-mysql
 - **`bx-csrf`** - Cross-Site Request Forgery protection
 - **`bx-esapi`** - Enterprise Security API for input validation  
 - **`bx-image`** - Image manipulation functionality
-- **`bx-mssql`** - Microsoft SQL Server database driver
 - **`bx-mysql`** - MySQL database driver
+
+#### Additional Database Support
+
+For other databases supported by CFWheels, install the corresponding BoxLang modules:
+
+- **Microsoft SQL Server**: `box install bx-mssql`
+- **PostGreSQL Server**: `box install bx-postgresql`
 
 #### Finding Additional Modules
 
-Browse available BoxLang modules on ForgeBox:
-- Visit [forgebox.io](https://www.forgebox.io)
-- Search for modules with `bx-` prefix
-- Install specific modules: `box install module-name`
+For any additional functionality or database drivers not included in the core dependencies:
+- **Browse ForgeBox**: Visit [forgebox.io](https://www.forgebox.io)
+- **Search for BoxLang modules**: Look for modules with `bx-` prefix
+- **Copy install command**: Each module page provides the exact `box install` command
+- **Install the module**: Run the command in your project directory
+
+Example: For Microsoft SQL Server support, visit the `bx-mssql` module page on ForgeBox and copy the installation command.
 
 ### Server Configuration
 
@@ -92,7 +99,7 @@ Create a `server.json` file in your application root to persist BoxLang settings
         }
     },
     "app": {
-        "cfengine": "boxlang@1.3.0"
+        "cfengine": "boxlang"
     }
 }
 ```
@@ -119,25 +126,25 @@ server start cfengine=boxlang
 
 BoxLang Mini-Server provides a lightweight, standalone option perfect for minimal setups or specific deployment scenarios.
 
-### Version Compatibility Warning
+### Installation
 
-⚠️ **Important**: CFWheels currently supports BoxLang 1.3.x. The latest BoxLang Mini-Server downloads include version 1.4.x, which may not be fully compatible with CFWheels.
+BoxLang Mini-Server can be downloaded directly from the official BoxLang releases. The latest version is fully compatible with CFWheels.
 
-**Download the specific 1.3.0 version:**
+**Download the latest BoxLang Mini-Server:**
 
 ```bash
-# Download BoxLang Mini-Server 1.3.0 JAR file
-curl -O https://downloads.ortussolutions.com/ortussolutions/boxlang-runtimes/boxlang-miniserver/1.3.0/boxlang-miniserver-1.3.0.jar
+# Download the latest BoxLang Mini-Server JAR file
+curl -LO https://downloads.ortussolutions.com/ortussolutions/boxlang-runtimes/boxlang-miniserver/boxlang-miniserver-latest.jar
 ```
 
 ### Installation Steps
 
-1. **Download BoxLang Mini-Server Package**
+1. **Download BoxLang Mini-Server Package** (optional, for additional files)
 
    ```bash
-   # Download complete package (optional, for additional files)
-   wget https://downloads.ortussolutions.com/ortussolutions/boxlang-runtimes/boxlang-miniserver/1.3.0/boxlang-miniserver-1.3.0.zip
-   unzip boxlang-miniserver-1.3.0.zip
+   # Download complete package with additional files
+   curl -LO https://github.com/ortus-solutions/boxlang/releases/latest/download/boxlang-miniserver.zip
+   unzip boxlang-miniserver.zip
    ```
 
 2. **Prepare Your Application Structure**
@@ -260,7 +267,7 @@ curl -O https://downloads.ortussolutions.com/ortussolutions/boxlang-runtimes/box
 #### Basic Command
 
 ```bash
-java -jar /path/to/boxlang-miniserver-1.3.0.jar \
+java -jar /path/to/boxlang-miniserver-1.4.0.jar \
   --webroot /path/to/your/app/public \
   --rewrite
 ```
@@ -268,7 +275,7 @@ java -jar /path/to/boxlang-miniserver-1.3.0.jar \
 #### Full Configuration Example
 
 ```bash
-java -jar /path/to/boxlang-miniserver-1.3.0.jar \
+java -jar /path/to/boxlang-miniserver-1.4.0.jar \
   --webroot /path/to/your/app/public \
   --host 127.0.0.1 \
   --port 8080 \
@@ -281,7 +288,7 @@ java -jar /path/to/boxlang-miniserver-1.3.0.jar \
 If using the CFWheels base template structure:
 
 ```bash
-java -jar /path/to/boxlang-miniserver-1.3.0.jar \
+java -jar /path/to/boxlang-miniserver-1.4.0.jar \
   --webroot /path/to/your/app/templates/base/src/public \
   --rewrite \
   --port 8080
@@ -320,7 +327,7 @@ You can read the further details from the boxlang mini-server documentation
 
 4. **Version Compatibility Issues**
    - **Problem**: Unexpected errors or features not working
-   - **Solution**: Verify you're using BoxLang 1.3.0, not 1.4.x
+   - **Solution**: Verify you're using a recent version of BoxLang 1.x
 
 5. **Path Resolution Problems**
    - **Problem**: Files not found or incorrect paths

--- a/docs/src/introduction/readme/running-local-development-servers.md
+++ b/docs/src/introduction/readme/running-local-development-servers.md
@@ -30,7 +30,7 @@ wheels docker init cfengine=adobe cfversion=2018 db=mysql
 **cfversion** options:
 - Major versions for Adobe ColdFusion: `2018`, `2021`, `2023`, `2025`
 - Major versions for Lucee: `5`, `6`, `7`
-- Major versions for BoxLang: `1.3.x`
+- Major versions for BoxLang: `1`
 
 **db** options:
 - `mysql` - MySQL database

--- a/docs/src/introduction/requirements.md
+++ b/docs/src/introduction/requirements.md
@@ -64,7 +64,7 @@ Wheels requires that you use one of these CFML engines:
 
 * [Adobe ColdFusion](http://www.adobe.com/products/coldfusion/) 2018 / 2021 / 2023
 * [Lucee](http://lucee.org) 5.2.1.9+ / 6 / 7
-* [BoxLang](https://boxlang.ortussolutions.com/) 1.3.x
+* [BoxLang](https://boxlang.ortussolutions.com/) 1
 
 #### Operating Systems
 

--- a/docs/src/working-with-wheels/contributing-to-wheels.md
+++ b/docs/src/working-with-wheels/contributing-to-wheels.md
@@ -53,7 +53,7 @@ Additionally, we recommend that any applications written using the Wheels framew
 
 ## Supported CFML Engines
 
-All code for Wheels should be written for use with Adobe ColdFusion 2018 upwards, Lucee 5 upwards and BoxLang 1.3.
+All code for Wheels should be written for use with Adobe ColdFusion 2018 upwards, Lucee 5 upwards and BoxLang 1.x.
 
 ## Naming Conventions
 

--- a/docs/src/working-with-wheels/using-the-test-environment.md
+++ b/docs/src/working-with-wheels/using-the-test-environment.md
@@ -6,7 +6,7 @@ Wheels includes a comprehensive test environment specifically designed for testi
 
 The Wheels test environment uses Docker containers to provide a standardized setup for testing core framework functionality across:
 
-- Multiple CFML engines (Lucee 5/6/7, Adobe ColdFusion 2018/2021/2023, BoxLang 1.3.x)
+- Multiple CFML engines (Lucee 5/6/7, Adobe ColdFusion 2018/2021/2023, BoxLang 1.x)
 - Multiple database platforms (MySQL, SQL Server, PostgreSQL, H2)
 - A modern test user interface (TestUI)
 - Automated test execution capabilities
@@ -103,7 +103,7 @@ The test environment includes several profiles you can use with `docker compose 
 | `ui-legacy` | The legacy TestUI interface |
 | `lucee` | Lucee 5, 6 and 7 engines |
 | `adobe` | Adobe ColdFusion 2018, 2021, 2023 engines |
-| `boxlang` | BoxLang 1.3.x engine |
+| `boxlang` | BoxLang 1 engine |
 | `db` | All database platforms |
 | `mysql` | MySQL database only |
 | `postgres` | PostgreSQL database only |

--- a/tools/docker/boxlang/box.json
+++ b/tools/docker/boxlang/box.json
@@ -9,7 +9,8 @@
         "bx-esapi":"^1.6.0+9",
         "bx-image":"^1.0.1",
         "bx-mssql":"^1.4.0+11",
-        "bx-mysql":"^1.0.1+7"
+        "bx-mysql":"^1.0.1+7",
+        "bx-postgresql":"^1.0.0+2"
     },
     "installPaths": {
         "wirebox": "vendor/wirebox/",

--- a/tools/docker/boxlang/server.json
+++ b/tools/docker/boxlang/server.json
@@ -14,7 +14,7 @@
 			}
 	},
 	"app":{
-			"cfengine":"boxlang@1.3.0+39",
+			"cfengine":"boxlang@1.4.0+40",
 			"libDirs":"tools/docker/boxlang/lib",
 			"serverHomeDirectory":".engine/boxlang"
 	},


### PR DESCRIPTION
feat: add BoxLang 1.4.x compatibility support and enhance PostgreSQL adapter compatibility

- Upgrade BoxLang version support from 1.3.x to 1.4.x.

- Update documentation across all files to reflect 1.4.x support.

- Fix PostgreSQL column parsing for BoxLang's different ReplaceList behavior.

- Add regex-based column name extraction for BoxLang compatibility.