### PR TITLE
ci: pass DOWNSTREAM_DISPATCH_TOKEN through workflow_call to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,12 @@ on:
         required: true
       FORGEBOX_PASS:
         required: true
+      # Optional — when present, the build job's "Dispatch downstream package
+      # managers" step fires repository_dispatch on homebrew/chocolatey-wheels
+      # so their auto-update workflows pick up the new release in ~5min instead
+      # of waiting for the daily cron. When absent, the step warns and exits 0.
+      DOWNSTREAM_DISPATCH_TOKEN:
+        required: false
 
 env:
   WHEELS_PRERELEASE: false

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -213,6 +213,7 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       FORGEBOX_API_TOKEN: ${{ secrets.FORGEBOX_API_TOKEN }}
       FORGEBOX_PASS: ${{ secrets.FORGEBOX_PASS }}
+      DOWNSTREAM_DISPATCH_TOKEN: ${{ secrets.DOWNSTREAM_DISPATCH_TOKEN }}
 
   #############################################
   # Deploy API docs snapshot to Cloudflare Pages


### PR DESCRIPTION
## Summary

Hot-fix for [#2320](https://github.com/wheels-dev/wheels/pull/2320). The dispatch step landed correctly, but it can't see the secret when \`release.yml\` is invoked via \`workflow_call\` from \`snapshot.yml\` (which is what happens on every push to \`develop\`). \`workflow_call\` requires:

1. Explicit declaration on the callee (\`release.yml\`'s \`workflow_call.secrets\` block)
2. Explicit passthrough from the caller (\`snapshot.yml\`'s \`secrets:\` block)

Without both, \`secrets.DOWNSTREAM_DISPATCH_TOKEN\` evaluates to empty inside \`release.yml\` regardless of whether the repo actually has the secret set.

## Symptom

The \`develop\` push for [#2321](https://github.com/wheels-dev/wheels/pull/2321) (merge SHA \`4fd8dc9\`) ran successfully end-to-end. Snapshot release was published, but the dispatch step printed:

\`\`\`
##[warning]DOWNSTREAM_DISPATCH_TOKEN is not set on the repository
— homebrew/chocolatey auto-update will fall back to the daily cron tick.
\`\`\`

…even though \`gh secret list --repo wheels-dev/wheels\` confirms the secret was set 7 minutes earlier at \`2026-04-27T01:22:19Z\`.

## Fix

7 lines:

- \`release.yml\`: add \`DOWNSTREAM_DISPATCH_TOKEN: required: false\` to \`workflow_call.secrets\`
- \`snapshot.yml\`: add \`DOWNSTREAM_DISPATCH_TOKEN: \${{ secrets.DOWNSTREAM_DISPATCH_TOKEN }}\` to the \`secrets:\` block of the \`build\` job

The secret is declared **optional** because the dispatch step still exits 0 when it's missing — releases are never blocked.

## Verification

After merge, the next \`develop\` push will trigger snapshot.yml → release.yml with the token visible. Confirm by:

\`\`\`bash
gh run view <run-id> --repo wheels-dev/wheels --log | grep -E "Dispatching|workflows dispatched|::warning"
\`\`\`

A successful run shows \`Dispatching wheels-released to wheels-dev/homebrew-wheels...\` followed by \`✓ homebrew-wheels dispatched\` etc.

## Why this wasn't caught in #2320 review

The \`workflow_call\` secret-passthrough requirement is one of those GitHub Actions footguns that only manifests at runtime (no schema validation flags it). The release.yml change worked locally and in tests against \`main\` (where it'd be triggered by direct push, not workflow_call), and \`gh actionlint\` doesn't check workflow_call secret coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)