### PR TITLE
fix(cli): wheels destroy controller removes views and preserves name casing

### DIFF
--- a/cli/lucli/services/Destroy.cfc
+++ b/cli/lucli/services/Destroy.cfc
@@ -70,39 +70,63 @@ component {
 	}
 
 	/**
-	 * Destroy a model and its test, generate drop-table migration
+	 * Destroy a model and its test, generate drop-table migration.
+	 *
+	 * Uses the input name verbatim for the filename (mirroring how
+	 * `wheels generate model <Name>` writes it). Pluralisation only
+	 * applies to the table name in the drop-table migration, where
+	 * the case-preserving smart pluraliser produces the right output.
 	 */
 	public struct function destroyModel(required string name) {
 		var result = {success: true, deleted: [], warnings: [], migrationPath: ""};
-		var names = getNameVariants(arguments.name);
+		var clean = variables.helpers.stripSpecialChars(trim(arguments.name));
+		var modelCap = variables.helpers.capitalize(clean);
 
 		deleteFileIfExists(
-			variables.projectRoot & "/app/models/" & names.singularCap & ".cfc",
+			variables.projectRoot & "/app/models/" & modelCap & ".cfc",
 			result
 		);
 		deleteFileIfExists(
-			variables.projectRoot & "/tests/specs/models/" & names.singularCap & "Spec.cfc",
+			variables.projectRoot & "/tests/specs/models/" & modelCap & "Spec.cfc",
 			result
 		);
 
-		result.migrationPath = generateRemoveTableMigration(names.plural);
+		// Table name is the lowercase plural of the model name.
+		result.migrationPath = generateRemoveTableMigration(lCase(variables.helpers.pluralize(clean)));
 
 		return result;
 	}
 
 	/**
-	 * Destroy a controller and its test
+	 * Destroy a controller, its views, and its test.
+	 *
+	 * Uses the input name verbatim (just capitalised for the filename), to
+	 * mirror how `wheels generate controller <Name>` writes the file. The
+	 * previous implementation pluralised + lowercased + recapitalised, so
+	 * `wheels destroy WidgetTest controller` looked for `Widgettests.cfc`
+	 * — which was never created. See issue #2330 and the related
+	 * name-mangling side-finding.
 	 */
 	public struct function destroyController(required string name) {
 		var result = {success: true, deleted: [], warnings: []};
-		var names = getNameVariants(arguments.name);
+		var clean = variables.helpers.stripSpecialChars(trim(arguments.name));
+		var controllerCap = variables.helpers.capitalize(clean);
+		var viewsDir = lCase(controllerCap);
 
 		deleteFileIfExists(
-			variables.projectRoot & "/app/controllers/" & names.pluralCap & ".cfc",
+			variables.projectRoot & "/app/controllers/" & controllerCap & ".cfc",
+			result
+		);
+		// Views directory is generated alongside the controller; destroy
+		// removes it too. Issue #2330: previously views were left behind,
+		// making `wheels generate scaffold` over the same name fail with
+		// orphaned partial state.
+		deleteDirIfExists(
+			variables.projectRoot & "/app/views/" & viewsDir,
 			result
 		);
 		deleteFileIfExists(
-			variables.projectRoot & "/tests/specs/controllers/" & names.pluralCap & "Spec.cfc",
+			variables.projectRoot & "/tests/specs/controllers/" & controllerCap & "Spec.cfc",
 			result
 		);
 
@@ -167,8 +191,14 @@ component {
 				arrayAppend(preview, "Migration: drop table " & names.plural);
 				break;
 			case "controller":
-				arrayAppend(preview, "app/controllers/" & names.pluralCap & ".cfc");
-				arrayAppend(preview, "tests/specs/controllers/" & names.pluralCap & "Spec.cfc");
+				// Controller destroy uses the input verbatim (matching how
+				// `generate controller` writes the file), not the pluralised
+				// name. Views directory comes along too.
+				var clean = variables.helpers.stripSpecialChars(trim(arguments.name));
+				var controllerCap = variables.helpers.capitalize(clean);
+				arrayAppend(preview, "app/controllers/" & controllerCap & ".cfc");
+				arrayAppend(preview, "app/views/" & lCase(controllerCap) & "/");
+				arrayAppend(preview, "tests/specs/controllers/" & controllerCap & "Spec.cfc");
 				break;
 			case "view":
 				if (find("/", arguments.name)) {
@@ -191,12 +221,18 @@ component {
 	// ── Private helpers ──────────────────────────────────────
 
 	private struct function getNameVariants(required string name) {
+		// Don't lowercase the input before singularize/pluralize. The helper's
+		// pluraliser detects PascalCase and operates on the trailing word only,
+		// preserving inner caps — so `pluralize("WidgetTest")` returns
+		// "WidgetTests", not "widgettests". Lowercasing first wrecks the
+		// inner caps (capitalize() only re-uppercases the first letter), which
+		// is the root of the destroy name-mangling bug related to #2330.
 		var clean = variables.helpers.stripSpecialChars(trim(arguments.name));
-		var singular = variables.helpers.singularize(lCase(clean));
-		var plural = variables.helpers.pluralize(lCase(clean));
+		var singular = variables.helpers.singularize(clean);
+		var plural = variables.helpers.pluralize(clean);
 		return {
-			singular: singular,
-			plural: plural,
+			singular: lCase(singular),
+			plural: lCase(plural),
 			singularCap: variables.helpers.capitalize(singular),
 			pluralCap: variables.helpers.capitalize(plural)
 		};

--- a/cli/lucli/tests/specs/services/DestroySpec.cfc
+++ b/cli/lucli/tests/specs/services/DestroySpec.cfc
@@ -50,21 +50,43 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 
 			describe("destroyController()", () => {
 
-				it("deletes controller and test files", () => {
+				it("deletes controller, views directory, and test files (##2330)", () => {
 					var controllerPath = tempRoot & "/app/controllers/Deletemes.cfc";
+					var viewsDir = tempRoot & "/app/views/deletemes";
 					var testPath = tempRoot & "/tests/specs/controllers/DeletemesSpec.cfc";
 					directoryCreate(getDirectoryFromPath(controllerPath), true, true);
+					directoryCreate(viewsDir, true, true);
+					fileWrite(viewsDir & "/index.cfm", "<p>i</p>");
 					directoryCreate(getDirectoryFromPath(testPath), true, true);
 					fileWrite(controllerPath, 'component extends="Controller" {}');
 					fileWrite(testPath, 'component {}');
 
-					var result = destroy.destroyController("Deleteme");
+					// Input matches the controller filename verbatim — destroy
+					// no longer pluralises (which used to produce wrong target
+					// filenames for non-conventional names; see #2330).
+					var result = destroy.destroyController("Deletemes");
 					expect(fileExists(controllerPath)).toBeFalse();
+					expect(directoryExists(viewsDir)).toBeFalse();
 					expect(fileExists(testPath)).toBeFalse();
 				});
 
+				it("preserves PascalCase for non-conventional names (##2330 side-finding)", () => {
+					// The previous implementation pluralised + lowercased then
+					// recapitalised, mangling `WidgetTest` into `Widgettests`
+					// which never matched the actually-generated file.
+					var controllerPath = tempRoot & "/app/controllers/WidgetTest.cfc";
+					var viewsDir = tempRoot & "/app/views/widgettest";
+					directoryCreate(getDirectoryFromPath(controllerPath), true, true);
+					directoryCreate(viewsDir, true, true);
+					fileWrite(controllerPath, 'component extends="Controller" {}');
+
+					var result = destroy.destroyController("WidgetTest");
+					expect(fileExists(controllerPath)).toBeFalse();
+					expect(directoryExists(viewsDir)).toBeFalse();
+				});
+
 				it("does not generate a migration", () => {
-					var result = destroy.destroyController("Deleteme");
+					var result = destroy.destroyController("Deletemes");
 					expect(structKeyExists(result, "migrationPath")).toBeFalse();
 				});
 
@@ -157,9 +179,14 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					expect(arrayToList(preview)).toInclude("drop table");
 				});
 
-				it("returns expected items for controller type", () => {
-					var preview = destroy.previewDestroy("Product", "controller");
-					expect(arrayLen(preview)).toBe(2);
+				it("returns expected items for controller type (##2330)", () => {
+					// 3 items: controller .cfc, views/ directory, controller spec.
+					// Issue #2330 added the views directory to controller destroy.
+					var preview = destroy.previewDestroy("Products", "controller");
+					expect(arrayLen(preview)).toBe(3);
+					expect(arrayToList(preview)).toInclude("Products.cfc");
+					expect(arrayToList(preview)).toInclude("app/views/products/");
+					expect(arrayToList(preview)).toInclude("ProductsSpec.cfc");
 				});
 
 			});


### PR DESCRIPTION
## Summary

Two coordinated bugs in the destroy-controller path. The tutorial's "drop the hand-written controller and views" instruction couldn't be reproduced via the CLI:

\`\`\`
$ wheels generate controller WidgetTest index
  create  app/controllers/WidgetTest.cfc

$ wheels destroy WidgetTest controller --force
The following will be deleted:
  app/controllers/Widgettests.cfc           ← wrong filename
  tests/specs/controllers/WidgettestsSpec.cfc

  skip    Not found: …/Widgettests.cfc      ← never existed
\`\`\`

And even for conventional names (\`Posts\`), \`destroy --force\` removed only the .cfc — the matching \`app/views/posts/\` directory was left behind.

## Root causes

1. **\`destroyController()\` didn't touch views.** It deleted \`<plural>.cfc\` and the spec; views directory wasn't in the destroy list.
2. **\`getNameVariants()\` mangled non-conventional names.** It ran inputs through \`lCase() → singularize/pluralize → capitalize()\`. \`capitalize\` only re-uppercases the first letter, so inner caps in PascalCase names were destroyed: \`WidgetTest\` → \`widgettests\` → \`Widgettests\`. The helper's pluraliser actually preserves PascalCase by detecting the trailing word, so calling it on the original input would have produced \`WidgetTests\` correctly — but the lowercase-first step defeated that.

## Fix

- **\`destroyController\`:** use the input name verbatim (just \`capitalize\` for the .cfc filename) — mirrors how \`generate controller <Name>\` writes the file. Add \`app/views/<lCase(name)>/\` to the destroy list.
- **\`destroyModel\`:** same treatment for the .cfc filename; pluraliser handles the drop-table migration's table name.
- **\`getNameVariants\`:** drop the \`lCase()\` before \`singularize\`/\`pluralize\`. The helper handles PascalCase smartly. Lowercase only at the end for path components that need it (view dir names, table names).
- **\`previewDestroy\`:** include \`app/views/<name>/\` in the controller-type preview so users see what will be deleted.

## After the fix

\`\`\`
$ wheels destroy Posts controller --force
The following will be deleted:
  app/controllers/Posts.cfc
  app/views/posts/
  tests/specs/controllers/PostsSpec.cfc

  delete  …/app/controllers/Posts.cfc
  delete  …/app/views/posts/

$ wheels destroy WidgetTest controller --force
The following will be deleted:
  app/controllers/WidgetTest.cfc
  app/views/widgettest/
  tests/specs/controllers/WidgetTestSpec.cfc

  delete  …/app/controllers/WidgetTest.cfc
  delete  …/app/views/widgettest/
\`\`\`

## Test plan

- [x] \`bash tools/test-cli-local.sh\` — 448 pass / 3 fail / 0 error (the 3 failures are pre-existing Doctor Service issues #2260, unrelated).
- [x] DestroySpec tests updated:
  - "deletes controller and test files" → "deletes controller, views directory, and test files (#2330)"
  - New "preserves PascalCase for non-conventional names (#2330 side-finding)" — guards against the \`WidgetTest\` regression.
  - "returns expected items for controller type" — count now 3 (was 2), with explicit content assertions.
- [x] \`bash tools/test-onboarding.sh\` Phase 13 flips SKIP → PASS: "wheels destroy controller removed both .cfc and views/".

Closes #2330