### PR TITLE
Add CLI command guides for wheels get settings/environment and clean …

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -7,7 +7,6 @@
   * [Beginner Tutorial: Hello World](introduction/readme/beginner-tutorial-hello-world.md)
   * [Beginner Tutorial: Hello Database](introduction/readme/beginner-tutorial-hello-database.md)
   * [Tutorial: Wheels, AJAX, and You](introduction/readme/tutorial-wheels-ajax-and-you.md)
-  * [Boxlang Support](introduction/readme/boxlang-support.md)
 * [Frameworks and Wheels](introduction/frameworks-and-wheels.md)
 * [Requirements](introduction/requirements.md)
 * [Manual Installation](introduction/manual-installation.md)
@@ -25,7 +24,6 @@
     * [wheels reload](command-line-tools/commands/core/reload.md)
     * [wheels deps](command-line-tools/commands/core/deps.md)
     * [wheels destroy](command-line-tools/commands/core/destroy.md)
-    * [wheels watch](command-line-tools/commands/core/watch.md)
   * Code Generation
     * [wheels generate app](command-line-tools/commands/generate/app.md)
     * [wheels generate app-wizard](command-line-tools/commands/generate/app-wizard.md)
@@ -34,27 +32,13 @@
     * [wheels generate view](command-line-tools/commands/generate/view.md)
     * [wheels generate property](command-line-tools/commands/generate/property.md)
     * [wheels generate route](command-line-tools/commands/generate/route.md)
-    * [wheels generate resource](command-line-tools/commands/generate/resource.md)
-    * [wheels generate api-resource](command-line-tools/commands/generate/api-resource.md)
-    * [wheels generate frontend](command-line-tools/commands/generate/frontend.md)
     * [wheels generate test](command-line-tools/commands/generate/test.md)
     * [wheels generate snippets](command-line-tools/commands/generate/snippets.md)
-    * [wheels scaffold](command-line-tools/commands/generate/scaffold.md)
+    * [wheels generate scaffold](command-line-tools/commands/generate/scaffold.md)
   * Database Commands
-    * [Database Management Overview](command-line-tools/commands/database/database-management.md)
     * Database Operations
       * [wheels db create](command-line-tools/commands/database/db-create.md)
       * [wheels db drop](command-line-tools/commands/database/db-drop.md)
-      * [wheels db setup](command-line-tools/commands/database/db-setup.md)
-      * [wheels db reset](command-line-tools/commands/database/db-reset.md)
-      * [wheels db status](command-line-tools/commands/database/db-status.md)
-      * [wheels db version](command-line-tools/commands/database/db-version.md)
-      * [wheels db rollback](command-line-tools/commands/database/db-rollback.md)
-      * [wheels db seed](command-line-tools/commands/database/db-seed.md)
-      * [wheels db dump](command-line-tools/commands/database/db-dump.md)
-      * [wheels db restore](command-line-tools/commands/database/db-restore.md)
-      * [wheels db shell](command-line-tools/commands/database/db-shell.md)
-      * [wheels db schema](command-line-tools/commands/database/db-schema.md)
     * Migration Commands
       * [wheels dbmigrate info](command-line-tools/commands/database/dbmigrate-info.md)
       * [wheels dbmigrate latest](command-line-tools/commands/database/dbmigrate-latest.md)
@@ -68,69 +52,21 @@
       * [wheels dbmigrate remove table](command-line-tools/commands/database/dbmigrate-remove-table.md)
   * Testing Commands
     * [wheels test](command-line-tools/commands/testing/test.md)
-    * [wheels test run](command-line-tools/commands/testing/test-run.md)
-    * [wheels test coverage](command-line-tools/commands/testing/test-coverage.md)
-    * [wheels test debug](command-line-tools/commands/testing/test-debug.md)
-  * Configuration Commands
-    * [wheels config list](command-line-tools/commands/config/config-list.md)
-    * [wheels config set](command-line-tools/commands/config/config-set.md)
-    * [wheels config env](command-line-tools/commands/config/config-env.md)
   * Environment Management
-    * [wheels env](command-line-tools/commands/environment/env.md)
     * [wheels env setup](command-line-tools/commands/environment/env-setup.md)
     * [wheels env list](command-line-tools/commands/environment/env-list.md)
-    * [wheels env switch](command-line-tools/commands/environment/env-switch.md)
-    * [wheels environment](command-line-tools/commands/environment/environment.md)
-    * [wheels console](command-line-tools/commands/environment/console.md)
-    * [wheels runner](command-line-tools/commands/environment/runner.md)
-  * Server Management
-    * [wheels server](command-line-tools/commands/server/server.md)
-    * [wheels server start](command-line-tools/commands/server/server-start.md)
-    * [wheels server stop](command-line-tools/commands/server/server-stop.md)
-    * [wheels server restart](command-line-tools/commands/server/server-restart.md)
-    * [wheels server status](command-line-tools/commands/server/server-status.md)
-    * [wheels server log](command-line-tools/commands/server/server-log.md)
-    * [wheels server open](command-line-tools/commands/server/server-open.md)
-  * Plugin Management
-    * [wheels plugins](command-line-tools/commands/plugins/plugins.md)
-    * [wheels plugins list](command-line-tools/commands/plugins/plugins-list.md)
-    * [wheels plugins install](command-line-tools/commands/plugins/plugins-install.md)
-    * [wheels plugins remove](command-line-tools/commands/plugins/plugins-remove.md)
   * Code Analysis
