### PR TITLE
Feat/docs update for datasources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ----
 
-# [3.0.0-SNAPSHOT](https://github.com/cfwheels/cfwheels/tree/develop) => TBD
+# [3.0.0-SNAPSHOT](https://github.com/wheels-dev/wheels/tree/develop) => TBD
 
 ### Controller Enhancements
 

--- a/core/src/wheels/Model.cfc
+++ b/core/src/wheels/Model.cfc
@@ -285,7 +285,7 @@ component output="false" displayName="Model" extends="wheels.Global"{
 
 					/*
 						To fix the issue below:
-						https://github.com/cfwheels/cfwheels/issues/580
+						https://github.com/wheels-dev/wheels/issues/580
 
 						Added a new property called aliasedPropertyList in model class that will contain column names list that are prepended with the tablename.
 						For example, if there is a "user" table then the columns "id,createdat,updatedat,deletedat" will be added in the list with "user" prepended to it.

--- a/core/src/wheels/controller/miscellaneous.cfc
+++ b/core/src/wheels/controller/miscellaneous.cfc
@@ -187,7 +187,7 @@ component {
 			}
 			local.fullPath = Replace(local.folder, "\", "/", "all");
 			local.fullPath = ListAppend(local.fullPath, arguments.file, "/");
-			// https://github.com/cfwheels/cfwheels/issues/873 Don't expand path if already contains root
+			// https://github.com/wheels-dev/wheels/issues/873 Don't expand path if already contains root
 			if (local.fullPath DOES NOT CONTAIN Replace(local.root, "\", "/", "all")) {
 				//added this section for the "/wheels" mapping to work correctly
 				if (local.fullPath CONTAINS "/wheels") {

--- a/core/src/wheels/model/properties.cfc
+++ b/core/src/wheels/model/properties.cfc
@@ -220,7 +220,7 @@ component {
 		}
 
 		/* To fix the bug below:
-			https://github.com/cfwheels/cfwheels/issues/1029
+			https://github.com/wheels-dev/wheels/issues/1029
 
 			This will return a numeric value if the primary key is Numeric and a String otherwise.
 		*/

--- a/core/src/wheels/model/serialize.cfc
+++ b/core/src/wheels/model/serialize.cfc
@@ -156,7 +156,7 @@ component {
 				}
 
 				/* To fix the bug below:
-					https://github.com/cfwheels/cfwheels/issues/605
+					https://github.com/wheels-dev/wheels/issues/605
 
 					Added callback for Afterfind in function. The afterFind hook was not being called when findAll(returnAs = 'struct') is used on the model.
 					Called the afterFind hook, the hook adds the arguments defined in the hook to the object so get the properties using properties() function and then append the property struct to the individual record struct

--- a/core/src/wheels/model/sql.cfc
+++ b/core/src/wheels/model/sql.cfc
@@ -398,7 +398,7 @@ component {
 		// go through the properties and map them to the database unless the developer passed in a table name or an alias in which case we assume they know what they're doing and leave the select clause as is
 
 		/* To fix the issue below:
-			https://github.com/cfwheels/cfwheels/issues/1048
+			https://github.com/wheels-dev/wheels/issues/1048
 
 			The original issue was due to the alias not being passed in to identify the same columns in multiple tables. When we pass in the alias/dot notation in the select clause, it does not add the calculated properties due to the below condition which causes the original name of calculated property to be passed in the final query instead of the definition of calculated property, and that gives an invalid column when executed. Commented the below if and else condition and made fixes in case "." and " AS " is passed in.
 		*/
@@ -416,7 +416,7 @@ component {
 				local.addedProperties = ListAppend(local.addedProperties, local.iItem);
 
 				/* To fix the issue below:
-					https://github.com/cfwheels/cfwheels/issues/1048
+					https://github.com/wheels-dev/wheels/issues/1048
 
 					In case "." or " AS " is passed in the column name item, append that as it is in the select query and then move onto the next iteration.
 				*/
@@ -455,7 +455,7 @@ component {
 
 						/*
 							To fix the issue below:
-							https://github.com/cfwheels/cfwheels/issues/580
+							https://github.com/wheels-dev/wheels/issues/580
 
 							Get the column passed in the select argument with the included table's name prepended to it and replace table name to get the original name.
 
@@ -515,7 +515,7 @@ component {
 
 				/*
 					To fix the bug below:
-					https://github.com/cfwheels/cfwheels/issues/591
+					https://github.com/wheels-dev/wheels/issues/591
 
 					Added an exception in case the column specified in the select or group argument does not exist in the database.
 					This will only be in case when not using "table.column" or "column AS something" since in those cases Wheels passes through the select clause unchanged.
@@ -1084,7 +1084,7 @@ component {
 
 			/*
 				To fix the issue below:
-				https://github.com/cfwheels/cfwheels/issues/580
+				https://github.com/wheels-dev/wheels/issues/580
 
 				Add aliasedPropertyList in the associated class that will be used to check the duplicate column
 			*/

--- a/core/src/wheels/public/docs/core.cfm
+++ b/core/src/wheels/public/docs/core.cfm
@@ -41,7 +41,7 @@ if (StructKeyExists(application.wheels, "docs")) {
 	
 	/* 
 		To fix the issue below:
-		https://github.com/cfwheels/cfwheels/issues/1132
+		https://github.com/wheels-dev/wheels/issues/1132
 		
 		To add the test framework functions in the documentation. Added the Test componenet in the documentscope.
 

--- a/core/src/wheels/public/tests/json.cfm
+++ b/core/src/wheels/public/tests/json.cfm
@@ -8,7 +8,7 @@
   content(type="text/json");
   writeOutput(serializeJSON(testResults));
 </cfscript--->
-<!--- Moved back to tags - see https://github.com/cfwheels/cfwheels/issues/659 --->
+<!--- Moved back to tags - see https://github.com/wheels-dev/wheels/issues/659 --->
 <cfset request.wheels.showDebugInformation = false>
 <cfsetting showdebugoutput="false">
 <cfcontent type="text/json">

--- a/core/src/wheels/public/views/congratulations.cfm
+++ b/core/src/wheels/public/views/congratulations.cfm
@@ -20,14 +20,14 @@
 
 	<div class="row">
 		<div class="column">
-			<a class="" href="https://guides.cfwheels.org/cfwheels-guides/3.0.0-snapshot/introduction/readme/beginner-tutorial-hello-world" target="_blank">View and code along with our
+			<a class="" href="https://wheels.dev/3.0.0/guides/introduction/readme/beginner-tutorial-hello-world" target="_blank">View and code along with our
 		&quot;Hello World&quot; tutorial.</a>
 		</div>
 		<div class="column">
-			<a class="" href="https://guides.cfwheels.org/cfwheels-guides/3.0.0-snapshot" target="_blank">Have a look at the rest of our documentation.</a>
+			<a class="" href="https://wheels.dev/3.0.0/guides" target="_blank">Have a look at the rest of our documentation.</a>
 		</div>
 		<div class="column">
-			<a class="" href="https://github.com/cfwheels/cfwheels/discussions" target="_blank">Say &quot;Hello!&quot; to everyone in the Wheels community.</a>
+			<a class="" href="https://github.com/wheels-dev/wheels/discussions" target="_blank">Say &quot;Hello!&quot; to everyone in the Wheels community.</a>
 		</div>
 		<div class="column">Build the next killer website on the World Wide Web...</div>
 	</div>

--- a/core/src/wheels/tests/dispatch/getrequestmethod.cfc
+++ b/core/src/wheels/tests/dispatch/getrequestmethod.cfc
@@ -23,7 +23,7 @@ component extends="wheels.tests.Test" {
 		assert('method eq "GET"');
 	}
 
-	// https://github.com/cfwheels/cfwheels/issues/886
+	// https://github.com/wheels-dev/wheels/issues/886
 	function test_get_disallow_override() {
 		request.cgi["request_method"] = "GET";
 		url._method = "delete";

--- a/core/src/wheels/tests/model/crud/order.cfc
+++ b/core/src/wheels/tests/model/crud/order.cfc
@@ -53,7 +53,7 @@ component extends="wheels.tests.Test" {
 			assert("result['title'][1] IS 'Title for first test post'");
 		} else {
 			// Skipping on MySQL, see issue for details:
-			// https://github.com/cfwheels/cfwheels/issues/666
+			// https://github.com/wheels-dev/wheels/issues/666
 			assert(true);
 		}
 	}
@@ -69,7 +69,7 @@ component extends="wheels.tests.Test" {
 			assert("result['title'][1] IS 'Title for fifth test post'");
 		} else {
 			// Skipping on MySQL, see issue for details:
-			// https://github.com/cfwheels/cfwheels/issues/666
+			// https://github.com/wheels-dev/wheels/issues/666
 			assert(true);
 		}
 	}

--- a/core/src/wheels/tests/model/validations/standard_validations.cfc
+++ b/core/src/wheels/tests/model/validations/standard_validations.cfc
@@ -440,7 +440,7 @@ component extends="wheels.tests.Test" {
 		user.validatesUniquenessOf(property = "firstName");
 		assert('user.valid()');
 		// Special case for testing when we already have duplicates in the database:
-		// https://github.com/cfwheels/cfwheels/issues/480
+		// https://github.com/wheels-dev/wheels/issues/480
 		transaction action="begin" {
 			user.create(firstName = "Tony", username = "xxxx", password = "xxxx", lastname = "xxxx", validate = false);
 			firstUser = model("user").findOne(where = "firstName = 'Tony'", order = "id ASC");

--- a/core/src/wheels/tests_testbox/resources/app/config/environment.cfm
+++ b/core/src/wheels/tests_testbox/resources/app/config/environment.cfm
@@ -2,7 +2,7 @@
 // Use this file to set the current environment for your application.
 // You can set it to "development", "testing", "maintenance" or "production".
 // Don't forget to issue a reload request (e.g. reload=true) after making changes.
-// See http://docs.cfwheels.org/docs/switching-environments for more info.
+// See https://wheels.dev/3.0.0/guides/working-with-wheels/switching-environments for more info.
 
 // Below, we have set it to "development" for you since that is convenient when you are building your application.
 // We recommend that you change this to "production" when you're running your application live.

--- a/core/src/wheels/tests_testbox/resources/app/config/routes.cfm
+++ b/core/src/wheels/tests_testbox/resources/app/config/routes.cfm
@@ -1,7 +1,7 @@
 <cfscript>
 // Use this file to add routes to your application and point the root route to a controller action.
 // Don't forget to issue a reload request (e.g. reload=true) after making changes.
-// See http://docs.cfwheels.org/docs/routing for more info.
+// See https://wheels.dev/3.0.0/guides/handling-requests-with-controllers/routing for more info.
 mapper()
 	// The "wildcard" call below enables automatic mapping of "controller/action" type routes.
 	// This way you don't need to explicitly add a route every time you create a new action in a controller.

--- a/core/src/wheels/tests_testbox/resources/app/config/settings.cfm
+++ b/core/src/wheels/tests_testbox/resources/app/config/settings.cfm
@@ -2,7 +2,7 @@
 // Use this file to configure your application.
 // You can also use the environment specific files (e.g. /config/production/settings.cfm) to override settings set here.
 // Don't forget to issue a reload request (e.g. reload=true) after making changes.
-// See http://docs.cfwheels.org/docs/configuration-and-defaults for more info.
+// See https://wheels.dev/3.0.0/guides/working-with-wheels/configuration-and-defaults for more info.
 
 // If you leave the settings below commented out, CFWheels will set the data source name to the same name as the folder the application resides in.
 // set(dataSourceName="");

--- a/core/src/wheels/tests_testbox/specs/dispatch/getrequestmethod.cfc
+++ b/core/src/wheels/tests_testbox/specs/dispatch/getrequestmethod.cfc
@@ -28,7 +28,7 @@ component extends="testbox.system.BaseSpec" {
 				expect(method).toBe("GET")
 			})
 
-			// https://github.com/cfwheels/cfwheels/issues/886
+			// https://github.com/wheels-dev/wheels/issues/886
 			it("should not override in GET request", () => {
 				request.cgi["request_method"] = "GET"
 				url._method = "delete"

--- a/core/src/wheels/tests_testbox/specs/model/validations.cfc
+++ b/core/src/wheels/tests_testbox/specs/model/validations.cfc
@@ -892,7 +892,7 @@ component extends="testbox.system.BaseSpec" {
 				user.validatesUniquenessOf(property = "firstName")
 				expect(user.valid()).toBeTrue()
 				// Special case for testing when we already have duplicates in the database:
-				// https://github.com/cfwheels/cfwheels/issues/480
+				// https://github.com/wheels-dev/wheels/issues/480
 				transaction action="begin" {
 					user.create(firstName = "Tony", username = "xxxx", password = "xxxx", lastname = "xxxx", validate = false)
 					firstUser = g.model("user").findOne(where = "firstName = 'Tony'", order = "id ASC")

--- a/core/src/wheels/view/links.cfc
+++ b/core/src/wheels/view/links.cfc
@@ -233,7 +233,7 @@ component {
 		any encode
 	) {
 		/* To fix the bug below:
-			https://github.com/cfwheels/cfwheels/issues/942
+			https://github.com/wheels-dev/wheels/issues/942
 
 			The paginationLinks() function does not set the correct URL on the anchor tag if route is not passed in. Added condition to default the route, if it is not passed in, to the route defined in the request.wheels.params, if the action is index.
 		*/
@@ -341,7 +341,7 @@ component {
 
 						/*
 							To fix the bug below:
-							https://github.com/cfwheels/cfwheels/issues/908
+							https://github.com/wheels-dev/wheels/issues/908
 
 							We need the paginationLinks() function to set the active class to the parent of the current page item.
 							The changes made here set the active class to the immediate parent of the current page element in case nested elements are passed in.

--- a/core/src/wheels/view/miscellaneous.cfc
+++ b/core/src/wheels/view/miscellaneous.cfc
@@ -386,7 +386,7 @@ component {
 		}
 
 		/* To fix the bug below:
-		   https://github.com/cfwheels/cfwheels/issues/1115
+		   https://github.com/wheels-dev/wheels/issues/1115
 
 		   Checked if "addClass" attribute is present then add that attribute's value to class so that it does not overwrite the default class value present in config/settings.cfm
 		*/

--- a/design_docs/ai-specs/documentation-audit.md
+++ b/design_docs/ai-specs/documentation-audit.md
@@ -19,7 +19,7 @@ Conduct a comprehensive audit of CFWheels 3.0 documentation while simultaneously
 
 **Tasks**:
 
-- Clone and scan the `cfwheels/cfwheels` repository (focus on 3.0 branch if available)
+- Clone and scan the `wheels-dev/wheels` repository (focus on 3.0 branch if available)
 - Identify all documentation files (.md, .cfm, .html, README files, etc.)
 - Create a comprehensive directory structure map
 - Catalog different documentation types:
@@ -100,7 +100,7 @@ Conduct a comprehensive audit of CFWheels 3.0 documentation while simultaneously
 - Find all instances of “CFWheels” and determine appropriate replacement with “Wheels”
 - Locate all “cfwheels.org” references for replacement with “wheels.dev”
 - Handle edge cases and context-sensitive replacements:
-  - Repository names (cfwheels/cfwheels)
+  - Repository names (wheels-dev/wheels)
   - Package names and namespaces
   - Historical references that should remain unchanged
   - Code examples and variable names
@@ -155,7 +155,7 @@ Conduct a comprehensive audit of CFWheels 3.0 documentation while simultaneously
 
 ### Repository Structure
 
-- Primary focus: `cfwheels/cfwheels` main repository
+- Primary focus: `wheels-dev/wheels` main repository
 - Special attention to 3.0 branch/version if separate
 - Include `/guides` folder if present in repository
 - Check for documentation in `/docs`, `/readme`, `/examples` folders

--- a/design_docs/architecture/wheels-3-architecture-guide.md
+++ b/design_docs/architecture/wheels-3-architecture-guide.md
@@ -495,7 +495,7 @@ docs/
 ```yaml
 # mkdocs.yml
 site_name: Wheels Documentation
-site_url: https://docs.wheels.org
+site_url: https://wheels.dev/docs
 repo_url: https://github.com/wheels/wheels
 
 theme:

--- a/design_docs/architecture/wheels-cli-commandbox-implementation.md
+++ b/design_docs/architecture/wheels-cli-commandbox-implementation.md
@@ -97,7 +97,7 @@ wheels-cli/
     "version": "3.0.0",
     "author": "CFWheels Team",
     "homepage": "https://cfwheels.org",
-    "documentation": "https://guides.cfwheels.org/cli",
+    "documentation": "https://wheels.dev/3.0.0/guides/command-line-tools/commands/README",
     "repository": {
         "type": "git",
         "url": "https://github.com/cfwheels/wheels-cli"

--- a/design_docs/scratchpad/CLI-TEST-RESULTS-20250620-1st-run.md
+++ b/design_docs/scratchpad/CLI-TEST-RESULTS-20250620-1st-run.md
@@ -113,10 +113,10 @@ Application Statistics
   Migrations: 0
 
 Resources
-  Documentation: https://guides.cfwheels.org
-  API Reference: https://api.cfwheels.org
-  GitHub: https://github.com/cfwheels/cfwheels
-  Community: https://community.cfwheels.org
+  Documentation: https://wheels.dev/guides
+  API Reference: https://wheels.dev/api/v3.0.0
+  GitHub: https://github.com/wheels-dev/wheels
+  Community: https://wheels.dev/community
 ```
 
 **Validation**:

--- a/design_docs/scratchpad/CLI-TEST-RESULTS-20250620-2nd-run.md
+++ b/design_docs/scratchpad/CLI-TEST-RESULTS-20250620-2nd-run.md
@@ -116,7 +116,7 @@ Application Statistics
 Resources
   Documentation: https://guides.wheels.dev
   API Reference: https://api.wheels.dev
-  GitHub: https://github.com/cfwheels/cfwheels
+  GitHub: https://github.com/wheels-dev/wheels
   Community: https://community.wheels.dev
 ```
 **Notes**: Comprehensive information about the framework, CLI, and environment. Shows correct statistics even from framework root.

--- a/design_docs/testing/testing-with-testbox.md
+++ b/design_docs/testing/testing-with-testbox.md
@@ -1047,8 +1047,8 @@ expect(getCurrentContext()).toBe("tests.specs.unit.UserSpec");
 ## Additional Resources
 
 - [TestBox Documentation](https://testbox.ortusbooks.com/)
-- [Wheels Testing Guide](https://guides.cfwheels.org/docs/testing)
-- [Example Test Suite](https://github.com/cfwheels/cfwheels/tree/develop/tests)
+- [Wheels Testing Guide](https://wheels.dev/3.0.0/guides/working-with-wheels/testing-your-application)
+- [Example Test Suite](https://github.com/wheels-dev/wheels/tree/develop/tests)
 - [TestBox Migration Cheat Sheet](testbox-migration-cheatsheet.md)
 
 ## Contributing

--- a/docs/src/introduction/readme/beginner-tutorial-hello-database.md
+++ b/docs/src/introduction/readme/beginner-tutorial-hello-database.md
@@ -64,6 +64,73 @@ set(dataSourceName="back2thefuture");
 ```
 {% endcode %}
 
+### Datasource Configuration Methods
+
+While configuring datasources names in `/config/settings.cfm` is the approach for Wheels applications, you have add your database configuration in the `/config/app.cfm` depending on your CFML engine and database:
+
+#### Adobe ColdFusion Administrator
+If you're using Adobe ColdFusion, you can create and manage datasources through the ColdFusion Administrator:
+1. Access the administrator at `{SITE_URL}/CFIDE/administrator/index.cfm` (or your configured URL and port)
+2. Navigate to Data & Services > Data Sources
+3. Add a new datasource with the same name specified in your `dataSourceName` setting in `settings.cfm`
+4. Configure connection details, pooling, and advanced settings through the web interface
+
+#### Lucee Server/Web Administrator  
+For Lucee installations, you can manage datasources via the Lucee Administrator:
+1. Access the Server Administrator at `{SITE_URL}/lucee/admin/server.cfm`
+3. Navigate to Services > Datasource
+4. Create a new datasource matching your `dataSourceName` configuration
+5. Set up connection pooling, validation queries, and other database-specific settings
+
+#### BoxLang Configuration
+BoxLang only supports datasource configuration through its configuration files, following patterns to create datasources that match your Wheels application settings in the `/config/app.cfm` files.
+
+#### Datasource Configuration via app.cfm
+You can define datasources in your `/config/app.cfm` file using the `this.datasources` struct. This approach works across all CFML engines (Adobe ColdFusion, Lucee, and BoxLang):
+
+{% code title="/config/app.cfm" %}
+```javascript
+component {
+    this.name = "WheelsApp";
+    
+    // Define datasources programmatically
+    this.datasources["wheels-dev"] = {
+        class: "com.mysql.cj.jdbc.Driver",
+        connectionString: "jdbc:mysql://localhost:3306/wheels-dev?useSSL=false",
+        username: "mysql",
+        password: "yourpassword"
+    };
+    
+    // For SQLServer
+    // this.datasources["wheels-dev"] = {
+	// 	class: "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+	// 	connectionString: "jdbc:sqlserver://localhost:1434;databaseName=wheels-dev;encrypt=false",
+	// 	username: "sqlserver",
+	// 	password: "yourpassword"
+	// };
+
+    // For PostgreSQL
+    // this.datasources["wheels-dev"] = {
+    //     class: "org.postgresql.Driver",
+    //     connectionString: "jdbc:postgresql://localhost:5432/wheels-dev",
+    //     username: "postgres",
+    //     password: "yourpassword"
+    // };
+    
+    // For H2 (embedded database)
+    // this.datasources['wheels-dev'] = {
+	// 	class: 'org.h2.Driver', 
+	// 	connectionString: 'jdbc:h2:file:./db/h2/wheels-dev;MODE=MySQL', 
+	// 	username: 'sa'
+	// };
+
+    // you can check and define your configuration according to your settings.
+}
+```
+{% endcode %}
+
+Regardless of which method you choose, ensure that the datasource name and configuration in your Wheels configuration matches exactly with the datasource created in your CFML engine.
+
 ### Our Sample Data Structure
 
 Wheels supports MySQL, SQL Server, PostgreSQL, Oracle and H2. It doesn't matter which DBMS you use for this tutorial; we will all be writing the same CFML code to interact with the database. Wheels does everything behind the scenes that needs to be done to work with each DBMS.

--- a/docs/src/plugins/developing-plugins.md
+++ b/docs/src/plugins/developing-plugins.md
@@ -194,7 +194,7 @@ install:
   # Install CLI: needed to repackage the plugin to a zip on install
   - box install wheels-cli
   # Install Master Branch; nb, installed into folder of the git repo name, i.e neokoenig/wheels-ical4j
-  - box install cfwheels/cfwheels
+  - box install wheels-dev/wheels
   # Install the Plugin: use gitHub path to get the absolute latest rather than the forgebox version
   - box install neokoenig/wheels-ical4j
 before_script:

--- a/docs/src/upgrading/3.0.0-config-migration.md
+++ b/docs/src/upgrading/3.0.0-config-migration.md
@@ -32,7 +32,7 @@ We provide a CommandBox recipe that automates most of the migration process:
 
 ```bash
 # From your application root directory
-box recipe https://raw.githubusercontent.com/cfwheels/cfwheels/develop/cli/recipes/config-migration.boxr
+box recipe https://raw.githubusercontent.com/wheels-dev/wheels/develop/cli/recipes/config-migration.boxr
 ```
 
 The recipe will:
@@ -165,12 +165,12 @@ If you need to rollback:
 
 - [Configuration and Defaults](../working-with-wheels/configuration-and-defaults.md)
 - [CFWheels 3.0.0 Release Notes](../changelog.md#3.0.0)
-- [Community Support](https://community.cfwheels.org)
+- [Community Support](https://wheels.dev/community)
 
 ## Need Help?
 
 If you encounter issues during migration:
 
 1. Check the migration log (`config_migration.log`)
-2. Search existing issues on [GitHub](https://github.com/cfwheels/cfwheels/issues)
-3. Ask for help in the [CFWheels Community](https://community.cfwheels.org)
+2. Search existing issues on [GitHub](https://github.com/wheels-dev/wheels/issues)
+3. Ask for help in the [CFWheels Community](https://wheels.dev/community)

--- a/examples/starter-app/app/controllers/admin/Users.cfc
+++ b/examples/starter-app/app/controllers/admin/Users.cfc
@@ -161,7 +161,7 @@ component extends="app.controllers.Controller" {
 	/**
 	 * Reset a user's password. Generates a new one and emails it to them. Forces them to change it on login
 	 * NB Due to current bug in 2.x, we can't name this action resetPassword as it clashes with the plugin method
-	 * See https://github.com/cfwheels/cfwheels/issues/841
+	 * See https://github.com/wheels-dev/wheels/issues/841
 	 */
 	function reset() {
 		try{

--- a/examples/starter-app/config/environment.cfm
+++ b/examples/starter-app/config/environment.cfm
@@ -2,7 +2,7 @@
 // Use this file to set the current environment for your application.
 // You can set it to "development", "testing", "maintenance" or "production".
 // Don't forget to issue a reload request (e.g. reload=true) after making changes.
-// See https://guides.cfwheels.org/2.5.0/v/3.0.0-snapshot/working-with-cfwheels/switching-environments for more info.
+// See https://wheels.dev/3.0.0/guides/working-with-wheels/switching-environments for more info.
 
 // Below, we have set it to "development" for you since that is convenient when you are building your application.
 // We recommend that you change this to "production" when you're running your application live.

--- a/examples/starter-app/config/routes.cfm
+++ b/examples/starter-app/config/routes.cfm
@@ -2,7 +2,7 @@
 
 	// Use this file to add routes to your application and point the root route to a controller action.
 	// Don't forget to issue a reload request (e.g. reload=true) after making changes.
-	// See https://guides.cfwheels.org/2.5.0/v/3.0.0-snapshot/handling-requests-with-controllers/routing for more info.
+	// See https://wheels.dev/3.0.0/guides/handling-requests-with-controllers/routing for more info.
 
 	mapper()
 		// CLI-Appends-Here

--- a/examples/starter-app/config/settings.cfm
+++ b/examples/starter-app/config/settings.cfm
@@ -37,7 +37,7 @@
 
 	// Turn on URL rewriting by default.
 	// Commandbox urlrewrite.xml is provided.
-	// See https://guides.cfwheels.org/docs/url-rewriting for Apache/IIS etc
+	// See https://wheels.dev/guides/handling-requests-with-controllers/url-rewriting/README for Apache/IIS etc
 	set(URLRewriting="On");
 
 	// Don't include potentially sensitive data in error handling emails

--- a/templates/base/src/box.json
+++ b/templates/base/src/box.json
@@ -44,7 +44,7 @@
     "license":[
         {
             "type":"Apache License 2.0",
-            "URL":"https://github.com/cfwheels/cfwheels/blob/master/LICENSE"
+            "URL":"https://github.com/wheels-dev/wheels/blob/master/LICENSE"
         }
     ],
     "scripts":{

--- a/templates/base/src/config/environment.cfm
+++ b/templates/base/src/config/environment.cfm
@@ -2,7 +2,7 @@
 // Use this file to set the current environment for your application.
 // You can set it to "development", "testing", "maintenance" or "production".
 // Don't forget to issue a reload request (e.g. reload=true) after making changes.
-// See https://guides.cfwheels.org/2.5.0/v/3.0.0-snapshot/working-with-cfwheels/switching-environments for more info.
+// See https://wheels.dev/3.0.0/guides/working-with-wheels/switching-environments for more info.
 
 // Below, we have set it to "development" for you since that is convenient when you are building your application.
 // We recommend that you change this to "production" when you're running your application live.

--- a/templates/base/src/config/routes.cfm
+++ b/templates/base/src/config/routes.cfm
@@ -2,7 +2,7 @@
 
 	// Use this file to add routes to your application and point the root route to a controller action.
 	// Don't forget to issue a reload request (e.g. reload=true) after making changes.
-	// See https://guides.cfwheels.org/2.5.0/v/3.0.0-snapshot/handling-requests-with-controllers/routing for more info.
+	// See https://wheels.dev/3.0.0/guides/handling-requests-with-controllers/routing for more info.
 
 	mapper()
 		// CLI-Appends-Here

--- a/tests/README.md
+++ b/tests/README.md
@@ -138,4 +138,4 @@ wheels test migrate tests --recursive
 For comprehensive documentation, see:
 - [Testing with TestBox Guide](/docs/testing-with-testbox.md)
 - [TestBox Documentation](https://testbox.ortusbooks.com/)
-- [Wheels Testing Guide](https://guides.cfwheels.org/docs/testing)
+- [Wheels Testing Guide](https://wheels.dev/3.0.0/guides/working-with-wheels/testing-your-application)

--- a/tools/build/base/config/settings.cfm
+++ b/tools/build/base/config/settings.cfm
@@ -3,7 +3,7 @@
 		Use this file to configure your application.
 		You can also use the environment specific files (e.g. /config/production/settings.cfm) to override settings set here.
 		Don't forget to issue a reload request (e.g. reload=true) after making changes.
-		See http://docs.wheels.org/docs/configuration-and-defaults for more info.
+		See https://wheels.dev/3.0.0/guides/working-with-wheels/configuration-and-defaults for more info.
 	*/
 
 	/*

--- a/tools/build/cli/README.md
+++ b/tools/build/cli/README.md
@@ -41,7 +41,7 @@ wheels dbmigrate latest
 ## Documentation
 
 Full documentation is available at:
-https://guides.wheels.org/docs/command-line-tools/cli-commands
+https://wheels.dev/3.0.0/guides/command-line-tools/commands/README
 
 ## Requirements
 

--- a/tools/build/cli/box.json
+++ b/tools/build/cli/box.json
@@ -7,7 +7,7 @@
 	"createPackageDirectory":true,
 	"packageDirectory":"wheels-cli",
 	"homepage":"https://wheels.dev/",
-	"documentation":"https://guides.wheels.org/docs/command-line-tools/cli-commands",
+	"documentation":"https://wheels.dev/3.0.0/guides/command-line-tools/commands/README",
 	"repository":{
 			"type":"GIT",
 			"URL":"https://github.com/wheels-dev/wheels"

--- a/tools/docker/adobe2018/settings.cfm
+++ b/tools/docker/adobe2018/settings.cfm
@@ -3,7 +3,7 @@
 		Use this file to configure your application.
 		You can also use the environment specific files (e.g. /config/production/settings.cfm) to override settings set here.
 		Don't forget to issue a reload request (e.g. reload=true) after making changes.
-		See http://docs.cfwheels.org/docs/configuration-and-defaults for more info.
+		See https://wheels.dev/3.0.0/guides/working-with-wheels/configuration-and-defaults for more info.
 	*/
 
 	/*

--- a/tools/docker/adobe2021/settings.cfm
+++ b/tools/docker/adobe2021/settings.cfm
@@ -3,7 +3,7 @@
 		Use this file to configure your application.
 		You can also use the environment specific files (e.g. /config/production/settings.cfm) to override settings set here.
 		Don't forget to issue a reload request (e.g. reload=true) after making changes.
-		See http://docs.cfwheels.org/docs/configuration-and-defaults for more info.
+		See https://wheels.dev/3.0.0/guides/working-with-wheels/configuration-and-defaults for more info.
 	*/
 
 	/*

--- a/tools/docker/adobe2023/settings.cfm
+++ b/tools/docker/adobe2023/settings.cfm
@@ -3,7 +3,7 @@
 		Use this file to configure your application.
 		You can also use the environment specific files (e.g. /config/production/settings.cfm) to override settings set here.
 		Don't forget to issue a reload request (e.g. reload=true) after making changes.
-		See http://docs.cfwheels.org/docs/configuration-and-defaults for more info.
+		See https://wheels.dev/3.0.0/guides/working-with-wheels/configuration-and-defaults for more info.
 	*/
 
 	/*

--- a/tools/docker/adobe2025/settings.cfm
+++ b/tools/docker/adobe2025/settings.cfm
@@ -3,7 +3,7 @@
 		Use this file to configure your application.
 		You can also use the environment specific files (e.g. /config/production/settings.cfm) to override settings set here.
 		Don't forget to issue a reload request (e.g. reload=true) after making changes.
-		See http://docs.cfwheels.org/docs/configuration-and-defaults for more info.
+		See https://wheels.dev/3.0.0/guides/working-with-wheels/configuration-and-defaults for more info.
 	*/
 
 	/*

--- a/tools/docker/boxlang/settings.cfm
+++ b/tools/docker/boxlang/settings.cfm
@@ -3,7 +3,7 @@
 		Use this file to configure your application.
 		You can also use the environment specific files (e.g. /config/production/settings.cfm) to override settings set here.
 		Don't forget to issue a reload request (e.g. reload=true) after making changes.
-		See http://docs.cfwheels.org/docs/configuration-and-defaults for more info.
+		See https://wheels.dev/3.0.0/guides/working-with-wheels/configuration-and-defaults for more info.
 	*/
 
 	/*

--- a/tools/docker/lucee5/settings.cfm
+++ b/tools/docker/lucee5/settings.cfm
@@ -3,7 +3,7 @@
 		Use this file to configure your application.
 		You can also use the environment specific files (e.g. /config/production/settings.cfm) to override settings set here.
 		Don't forget to issue a reload request (e.g. reload=true) after making changes.
-		See http://docs.cfwheels.org/docs/configuration-and-defaults for more info.
+		See https://wheels.dev/3.0.0/guides/working-with-wheels/configuration-and-defaults for more info.
 	*/
 
 	/*

--- a/tools/docker/lucee6/settings.cfm
+++ b/tools/docker/lucee6/settings.cfm
@@ -3,7 +3,7 @@
 		Use this file to configure your application.
 		You can also use the environment specific files (e.g. /config/production/settings.cfm) to override settings set here.
 		Don't forget to issue a reload request (e.g. reload=true) after making changes.
-		See http://docs.cfwheels.org/docs/configuration-and-defaults for more info.
+		See https://wheels.dev/3.0.0/guides/working-with-wheels/configuration-and-defaults for more info.
 	*/
 
 	/*

--- a/tools/docker/lucee7/settings.cfm
+++ b/tools/docker/lucee7/settings.cfm
@@ -3,7 +3,7 @@
 		Use this file to configure your application.
 		You can also use the environment specific files (e.g. /config/production/settings.cfm) to override settings set here.
 		Don't forget to issue a reload request (e.g. reload=true) after making changes.
-		See http://docs.cfwheels.org/docs/configuration-and-defaults for more info.
+		See https://wheels.dev/3.0.0/guides/working-with-wheels/configuration-and-defaults for more info.
 	*/
 
 	/*


### PR DESCRIPTION
docs(guides): Add coverage of admin panels (Adobe CF, Lucee) and programmatic configuration via app.cfm with multi-database examples
Also update outdated links