### PR TITLE
Fix wheels env setup command base parameter and update comprehensive …

### DIFF
--- a/cli/src/commands/wheels/env/setup.cfc
+++ b/cli/src/commands/wheels/env/setup.cfc
@@ -95,50 +95,77 @@ component extends="../base" {
         
         var helpText = bold & brightCyan & "
         ================================================================
-                    WHEELS ENVIRONMENT SETUP COMMAND              
+                    WHEELS ENVIRONMENT SETUP COMMAND
         ================================================================
         " & reset & "
 
+        Setup comprehensive environment configurations for Wheels applications with
+        database settings, templates, and framework configurations.
+
         " & bold & yellow & "USAGE:" & reset & "
-            " & green & "wheels env setup" & reset & " " & brightBlue & "<environment>" & reset & " " & dim & "[options]" & reset & "
+            " & green & "wheels env setup" & reset & " " & brightBlue & "environment=<name>" & reset & " " & dim & "[options]" & reset & "
 
         " & bold & yellow & "ARGUMENTS:" & reset & "
             " & brightBlue & "environment" & reset & "     Name of the environment to create " & red & "(required)" & reset & "
+                              Examples: development, staging, production, testing
+                              " & red & "Note: Use named syntax environment=name to avoid parameter conflicts" & reset & "
 
         " & bold & yellow & "OPTIONS:" & reset & "
             " & cyan & "--template" & reset & "      Template type: " & magenta & "local" & reset & ", " & magenta & "docker" & reset & ", " & magenta & "vagrant" & reset & " " & dim & "(default: local)" & reset & "
-            " & cyan & "--dbtype" & reset & "        Database type: " & magenta & "mysql" & reset & ", " & magenta & "postgres" & reset & ", " & magenta & "mssql" & reset & ", " & magenta & "h2" & reset & " " & dim & "(default: h2)" & reset &  "
-            " & cyan & "--database" & reset & "      Database name " & dim & "(optional)" & reset & "
-            " & cyan & "--datasource" & reset & "    Datasource name " & dim & "(optional)" & reset & "
-            " & cyan & "--base" & reset & "          Base environment to copy from " & dim & "(optional)" & reset & "
+            " & cyan & "--dbtype" & reset & "        Database type: " & magenta & "h2" & reset & ", " & magenta & "mysql" & reset & ", " & magenta & "postgres" & reset & ", " & magenta & "mssql" & reset & " " & dim & "(default: h2)" & reset & "
+            " & cyan & "--database" & reset & "      Custom database name " & dim & "(default: wheels_[environment])" & reset & "
+            " & cyan & "--datasource" & reset & "    ColdFusion datasource name " & dim & "(default: wheels_[environment])" & reset & "
+            " & cyan & "--base" & reset & "          Base environment to copy settings from " & dim & "(copies config)" & reset & "
             " & cyan & "--force" & reset & "         Overwrite existing environment " & dim & "(default: false)" & reset & "
             " & cyan & "--debug" & reset & "         Enable debug settings " & dim & "(default: false)" & reset & "
             " & cyan & "--cache" & reset & "         Enable cache settings " & dim & "(default: false)" & reset & "
-            " & cyan & "--reloadPassword" & reset & "  Custom reload password " & dim & "(optional)" & reset & "
-            " & cyan & "--help" & reset & "          Show this help message
+            " & cyan & "--reloadPassword" & reset & "  Custom reload password " & dim & "(default: wheels[environment])" & reset & "
+            " & cyan & "--help" & reset & "          Show this detailed help message
 
-        " & bold & yellow & "EXAMPLES:" & reset & "
-            " & green & "wheels env setup dev" & reset & " " & cyan & "--dbtype=mysql" & reset & " " & cyan & "--debug=true" & reset & "
-            " & green & "wheels env setup prod" & reset & " " & cyan & "--dbtype=postgres" & reset & " " & cyan & "--cache=true" & reset & " " & cyan & "--debug=false" & reset & "
-            " & green & "wheels env setup test" & reset & " " & cyan & "--base=dev" & reset & " " & cyan & "--dbtype=h2" & reset & " " & cyan & "--reloadPassword=mypassword" & reset & "
-            " & green & "wheels env setup staging" & reset & " " & cyan & "--template=docker" & reset & " " & cyan & "--dbtype=mysql" & reset & " " & cyan & "--force" & reset & "
+        " & bold & yellow & "BASIC EXAMPLES:" & reset & "
+            " & green & "wheels env setup environment=development" & reset & "        ## H2 database (default)
+            " & green & "wheels env setup environment=staging" & reset & " " & cyan & "--dbtype=mysql" & reset & "  ## MySQL database
+            " & green & "wheels env setup environment=production" & reset & " " & cyan & "--dbtype=postgres" & reset & " " & cyan & "--cache=true" & reset & " " & cyan & "--debug=false" & reset & "
+
+        " & bold & yellow & "BASE ENVIRONMENT EXAMPLES:" & reset & "
+            " & green & "wheels env setup environment=testing" & reset & " " & cyan & "--base=development" & reset & " " & cyan & "--dbtype=postgres" & reset & "
+            " & green & "wheels env setup environment=qa" & reset & " " & cyan & "--base=production" & reset & " " & cyan & "--database=qa_db" & reset & "
+            " & green & "wheels env setup environment=feature-test" & reset & " " & cyan & "--base=development" & reset & " " & cyan & "--dbtype=h2" & reset & "
+
+        " & bold & yellow & "ADVANCED EXAMPLES:" & reset & "
+            " & green & "wheels env setup environment=integration" & reset & " " & cyan & "--dbtype=mysql" & reset & " " & cyan & "--database=int_db" & reset & " " & cyan & "--datasource=int_ds" & reset & "
+            " & green & "wheels env setup environment=docker-dev" & reset & " " & cyan & "--template=docker" & reset & " " & cyan & "--dbtype=postgres" & reset & "
+            " & green & "wheels env setup environment=vm-test" & reset & " " & cyan & "--template=vagrant" & reset & " " & cyan & "--dbtype=mysql" & reset & "
 
         " & bold & yellow & "TEMPLATES:" & reset & "
-            " & magenta & "local" & reset & "     - Local development setup
-            " & magenta & "docker" & reset & "    - Docker containerized setup
-            " & magenta & "vagrant" & reset & "   - Vagrant VM setup
+            " & magenta & "local" & reset & "     - Traditional server deployment " & dim & "(default)" & reset & "
+            " & magenta & "docker" & reset & "    - Containerized setup with docker-compose files
+            " & magenta & "vagrant" & reset & "   - VM setup with Vagrantfile and provisioning
 
         " & bold & yellow & "DATABASE TYPES:" & reset & "
-            " & magenta & "mysql" & reset & "     - MySQL database
-            " & magenta & "postgres" & reset & "  - PostgreSQL database
-            " & magenta & "mssql" & reset & "     - Microsoft SQL Server
-            " & magenta & "h2" & reset & "        - H2 embedded database " & dim & "(default)" & reset & "
+            " & magenta & "h2" & reset & "        - Embedded database, no network port " & dim & "(default, great for dev/test)" & reset & "
+            " & magenta & "mysql" & reset & "     - MySQL database server " & dim & "(port 3306)" & reset & "
+            " & magenta & "postgres" & reset & "  - PostgreSQL database server " & dim & "(port 5432)" & reset & "
+            " & magenta & "mssql" & reset & "     - Microsoft SQL Server " & dim & "(port 1433)" & reset & "
 
-        " & bold & brightGreen & "The command will create:" & reset & "
-            " & brightWhite & "*" & reset & " .env.[environment] file with environment variables
-            " & brightWhite & "*" & reset & " config/[environment]/settings.cfm with Wheels configuration
-            " & brightWhite & "*" & reset & " Docker/Vagrant files if using those templates
-            " & brightWhite & "*" & reset & " Updated server.json configuration
+        " & bold & yellow & "BASE ENVIRONMENT COPYING:" & reset & "
+            When using " & cyan & "--base" & reset & ", the command copies existing configuration:
+            " & brightWhite & reset & " Database credentials and host settings
+            " & brightWhite & reset & " Server configuration and custom variables
+            " & brightWhite & reset & " Overrides database type/driver/port with " & cyan & "--dbtype" & reset & "
+            " & brightWhite & reset & " Creates new environment-specific database name
+
+        " & bold & brightGreen & "FILES CREATED:" & reset & "
+            " & brightWhite  & reset & " .env.[environment] - Environment variables and database settings
+            " & brightWhite  & reset & " config/[environment]/settings.cfm - Wheels framework configuration
+            " & brightWhite  & reset & " docker-compose.[environment].yml - If using Docker template
+            " & brightWhite  & reset & " Vagrantfile.[environment] - If using Vagrant template
+            " & brightWhite  & reset & " Updated server.json - Environment-specific server settings
+
+        " & bold & brightGreen & "NEXT STEPS AFTER SETUP:" & reset & "
+            1. Switch environment: " & green & "wheels env switch environment=[name]" & reset & "
+            2. Start server: " & green & "box server start" & reset & "
+            3. Access app: " & green & "http://localhost:8080" & reset & "
         ";
         
         return helpText;

--- a/docs/src/command-line-tools/commands/environment/env-setup.md
+++ b/docs/src/command-line-tools/commands/environment/env-setup.md
@@ -1,242 +1,535 @@
 # wheels env setup
 
-Setup a new environment configuration for your Wheels application.
+Setup a new environment configuration for your Wheels application with comprehensive database, template, and configuration options.
 
 ## Synopsis
 
 ```bash
-wheels env setup [name] [options]
+wheels env setup environment=<name> [options]
 ```
 
 ## Description
 
-The `wheels env setup` command creates and configures new environments for your Wheels application. It generates environment-specific configuration files, database settings, and initializes the environment structure.
+The `wheels env setup` command creates and configures new environments for your Wheels application. It generates:
+- Environment-specific `.env.[environment]` files with database and server settings
+- Configuration files at `config/[environment]/settings.cfm` with Wheels settings
+- Template-specific files (Docker, Vagrant) if requested
+- Server.json updates for environment-specific configurations
 
+The command supports copying configurations from existing environments and allows full customization of database types, templates, and framework settings.
+
+## Arguments
+
+| Argument | Description | Required |
+|----------|-------------|----------|
+| `environment` | Environment name (e.g., development, staging, production, testing) | Yes |
+
+**Note**: Always use named parameter syntax: `environment=name` to avoid parameter conflicts.
 
 ## Options
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--name` | Environment name (e.g., staging, qa, production) | `required` |
-| `--base` | Base environment to copy from | `development` |
-| `--database` | Database name | `wheels_[name]` |
-| `--dbtype` | Database type | `H2` |
-| `--datasource` | CF datasource name | `wheels_[name]` |
-| `--debug` | Enable debug mode | `false` |
-| `--cache` | Enable caching | Based on name |
-| `--reloadPassword` | Password for reload | Random |
-| `--force` | Overwrite existing environment | `false` |
-| `--help` | Show help information |
+| Option | Description | Default | Valid Values |
+|--------|-------------|---------|--------------|
+| `--template` | Deployment template type | `local` | `local`, `docker`, `vagrant` |
+| `--dbtype` | Database type | `h2` | `h2`, `mysql`, `postgres`, `mssql` |
+| `--database` | Custom database name | `wheels_[environment]` | Any valid database name |
+| `--datasource` | ColdFusion datasource name | `wheels_[environment]` | Any valid datasource name |
+| `--base` | Base environment to copy from | *(none)* | Any existing environment name |
+| `--force` | Overwrite existing environment | `false` | `true`, `false` |
+| `--debug` | Enable debug settings | `false` | `true`, `false` |
+| `--cache` | Enable cache settings | `false` | `true`, `false` |
+| `--reloadPassword` | Custom reload password | `wheels[environment]` | Any string |
+| `--help` | Show detailed help information | `false` | - |
 
 ## Examples
 
-### Setup basic environment
+### Basic Environment Setup
 ```bash
-wheels env setup staging
+# Create development environment with H2 database (default)
+wheels env setup environment=development
+
+# Create staging environment with MySQL
+wheels env setup environment=staging --dbtype=mysql
+
+# Create production environment with PostgreSQL and caching enabled
+wheels env setup environment=production --dbtype=postgres --cache=true --debug=false
 ```
 
-### Setup with custom database
+### Using Base Environment
 ```bash
-wheels env setup qa --database=wheels_qa_db --datasource=qa_datasource --dbtype=mysql
+# Copy settings from development environment but use PostgreSQL
+wheels env setup environment=testing --base=development --dbtype=postgres
+
+# Create staging environment based on production settings
+wheels env setup environment=staging --base=production --database=staging_db
+
+# Create QA environment with custom settings
+wheels env setup environment=qa --base=development --dbtype=mysql --debug=true --cache=false
 ```
 
-### Copy from production settings
+### Advanced Configuration
 ```bash
-wheels env setup staging --base=production
+# Setup with custom database and datasource names
+wheels env setup environment=integration --dbtype=mysql --database=wheels_integration_db --datasource=integration_ds
+
+# Setup with specific reload password and debugging
+wheels env setup environment=dev --debug=true --reloadPassword=mypassword123 --force
+
+# Docker environment setup
+wheels env setup environment=docker-dev --template=docker --dbtype=postgres --database=wheels_docker
 ```
 
-### Setup with specific options
+### Template-Based Setups
 ```bash
-wheels env setup production --debug=false --cache=true --reloadPassword=secret123
+# Local development (default)
+wheels env setup environment=dev --template=local --dbtype=h2
+
+# Docker containerized environment
+wheels env setup environment=docker-staging --template=docker --dbtype=mysql
+
+# Vagrant VM environment
+wheels env setup environment=vm-test --template=vagrant --dbtype=postgres
 ```
 
+## What It Creates
 
-## What It Does
+### 1. Environment Variables File (`.env.[environment]`)
 
-1. **Creates Configuration Directory**:
-   ```
-   /config/[environment]/
-   └── settings.cfm
-   ```
+For H2 database:
+```bash
+## Wheels Environment: development
+## Generated on: 2025-01-18 12:30:00
 
-2. **Generates Settings File**:
-   - Database configuration
-   - Environment-specific settings
-   - Debug and cache options
-   - Security settings
+## Application Settings
+WHEELS_ENV=development
+WHEELS_RELOAD_PASSWORD=wheelsdevelopment
 
-3. **Updates Environment Registry**:
-   - Adds to available environments
-   - Sets up environment detection
+## Database Settings
+DB_TYPE=h2
+DB_DRIVER=H2
+DB_HOST=
+DB_NAME=./db/wheels_development
+DB_USER=sa
+DB_PASSWORD=
 
-## Generated Configuration
+## Server Settings
+SERVER_PORT=8080
+SERVER_CFENGINE=lucee5
+```
 
-Example `config/staging/settings.cfm`:
+For MySQL database:
+```bash
+## Wheels Environment: production
+## Generated on: 2025-01-18 12:30:00
+
+## Application Settings
+WHEELS_ENV=production
+WHEELS_RELOAD_PASSWORD=wheelsproduction
+
+## Database Settings
+DB_TYPE=mysql
+DB_DRIVER=MySQL
+DB_HOST=localhost
+DB_PORT=3306
+DB_NAME=wheels_production
+DB_USER=wheels
+DB_PASSWORD=wheels_password
+
+## Server Settings
+SERVER_PORT=8080
+SERVER_CFENGINE=lucee5
+```
+
+### 2. Configuration File (`config/[environment]/settings.cfm`)
 
 ```cfml
 <cfscript>
-// Environment: staging
-// Generated: 2024-01-15 10:30:45
+    // Environment: production
+    // Generated: 2025-01-18 12:30:00
+    // Debug Mode: Disabled
+    // Cache Mode: Enabled
 
-// Database settings
-set(dataSourceName="wheels_staging");
+    // Database settings
+    set(dataSourceName="wheels_production");
 
-// Environment settings
-set(environment="staging");
-set(showDebugInformation=true);
-set(showErrorInformation=true);
+    // Environment settings
+    set(environment="production");
 
-// Caching
-set(cacheFileChecking=false);
-set(cacheImages=false);
-set(cacheModelInitialization=false);
-set(cacheControllerInitialization=false);
-set(cacheRoutes=false);
-set(cacheActions=false);
-set(cachePages=false);
-set(cachePartials=false);
-set(cacheQueries=false);
+    // Debug settings - controlled by debug argument
+    set(showDebugInformation=false);
+    set(showErrorInformation=false);
 
-// Security
-set(reloadPassword="generated_secure_password");
+    // Caching settings - controlled by cache argument
+    set(cacheFileChecking=true);
+    set(cacheImages=true);
+    set(cacheModelInitialization=true);
+    set(cacheControllerInitialization=true);
+    set(cacheRoutes=true);
+    set(cacheActions=true);
+    set(cachePages=true);
+    set(cachePartials=true);
+    set(cacheQueries=true);
 
-// URLs
-set(urlRewriting="partial");
+    // Security
+    set(reloadPassword="wheelsproduction");
 
-// Custom settings for staging
-set(sendEmailOnError=true);
-set(errorEmailAddress="dev-team@example.com");
+    // URLs
+    set(urlRewriting="partial");
+
+    // Environment-specific settings
+    set(sendEmailOnError=true);
+    set(errorEmailAddress="dev-team@example.com");
 </cfscript>
 ```
 
-## Environment Types
+### 3. Template-Specific Files
 
-### Development
-- Full debugging
-- No caching
-- Detailed errors
-- Hot reload
+#### Docker Template (`--template=docker`)
+Creates:
+- `docker-compose.[environment].yml`
+- `Dockerfile` (if not exists)
 
-### Testing
-- Test database
-- Debug enabled
-- Isolated data
-- Fast cleanup
+#### Vagrant Template (`--template=vagrant`)
+Creates:
+- `Vagrantfile.[environment]`
+- `vagrant/provision-[environment].sh`
 
-### Staging
-- Production-like
-- Some debugging
-- Performance testing
-- Pre-production validation
+## Database Types
 
-### Production
-- No debugging
-- Full caching
-- Error handling
-- Optimized performance
-
-### Custom
-Create specialized environments:
-```bash
-wheels env setup performance-testing --base=production --cache=false
-```
-
-## Environment Variables
-
-The command sets up support for:
+### H2 (Embedded)
+- **Use Case**: Development, testing, quick prototyping
+- **Connection**: No network port required (embedded)
+- **Database Path**: `./db/[database_name]`
+- **Default Credentials**: username=`sa`, password=*(empty)*
 
 ```bash
-# .env.staging
-WHEELS_ENV=staging
-WHEELS_DATASOURCE=wheels_staging
-WHEELS_DEBUG=true
-WHEELS_CACHE=false
-DATABASE_URL=mysql://localhost/wheels_staging
+wheels env setup environment=dev --dbtype=h2 --database=my_dev_db
 ```
 
-## Configuration Inheritance
+### MySQL
+- **Use Case**: Production, staging environments
+- **Default Port**: 3306
+- **Default Credentials**: username=`wheels`, password=`wheels_password`
 
-Environments can inherit settings:
-
-```cfml
-// config/staging/settings.cfm
-<cfinclude template="../production/settings.cfm">
-
-// Override specific settings
-set(showDebugInformation=true);
-set(cacheQueries=false);
+```bash
+wheels env setup environment=prod --dbtype=mysql --database=wheels_production
 ```
 
-## Validation
+### PostgreSQL
+- **Use Case**: Production, complex applications
+- **Default Port**: 5432
+- **Default Credentials**: username=`wheels`, password=`wheels_password`
 
-After setup, the command validates:
+```bash
+wheels env setup environment=staging --dbtype=postgres
+```
 
-1. Configuration file syntax
-2. Directory permissions
-3. Environment detection
+### Microsoft SQL Server
+- **Use Case**: Enterprise environments
+- **Default Port**: 1433
+- **Default Credentials**: username=`sa`, password=`Wheels_Pass123!`
 
-## Environment Detection
+```bash
+wheels env setup environment=enterprise --dbtype=mssql
+```
 
-Configure how environment is detected:
+## Base Environment Copying
+
+When using `--base`, the command copies configuration from an existing environment:
+
+### What Gets Copied:
+- Database host, username, and password
+- Server configuration (port, CF engine)
+- Custom environment variables
+
+### What Gets Modified:
+- Environment name
+- Database name (becomes `wheels_[new_environment]`)
+- Database type, driver, and port (based on `--dbtype`)
+- Reload password (becomes `wheels[new_environment]`)
+
+```bash
+# Copy from production but use H2 for testing
+wheels env setup environment=test --base=production --dbtype=h2
+
+# Copy from development but use different database name
+wheels env setup environment=feature-branch --base=development --database=feature_test_db
+```
+
+## Environment Naming Conventions
+
+### Recommended Names:
+- `development` or `dev` - Local development
+- `testing` or `test` - Automated testing
+- `staging` - Pre-production testing
+- `production` or `prod` - Live environment
+- `qa` - Quality assurance
+- `demo` - Client demonstrations
+
+### Custom Names:
+```bash
+wheels env setup environment=feature-auth --base=development
+wheels env setup environment=performance-test --base=production --cache=false
+wheels env setup environment=client-demo --base=staging
+```
+
+## Template Options
+
+### Local Template (default)
+Best for traditional server deployments:
+```bash
+wheels env setup environment=prod --template=local --dbtype=mysql
+```
+
+### Docker Template
+Creates containerized environment:
+```bash
+wheels env setup environment=docker-dev --template=docker --dbtype=postgres
+```
+
+Generated `docker-compose.docker-dev.yml`:
+```yaml
+version: '3.8'
+
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      - WHEELS_ENV=docker-dev
+      - DB_TYPE=postgres
+      - DB_HOST=db
+      - DB_PORT=5432
+      - DB_NAME=wheels
+      - DB_USER=wheels
+      - DB_PASSWORD=wheels_password
+    volumes:
+      - .:/app
+    depends_on:
+      - db
+
+  db:
+    image: postgres:14
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB=wheels
+      POSTGRES_USER=wheels
+      POSTGRES_PASSWORD=wheels_password
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+volumes:
+  db_data:
+```
+
+### Vagrant Template
+Creates VM-based environment:
+```bash
+wheels env setup environment=vm-test --template=vagrant --dbtype=mysql
+```
+
+## Next Steps After Setup
+
+The command provides environment-specific next steps:
+
+### Local Template:
+1. Switch to environment: `wheels env switch [environment]`
+2. Start server: `box server start`
+3. Access application at: http://localhost:8080
+
+### Docker Template:
+1. Start Docker environment: `docker-compose -f docker-compose.[environment].yml up`
+2. Access application at: http://localhost:8080
+3. Stop environment: `docker-compose -f docker-compose.[environment].yml down`
+
+### Vagrant Template:
+1. Start Vagrant VM: `vagrant up`
+2. Access application at: http://localhost:8080 or http://192.168.56.10:8080
+3. SSH into VM: `vagrant ssh`
+4. Stop VM: `vagrant halt`
+
+## Configuration Management
+
+### Environment Detection
+Update `config/environment.cfm` to automatically detect environments:
 
 ```cfml
-// config/environment.cfm
+<cfscript>
+// Auto-detect environment based on server name
 if (cgi.server_name contains "staging") {
-    set(environment="staging");
-} else if (cgi.server_name contains "qa") {
-    set(environment="qa");
+    this.env = "staging";
+} else if (cgi.server_name contains "test") {
+    this.env = "testing";
+} else if (cgi.server_name contains "demo") {
+    this.env = "demo";
+} else if (cgi.server_name contains "localhost") {
+    this.env = "development";
 } else {
-    set(environment="production");
+    this.env = "production";
 }
+</cfscript>
 ```
+
+### Environment Variables Integration
+Load `.env.[environment]` files in `Application.cfc`:
+
+```cfml
+<cfscript>
+component extends="wheels.Controller" {
+
+    function config() {
+        // Load environment-specific variables
+        var envFile = expandPath(".env." & get("environment"));
+        if (fileExists(envFile)) {
+            loadEnvironmentFile(envFile);
+        }
+    }
+
+    private function loadEnvironmentFile(filePath) {
+        var lines = fileRead(arguments.filePath).listToArray(chr(10));
+        for (var line in lines) {
+            if (len(trim(line)) && !line.startsWith("##")) {
+                var parts = line.listToArray("=");
+                if (arrayLen(parts) >= 2) {
+                    var key = trim(parts[1]);
+                    var value = trim(parts[2]);
+                    // Set as system property or use in configuration
+                    set(lCase(key), value);
+                }
+            }
+        }
+    }
+}
+</cfscript>
+```
+
+## Validation and Testing
+
+After creating an environment, validate the setup:
+
+```bash
+# List all environments to verify creation
+wheels env list
+
+# Switch to the new environment
+wheels env switch [environment]
+
+# Test database connection
+wheels test run --type=core
+
+# Check configuration
+wheels env current
+```
+
+## Error Handling
+
+### Common Issues and Solutions:
+
+**Environment already exists:**
+```bash
+wheels env setup environment=staging --force
+```
+
+**Base environment not found:**
+```bash
+# Check available environments
+wheels env list
+# Use correct base environment name
+wheels env setup environment=test --base=development
+```
+
+**Database connection issues:**
+- Verify database credentials in `.env.[environment]`
+- Check database server is running
+- Validate port configuration
+
+**Permission issues:**
+- Ensure write permissions for config directory
+- Check file system permissions
 
 ## Best Practices
 
-1. **Naming Convention**: Use clear, consistent names
-2. **Base Selection**: Choose appropriate base environment
-3. **Security**: Use strong reload passwords
-4. **Documentation**: Document environment purposes
-5. **Testing**: Test configuration before use
+### 1. Environment Naming
+- Use consistent, descriptive names
+- Avoid spaces and special characters
+- Follow team conventions
 
+### 2. Database Management
+- Use separate databases per environment
+- Document database naming conventions
+- Implement proper backup strategies
 
-### Feature Flags
-```cfml
-// In settings.cfm
-set(features={
-    newCheckout: true,
-    betaAPI: false,
-    debugToolbar: true
-});
+### 3. Security
+- Use strong, unique reload passwords
+- Never commit sensitive credentials
+- Use environment variables for secrets
+
+### 4. Configuration
+- Start with a solid base environment
+- Document environment purposes
+- Test configurations thoroughly
+
+### 5. Template Selection
+- `local`: Traditional server deployments
+- `docker`: Containerized applications
+- `vagrant`: Isolated development VMs
+
+## Integration Examples
+
+### CI/CD Pipeline
+```bash
+# Create testing environment for CI
+wheels env setup environment=ci-test --base=production --dbtype=h2 --debug=false
+
+# Create staging environment for deployment testing
+wheels env setup environment=staging --base=production --dbtype=mysql --cache=true
+```
+
+### Feature Development
+```bash
+# Create feature-specific environment
+wheels env setup environment=feature-login --base=development --database=login_feature_db
+
+# Create A/B testing environments
+wheels env setup environment=variant-a --base=production --database=variant_a_db
+wheels env setup environment=variant-b --base=production --database=variant_b_db
 ```
 
 ## Troubleshooting
 
-### Configuration Errors
-- Check syntax in settings.cfm
-- Verify file permissions
-- Review error logs
+### Configuration File Issues
+1. Check syntax in generated `settings.cfm`
+2. Verify file permissions in config directory
+3. Review environment variable formats
 
-### Environment Not Detected
-- Check environment.cfm logic
-- Verify server variables
-- Test detection rules
+### Database Connection Problems
+1. Verify database server is running
+2. Check credentials in `.env.[environment]`
+3. Test connection manually
+4. Review port configurations (remember H2 has no port)
 
-## Use Cases
+### Environment Detection
+1. Check `config/environment.cfm` logic
+2. Verify server variables
+3. Test detection rules manually
 
-1. **Multi-Stage Pipeline**: dev → staging → production
-2. **Feature Testing**: Isolated feature environments
-3. **Performance Testing**: Dedicated performance environment
-4. **Client Demos**: Separate demo environments
-5. **A/B Testing**: Multiple production variants
+## Performance Considerations
 
-## Notes
+### Development Environments
+- Enable debugging for detailed information
+- Disable caching for hot reload
+- Use H2 for fast setup and teardown
 
-- Environment names should be lowercase
-- Avoid spaces in environment names
-- Each environment needs unique database
-- Restart application after setup
-- Test thoroughly before using
+### Production Environments
+- Disable debugging for performance
+- Enable all caching options
+- Use optimized database configurations
 
 ## See Also
-- [wheels env list](env-list.md) - List environments
-- [wheels env switch](env-switch.md) - Switch environments
+
+- [wheels env list](env-list.md) - List all environments
+- [wheels env switch](env-switch.md) - Switch between environments
+- [wheels env current](env-current.md) - Show current environment
+- [Environment Configuration Guide](../../working-with-wheels/switching-environments.md)


### PR DESCRIPTION
…  documentation

FIXES:
  - Fix base parameter not copying .env.[base_env] file contents due to missing path separator
  - Fix datasourceInfo structure mismatch in setupFromBaseEnvironment function
  - Fix H2 database (H2 is embedded, no port needed)
  - Fix parameter syntax mixing issues in all documentation examples

  ENHANCEMENTS:
  - Add comprehensive env-setup.md guide with all parameters, examples, and use cases
  - Update command help text with detailed, color-coded information
  - Add base environment copying documentation explaining what gets copied/modified
  - Add database type details (H2, MySQL, PostgreSQL, MSSQL) with proper port handling
  - Add template explanations (local, docker, vagrant) with generated file examples
  - Add troubleshooting section with common issues and solutions
  - Add best practices for environment management and security