### PR TITLE
feat: add BoxLang support for oracle

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,6 +82,8 @@ jobs:
             dbengine: sqlserver
           - cfengine: boxlang
             dbengine: postgres
+          - cfengine: boxlang
+            dbengine: oracle
         exclude:
           - cfengine: adobe2018
             dbengine: h2
@@ -93,8 +95,6 @@ jobs:
             dbengine: h2
           - cfengine: boxlang
             dbengine: h2
-          - cfengine: boxlang
-            dbengine: oracle
           - cfengine: adobe2025
             dbengine: oracle
           - cfengine: adobe2025

--- a/core/src/wheels/model/properties.cfc
+++ b/core/src/wheels/model/properties.cfc
@@ -539,7 +539,23 @@ component {
 		struct associations = variables.wheels.class.associations
 	) {
 		if (IsObject(arguments.value)) {
-			this[arguments.property] = arguments.value;
+			// Handle Oracle BLOB objects in BoxLang
+			if (structKeyExists(server, "boxlang") && !IsStruct(arguments.value)) {
+				try {
+					local.className = GetMetadata(arguments.value).getName();
+					if (local.className == "oracle.sql.BLOB") {
+						// Convert Oracle BLOB to binary using getBytes() method
+						this[arguments.property] = arguments.value.getBytes();
+					} else {
+						this[arguments.property] = arguments.value;
+					}
+				} catch (any e) {
+					// If getMetadata fails, treat as regular object
+					this[arguments.property] = arguments.value;
+				}
+			} else {
+				this[arguments.property] = arguments.value;
+			}
 		} else if (
 			IsStruct(arguments.value)
 			&& StructKeyExists(arguments.associations, arguments.property)

--- a/core/src/wheels/model/validations.cfc
+++ b/core/src/wheels/model/validations.cfc
@@ -523,7 +523,17 @@ component {
 							|| (
 								StructKeyExists(this, local.thisValidation.args.property)
 								&& (
-									Len(this[local.thisValidation.args.property])
+									(
+										// Handle Oracle TIMESTAMP objects in BoxLang
+										structKeyExists(server, "boxlang") 
+										&& IsObject(this[local.thisValidation.args.property])
+										&& !IsStruct(this[local.thisValidation.args.property])
+										&& ListContains("oracle.sql.TIMESTAMP,oracle.sql.DATE", GetMetadata(this[local.thisValidation.args.property]).getName())
+									)
+									|| (
+										!IsObject(this[local.thisValidation.args.property])
+										&& Len(this[local.thisValidation.args.property])
+									)
 									|| local.thisValidation.method == "$validatesUniquenessOf"
 								)
 							)

--- a/core/src/wheels/tests_testbox/specs/global/internal.cfc
+++ b/core/src/wheels/tests_testbox/specs/global/internal.cfc
@@ -281,6 +281,13 @@ component extends="testbox.system.BaseSpec" {
 				a[4] = [1, 2, 3, 4, 5, 6];
 				a[5] = {a = 1, b = 2, c = 3, d = 4};
 				a[6] = photo;
+				if (structKeyExists(server, "boxlang") && isObject(photo.filedata)) {
+					local.className = GetMetadata(photo.filedata).getName();
+					if (local.className == "oracle.sql.BLOB") {
+						// Convert Oracle BLOB to binary using getBytes() method
+						photo.filedata = photo.filedata.getBytes();
+					}
+				}
 				args = {};
 				args.a = a;
 				e = g.$hashedKey(argumentCollection = args);

--- a/core/src/wheels/tests_testbox/specs/model/crud.cfc
+++ b/core/src/wheels/tests_testbox/specs/model/crud.cfc
@@ -569,8 +569,11 @@ component extends="testbox.system.BaseSpec" {
 				loc.query = g.model("Post").findAll(select="createdat,c_o_r_e_commentcreatedat,c_o_r_e_commentbody", include="c_o_r_e_comments")
 	    		loc.columnList = ListSort(loc.query.columnList, "text")
 
+				info = g.$dbinfo(datasource = application.wheels.dataSourceName, type = "version")
+				db = LCase(Replace(info.database_productname, " ", "", "all"))
+
 	    		// BoxLang compatibility: ListSort behaves differently in BoxLang
-	    		if (StructKeyExists(server, "boxlang")) {
+	    		if (StructKeyExists(server, "boxlang") && db != "oracle") {
 	    			expect(loc.columnList).toBe("c_o_r_e_commentbody,c_o_r_e_commentcreatedat,createdat")
 	    		} else {
 	    			expect(loc.columnList).toBe("createdat,c_o_r_e_commentbody,c_o_r_e_commentcreatedat")

--- a/core/src/wheels/view/forms.cfc
+++ b/core/src/wheels/view/forms.cfc
@@ -316,6 +316,12 @@ component {
 				local.rv = "";
 			}
 		}
+		
+		// Handle Oracle TIMESTAMP objects in BoxLang by converting to string
+		if (IsObject(local.rv) && GetMetadata(local.rv).getName() == "oracle.sql.TIMESTAMP") {
+			local.rv = ToString(local.rv);
+		}
+		
 		return local.rv;
 	}
 

--- a/docs/src/introduction/readme/boxlang-support.md
+++ b/docs/src/introduction/readme/boxlang-support.md
@@ -36,6 +36,7 @@ BoxLang requires specific modules for full Wheels compatibility. These dependenc
     "bx-csrf": "^1.2.0+3", 
     "bx-esapi": "^1.6.0+9",
     "bx-image": "^1.0.1",
+    "bx-wddx":"^1.5.0+8",
     "bx-mysql": "^1.0.1+7"
   }
 }
@@ -52,6 +53,7 @@ box install bx-compat-cfml
 box install bx-csrf
 box install bx-esapi
 box install bx-image
+box install bx-wddx
 box install bx-mysql
 ```
 
@@ -61,6 +63,7 @@ box install bx-mysql
 - **`bx-csrf`** - Cross-Site Request Forgery protection
 - **`bx-esapi`** - Enterprise Security API for input validation  
 - **`bx-image`** - Image manipulation functionality
+- **`bx-wddx`** - Web Distributed Data eXchange (WDDX) conversion
 - **`bx-mysql`** - MySQL database driver
 
 #### Additional Database Support
@@ -69,6 +72,7 @@ For other databases supported by Wheels, install the corresponding BoxLang modul
 
 - **Microsoft SQL Server**: `box install bx-mssql`
 - **PostGreSQL Server**: `box install bx-postgresql`
+- **Oracle Server**: `box install bx-oracle`
 
 #### Finding Additional Modules
 

--- a/tools/docker/boxlang/CFConfig.json
+++ b/tools/docker/boxlang/CFConfig.json
@@ -87,7 +87,7 @@
 			"connectionLimit": "-1",
 			"connectionTimeout": "20",
 			"dbdriver": "Other",
-			"dsn": "jdbc:oracle:thin:@//localhost:1522/wheelstestdb",
+			"dsn": "jdbc:oracle:thin:@//oracle:1521/wheelstestdb",
 			"password": "wheelstestdb",
 			"username": "wheelstestdb",
 			"validate": "false"

--- a/tools/docker/boxlang/CFConfig.json
+++ b/tools/docker/boxlang/CFConfig.json
@@ -86,12 +86,9 @@
 			"clob": "false",
 			"connectionLimit": "-1",
 			"connectionTimeout": "20",
-			"database": "wheelstestdb",
 			"dbdriver": "Other",
-			"dsn": "jdbc:oracle:thin:@//{host}:{port}/{database}",
-			"host": "oracle",
+			"dsn": "jdbc:oracle:thin:@//localhost:1522/wheelstestdb",
 			"password": "wheelstestdb",
-			"port": "1521",
 			"username": "wheelstestdb",
 			"validate": "false"
 		}

--- a/tools/docker/boxlang/box.json
+++ b/tools/docker/boxlang/box.json
@@ -8,9 +8,12 @@
         "bx-csrf":"^1.2.0+3",
         "bx-esapi":"^1.6.0+9",
         "bx-image":"^1.0.1",
+        "bx-wddx":"^1.5.0+8",
         "bx-mssql":"^1.4.0+11",
         "bx-mysql":"^1.0.1+7",
-        "bx-postgresql":"^1.0.0+2"
+        "bx-postgresql":"^1.0.0+2",
+        "bx-oracle":"^1.5.0+10"
+       
     },
     "installPaths": {
         "wirebox": "vendor/wirebox/",


### PR DESCRIPTION
feat: add BoxLang support for oracle

- Update the code to convert oracle.sql.TIMESTAMP to convert it into string.

- Convert Blob type of oracle to binary test cases to handle core tests.