### PR TITLE
fix(cli): wheels routes prints route table instead of AI-docs JSON dump

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -505,10 +505,68 @@ component extends="modules.BaseModule" {
 		var serverPort = $requireRunningServer();
 
 		try {
-			var routesUrl = "http://localhost:#serverPort#/wheels/ai?context=routing";
+			// /wheels/cli?command=routes returns the actual application route
+			// table as JSON. (The previous endpoint, /wheels/ai?context=routing,
+			// returns AI-documentation about routing patterns — not what users
+			// asking "what routes does my app have?" expect to see.)
+			var routesUrl = "http://localhost:#serverPort#/wheels/cli?command=routes&format=json";
 			var httpResult = makeHttpRequest(routesUrl);
 
-			out(httpResult);
+			var result = "";
+			try {
+				result = deserializeJSON(httpResult);
+			} catch (any jsonErr) {
+				out("Failed to parse routes response", "red");
+				verbose(httpResult);
+				return "";
+			}
+
+			if (!structKeyExists(result, "success") || !result.success) {
+				out("Failed to fetch routes: #result.message ?: 'unknown error'#", "red");
+				return "";
+			}
+
+			if (!structKeyExists(result, "routes") || !arrayLen(result.routes)) {
+				out("No routes configured.", "yellow");
+				return "";
+			}
+
+			// Normalise patterns so the leading "/" is shown exactly once. The
+			// framework stores routes with the leading slash already present,
+			// but defensively handle the case where it isn't.
+			var formatPattern = function(p) {
+				p = p ?: "";
+				return left(p, 1) == "/" ? p : "/" & p;
+			};
+
+			// Compute column widths from the data so the table aligns cleanly.
+			var maxMethod  = len("METHOD");
+			var maxPattern = len("PATTERN");
+			var maxAction  = len("CONTROLLER##ACTION");
+			for (var route in result.routes) {
+				var methodWidth  = len(uCase(route.methods ?: ""));
+				var patternWidth = len(formatPattern(route.pattern));
+				var actionWidth  = len((route.controller ?: "") & "##" & (route.action ?: ""));
+				if (methodWidth  > maxMethod)  maxMethod  = methodWidth;
+				if (patternWidth > maxPattern) maxPattern = patternWidth;
+				if (actionWidth  > maxAction)  maxAction  = actionWidth;
+			}
+
+			out(lJustify("METHOD", maxMethod) & "  " & lJustify("PATTERN", maxPattern) & "  " & "CONTROLLER##ACTION", "bold");
+			out(repeatString("-", maxMethod + maxPattern + maxAction + 4));
+
+			for (var route in result.routes) {
+				var line = lJustify(uCase(route.methods ?: ""), maxMethod)
+					& "  " & lJustify(formatPattern(route.pattern), maxPattern)
+					& "  " & (route.controller ?: "") & "##" & (route.action ?: "");
+				if (structKeyExists(route, "name") && len(route.name)) {
+					line &= "  (" & route.name & ")";
+				}
+				out(line);
+			}
+
+			out("");
+			out("#arrayLen(result.routes)# route(s)", "cyan");
 		} catch (any e) {
 			out("Failed to fetch routes: #e.message#", "red");
 		}

--- a/vendor/wheels/public/views/cli.cfm
+++ b/vendor/wheels/public/views/cli.cfm
@@ -417,14 +417,14 @@ try {
 				break;
 				
 			case "routes":
-				// Return application routes
+				// Return application routes. Routes live at application.wheels.routes
+				// (the convention every other case in this file uses); the previous
+				// `application[application.wheels.appKey]` indirection was broken
+				// because `appKey` is a function, not a property.
 				data.success = true;
 				data.routes = [];
-				
-				// Get routes from application
-				local.appKey = application.wheels.appKey;
-				if (structKeyExists(application, local.appKey) && structKeyExists(application[local.appKey], "routes")) {
-					for (local.route in application[local.appKey].routes) {
+				if (structKeyExists(application, "wheels") && structKeyExists(application.wheels, "routes")) {
+					for (local.route in application.wheels.routes) {
 						local.routeInfo = {
 							name = structKeyExists(local.route, "name") ? local.route.name : "",
 							pattern = structKeyExists(local.route, "pattern") ? local.route.pattern : "",


### PR DESCRIPTION
## Summary

\`wheels routes\` was hitting \`/wheels/ai?context=routing\` — the framework's AI-documentation endpoint, which dumps ~500KB of JSON describing routing helpers and patterns. The user expected (and the CLI help promised) the application's actual configured routes.

Two coordinated fixes:

### CLI side (\`cli/lucli/Module.cfc\`)

Switch \`routes()\` to hit \`/wheels/cli?command=routes&format=json\` (the existing endpoint that serializes \`application.wheels.routes\`), parse the JSON response, and print a formatted table with auto-sized METHOD / PATTERN / CONTROLLER##ACTION columns plus the route name in parentheses where set. Leading-slash on patterns is normalised so each row has exactly one.

### Framework side (\`vendor/wheels/public/views/cli.cfm\`)

The \`case "routes":\` branch was reading \`application.wheels.appKey\` as a property — but \`appKey\` is a function (\`\$appKey()\`), not a property. The lookup failed silently and the endpoint returned \`data.routes = []\` with \`success: false\` for every fresh app. Replaced with direct \`application.wheels.routes\` access — the convention every other case in this file already uses (lines 5, 9, 10, 197, 206, 324, 449, ...).

## Sample output

\`\`\`
METHOD  PATTERN                                CONTROLLER##ACTION
------------------------------------------------------------------------------------
GET     /wheels/info                          wheels.public##info  (wheelsInfo)
GET     /wheels/routes                        wheels.public##routes  (wheelsRoutes)
POST    /wheels/route-tester                  wheels.public##routetester  (wheelsRouteTester)
...
GET     /[controller]/[action]                ##  (wildcard)
GET     /[controller]                         ##index  (wildcard)
GET     /                                     main##index  (root)

35 route(s)
\`\`\`

## Test plan

- [x] \`bash tools/test-cli-local.sh\` — 443 pass / 3 fail / 0 error. The 3 failures are pre-existing Doctor Service issues (#2260) unrelated to this change.
- [x] \`bash tools/test-onboarding.sh\` Phase 8 flips SKIP → PASS (\`wheels routes returned a route table\`).
- [x] Manual probe against fresh app: 35-row route table renders cleanly with single leading slash.

Closes #2317