### PR TITLE
docs: document tools/test-onboarding.sh in CLAUDE.md and .ai/

### DIFF
--- a/.ai/wheels/testing/onboarding-harness.md
+++ b/.ai/wheels/testing/onboarding-harness.md
@@ -1,0 +1,171 @@
+# Local Onboarding Harness
+
+`tools/test-onboarding.sh` is a local fresh-install simulator. It exercises
+the same `wheels new → wheels start → wheels migrate latest → wheels seed`
+path that a brand-new user follows, in an isolated `LUCLI_HOME` so it
+doesn't touch the developer's daily wheels install.
+
+The harness is not a unit test runner. It exists to **validate cliff fixes
+locally before asking for a fresh-VM tutorial run**. A fresh VM costs ~30
+minutes round-trip; the harness costs ~90 seconds.
+
+## When to reach for it
+
+- Editing CLI / framework / template code that affects `wheels new`,
+  `wheels start`, `wheels migrate latest`, or `wheels seed`.
+- Working on a finding from a fresh-VM tutorial-onboarding journal — the
+  harness output mirrors that journal format so signatures map directly.
+- Diagnosing dotted-path resolution issues, Lucee bundle problems, or
+  config emission bugs that only surface in install contexts that copy
+  the module rather than symlinking it (i.e., Homebrew bottle, Chocolatey
+  package, real fresh VMs).
+- Validating that a doc fix matches the actual behaviour the user sees.
+
+The harness is NOT the right tool for:
+
+- Running framework unit tests — use `bash tools/test-local.sh`.
+- Running CLI module unit tests — use `bash tools/test-cli-local.sh`.
+- Cross-engine compatibility checks — use the Docker matrix
+  (`docker compose up`).
+- Browser automation tests — use `wheels browser test` or the Playwright
+  spec runner.
+
+## How it works
+
+The harness creates a temporary `LUCLI_HOME` at `$TMPDIR/.lucli` (the literal
+`.lucli` suffix matters because LuCLI's `getComponentPath()` hardcodes that
+directory name when deciding whether to load `Module.cfc` by absolute file
+path). It then mounts the worktree's `cli/lucli/` into
+`$LUCLI_HOME/modules/wheels` (default: symlink, `MODE=copy` for closer
+brew-install simulation), sets `WHEELS_FRAMEWORK_PATH` to the worktree's
+`vendor/wheels`, and symlinks the user's existing Lucee Express install
+under `$LUCLI_HOME/express` so the 74MB download is skipped.
+
+`JAVA_HOME` is auto-resolved (via `/usr/libexec/java_home -v 21` first, then
+falling back to `brew --prefix openjdk@21` for keg-only installs). The
+`wheels` wrapper resolves Java internally, but `lucli server run` (which the
+harness uses to avoid the wrapper's 30-second startup timeout) does not, so
+`JAVA_HOME` must be exported explicitly.
+
+The temp directory is wiped on exit. Use `KEEP_TEMP=1` to preserve it for
+inspection (logs, generated app, server stdout) — paths are printed at the
+end of the run.
+
+## Phases
+
+```
+Phase 1: Setup isolated LUCLI_HOME
+Phase 2: wheels new (file tree, no bundleName, no duplicates)
+Phase 3: server boot via `lucli server run` + sqlite-jdbc shim
+Phase 4: migration cliff (assert real schema, not just exit 0)
+Phase 5: seed (cfscript wrapper + seedOnce idempotency)
+Phase 6: CRUD walkthrough (chapters 2-3 happy path)
+Phase 7: wheels packages list (currently SKIP pending follow-up)
+```
+
+Each phase emits `✓` (pass), `✗` (fail), or `-` (skip) lines. The summary
+counts add up across all phases. A failure in Phase 1-3 aborts subsequent
+phases (no point running migrations against a server that didn't start).
+
+## Modes
+
+| Mode | Invocation | Use case |
+|---|---|---|
+| symlink (default) | `bash tools/test-onboarding.sh` | Fast iteration on worktree changes |
+| copy | `MODE=copy bash tools/test-onboarding.sh` | Closer simulation of fresh brew install (forces `Lucee` to walk the actual directory hierarchy rather than the symlink target) |
+| baseline | `BASELINE=1 bash tools/test-onboarding.sh` | Run against the user's brew-installed `wheels` rather than the worktree (sanity check for what a real user sees today) |
+| keep | `KEEP_TEMP=1 bash tools/test-onboarding.sh` | Preserve the temp dirs (LUCLI_HOME, app dir, server log) so you can inspect state |
+| skip | `FROM_PHASE=4 bash tools/test-onboarding.sh` | Skip earlier phases when you only care about Phase N+ |
+| port | `PORT=9787 bash tools/test-onboarding.sh` | Override server port (default 9988) |
+
+Modes compose: `MODE=copy KEEP_TEMP=1 PORT=9787 bash tools/test-onboarding.sh`.
+
+## Reading the output
+
+The harness mirrors the fresh-VM onboarding journal format used by the
+manual VM-test runs. Each phase prints a header (`━━━ Phase N: title ━━━`)
+followed by per-check lines.
+
+A green run produces something like:
+
+```
+━━━ Phase 4: Migration cliff — wheels migrate latest (covers F2/F5) ━━━
+  ✓ ch02 migration written
+  ✓ wheels migrate latest exited 0
+  ✓ F5: db/development.sqlite is non-empty (24576 bytes)
+  ✓ F5: posts table exists in development.sqlite
+      |       CREATE TABLE IF NOT EXISTS "posts" (
+```
+
+A failure looks like:
+
+```
+━━━ Phase 4: Migration cliff — wheels migrate latest (covers F2/F5) ━━━
+  ✓ ch02 migration written
+  ✓ wheels migrate latest exited 0
+  ✗ F5: db/development.sqlite is 0 bytes — migration silently no-op'd
+      migrate-output:
+      | Running migration: latest...
+      | Migration latest completed.
+```
+
+The "F5" prefix references the finding ID from the second fresh-VM
+onboarding journal. Lookup table:
+
+| ID | Finding | Status as of merge of #2304/2306/2307/2308/2309 |
+|---|---|---|
+| F1 | bundleName forces broken OSGi resolution | fixed (bundleName stripped from template) |
+| F2/F5 | `wheels migrate latest` silently no-ops | fixed (correct command name) |
+| F3 | duplicate `create blog/Application.cfc` lines | open ([#2311](https://github.com/wheels-dev/wheels/issues/2311), didn't reproduce locally) |
+| F3-orig | seedOnce non-idempotent | likely downstream of F1 (column case-folding); covered by Phase 5 |
+| F4 | tutorial file tree out of date | fixed (regenerated from real `wheels new`) |
+| F7 | `cli.lucli.X` doesn't resolve in copy installs | fixed (rewrote to `modules.wheels.X`) |
+| F7 follow-up | `wheels.SemVer` not loaded in CLI context | open ([#2310](https://github.com/wheels-dev/wheels/issues/2310)) |
+
+## Required state
+
+The harness needs:
+
+- A worktree-style checkout of `wheels-dev/wheels` (not just the brew-installed bottle)
+- `wheels` (i.e. lucli) on `PATH`
+- Java 21 (`brew install openjdk@21` on macOS)
+- An existing Lucee Express install under `~/.wheels/express/` or `~/.lucli/express/` (created by any prior `wheels start` — the symlink reuses it). If neither exists, the harness will trigger one during Phase 3 (slower first run).
+- `sqlite3` on PATH (used to verify schema)
+
+If `sqlite3` is missing, the schema verification check skips with a warning;
+the rest of the harness runs. Other missing dependencies abort with a
+specific error.
+
+## Adding new phases
+
+Each phase is gated by the `phase` helper (`if phase N "title"; then ...`),
+which respects `FROM_PHASE`. New phases should:
+
+- Mirror the journal format — emit `pass` / `fail` / `skip` calls per check
+- Reference fresh-VM finding IDs (F-numbers) in the section title and
+  per-check labels so signatures stay greppable
+- Expose log files via `$TMPDIR/wheels-<phase>.log` for inspection in
+  `KEEP_TEMP=1` mode
+
+The harness is intentionally one bash file. A multi-phase walkthrough is
+easier to audit and modify in one place than spread across modules.
+
+## Related documentation
+
+- `tools/test-onboarding.sh` — the script itself, with extensive header
+  comments documenting every mode and phase
+- [PR #2308](https://github.com/wheels-dev/wheels/pull/2308) — the
+  introduction PR with full design context
+- The original fresh-VM tutorial-onboarding journals (April 2026) that
+  motivated the harness
+
+## Why a separate harness vs extending `tools/test-local.sh`
+
+`tools/test-local.sh` runs the framework's own unit-test suite (3328+ specs)
+inside a running Wheels server. It assumes the framework is correctly
+loaded — which is the very assumption a brand-new user can't make. The
+onboarding harness exists below that assumption: it boots from
+`wheels new` and proves the cliff is closed at every step the user
+actually walks through. Folding it into `tools/test-local.sh` would mix
+two different test layers; keeping them separate keeps each one fast and
+clearly scoped.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -634,6 +634,46 @@ curl -s "http://localhost:62023/wheels/core/tests?db=mysql&format=json" | \
 docker compose down    # Stop all containers
 ```
 
+## Local Onboarding Harness
+
+`tools/test-onboarding.sh` simulates the brand-new-user fresh-install flow without
+touching the user's daily wheels install. It is the right tool when:
+
+- Fixing CLI / framework / template code that affects the `wheels new` →
+  `wheels start` → `wheels migrate latest` cliff.
+- Validating cliff fixes BEFORE asking for a fresh-VM tutorial run.
+- Iterating on dotted-path resolution, Lucee bundle issues, or generated
+  config emission.
+
+```bash
+bash tools/test-onboarding.sh             # symlink-mount worktree (default)
+MODE=copy bash tools/test-onboarding.sh   # closer to brew-install simulation
+BASELINE=1 bash tools/test-onboarding.sh  # use the brew-installed wheels
+KEEP_TEMP=1 bash tools/test-onboarding.sh # preserve temp dirs for inspection
+FROM_PHASE=4 bash tools/test-onboarding.sh # skip earlier phases when iterating
+```
+
+The harness uses `LUCLI_HOME` isolation (writes only into `mktemp -d`), reuses
+the user's existing Lucee Express via symlink to skip the ~74MB redownload, and
+runs ~90 seconds end-to-end through 7 phases mirroring the fresh-VM onboarding
+journal format. Output is directly comparable to fresh-VM run reports.
+
+| Phase | Covers | Fresh-VM findings |
+|---|---|---|
+| 1 | Setup isolated `LUCLI_HOME`, framework path, Lucee Express symlink | — |
+| 2 | `wheels new` (no duplicate `create` lines, file tree, no `bundleName`) | F1, F3, F4 |
+| 3 | Server boot via `lucli server run` + sqlite-jdbc shim | (formula simulation) |
+| 4 | Migration cliff — verify the actual sqlite db has tables, not just exit 0 | F2, F5 |
+| 5 | Seed (cfscript wrapper + `seedOnce` idempotency) | F3-orig |
+| 6 | CRUD walkthrough (tutorial chapters 2-3 happy path) | tutorial verification |
+| 7 | `wheels packages list` | F7 (currently SKIP pending follow-up) |
+
+Output uses `✓` / `✗` / `-` per check. A green local run is a strong predictor
+of a green fresh-VM run; the SKIP markers signal known pending issues that are
+expected to fail until their respective follow-up PRs ship.
+
+Deeper reference: [.ai/wheels/testing/onboarding-harness.md](.ai/wheels/testing/onboarding-harness.md).
+
 ## Auto-Migration Quick Reference
 
 Generate migrations from model/DB schema diffs. Rename detection via explicit hints (authoritative) + heuristic suggestions (normalized-token + Levenshtein).
@@ -945,7 +985,7 @@ Deeper documentation lives in `.ai/` — Claude will search it automatically whe
 - `.ai/wheels/mcp/` — AI agent integration via LuCLI stdio MCP (setup, tool reference, auto-discovery)
 - `.ai/wheels/packages/` — first-party packages (sentry, hotwire, basecoat) + activation model
 - `.ai/wheels/cli/` — generators (model, controller, scaffold, admin, migrations)
-- `.ai/wheels/testing/` — WheelsTest BDD, browser testing, browser automation patterns
+- `.ai/wheels/testing/` — WheelsTest BDD, browser testing, browser automation patterns, **onboarding harness** (fresh-install simulation for cliff fixes)
 - `.ai/wheels/security/` — CSRF protection, HTTPS detection
 - `.ai/wheels/patterns/` — authentication, CRUD, validation templates
 - `.ai/wheels/snippets/` — copy-paste model + controller examples


### PR DESCRIPTION
## Summary

Makes the local onboarding harness (\`tools/test-onboarding.sh\`, shipped in [#2308](https://github.com/wheels-dev/wheels/pull/2308)) discoverable from the documentation Claude Code reads at session start.

Two files updated:

- **CLAUDE.md** — adds a \"Local Onboarding Harness\" Quick Reference section between the existing test sections and Auto-Migration. Lists modes, phases, and the F1-F7 finding-ID mapping. Auto-loaded into every Claude session in this repo, so future contributors using Claude Code immediately know the harness exists and when to reach for it.
- **.ai/wheels/testing/onboarding-harness.md** (new) — deeper reference covering how the harness works internally, when to reach for it vs the other test scripts (\`test-local.sh\`, \`test-cli-local.sh\`, Docker matrix, browser tests), required state, output reading guide, and the design decision behind keeping it separate from \`tools/test-local.sh\`. Auto-searched when a Claude session is specifically about testing.

Plus a one-line update to the existing \`.ai/wheels/testing/\` entry in CLAUDE.md's \"Reference Docs\" listing so the new file shows up there too.

## Why now

The harness itself shipped in #2308. Without this PR, the only way to discover it is to grep \`tools/\` or read PR descriptions. Putting it in CLAUDE.md (which gets loaded into every Claude Code session in this repo) ensures the next contributor working on a cliff-adjacent fix knows to validate locally before asking for a fresh-VM test.

The \`.ai/\` deeper doc gives Claude a richer reference when a session is specifically about the harness — modes, phase details, finding-ID mapping, when-to-reach-for-it vs other test scripts, etc.

## Test plan

- [ ] No build / runtime / test impact (pure docs).
- [ ] Markdown fences balanced in the new \`.ai/\` doc (verified locally with \`python3 -c\` count check — 6 fences = 3 code blocks).
- [ ] CLAUDE.md cross-reference link \`.ai/wheels/testing/onboarding-harness.md\` resolves to the new file.