### PR TITLE
fix(cli): escape literal # in resolveFrameworkSourceOrFail help text

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -3537,8 +3537,8 @@ component extends="modules.BaseModule" {
 		out("  2. Run `wheels new` from inside a directory that contains vendor/wheels/");
 		out("     (e.g. an existing Wheels project, or a checkout of the wheels repo).");
 		out("  3. Download the framework source manually and point at it:");
-		out("       # Pick the wheels-core-<version>.zip for the latest release at:");
-		out("       #   https://github.com/wheels-dev/wheels/releases");
+		out("       ## Pick the wheels-core-<version>.zip for the latest release at:");
+		out("       ##   https://github.com/wheels-dev/wheels/releases");
 		out("       unzip wheels-core-<version>.zip -d ~/.wheels/modules/wheels/vendor/");
 		out("       wheels new #appName#");
 		out("");


### PR DESCRIPTION
## Summary

Two help-text lines added in #2294 contained a single literal `#` (a shell-comment marker shown to users in the manual-recovery instructions). CFML treats `#` as the start of a `#expr#` interpolation, so Lucee parsed the strings as unterminated interpolations and `Module.cfc` failed to compile:

```
[ERROR] lucee.transformer.cfml.script.AbstrCFMLScriptTransformer$ComponentTemplateException:
  Invalid Syntax Closing [#] not found, at [3540:22] in
  [out("       # Pick the wheels-core-<version>.zip for the latest release at:");]
```

This broke the post-merge `Wheels Snapshots` run on `develop` ([run 24922776182](https://github.com/wheels-dev/wheels/actions/runs/24922776182)) — specifically the **Smoke Test Installed Distribution** job that #2294 added to catch exactly this class of distribution-time regression. The smoke test did its job; this PR addresses what it found.

## Fix

Doubled `#` to `##` on the two affected lines — CFML's literal-hash escape.

The other `#` references in the surrounding block (`#appName#`, `#candidate#`, `#projectCandidate#`) are proper interpolations with matched pairs and remain unchanged.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, next ` Wheels Snapshots` run on `develop` passes the Smoke Test Installed Distribution job
- [ ] Manual sanity: `wheels new` from a context where framework source is missing now prints the recovery instructions instead of throwing a CFML compile error

🤖 Generated with [Claude Code](https://claude.com/claude-code)