### PR TITLE
fix(cli): wheels generate scaffold tolerates existing model

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -2166,7 +2166,7 @@ component extends="modules.BaseModule" {
 
 	private string function generateScaffold(required array args) {
 		if (!arrayLen(args)) {
-			out("Usage: wheels generate scaffold <Name> [properties...]", "yellow");
+			out("Usage: wheels generate scaffold <Name> [properties...] [--force]", "yellow");
 			out("  Example: wheels generate scaffold Post title body:text publishedAt:datetime");
 			return "";
 		}
@@ -2175,24 +2175,43 @@ component extends="modules.BaseModule" {
 		var controllerName = getService("helpers").pluralize(modelName);
 		var properties = args.len() > 1 ? args.slice(2) : [];
 
+		// Extract --force from args before parseGeneratorArgs (which doesn't
+		// handle flags). Issue #2327: previously --force was silently dropped,
+		// so scaffolding over an existing model was impossible from the CLI.
+		var force = false;
+		var filteredProperties = [];
+		for (var a in properties) {
+			if (a == "--force") {
+				force = true;
+			} else {
+				arrayAppend(filteredProperties, a);
+			}
+		}
+
 		out("Scaffolding #modelName#...", "cyan");
 		out("");
 
-		// Parse properties
-		var parsed = parseGeneratorArgs(properties);
+		var parsed = parseGeneratorArgs(filteredProperties);
 
 		var scaffold = getService("scaffold");
 		var results = scaffold.generateScaffold(
 			name = modelName,
 			properties = parsed.properties,
 			belongsTo = arrayToList(parsed.belongsTo),
-			hasMany = arrayToList(parsed.hasMany)
+			hasMany = arrayToList(parsed.hasMany),
+			force = force
 		);
 
 		if (results.success) {
 			for (var item in results.generated) {
 				var relPath = listLast(item.path, "/\");
 				printCreated("#item.type#: #relPath#");
+			}
+			// Issue #2327: scaffold can succeed with skipped artifacts. Surface
+			// what was skipped so users know why their existing model wasn't
+			// touched and how to force a rewrite if they wanted one.
+			for (var note in results.skipped ?: []) {
+				out("  skip    #note#", "yellow");
 			}
 
 			out("");

--- a/cli/lucli/services/Scaffold.cfc
+++ b/cli/lucli/services/Scaffold.cfc
@@ -31,7 +31,7 @@ component {
 		boolean tests = true,
 		boolean force = false
 	) {
-		var results = {success: true, generated: [], errors: [], rollback: []};
+		var results = {success: true, generated: [], skipped: [], errors: [], rollback: []};
 		var pluralName = variables.helpers.pluralize(arguments.name);
 
 		try {
@@ -50,7 +50,9 @@ component {
 				}
 			}
 
-			// 1. Generate Model
+			// 1. Generate Model. Issue #2327: existing model is no longer fatal —
+			// scaffold skips and continues so users can scaffold the controller +
+			// views over a hand-edited model. Pass --force to overwrite.
 			var modelResult = variables.codeGenService.generateModel(
 				name = arguments.name,
 				properties = props,
@@ -61,16 +63,24 @@ component {
 			if (modelResult.success) {
 				arrayAppend(results.generated, {type: "model", path: modelResult.path});
 				arrayAppend(results.rollback, modelResult.path);
+			} else if (isExistsError(modelResult.error)) {
+				arrayAppend(results.skipped, "model: " & modelResult.error & " (use --force to overwrite)");
 			} else {
 				throw(type="ScaffoldError", message="Model: #modelResult.error#");
 			}
 
-			// 2. Generate Migration
-			var migrationPath = createMigrationWithProperties(arguments.name, props);
-			arrayAppend(results.generated, {type: "migration", path: migrationPath});
-			arrayAppend(results.rollback, migrationPath);
+			// 2. Generate Migration. Skip if a *_create_<plural>_table migration
+			// already exists — re-running scaffold over a hand-edited model
+			// shouldn't produce duplicate migrations.
+			if (!migrationAlreadyExists(arguments.name)) {
+				var migrationPath = createMigrationWithProperties(arguments.name, props);
+				arrayAppend(results.generated, {type: "migration", path: migrationPath});
+				arrayAppend(results.rollback, migrationPath);
+			} else {
+				arrayAppend(results.skipped, "migration: create_" & lCase(pluralName) & "_table already exists");
+			}
 
-			// 3. Generate Controller
+			// 3. Generate Controller — same skip-on-exists policy as model.
 			var controllerResult = variables.codeGenService.generateController(
 				name = pluralName,
 				crud = true,
@@ -82,6 +92,8 @@ component {
 			if (controllerResult.success) {
 				arrayAppend(results.generated, {type: "controller", path: controllerResult.path});
 				arrayAppend(results.rollback, controllerResult.path);
+			} else if (isExistsError(controllerResult.error)) {
+				arrayAppend(results.skipped, "controller: " & controllerResult.error & " (use --force to overwrite)");
 			} else {
 				throw(type="ScaffoldError", message="Controller: #controllerResult.error#");
 			}
@@ -131,6 +143,31 @@ component {
 		}
 
 		return results;
+	}
+
+	/**
+	 * Detect "already exists" errors from CodeGen so scaffolding can skip them
+	 * cleanly rather than treating them as fatal. The error message format is
+	 * stable: CodeGen emits "Model already exists: ..." / "Controller already
+	 * exists: ..." / "View already exists: ...".
+	 */
+	private boolean function isExistsError(string error = "") {
+		return reFindNoCase("\balready exists:", arguments.error) > 0;
+	}
+
+	/**
+	 * Check whether a migration that would create the resource's table is
+	 * already present. Match on the canonical filename suffix
+	 * `_create_<plural>_table.cfc` so timestamped duplicates are avoided
+	 * when a user re-runs scaffold over an existing model.
+	 */
+	private boolean function migrationAlreadyExists(required string name) {
+		var migrationDir = variables.projectRoot & "/app/migrator/migrations";
+		if (!directoryExists(migrationDir)) return false;
+		var tableName = variables.helpers.pluralize(lCase(arguments.name));
+		var suffix = "_create_" & tableName & "_table.cfc";
+		var existing = directoryList(migrationDir, false, "name", "*" & suffix);
+		return arrayLen(existing) > 0;
 	}
 
 	/**

--- a/tools/test-onboarding.sh
+++ b/tools/test-onboarding.sh
@@ -882,11 +882,17 @@ if phase 11 "wheels generate scaffold tolerates existing model (issue #2327)"; t
     "$WHEELS_CMD" generate scaffold Post title:string body:text status:enum --force \
         > "$SCAFFOLD_LOG" 2>&1 || true
 
-    if grep -qiE "Model already exists|Scaffold failed.*Model already" "$SCAFFOLD_LOG"; then
+    # Distinguish the bug shape from the fix shape:
+    #   - Bug: "Scaffold failed:" (the entire scaffold aborts)
+    #   - Fix: "Scaffold complete!" with the existing model skipped or
+    #     overwritten (with --force) and the controller/views written.
+    # Both can mention "Model already exists:" — the bug as the abort
+    # reason, the fix as part of the per-artifact "skip ..." annotation.
+    if grep -qE "Scaffold failed" "$SCAFFOLD_LOG"; then
         skip "wheels generate scaffold aborts when model exists — issue #2327 not fixed yet"
         head -8 "$SCAFFOLD_LOG" | sed 's/^/      | /'
-    elif grep -qiE "Scaffolded|Created.*controller|Generated.*controller|controller.*created" "$SCAFFOLD_LOG"; then
-        pass "wheels generate scaffold produced controller/views with existing model"
+    elif grep -qE "Scaffold complete" "$SCAFFOLD_LOG"; then
+        pass "wheels generate scaffold completed with existing model present"
     else
         skip "wheels generate scaffold output unrecognized — review $SCAFFOLD_LOG"
         head -10 "$SCAFFOLD_LOG" | sed 's/^/      | /'


### PR DESCRIPTION
## Summary

\`wheels generate scaffold Post title:string body:text --force\` failed once the user already had a \`Post\` model — and tutorial chapter 3 puts users in exactly that state (chapter 2 generates the model, chapter 3 expects scaffold to add the controller and views over it).

\`\`\`
$ wheels generate model Post title:string body:text
$ wheels generate scaffold Post title:string body:text status:enum
Scaffolding Post...
Scaffold failed:
  Model: Model already exists: app/models/Post.cfc

$ wheels generate scaffold Post title:string body:text status:enum --force
# same error
\`\`\`

Two coordinated bugs:

1. **\`--force\` was silently dropped.** \`parseGeneratorArgs()\` only handled \`--belongsTo=\` / \`--hasMany=\` / \`--hasOne=\`. \`--force\` fell through every branch. The CLI's \`generateScaffold()\` never even passed \`force\` into the Scaffold service.
2. **Scaffold aborted on the first existing artifact.** Per the docs ("creates the controller, the seven CRUD views, and (if it didn't already exist) the model and migration"), it should skip what's already there and continue. Instead it threw \`ScaffoldError\` and rolled back.

## Fix

### \`cli/lucli/Module.cfc\`

Extract \`--force\` from args before \`parseGeneratorArgs()\`, pass it through. Surface the new \`results.skipped\` array as yellow "skip" lines so users see why an artifact wasn't touched.

### \`cli/lucli/services/Scaffold.cfc\`

Replace the abort-on-exists pattern with skip-and-continue. New \`isExistsError()\` helper recognises CodeGen's "X already exists:" messages and treats them as \`skipped\` rather than fatal. Migration gets a \`migrationAlreadyExists()\` check that matches the canonical \`*_create_<plural>_table.cfc\` filename suffix — re-running scaffold over a hand-edited model shouldn't produce duplicate timestamped migrations.

### \`tools/test-onboarding.sh\` Phase 11

The old regex distinguished bug from fix by looking for "Model already exists:" — but that string appears in both shapes now (as the abort reason in the bug, as part of the per-artifact skip annotation in the fix). Switch to detecting "Scaffold failed:" vs "Scaffold complete!" — those are unique to each shape.

## Three-way behavior verification

| Scenario | Expected | Actual |
|---|---|---|
| Fresh project, \`scaffold Post\` | create model + migration + controller + views + tests | ✓ |
| \`scaffold Post\` again (no --force) | skip model/migration/controller, still generate tests; complete with yellow skip lines | ✓ |
| \`scaffold Post --force\` | overwrite model and controller, skip migration (no dup timestamps); complete | ✓ |

## Test plan

- [x] \`bash tools/test-cli-local.sh\` — 447 pass / 3 fail / 0 error. The 3 failures are pre-existing Doctor Service issues (#2260) unrelated.
- [x] \`bash tools/test-onboarding.sh\` Phase 11 flips SKIP → PASS: "wheels generate scaffold completed with existing model present" — score now **40 pass / 1 fail / 3 skip**.

Closes #2327