### PR TITLE
fix(cli): wheels test runs user app specs instead of silent '0 passed'

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -311,12 +311,13 @@ component extends="modules.BaseModule" {
 			}
 		}
 
-		// Auto-detect: if vendor/wheels/tests/ exists, default to core tests
-		if (!coreTests && len(variables.projectRoot)) {
-			if (directoryExists(variables.projectRoot & "/vendor/wheels/tests")) {
-				coreTests = true;
-			}
-		}
+		// Default to APP mode unless --core is set explicitly. The previous
+		// auto-detection ("if vendor/wheels/tests/ exists, default to core")
+		// always picked core mode for user apps because every Wheels app has
+		// the framework's tests vendored at vendor/wheels/tests/. That meant
+		// `wheels test` from a user's app pointed at framework specs instead
+		// of the user's own tests/specs/, producing "0 passed" silently with
+		// no spec discovery.
 
 		return runTests(filter, reporter, format, verboseOutput, coreTests, db, ciMode);
 	}

--- a/cli/lucli/services/TestRunner.cfc
+++ b/cli/lucli/services/TestRunner.cfc
@@ -121,12 +121,14 @@ component {
 	/**
 	 * Determine whether tests should run as core (framework) or app tests.
 	 *
-	 * @return "core" if vendor/wheels/tests/ exists, "app" otherwise
+	 * Always returns "app" — every Wheels app has the framework's tests
+	 * vendored at vendor/wheels/tests/, so that signal can't tell user apps
+	 * apart from the framework repo. Callers that explicitly want to run
+	 * framework specs should pass `--core` (CLI) or `type: "core"` (service).
+	 *
+	 * @return "app" — the safe default for user apps
 	 */
 	public string function detectTestType() {
-		if (directoryExists(variables.projectRoot & "/vendor/wheels/tests")) {
-			return "core";
-		}
 		return "app";
 	}
 

--- a/cli/lucli/tests/specs/services/TestRunnerSpec.cfc
+++ b/cli/lucli/tests/specs/services/TestRunnerSpec.cfc
@@ -16,14 +16,16 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 
 			describe("detectTestType()", () => {
 
-				it("returns core when vendor/wheels/tests exists", () => {
-					// Create the vendor/wheels/tests directory
-					var testsDir = tempRoot & "/vendor/wheels/tests";
-					directoryCreate(testsDir, true, true);
-
+				it("always returns app — vendor/wheels/tests existence is not a discriminator (##2318)", () => {
+					// Both with and without vendor/wheels/tests, detectTestType
+					// should return "app". Every Wheels app vendors the
+					// framework's tests, so that signal is meaningless. Users
+					// who explicitly want core tests pass --core (CLI) or
+					// type:"core" (service).
+					var withVendor = tempRoot & "/vendor/wheels/tests";
+					directoryCreate(withVendor, true, true);
 					var runner = new cli.lucli.services.TestRunner(projectRoot = tempRoot);
-					var result = runner.detectTestType();
-					expect(result).toBe("core");
+					expect(runner.detectTestType()).toBe("app");
 				});
 
 				it("returns app when vendor/wheels/tests does not exist", () => {

--- a/vendor/wheels/Public.cfc
+++ b/vendor/wheels/Public.cfc
@@ -129,7 +129,18 @@ component output="false" displayName="Internal GUI" extends="wheels.Global" {
 
 	function testbox(){
 		$blockInProduction();
-		include "/tests/runner.cfm";
+		// Prefer the project's own runner if it exists (advanced users who
+		// scaffolded a custom tests/runner.cfm). Otherwise fall back to a
+		// built-in app-test runner that scans tests.specs/ via TestBox and
+		// emits the same JSON shape as the framework's core runner. Without
+		// this fallback, fresh apps got "Page [/tests/runner.cfm] not found"
+		// because `wheels new` doesn't scaffold one.
+		var projectRunner = expandPath("/tests/runner.cfm");
+		if (fileExists(projectRunner)) {
+			include "/tests/runner.cfm";
+			return;
+		}
+		include "/wheels/tests/app-runner.cfm";
 	}
 
 	public function tests_testbox(){

--- a/vendor/wheels/tests/app-runner.cfm
+++ b/vendor/wheels/tests/app-runner.cfm
@@ -1,0 +1,82 @@
+<cfsetting requestTimeOut="1800">
+<cfscript>
+    // Built-in app-test runner. Used as a fallback by Public.cfc::testbox()
+    // when the project doesn't have its own tests/runner.cfm. Scans the
+    // project's tests/specs/ via TestBox and emits the same JSON shape as
+    // the framework's core runner so the CLI's displayTestResults() can
+    // parse it without a special case.
+    //
+    // The framework's runner (vendor/wheels/tests/runner.cfm) is heavy: it
+    // overrides controllerPath/viewPath/modelPath to framework test assets,
+    // hardcodes the wheelstestdb_<db> datasource convention, and applies
+    // dozens of test-only settings. None of that fits user apps — user
+    // tests should run against the same models/controllers/views that
+    // power the live application, with the user's own datasource. So this
+    // file deliberately does NOT include /wheels/tests/runner.cfm.
+
+    // Resolve the test directory. Default to tests.specs (the convention
+    // every Wheels app has), but allow ?directory= to scope to a subdir
+    // like tests.specs.models. Only accept dotted paths beginning with
+    // "tests." to avoid arbitrary CFC compilation.
+    local.testDirectory = "tests.specs";
+    if (StructKeyExists(url, "directory") && Len(Trim(url.directory))) {
+        local.requested = Trim(url.directory);
+        if (ReFindNoCase("^tests(\.[a-zA-Z0-9_]+)*$", local.requested)) {
+            local.testDirectory = local.requested;
+        }
+    }
+
+    try {
+        testBox = new wheels.wheelstest.system.TestBox(
+            directory = local.testDirectory,
+            options   = { coverage = { enabled = false } }
+        );
+    } catch (any e) {
+        cfheader(statuscode="500");
+        cfcontent(type="application/json");
+        writeOutput(SerializeJSON({
+            success: false,
+            error: "Failed to create TestBox instance",
+            message: e.message
+        }));
+        abort;
+    }
+
+    // Sort bundles for stable output
+    local.sortedBundles = testBox.getBundles();
+    arraySort(local.sortedBundles, "textNoCase");
+    testBox.setBundles(local.sortedBundles);
+
+    if (!StructKeyExists(url, "format") || url.format == "html") {
+        result = testBox.run(reporter = "wheels.wheelstest.system.reports.JSONReporter");
+        decoded = DeserializeJSON(result);
+        cfheader(statuscode = (decoded.totalFail > 0 || decoded.totalError > 0) ? 417 : 200);
+        // For the html case the framework runner falls through to html.cfm;
+        // for the app-runner we just emit the JSON in this branch too since
+        // app tests are typically requested over JSON (CLI/CI). Users hitting
+        // the URL in a browser still get a structured response they can read.
+        cfcontent(type="application/json");
+        writeOutput(result);
+    } else if (url.format == "json") {
+        result = testBox.run(reporter = "wheels.wheelstest.system.reports.JSONReporter");
+        decoded = DeserializeJSON(result);
+        if (decoded.totalFail > 0 || decoded.totalError > 0) {
+            if (!StructKeyExists(url, "cli") || !url.cli) {
+                cfheader(statuscode = 417);
+            }
+        } else {
+            cfheader(statuscode = 200);
+        }
+        cfcontent(type="application/json");
+        cfheader(name="Access-Control-Allow-Origin", value="*");
+        writeOutput(result);
+    } else if (url.format == "txt") {
+        result = testBox.run(reporter = "wheels.wheelstest.system.reports.TextReporter");
+        cfcontent(type = "text/plain");
+        writeOutput(result);
+    } else if (url.format == "junit") {
+        result = testBox.run(reporter = "wheels.wheelstest.system.reports.ANTJUnitReporter");
+        cfcontent(type = "text/xml");
+        writeOutput(result);
+    }
+</cfscript>


### PR DESCRIPTION
## Summary

The bug surface from the fresh-VM tutorial:

\`\`\`
$ wheels test
Running core tests (sqlite)...
0 passed
\`\`\`

— no spec discovery, no failure, no error. Tutorial chapter 7 asks users to write specs and run \`wheels test\`, but every invocation defaulted to core mode and pointed at framework specs the user didn't write.

## Root cause (three layers)

1. **CLI auto-detection was wrong.** \`Module.cfc::test\` and \`TestRunner.cfc::detectTestType\` both keyed off "does \`vendor/wheels/tests/\` exist?" — but every Wheels app has the framework's tests vendored there, so the check was always true. \`coreTests\` defaulted to \`true\` for users.
2. **App-mode endpoint had no usable runner.** \`Public.cfc::testbox()\` (handler for \`/wheels/app/tests\`) just \`include\`d \`/tests/runner.cfm\` from the project root. \`wheels new\` doesn't scaffold one, so fresh apps got \`Page [/tests/runner.cfm] not found\`.
3. **Reusing the framework's runner doesn't fit.** \`vendor/wheels/tests/runner.cfm\` overrides \`controllerPath\`/\`viewPath\`/\`modelPath\` to framework test assets and hardcodes the \`wheelstestdb_<db>\` datasource convention. Pointing user tests at it would break them.

## Fix

### 1. \`cli/lucli/Module.cfc\` + \`cli/lucli/services/TestRunner.cfc\`

Default to app mode. \`--core\` (CLI flag) or \`type: "core"\` (service arg) is the explicit opt-in for framework specs. Updated \`TestRunnerSpec\` to assert the new behavior.

### 2. \`vendor/wheels/Public.cfc::testbox()\`

Prefer the project's \`tests/runner.cfm\` when it exists (advanced users with custom runners), but fall back to a new built-in runner when it doesn't.

### 3. \`vendor/wheels/tests/app-runner.cfm\` (new file)

Minimal TestBox-driven app-test runner. Scans \`tests.specs.*\` in the project root, emits the same JSON shape as the framework's core runner (so the CLI's \`displayTestResults\` parses it without a special case). Deliberately does NOT delegate to the framework runner — it would override paths and datasource in ways that break user tests.

## Result

Smoke spec at \`tests/specs/smoke/SimpleSpec.cfc\`:

\`\`\`cfm
component extends="wheels.WheelsTest" {
    function run() {
        describe("Simple smoke", () => {
            it("can add", () => { expect(1 + 1).toBe(2); });
        });
    }
}
\`\`\`

Now runs and reports counts via \`wheels test\`.

## Test plan

- [x] \`bash tools/test-cli-local.sh\` — 443 pass / 3 fail / 0 error. The 3 failures are pre-existing Doctor Service issues (#2260) unrelated to this change.
- [x] \`TestRunnerSpec\` updated (one test rewritten to assert new "always returns app" behavior; cleanup test still asserts app mode without vendor dir).
- [x] \`bash tools/test-onboarding.sh\` Phase 9 flips SKIP → PASS: "wheels test reports the smoke spec".

Closes #2318