### PR TITLE
fix(cli): drop bundlename hint from new-app sqlite datasources

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -3458,7 +3458,9 @@ component extends="modules.BaseModule" {
 	/**
 	 * Configure SQLite as the zero-config default database by creating the db
 	 * directory and injecting datasource configuration into config/app.cfm.
-	 * Lucee auto-downloads the SQLite JDBC bundle via the bundleName hint.
+	 * The SQLite JDBC driver is loaded from the standard Lucee classpath
+	 * (shipped with the Wheels distribution) rather than via OSGi bundle
+	 * resolution, which is currently unreliable on Lucee 7's BundleProvider.
 	 */
 	private void function configureSQLiteDatabase(
 		required string targetDir,
@@ -3482,14 +3484,12 @@ component extends="modules.BaseModule" {
 		sqliteConfig &= tab & "// SQLite zero-config database (configured by wheels new)" & nl;
 		sqliteConfig &= tab & 'this.datasources["#datasourceName#"] = {' & nl;
 		sqliteConfig &= tab & tab & 'class: "org.sqlite.JDBC",' & nl;
-		sqliteConfig &= tab & tab & 'bundleName: "org.xerial.sqlite-jdbc",' & nl;
 		sqliteConfig &= tab & tab & 'connectionString: "jdbc:sqlite:" & expandPath("../db/development.sqlite")' & nl;
 		sqliteConfig &= tab & "};";
 
 		// Also add a test database datasource
 		sqliteConfig &= nl & tab & 'this.datasources["#datasourceName#_test"] = {' & nl;
 		sqliteConfig &= tab & tab & 'class: "org.sqlite.JDBC",' & nl;
-		sqliteConfig &= tab & tab & 'bundleName: "org.xerial.sqlite-jdbc",' & nl;
 		sqliteConfig &= tab & tab & 'connectionString: "jdbc:sqlite:" & expandPath("../db/test.sqlite")' & nl;
 		sqliteConfig &= tab & "};";
 


### PR DESCRIPTION
## Summary

- Strips `bundleName: \"org.xerial.sqlite-jdbc\"` from the SQLite datasource block emitted by `wheels new` into a fresh app's `config/app.cfm`.
- Updates the docstring on `configureSQLiteDatabase` to reflect the new (classpath) loading path.

## Why

A fresh-VM tutorial onboarding run (macOS arm64, only Homebrew + Claude Code pre-installed) found that the very first migration after `wheels new` silently no-ops — the database file stays at 0 bytes and `wheels migrate latest` exits 0. The server log reveals the real failure:

\`\`\`
java.io.IOException: java.lang.IllegalArgumentException: invalid version \"3.9.0.GA copy\":
  invalid qualifier \"GA copy\"
  ...at lucee.runtime.config.s3.BundleProvider.read(BundleProvider.java:520)

Caused by: java.lang.IllegalArgumentException: Illegal character in query at index 67:
  https://bundle-download.s3.amazonaws.com/?marker=javassist-3.9.0.GA copy.jar
\`\`\`

Lucee 7's `BundleProvider` is being invoked because of the `bundleName` hint in the generated datasource. It tries to enumerate the upstream S3 bucket and dies on a malformed listing entry (`javassist-3.9.0.GA copy.jar` — looks like a Mac-Finder \"copy\" duplicate uploaded to the bucket). The space + \" copy\" suffix is both an illegal URI character and an invalid OSGi version qualifier, so the entire bundle resolution path crashes and the SQLite driver never loads.

Without the hint, Lucee falls through to the standard classpath resolution, which resolves `org.sqlite.JDBC` normally — provided the JAR is shipped on the lib path. Companion changes to bundle `sqlite-jdbc` directly in [wheels-dev/homebrew-wheels](https://github.com/wheels-dev/homebrew-wheels) and [wheels-dev/chocolatey-wheels](https://github.com/wheels-dev/chocolatey-wheels) will follow at the next release cut.

## Out of scope

- `cli/src/` (the legacy CommandBox surface) still emits the same `bundleName` hint at `commands/wheels/db/create.cfc:974` and `models/EnvironmentService.cfc:1009`. Worth a follow-up if that distribution is still being shipped, but not addressed here.
- Upstream Lucee `BundleProvider` should not crash on a malformed S3 listing entry — courtesy bug report to be filed separately.

## Test plan

- [ ] Run `wheels new blogtest` on a clean machine, inspect generated `config/app.cfm` — confirm no `bundleName` line appears in either datasource block.
- [ ] Run `wheels migrate latest` after creating a sample migration — confirm tables are actually created (verify with `sqlite3 db/development.sqlite \".schema\"`).
- [ ] CI: confirm the existing test matrix still passes (no tests touch `configureSQLiteDatabase`, but the broader suite needs to be green).