### PR TITLE
fix(cli): use migrateToLatest command name for `wheels migrate latest`

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -2760,17 +2760,13 @@ component extends="modules.BaseModule" {
 		try {
 			var command = "";
 			switch (action) {
-				case "latest": command = "migrateTo"; break;
+				case "latest": command = "migrateToLatest"; break;
 				case "up":     command = "migrateUp"; break;
 				case "down":   command = "migrateDown"; break;
 				case "info":   command = "info"; break;
 			}
 
 			var migrateUrl = "http://localhost:#serverPort#/wheels/cli?command=#command#&format=json";
-			if (action == "latest") {
-				// migrateTo needs a version — omitting it runs to latest
-				migrateUrl &= "&version=";
-			}
 
 			var httpResult = makeHttpRequest(migrateUrl);
 

--- a/cli/lucli/services/MigrationRunner.cfc
+++ b/cli/lucli/services/MigrationRunner.cfc
@@ -89,7 +89,7 @@ component {
 	public struct function runViaHttp(required numeric serverPort, required string action) {
 		var command = "";
 		switch (action) {
-			case "latest": command = "migrateTo"; break;
+			case "latest": command = "migrateToLatest"; break;
 			case "up":     command = "migrateUp"; break;
 			case "down":   command = "migrateDown"; break;
 			case "info":   command = "info"; break;


### PR DESCRIPTION
## Summary

Two call sites mapped the user-visible \`latest\` action to the framework HTTP command name \`migrateTo\` instead of \`migrateToLatest\`. The framework's \`/wheels/cli\` endpoint treats \`migrateTo\` as "migrate to a specific version" and **silently no-ops when no version parameter is provided**. The correct command name is \`migrateToLatest\`, which the endpoint dispatches via \`migrator.migrateToLatest()\`.

Affects:
- [cli/lucli/Module.cfc](cli/lucli/Module.cfc) line 2763 (the inline migrate dispatch)
- [cli/lucli/services/MigrationRunner.cfc](cli/lucli/services/MigrationRunner.cfc) line 92 (the same logic in the service used by other code paths)

## Symptoms users see

\`wheels migrate latest\` exits 0 with the message \"Migration latest completed.\" in green — but no migration is actually applied. The bug surfaces in two ways depending on what state the framework is in:

- **First VM-onboarding journal** (April 2026): \"Migrating from 0 down to .\" — the framework rolling back to nothing because \`migrateTo\` with no version means \"migrate to nothing\".
- **Second VM-onboarding journal** (April 2026): \`db/development.sqlite\` stays at 0 bytes; no schema appears. Same root cause, slightly different rendering.

Either way the user has zero indication anything is wrong from the CLI output.

## Smoking gun

In \`Module.cfc\`, an empty \`&version=\` was being appended to the URL with a comment claiming \"omitting it runs to latest\". That comment described the author's intent, not the framework's actual behavior. Removed.

## How this was found

Built a local fresh-install harness ([tools/test-onboarding.sh](tools/test-onboarding.sh) — separate PR) that simulates the brand-new-user flow in an isolated \`LUCLI_HOME\`. The harness asserts the actual sqlite database contains the migrated tables after \`wheels migrate latest\`, not just that the command exited 0. Without that assertion, the bug stays invisible.

Companion to:
- [#2304](https://github.com/wheels-dev/wheels/pull/2304) — strips \`bundleName\` from the new-app sqlite datasource template (the prerequisite for sqlite-jdbc to actually load)
- [#2306](https://github.com/wheels-dev/wheels/pull/2306) — tutorial doc fixes

Together with shipping \`sqlite-jdbc.jar\` in the homebrew-wheels and chocolatey-wheels formulae (forthcoming), this closes the cliff that breaks the tutorial on a brand-new install.

## Test plan

- [ ] On a fresh \`wheels new\` app with sqlite-jdbc available on the classpath, run \`wheels migrate latest\` against a non-empty migrations directory.
- [ ] Verify exit 0 AND that \`db/development.sqlite\` actually contains the migrated tables (\`sqlite3 db/development.sqlite \".tables\"\` should list the user's tables, not just framework bookkeeping).
- [ ] Re-run \`wheels migrate latest\` — it should be a no-op, not a rollback. (Without this fix, re-running the documented command **destroys your schema**.)
- [ ] CI: confirm the existing test matrix still passes.