### PR TITLE
docs(docs): call out openjdk@21 keg-only behavior on macOS (closes #2295)

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
@@ -18,6 +18,8 @@ Install the `wheels` CLI. Five minutes.
 
 <Aside type="note">
   **Prerequisite:** Java 21 or newer. `wheels` bundles a CFML runtime (Lucee) that targets JDK 21. Install it from [Adoptium](https://adoptium.net/) if you don't already have it. On macOS: `brew install openjdk@21`.
+
+  On macOS, `openjdk@21` is keg-only — Homebrew won't symlink it into `/opt/homebrew`. The `wheels` CLI handles this itself, but if you want to call `java` directly (or use it from an IDE, Maven, Gradle, etc.) you'll also need to set `JAVA_HOME` and add it to your `PATH`. See [Troubleshooting](#troubleshooting) below.
 </Aside>
 
 ## Install the CLI
@@ -147,13 +149,14 @@ Your shell's `PATH` doesn't include the CLI. Restart your shell, or on Linux sou
 
 **`Error: unable to find Java runtime`**
 
-Install Java 21+ from [Adoptium](https://adoptium.net/). On macOS: `brew install openjdk@21`. Then export `JAVA_HOME` in your shell profile:
+Install Java 21+ from [Adoptium](https://adoptium.net/). On macOS: `brew install openjdk@21`. The `wheels` wrapper resolves Java on its own, but anything else (`java -version`, IDEs, Maven, Gradle) needs `JAVA_HOME` and `PATH` set in your shell profile:
 
 ```bash title="~/.zshrc or ~/.bashrc"
-export JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.8/libexec/openjdk.jdk/Contents/Home
+export JAVA_HOME="$(brew --prefix openjdk@21)/libexec/openjdk.jdk/Contents/Home"
+export PATH="$JAVA_HOME/bin:$PATH"
 ```
 
-Path will differ if you installed from Adoptium directly — use whatever `/usr/libexec/java_home -v 21` prints.
+If you installed from Adoptium directly instead of Homebrew, use whatever `/usr/libexec/java_home -v 21` prints for `JAVA_HOME`.
 
 **`brew: cask 'wheels' has no formulae to install from`**
 


### PR DESCRIPTION
## Summary

- Add a keg-only callout to the Aside on [start-here/installing](https://guides.wheels.dev/v4-0-0-snapshot/start-here/installing/), explaining that `brew install openjdk@21` won't symlink into `/opt/homebrew`. The `wheels` wrapper handles this internally, but `java -version`, IDEs, Maven, Gradle, etc. won't see it without `JAVA_HOME` + `PATH`.
- Tighten the Troubleshooting block to use `brew --prefix openjdk@21` (durable across openjdk point releases) instead of a hardcoded `21.0.8` Cellar path, and add the missing `PATH` export.

Closes #2295.

## Test plan

- [ ] `web/sites/guides` builds without MDX errors (Astro/Starlight).
- [ ] Anchor link `#troubleshooting` from the Aside resolves to the Troubleshooting heading on the same page.
- [ ] On a fresh macOS box: `brew install openjdk@21` → follow the snippet → `java -version` reports 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)