### PR TITLE
fix(docs): restore search bar in starlight header (closes #2299)

### DIFF
--- a/web/packages/ui/src/components/Header.astro
+++ b/web/packages/ui/src/components/Header.astro
@@ -23,6 +23,14 @@ const links = [
 		<slot name="after-brand" />
 	</div>
 
+	{
+		Astro.slots.has('search') && (
+			<div class="wd-header__search">
+				<slot name="search" />
+			</div>
+		)
+	}
+
 	<button
 		class="wd-header__toggle"
 		type="button"
@@ -112,6 +120,16 @@ const links = [
 		text-decoration: none;
 	}
 
+	.wd-header__search {
+		display: flex;
+		align-items: center;
+		margin-left: auto;
+	}
+
+	.wd-header__search :global(site-search button[data-open-modal]) {
+		font-family: var(--font-sans);
+	}
+
 	.wd-header__nav {
 		display: flex;
 		align-items: center;
@@ -162,6 +180,10 @@ const links = [
 	@media (max-width: 720px) {
 		.wd-header__toggle {
 			display: flex;
+		}
+
+		.wd-header__search {
+			margin-right: var(--space-2);
 		}
 
 		.wd-header__nav {

--- a/web/packages/ui/src/components/starlight/Header.astro
+++ b/web/packages/ui/src/components/starlight/Header.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
+import Search from 'virtual:starlight/components/Search';
 import Header from '../Header.astro';
 import VersionSwitcher from './VersionSwitcher.astro';
 import { computeVersionOptions } from '@wheels-dev/ui/data/versions';
@@ -32,6 +33,7 @@ const currentVersion = computed?.currentVersion ?? null;
 		options={options}
 		currentVersion={currentVersion}
 	/>
+	<Search slot="search" />
 	<VersionSwitcher
 		slot="in-nav-drawer"
 		variant="drawer"


### PR DESCRIPTION
## Summary
- Restores the search/filter feature on **api.wheels.dev** and **guides.wheels.dev** that disappeared during the docs site update.
- **Root cause:** the shared `@wheels-dev/ui` Header override replaced Starlight's default header without re-mounting `<Search />`, so Pagefind's button never made it to the DOM.
- **Fix:** add a conditional `search` slot to the shared `Header.astro` and fill it from the Starlight override using `virtual:starlight/components/Search` — the same virtual-component pattern already used in `Footer.astro` for `EditLink` / `LastUpdated` / `Pagination`.

Landing/blog/packages sites pass no search slot, so the new container is not rendered (`Astro.slots.has('search')` guard) — those sites are unaffected.

Closes #2299. Closes #2302.

## Test plan
- [x] `pnpm --filter @wheels-dev/site-api dev` — search button renders top-right with `⌘K` hint on desktop.
- [x] Click button → Pagefind dialog opens (shows "search only available in production builds" — expected dev-mode message; index is built at `astro build` time).
- [x] Mobile viewport (375×812) — search icon visible alongside hamburger toggle, no layout regression.
- [x] `pnpm --filter @wheels-dev/site-api build` — Pagefind indexed 2351 pages, build green.
- [x] `pnpm --filter @wheels-dev/site-guides build` — Pagefind indexed 425 pages, build green.
- [x] `pnpm --filter @wheels-dev/site-landing build` — green; non-Starlight sites unaffected by the new slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)