-    * [wheels analyze](command-line-tools/commands/analysis/analyze.md)
     * [wheels analyze code](command-line-tools/commands/analysis/analyze-code.md)
     * [wheels analyze performance](command-line-tools/commands/analysis/analyze-performance.md)
     * [wheels analyze security](command-line-tools/commands/analysis/analyze-security.md)
-  * Security Commands
-    * [wheels security](command-line-tools/commands/security/security.md)
-    * [wheels security scan](command-line-tools/commands/security/security-scan.md)
-  * Performance Commands
-    * [wheels optimize](command-line-tools/commands/performance/optimize.md)
-    * [wheels optimize performance](command-line-tools/commands/performance/optimize-performance.md)
-  * Documentation Commands
-    * [wheels docs](command-line-tools/commands/documentation/docs.md)
-    * [wheels docs generate](command-line-tools/commands/documentation/docs-generate.md)
-    * [wheels docs serve](command-line-tools/commands/documentation/docs-serve.md)
   * CI/CD Commands
     * [wheels ci init](command-line-tools/commands/ci/ci-init.md)
   * Docker Commands
     * [wheels docker init](command-line-tools/commands/docker/docker-init.md)
     * [wheels docker deploy](command-line-tools/commands/docker/docker-deploy.md)
-  * Deployment Commands
-    * [wheels deploy](command-line-tools/commands/deploy/deploy.md)
-    * [wheels deploy audit](command-line-tools/commands/deploy/deploy-audit.md)
-    * [wheels deploy exec](command-line-tools/commands/deploy/deploy-exec.md)
-    * [wheels deploy hooks](command-line-tools/commands/deploy/deploy-hooks.md)
-    * [wheels deploy init](command-line-tools/commands/deploy/deploy-init.md)
-    * [wheels deploy lock](command-line-tools/commands/deploy/deploy-lock.md)
-    * [wheels deploy logs](command-line-tools/commands/deploy/deploy-logs.md)
-    * [wheels deploy proxy](command-line-tools/commands/deploy/deploy-proxy.md)
-    * [wheels deploy push](command-line-tools/commands/deploy/deploy-push.md)
-    * [wheels deploy rollback](command-line-tools/commands/deploy/deploy-rollback.md)
-    * [wheels deploy secrets](command-line-tools/commands/deploy/deploy-secrets.md)
-    * [wheels deploy setup](command-line-tools/commands/deploy/deploy-setup.md)
-    * [wheels deploy status](command-line-tools/commands/deploy/deploy-status.md)
-    * [wheels deploy stop](command-line-tools/commands/deploy/deploy-stop.md)
+  * Get Commands
+    * [wheels get environment](command-line-tools/commands/get/get-environment.md)
+    * [wheels get settings](command-line-tools/commands/get/get-settings.md)
 * CLI Development Guides
   * [Configuration Management](command-line-tools/configuration.md)
   * [Creating Commands](command-line-tools/cli-guides/creating-commands.md)
@@ -208,11 +144,6 @@
   * [Migrations in Production](database-interaction-through-models/database-migrations/migrations-in-production.md)
 * [Using Multiple Data Sources](database-interaction-through-models/using-multiple-data-sources.md)
 
-## Plugins
-
-* [Installing and Using Plugins](plugins/installing-and-using-plugins.md)
-* [Developing Plugins](plugins/developing-plugins.md)
-* [Publishing Plugins](plugins/publishing-plugins.md)
 
 ## Project Documentation
 

--- a/docs/src/command-line-tools/commands/README.md
+++ b/docs/src/command-line-tools/commands/README.md
@@ -9,12 +9,9 @@ Complete reference for all Wheels CLI commands organized by category.
 | Command | Description |
 |---------|-------------|
 | `wheels generate app [name]` | Create new application |
-| `wheels scaffold [name]` | Generate complete CRUD |
+| `wheels generate scaffold [name]` | Generate complete CRUD |
 | `wheels dbmigrate latest` | Run database migrations |
-| `wheels test run` | Run application tests |
-| `wheels server start` | Start development server |
-| `wheels server status` | Check server status |
-| `wheels watch` | Watch files for changes |
+| `wheels test` | Run application tests |
 | `wheels reload` | Reload application |
 
 ## Core Commands
@@ -25,30 +22,9 @@ Essential commands for managing your Wheels application.
 |---------|-------------|---------------|
 | `wheels init` | Bootstrap existing app for CLI | [Details](core/init.md) |
 | `wheels info` | Display version information | [Details](core/info.md) |
