### PR TITLE
CLI/Fix Wheels plugin management commands and documentation

### DIFF
--- a/cli/src/commands/wheels/plugins/install.cfc
+++ b/cli/src/commands/wheels/plugins/install.cfc
@@ -5,8 +5,8 @@
  * wheels plugins install wheels-docker --dev
  * wheels plugins install https://github.com/user/wheels-plugin --global
  */
-component extends="../base" {
-    
+component aliases="wheels plugin install" extends="../base" {
+
     property name="pluginService" inject="PluginService@wheels-cli";
     
     /**
@@ -21,22 +21,23 @@ component extends="../base" {
         boolean global = false,
         string version = ""
     ) {
-        print.yellowLine("📦 Installing plugin: #arguments.name#...")
+        arguments = reconstructArgs(arguments);
+        print.yellowLine("Installing plugin: #arguments.name#...")
              .line();
         
         var result = pluginService.install(argumentCollection = arguments);
         
         if (result.success) {
-            print.greenLine("✅ Plugin installed successfully");
+            print.greenLine("Plugin installed successfully");
             
             if (result.keyExists("plugin") && result.plugin.keyExists("description")) {
-                print.line("📝 #result.plugin.description#");
+                print.line("#result.plugin.description#");
             }
             
             print.line()
                  .yellowLine("Run 'wheels plugins list' to see installed plugins");
         } else {
-            print.redLine("❌ Failed to install plugin: #result.error#");
+            print.redLine("Failed to install plugin: #result.error#");
             setExitCode(1);
         }
     }

--- a/cli/src/commands/wheels/plugins/list.cfc
+++ b/cli/src/commands/wheels/plugins/list.cfc
@@ -41,27 +41,48 @@ component aliases="wheels plugin list" extends="../base" {
         }
         
         if (arguments.format == "json") {
-            print.line(serializeJSON(plugins, true));
+            // JSON format output
+            var jsonOutput = {
+                "plugins": plugins
+            };
+            print.line(serializeJSON(jsonOutput, true));
         } else {
-            print.greenBoldLine(" Installed Wheels CLI Plugins" & (arguments.global ? " (Global)" : ""))
+            // Table format output (matching the guide)
+            print.line("Installed Wheels CLI Plugins" & (arguments.global ? " (Global)" : ""))
                  .line();
             
-            // Display plugins in a formatted way
-            for (var plugin in plugins) {
-                print.line(" #plugin.name# (#plugin.version#)");
+            if (arrayLen(plugins) > 0) {
+                // Print table header
+                print.line("Name                Version    Description");
+                print.line("---------------------------------------------");
                 
-                if (plugin.keyExists("dev") && plugin.dev) {
-                    print.text("    Dev Dependency");
-                }
-                
-                if (plugin.keyExists("description") && len(plugin.description)) {
-                    print.line("    #plugin.description#");
+                // Display plugins in table format
+                for (var plugin in plugins) {
+                    var name = padRight(plugin.name, 20);
+                    var version = padRight(plugin.version, 11);
+                    var description = plugin.keyExists("description") && len(plugin.description) ? plugin.description : "";
+                    
+                    // Truncate description if too long
+                    if (len(description) > 40) {
+                        description = left(description, 37) & "...";
+                    }
+                    
+                    print.line("#name##version##description#");
                 }
                 
                 print.line();
+                print.yellowLine("Total: #arrayLen(plugins)# plugin" & (arrayLen(plugins) != 1 ? "s" : ""));
             }
-            
-            print.yellowLine("Total plugins: #arrayLen(plugins)#");
         }
+    }
+    
+    /**
+     * Pad string to right with spaces
+     */
+    private function padRight(required string text, required numeric length) {
+        if (len(arguments.text) >= arguments.length) {
+            return left(arguments.text, arguments.length);
+        }
+        return arguments.text & repeatString(" ", arguments.length - len(arguments.text));
     }
 }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -81,6 +81,9 @@
   * Test
     * [wheels test run](command-line-tools/commands/test/test-run.md)
     * [wheels advanced testing](command-line-tools/commands/test/test-advanced.md)
+  * Plugins
+    * [wheels plugin install](command-line-tools/commands/plugins/plugins-install.md)
+    * [wheels plugin list](command-line-tools/commands/plugins/plugins-list.md)
 * CLI Development Guides
   * [Configuration Management](command-line-tools/configuration.md)
   * [Creating Commands](command-line-tools/cli-guides/creating-commands.md)

--- a/docs/src/command-line-tools/commands/plugins/plugins-install.md
+++ b/docs/src/command-line-tools/commands/plugins/plugins-install.md
@@ -1,0 +1,123 @@
+# plugins install
+
+Installs a Wheels CLI plugin from various sources including ForgeBox, GitHub, or local files.
+
+## Usage
+
+```bash
+wheels plugins install <name> [--dev] [--global] [--version=<version>]
+```
+
+## Parameters
+
+- `name` - (Required) Plugin name or repository URL
+- `--dev` - (Optional) Install as development dependency
+- `--global` - (Optional) Install globally
+- `--version` - (Optional) Specific version to install
+
+## Description
+
+The `plugins install` command downloads and installs Wheels plugins into your application. It supports multiple installation sources:
+
+- **ForgeBox Registry**: Official and community plugins
+- **GitHub Repositories**: Direct installation from GitHub
+- **Local Files**: ZIP files or directories
+- **URL Downloads**: Direct ZIP file URLs
+
+The command automatically:
+- Checks plugin compatibility
+- Resolves dependencies
+- Backs up existing plugins
+- Runs installation scripts
+
+## Examples
+
+### Install from ForgeBox
+```bash
+wheels plugins install wheels-vue-cli
+```
+
+### Install specific version
+```bash
+wheels plugins install wheels-docker --version=2.0.0
+```
+
+### Install from GitHub
+```bash
+wheels plugins install https://github.com/user/wheels-plugin
+```
+
+### Install as development dependency
+```bash
+wheels plugins install wheels-docker --dev
+```
+
+### Install globally
+```bash
+wheels plugins install wheels-cli-tools --global
+```
+
+### Install with multiple options
+```bash
+wheels plugins install wheels-testing --dev --version=1.5.0
+```
+
+## Installation Process
+
+1. **Download**: Fetches plugin from specified source
+2. **Validation**: Checks compatibility and requirements
+3. **Backup**: Creates backup of existing plugin (if any)
+4. **Installation**: Extracts files to plugins directory
+5. **Dependencies**: Installs required dependencies
+6. **Initialization**: Runs plugin setup scripts
+7. **Verification**: Confirms successful installation
+
+## Output
+
+```
+Installing plugin: wheels-vue-cli...
+
+Plugin installed successfully
+```
+
+If installation fails:
+```
+Installing plugin: invalid-plugin...
+
+Plugin installation failed
+Error: Plugin not found in repository
+```
+
+## Plugin Sources
+
+### ForgeBox
+```bash
+# Install by name (searches ForgeBox)
+wheels plugins install plugin-name
+
+```
+
+### GitHub
+```bash
+# HTTPS URL
+wheels plugins install https://github.com/user/repo
+
+# GitHub shorthand
+wheels plugins install github:user/repo
+
+# Specific branch/tag
+wheels plugins install github:user/repo#v2.0.0
+```
+
+### Direct URL
+```bash
+wheels plugins install https://example.com/plugin.zip
+```
+
+## Notes
+
+- Plugins must be compatible with your Wheels version
+- Always backup your application before installing plugins
+- Some plugins require manual configuration after installation
+- Use `wheels plugins list` to verify installation
+- Restart your application to activate new plugins

--- a/docs/src/command-line-tools/commands/plugins/plugins-list.md
+++ b/docs/src/command-line-tools/commands/plugins/plugins-list.md
@@ -1,0 +1,87 @@
+# wheels plugins list
+
+Lists installed Wheels CLI plugins or shows available plugins from ForgeBox.
+
+## Usage
+
+```bash
+wheels plugins list [--global] [--format=<format>] [--available]
+```
+
+## Parameters
+
+- `--global` - (Optional) Show globally installed plugins
+- `--format` - (Optional) Output format: `table`, `json`. Default: `table`
+- `--available` - (Optional) Show available plugins from ForgeBox
+
+## Description
+
+The `plugins list` command displays information about all plugins installed in your Wheels application, including:
+
+- Plugin name and version
+- Description and author information
+- Dependencies on other plugins
+
+## Examples
+
+### List all local plugins
+```bash
+wheels plugins list
+```
+
+### Show globally installed plugins
+```bash
+wheels plugins list --global
+```
+
+### Export as JSON
+```bash
+wheels plugins list --format=json
+```
+
+### Show available plugins from ForgeBox
+```bash
+wheels plugins list --available
+```
+
+## Output
+
+### Table Format (Default)
+```
+Installed Wheels CLI Plugins
+
+Name                Version    Description
+---------------------------------------------
+wheels-vue-cli      1.2.0     Vue.js integration for Wheels
+wheels-docker       2.0.1     Docker deployment tools
+wheels-testing      1.5.0     Advanced testing utilities
+
+Total: 3 plugins
+```
+
+### Available Plugins from ForgeBox
+```
+================ Available Wheels Plugins From ForgeBox ======================
+[Lists all available cfwheels-plugins from ForgeBox]
+=============================================================================
+```
+
+### JSON Format
+```json
+{
+  "plugins": [
+    {
+      "name": "wheels-vue-cli",
+      "version": "1.2.0",
+      "description": "Vue.js integration for Wheels"
+    }
+  ]
+}
+```
+
+## Notes
+
+- Local plugins are stored in your project
+- Global plugins are available to all projects
+- Use `wheels plugins install` to add new plugins
+- The `--available` flag queries the ForgeBox registry


### PR DESCRIPTION
Fixed plugin installation and listing functionality to work with actual Wheels
  plugin structure:

  Plugin Installation (PluginService.cfc)

  - Fixed invalid packageService.getPackage() method call that was causing plugin validation failures
  - Updated plugin installation to detect Wheels applications vs CLI projects and handle them appropriately
  - Fixed path resolution issues by using proper fileSystemUtil.resolvePath() method
  - Fixed CFML syntax errors with unescaped # characters and backslashes in strings

  Plugin Listing (PluginService.cfc, list.cfc)

  - Fixed plugins list command to read from /plugins folder instead of only checking box.json
  - Implemented proper table format output matching documentation specifications
  - Added support for all documented parameters: --global, --format=json, --available
  - Fixed ConfigService injection and method calls for global plugin listing

  Documentation Updates

  - Updated plugin command guides to remove "coming soon" warnings
  - Standardized output formats and parameter descriptions
  - Aligned command behavior with documented specifications

  Bug Fixes

  - Resolved path resolution issues on Windows systems
  - Fixed multiple CFML compilation errors preventing command execution
  - Corrected plugin detection logic to work with actual Wheels application structure

  Result: wheels plugin install and wheels plugin list commands now work correctly
  according to documentation, properly installing plugins to /plugins folder and
  detecting installed plugins from zip files.