-| `wheels reload [mode]` | Reload application | [Details](core/reload.md) |
+| `wheels reload` | Reload application | [Details](core/reload.md) |
 | `wheels deps` | Manage dependencies | [Details](core/deps.md) |
 | `wheels destroy [type] [name]` | Remove generated code | [Details](core/destroy.md) |
-| `wheels watch` | Watch for file changes | [Details](core/watch.md) |
-
-## Server Management
-
-Enhanced server commands that wrap CommandBox's native functionality with Wheels-specific features.
-
-| Command | Description | Documentation |
-|---------|-------------|---------------|
-| `wheels server` | Display server commands help | [Details](server/server.md) |
-| `wheels server start` | Start development server | [Details](server/server-start.md) |
-| `wheels server stop` | Stop development server | [Details](server/server-stop.md) |
-| `wheels server restart` | Restart server and reload app | [Details](server/server-restart.md) |
-| `wheels server status` | Show server status with Wheels info | [Details](server/server-status.md) |
-| `wheels server log` | Tail server logs | [Details](server/server-log.md) |
-| `wheels server open` | Open application in browser | [Details](server/server-open.md) |
-
-### Server Command Features
-- Validates Wheels application directory
-- Shows framework-specific information
-- Integrates with application reload
-- Provides helpful error messages
 
 ## Code Generation
 
@@ -63,12 +39,9 @@ Commands for generating application code and resources.
 | `wheels generate view` | `wheels g view` | Generate view | [Details](generate/view.md) |
 | `wheels generate property` | | Add model property | [Details](generate/property.md) |
 | `wheels generate route` | | Generate route | [Details](generate/route.md) |
-| `wheels generate resource` | | REST resource | [Details](generate/resource.md) |
-| `wheels generate api-resource` | | API resource (**Currently broken**) | [Details](generate/api-resource.md) |
-| `wheels generate frontend` | | Frontend code | [Details](generate/frontend.md) |
 | `wheels generate test` | | Generate tests | [Details](generate/test.md) |
 | `wheels generate snippets` | | Code snippets | [Details](generate/snippets.md) |
-| `wheels scaffold` | | Complete CRUD | [Details](generate/scaffold.md) |
+| `wheels generate scaffold` | | Complete CRUD | [Details](generate/scaffold.md) |
 
 ### Generator Options
 
@@ -79,6 +52,13 @@ Common options across generators:
 ## Database Commands
 
 Commands for managing database schema and migrations.
+
+### Database Operations
+
+| Command | Description | Documentation |
+|---------|-------------|---------------|
+| `wheels db create` | Create database | [Details](database/db-create.md) |
+| `wheels db drop` | Drop database | [Details](database/db-drop.md) |
 
 ### Migration Management
 
@@ -100,40 +80,13 @@ Commands for managing database schema and migrations.
 | `wheels dbmigrate create column [table] [column]` | Add column migration | [Details](database/dbmigrate-create-column.md) |
 | `wheels dbmigrate remove table [name]` | Drop table migration | [Details](database/dbmigrate-remove-table.md) |
 
-### Database Operations
-
-| Command | Description | Documentation |
-|---------|-------------|---------------|
-| `wheels db schema` | Export/import schema | [Details](database/db-schema.md) |
-| `wheels db seed` | Seed database | [Details](database/db-seed.md) |
-
 ## Testing Commands
 
 Commands for running and managing tests.
 
 | Command | Description | Documentation |
 |---------|-------------|---------------|
-| `wheels test [type]` | Run framework tests | [Details](testing/test.md) |
-| `wheels test run [spec]` | Run TestBox tests | [Details](testing/test-run.md) |
-| `wheels test coverage` | Generate coverage report | [Details](testing/test-coverage.md) |
-| `wheels test debug` | Debug test execution | [Details](testing/test-debug.md) |
-
-### Test Options
-
-- `--watch` - Auto-run on changes
-- `--reporter` - Output format (simple, json, junit)
-- `--bundles` - Specific test bundles
-- `--labels` - Filter by labels
-
-## Configuration Commands
-
-Commands for managing application configuration.
-
-| Command | Description | Documentation |
-|---------|-------------|---------------|
-| `wheels config list` | List configuration | [Details](config/config-list.md) |
-| `wheels config set [key] [value]` | Set configuration | [Details](config/config-set.md) |
-| `wheels config env` | Environment config | [Details](config/config-env.md) |
+| `wheels test` | Run framework tests | [Details](testing/test.md) |
 
 ## Environment Management
 
@@ -141,35 +94,9 @@ Commands for managing development environments and application context.
 
 | Command | Description | Documentation |
 |---------|-------------|---------------|
-| `wheels environment` | Display/switch environment | [Details](environment/environment.md) |
-| `wheels environment set [env]` | Set environment with reload | [Details](environment/environment.md) |
-| `wheels environment list` | List available environments | [Details](environment/environment.md) |
-| `wheels console` | Interactive REPL console | [Details](environment/console.md) |
-| `wheels runner [script]` | Execute scripts with context | [Details](environment/runner.md) |
-
-### Legacy Environment Commands
-| Command | Description | Documentation |
-|---------|-------------|---------------|
 | `wheels env` | Environment base command | [Details](environment/env.md) |
 | `wheels env setup [name]` | Setup environment | [Details](environment/env-setup.md) |
 | `wheels env list` | List environments | [Details](environment/env-list.md) |
-| `wheels env switch [name]` | Switch environment | [Details](environment/env-switch.md) |
-
-## Plugin Management
-
-Commands for managing Wheels plugins.
-
-| Command | Description | Documentation |
-|---------|-------------|---------------|
-| `wheels plugins` | Plugin management base command | [Details](plugins/plugins.md) |
-| `wheels plugins list` | List plugins | [Details](plugins/plugins-list.md) |
-| `wheels plugins install [name]` | Install plugin | [Details](plugins/plugins-install.md) |
-| `wheels plugins remove [name]` | Remove plugin | [Details](plugins/plugins-remove.md) |
-
-### Plugin Options
-
-- `--global` - Install/list globally
-- `--dev` - Development dependency
 
 ## Code Analysis
 
@@ -180,63 +107,7 @@ Commands for analyzing code quality and patterns.
 | `wheels analyze` | Code analysis base command | [Details](analysis/analyze.md) |
 | `wheels analyze code` | Analyze code quality | [Details](analysis/analyze-code.md) |
 | `wheels analyze performance` | Performance analysis | [Details](analysis/analyze-performance.md) |
-| `wheels analyze security` | Security analysis (deprecated) | [Details](analysis/analyze-security.md) |
-
-## Security Commands
-
-Commands for security scanning and hardening.
-
-| Command | Description | Documentation |
-|---------|-------------|---------------|
-| `wheels security` | Security management base command | [Details](security/security.md) |
-| `wheels security scan` | Scan for vulnerabilities | [Details](security/security-scan.md) |
-
-### Security Options
-
-- `--fix` - Auto-fix issues
-- `--path` - Specific path to scan
-
-## Performance Commands
-
-Commands for optimizing application performance.
-
-| Command | Description | Documentation |
-|---------|-------------|---------------|
-| `wheels optimize` | Optimization base command | [Details](performance/optimize.md) |
-| `wheels optimize performance` | Optimize application | [Details](performance/optimize-performance.md) |
-
-## Documentation Commands
-
-Commands for generating and serving documentation.
-
-| Command | Description | Documentation |
-|---------|-------------|---------------|
-| `wheels docs` | Documentation base command (**Currently broken**) | [Details](documentation/docs.md) |
-| `wheels docs generate` | Generate documentation | [Details](documentation/docs-generate.md) |
-| `wheels docs serve` | Serve documentation | [Details](documentation/docs-serve.md) |
-
-### Documentation Options
-
-- `--format` - Output format (html, markdown)
-- `--output` - Output directory
-- `--port` - Server port
-
-## Maintenance Commands
-
-Commands for managing application maintenance mode and cleanup tasks.
-
-| Command | Description | Documentation |
-|---------|-------------|---------------|
-| `wheels maintenance:on` | Enable maintenance mode | [Details](maintenance/maintenance-mode.md#wheels-maintenanceon) |
-| `wheels maintenance:off` | Disable maintenance mode | [Details](maintenance/maintenance-mode.md#wheels-maintenanceoff) |
-| `wheels cleanup:logs` | Remove old log files | [Details](maintenance/cleanup-commands.md#wheels-cleanuplogs) |
-| `wheels cleanup:tmp` | Remove temporary files | [Details](maintenance/cleanup-commands.md#wheels-cleanuptmp) |
-| `wheels cleanup:sessions` | Remove expired sessions | [Details](maintenance/cleanup-commands.md#wheels-cleanupsessions) |
-
-### Maintenance Options
-
-- `--force` - Skip confirmation prompts
-- `--dryRun` - Preview changes without executing
+| `wheels analyze security` | Security analysis | [Details](analysis/analyze-security.md) |
 
 ## CI/CD Commands
 
@@ -254,33 +125,6 @@ Commands for Docker container management and deployment.
 |---------|-------------|---------------|
 | `wheels docker init` | Initialize Docker configuration | [Details](docker/docker-init.md) |
 | `wheels docker deploy` | Deploy using Docker | [Details](docker/docker-deploy.md) |
-
-## Deployment Commands
-
-Commands for managing application deployments.
-
-| Command | Description | Documentation |
-|---------|-------------|---------------|
-| `wheels deploy` | Deployment base command | [Details](deploy/deploy.md) |
-| `wheels deploy audit` | Audit deployment configuration | [Details](deploy/deploy-audit.md) |
-| `wheels deploy exec` | Execute deployment | [Details](deploy/deploy-exec.md) |
-| `wheels deploy hooks` | Manage deployment hooks | [Details](deploy/deploy-hooks.md) |
-| `wheels deploy init` | Initialize deployment | [Details](deploy/deploy-init.md) |
-| `wheels deploy lock` | Lock deployment state | [Details](deploy/deploy-lock.md) |
-| `wheels deploy logs` | View deployment logs | [Details](deploy/deploy-logs.md) |
-| `wheels deploy proxy` | Configure deployment proxy | [Details](deploy/deploy-proxy.md) |
-| `wheels deploy push` | Push deployment | [Details](deploy/deploy-push.md) |
-| `wheels deploy rollback` | Rollback deployment | [Details](deploy/deploy-rollback.md) |
-| `wheels deploy secrets` | Manage deployment secrets | [Details](deploy/deploy-secrets.md) |
-| `wheels deploy setup` | Setup deployment environment | [Details](deploy/deploy-setup.md) |
-| `wheels deploy status` | Check deployment status | [Details](deploy/deploy-status.md) |
-| `wheels deploy stop` | Stop deployment | [Details](deploy/deploy-stop.md) |
-
-### Deployment Options
-
-- `--environment` - Target environment
-- `--force` - Force deployment
-- `--dry-run` - Preview changes without deploying
 
 ## Command Patterns
 
@@ -308,40 +152,23 @@ wheels new myapp         # Same as: wheels generate app myapp
 
 **Creating a new feature:**
 ```bash
-wheels scaffold name=product properties=name:string,price:decimal
+wheels generate scaffold name=product properties=name:string,price:decimal
 wheels dbmigrate latest
-wheels test run
+wheels test
 ```
 
 **Starting development:**
 ```bash
-wheels server start      # Start the server
-wheels watch            # Terminal 1: Watch for file changes
-wheels server log       # Terminal 2: Monitor logs
-wheels test run --watch # Terminal 3: Run tests in watch mode
+wheels reload            # Reload the application
+wheels test             # Run tests
 ```
 
 **Deployment preparation:**
 ```bash
-wheels test run
-wheels security scan
-wheels optimize performance
+wheels test
+wheels analyze security
+wheels analyze performance
 wheels dbmigrate info
-wheels environment production
-```
-
-**Interactive debugging:**
-```bash
-wheels console                    # Start REPL
-wheels console environment=testing # Test in specific env
-wheels console execute="model('User').count()"  # Quick check
-```
-
-**Running maintenance scripts:**
-```bash
-wheels runner scripts/cleanup.cfm
-wheels runner scripts/migrate.cfm environment=production
-wheels runner scripts/report.cfm params='{"month":12}'
 ```
 
 ## Environment Variables
@@ -363,23 +190,10 @@ wheels runner scripts/report.cfm params='{"month":12}'
 | `4` | Permission denied |
 | `5` | Database error |
 
-## Command Status Notes
-
-Some commands in the Wheels CLI are currently in various states of development or maintenance:
-
-### Broken Commands
-- `wheels docs` - Base documentation command is currently broken
-- `wheels generate api-resource` - API resource generation is currently broken
-
-### Disabled Commands
-The following commands exist in the codebase but are currently disabled:
-- Some CI and Docker commands have disabled variants in the codebase
-
-These commands may be re-enabled in future versions of Wheels.
-
 ## See Also
 
-- [Installation Guide](../guides/installation.md)
-- [Quick Start Guide](../guides/quick-start.md)
-- [Creating Custom Commands](../guides/creating-commands.md)
-- [CLI Architecture](../guides/service-architecture.md)
+- [Quick Start Guide](../quick-start.md)
+- [CLI Development Guides](../cli-guides/creating-commands.md)
+- [Service Architecture](../cli-guides/service-architecture.md)
+- [Migrations Guide](../cli-guides/migrations.md)
+- [Testing Guide](../cli-guides/testing.md)

--- a/docs/src/command-line-tools/commands/get/get-environment.md
+++ b/docs/src/command-line-tools/commands/get/get-environment.md
@@ -1,0 +1,237 @@
+# Wheels get environment
+
+## Overview
+
+The `wheels get environment` command displays the current environment setting for your Wheels application. It automatically detects which environment your application is configured to run in (development, staging, production, etc.) and shows where this configuration is coming from.
+
+## Command Syntax
+
+```bash
+wheels get environment
+```
+
+## Parameters
+
+This command takes no parameters.
+
+## Basic Usage
+
+### Display Current Environment
+```bash
+wheels get environment
+```
+
+This will output something like:
+```
+Current Environment:
+development
+
+Configured in: .env file
+```
+
+## How It Works
+
+### Detection Priority
+
+The command checks for environment configuration in the following order of precedence:
+
+1. **`.env` file** - Looks for `WHEELS_ENV` variable in your `.env` file
+2. **System environment variable** - Checks the `WHEELS_ENV` system environment variable
+3. **`server.json`** - Looks for `env.WHEELS_ENV` in your CommandBox `server.json` file
+4. **Default** - Falls back to `development` if no configuration is found
+
+The first valid configuration found is used and reported.
+
+### Configuration Sources
+
+#### 1. .env File
+The command looks for a `WHEELS_ENV` variable in your application's `.env` file:
+```bash
+# .env file
+WHEELS_ENV=production
+DATABASE_HOST=localhost
+```
+
+The regex pattern used ensures it correctly reads the value while ignoring:
+- Comments after the value
+- Trailing whitespace
+- Lines that are commented out
+
+#### 2. System Environment Variable
+If not found in `.env`, it checks for a system-level environment variable:
+```bash
+# Linux/Mac
+export WHEELS_ENV=staging
+
+# Windows
+set WHEELS_ENV=staging
+```
+
+#### 3. server.json Configuration
+For CommandBox deployments, it checks the `server.json` file:
+```json
+{
+  "env": {
+    "WHEELS_ENV": "production"
+  }
+}
+```
+
+#### 4. Default Value
+If no configuration is found anywhere, it defaults to `development`.
+
+## Output Examples
+
+### Configured in .env File
+```
+Current Environment:
+production
+
+Configured in: .env file
+```
+
+### Configured via System Variable
+```
+Current Environment:
+staging
+
+Configured in: System environment variable
+```
+
+### Configured in server.json
+```
+Current Environment:
+production
+
+Configured in: server.json
+```
+
+### Using Default
+```
+Current Environment:
+development
+
+Using default: development
+```
+
+## Common Use Cases
+
+### Verify Environment Before Deployment
+```bash
+# Check environment before starting server
+wheels get environment
+commandbox server start
+```
+
+### Troubleshooting Configuration Issues
+```bash
+# Verify which configuration source is being used
+wheels get environment
+
+# If unexpected, check each source in order
+cat .env | grep WHEELS_ENV
+echo $WHEELS_ENV
+cat server.json | grep WHEELS_ENV
+```
+
+### CI/CD Pipeline Verification
+```bash
+# In deployment script
+wheels get environment
+if [ $? -eq 0 ]; then
+    echo "Environment configured successfully"
+fi
+```
+
+## Error Handling
+
+The command will show an error if:
+- It's not run from a Wheels application directory
+- There's an error reading configuration files
+- File permissions prevent reading configuration
+
+### Not a Wheels Application
+```
+Error: This command must be run from a Wheels application directory
+```
+
+### Read Error
+```
+Error reading environment: [specific error message]
+```
+
+## Best Practices
+
+1. **Consistent Configuration** - Use one primary method for setting environment across your team
+
+2. **Environment-Specific Files** - Consider using `.env.production`, `.env.development` files with the merge command
+
+3. **Don't Commit Production Settings** - Keep production `.env` files out of version control
+
+4. **Document Your Setup** - Document which configuration method your team uses in your README
+
+5. **Verify Before Deployment** - Always run this command to verify environment before deploying
+
+## Environment Precedence
+
+Understanding precedence is important when multiple configurations exist:
+
+```
+.env file (highest priority)
+    ↓
+System environment variable
+    ↓
+server.json
+    ↓
+Default: development (lowest priority)
+```
+
+If `WHEELS_ENV` is set in both `.env` and as a system variable, the `.env` value takes precedence.
+
+## Integration with Other Commands
+
+This command works well with other Wheels CLI commands:
+
+```bash
+# Check environment, then run migrations
+wheels get environment
+wheels db migrate
+
+# Verify environment before running tests
+wheels get environment
+wheels test
+
+# Check environment, then start server
+wheels get environment
+commandbox server start
+```
+
+## Tips
+
+- The command must be run from your Wheels application root directory
+- The environment value is case-sensitive (`development` ≠ `Development`)
+- Comments in `.env` files are properly ignored
+- Whitespace around values is automatically trimmed
+- The command provides clear feedback about where the configuration is coming from
+
+## Troubleshooting
+
+### Environment Not Changing
+If changing `WHEELS_ENV` doesn't seem to work:
+1. Run `wheels get environment` to see which source is being used
+2. Remember `.env` file takes precedence over system variables
+3. Restart your CommandBox server after changes
+4. Check for typos in the variable name (`WHEELS_ENV` not `WHEEL_ENV`)
+
+### Permission Errors
+If you get permission errors:
+- Ensure you have read access to `.env` and `server.json` files
+- Check that you're in the correct directory
+- Verify file ownership and permissions
+
+### Unexpected Default
+If you're getting the default `development` when you expect a different value:
+- Check for typos in configuration files
+- Ensure `.env` file is in the application root
+- Verify system environment variables are properly exported
+- Check that `server.json` has the correct structure

--- a/docs/src/command-line-tools/commands/get/get-settings.md
+++ b/docs/src/command-line-tools/commands/get/get-settings.md
@@ -1,0 +1,350 @@
+# Wheels get settings
+
+## Overview
+
+The `wheels get settings` command displays the current CFWheels application settings for your environment. It shows all configuration settings that are active, including defaults and any custom overrides from your configuration files. You can view all settings or filter to see specific ones.
+
+## Command Syntax
+
+```bash
+wheels get settings [settingName]
+```
+
+## Parameters
+
+### Optional Parameters
+- **`settingName`** - Optional setting name or pattern to filter results. Can be a partial match.
+
+## Basic Usage Examples
+
+### Display All Settings
+```bash
+wheels get settings
+```
+Shows all active settings for the current environment
+
+### Filter Specific Setting
+```bash
+wheels get settings cacheQueries
+```
+Shows only the `cacheQueries` setting
+
+### Filter by Pattern
+```bash
+wheels get settings cache
+```
+Shows all settings containing "cache" in their name (e.g., `cacheQueries`, `cachePages`, `cacheImages`)
+
+## How It Works
+
+### Settings Resolution Order
+
+The command resolves settings in the same order as CFWheels:
+
+1. **Default Wheels Settings** - Built-in framework defaults
+2. **Application Settings** - From `/config/settings.cfm`
+3. **Environment Settings** - From `/config/[environment]/settings.cfm`
+
+Each level overrides the previous one, with environment-specific settings having the highest priority.
+
+### Environment Detection
+
+The command automatically detects the current environment using the same logic as `wheels get environment`:
+- Checks `.env` file for `WHEELS_ENV`
+- Checks system environment variable
+- Checks `server.json`
+- Defaults to `development`
+
+### Settings Parsing
+
+The command parses `set()` function calls in your settings files:
+```coldfusion
+// config/settings.cfm
+set(dataSourceName="myapp_db");
+set(cacheQueries=true);
+set(errorEmailAddress="admin@example.com");
+```
+
+## Output Examples
+
+### All Settings Display
+```
+Wheels Settings (development environment):
+
+allowConcurrentRequestScope:   false
+cacheActions:                  false
+cacheCullInterval:              5
+cacheCullPercentage:            10
+cacheDatabaseSchema:            false
+cacheFileChecking:              false
+cacheImages:                    false
+cacheModelConfig:               false
+cachePages:                     false
+cachePartials:                  false
+cacheQueries:                   false
+cacheRoutes:                    false
+dataSourceName:                 myapp_db
+errorEmailAddress:              admin@example.com
+showDebugInformation:           true
+showErrorInformation:           true
+URLRewriting:                   partial
+
+Total settings: 17
+```
+
+### Filtered Settings Display
+```bash
+wheels get settings cache
+```
+```
+Wheels Settings (development environment):
+
+cacheActions:                   false
+cacheCullInterval:              5
+cacheCullPercentage:            10
+cacheDatabaseSchema:            false
+cacheFileChecking:              false
+cacheImages:                    false
+cacheModelConfig:               false
+cachePages:                     false
+cachePartials:                  false
+cacheQueries:                   true
+cacheRoutes:                    false
+
+Total settings: 11
+```
+
+### Single Setting Display
+```bash
+wheels get settings dataSourceName
+```
+```
+Wheels Settings (production environment):
+
+dataSourceName:                 production_db
+
+Total settings: 1
+```
+
+### No Matches Found
+```bash
+wheels get settings nonexistent
+```
+```
+No settings found matching 'nonexistent'
+```
+
+## Common Wheels Settings
+
+### Caching Settings
+- `cacheActions` - Cache action output
+- `cacheQueries` - Cache database query results
+- `cachePages` - Cache entire page output
+- `cachePartials` - Cache partial/template output
+- `cacheImages` - Cache generated images
+- `cacheRoutes` - Cache routing configuration
+- `cacheModelConfig` - Cache model configurations
+- `cacheControllerConfig` - Cache controller configurations
+- `cacheViewConfig` - Cache view configurations
+- `cacheDatabaseSchema` - Cache database schema information
+- `cacheFileChecking` - Check for file changes when caching
+
+### Database Settings
+- `dataSourceName` - Primary datasource name
+- `useExpandedColumnAliases` - Use expanded column aliases in queries
+- `useTimestampsOnDeletedColumn` - Add timestamps to soft-deleted records
+- `migratorTableName` - Table name for migration versions
+
+### Error Handling Settings
+- `showDebugInformation` - Display debug information
+- `showErrorInformation` - Display error details
+- `sendEmailOnError` - Send email notifications on errors
+- `errorEmailAddress` - Email address for error notifications
+- `errorEmailServer` - SMTP server for error emails
+- `errorEmailSubject` - Subject line for error emails
+- `includeErrorInEmailSubject` - Include error details in email subject
+
+### URL Settings
+- `URLRewriting` - URL rewriting mode (`none`, `partial`, `full`)
+
+### Plugin Settings
+- `overwritePlugins` - Allow plugin overwrites
+- `deletePluginDirectories` - Delete plugin directories on uninstall
+- `loadIncompatiblePlugins` - Load plugins with version mismatches
+
+## Common Use Cases
+
+### Development vs Production Comparison
+```bash
+# Check development settings
+WHEELS_ENV=development wheels get settings cache
+
+# Check production settings
+WHEELS_ENV=production wheels get settings cache
+```
+
+### Verify Database Configuration
+```bash
+wheels get settings dataSourceName
+```
+
+### Check All Caching Settings
+```bash
+wheels get settings cache
+```
+
+### Debugging Configuration Issues
+```bash
+# See all current settings
+wheels get settings
+
+# Check specific problematic setting
+wheels get settings showDebugInformation
+```
+
+### Pre-deployment Verification
+```bash
+# Verify production settings
+WHEELS_ENV=production wheels get settings
+```
+
+## Settings File Examples
+
+### Basic Application Settings
+```coldfusion
+// config/settings.cfm
+set(dataSourceName="myapp");
+set(URLRewriting="partial");
+set(errorEmailAddress="admin@myapp.com");
+```
+
+### Environment-Specific Settings
+```coldfusion
+// config/production/settings.cfm
+set(cacheQueries=true);
+set(cachePages=true);
+set(cachePartials=true);
+set(showDebugInformation=false);
+set(showErrorInformation=false);
+set(sendEmailOnError=true);
+```
+
+```coldfusion
+// config/development/settings.cfm
+set(cacheQueries=false);
+set(showDebugInformation=true);
+set(showErrorInformation=true);
+set(sendEmailOnError=false);
+```
+
+## Data Type Support
+
+The command correctly interprets different data types:
+
+### Boolean Values
+```coldfusion
+set(cacheQueries=true);
+set(showDebugInformation=false);
+```
+
+### Numeric Values
+```coldfusion
+set(cacheCullInterval=5);
+set(cacheCullPercentage=10);
+```
+
+### String Values
+```coldfusion
+set(dataSourceName="myapp_db");
+set(errorEmailAddress="admin@example.com");
+```
+
+### Complex Values
+Arrays and structs are displayed with summary information:
+```
+complexSetting:                 [array with 5 items]
+structSetting:                  {3 items}
+```
+
+## Error Handling
+
+The command will show an error if:
+- Not run from a Wheels application directory
+- Settings files cannot be read
+- Settings files contain syntax errors
+
+### Not a Wheels Application
+```
+Error: This command must be run from a Wheels application directory
+```
+
+### Read Error
+```
+Error reading settings: [specific error message]
+Details: [additional error details if available]
+```
+
+## Best Practices
+
+1. **Environment-Specific Configs** - Keep environment-specific settings in separate files (`/config/[environment]/settings.cfm`)
+
+2. **Document Custom Settings** - Comment your custom settings in the configuration files
+
+3. **Use Consistent Naming** - Follow Wheels naming conventions for custom settings
+
+4. **Verify Before Deployment** - Always check settings for the target environment before deploying
+
+5. **Sensitive Data** - Keep sensitive settings (API keys, passwords) in environment variables or `.env` files
+
+## Integration with Other Commands
+
+Works well with other Wheels CLI commands:
+
+```bash
+# Check environment, then settings
+wheels get environment
+wheels get settings
+
+# Verify cache settings before clearing cache
+wheels get settings cache
+wheels clear cache
+
+# Check database settings before running migrations
+wheels get settings dataSourceName
+wheels db migrate
+```
+
+## Tips
+
+- Setting names are case-insensitive when filtering
+- The filter matches any part of the setting name
+- Settings are displayed in alphabetical order
+- Boolean values display as `true` or `false`
+- Complex values (arrays, structs) show a summary
+- The command shows which environment's settings are being displayed
+
+## Troubleshooting
+
+### Settings Not Showing Expected Values
+1. Check which environment is active: `wheels get environment`
+2. Verify the settings file exists in the correct location
+3. Check for syntax errors in your settings files
+4. Ensure settings use the correct `set()` function syntax
+
+### Missing Settings
+If expected settings are missing:
+- Verify they're defined using `set()` function
+- Check file paths: `/config/settings.cfm` and `/config/[environment]/settings.cfm`
+- Ensure no syntax errors prevent parsing
+
+### Filter Not Working
+- Remember the filter is case-insensitive
+- The filter matches any part of the setting name
+- Use more specific terms for precise filtering
+
+## Limitations
+
+- The command parses settings files statically and may not capture all dynamic settings
+- Complex CFML expressions in settings may not be fully evaluated
+- Settings defined outside of `set()` function calls may not be detected
+- Runtime settings modifications are not reflected


### PR DESCRIPTION
…up README and SUMMARY

Added comprehensive documentation for Wheels CLI commands and cleaned up command reference:

New Documentation:
- Add complete guide for 'wheels get settings' command
- Add complete guide for 'wheels get environment' command
- Document all configuration options, usage examples, and troubleshooting

README Cleanup:
- Remove all undocumented commands from README.md
- Keep only commands that have corresponding .md files in SUMMARY.md
- Remove sections: Server Management, Configuration, Plugins, Security, Performance, Documentation, Maintenance, Deployment commands
- Clean up command aliases and workflows to match available commands
- Update quick reference table with actually available commands

The README now accurately reflects only the documented and available CLI commands, preventing confusion from referencing non-existent or undocumented functionality.