### PR TITLE
fix(cli): substitute @build.version@ for brew/chocolatey installs via cliVersion fallback

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -3653,7 +3653,8 @@ component extends="modules.BaseModule" {
 		directoryCopy(wheelsSource, vendorDir, true);
 		new services.FrameworkInstaller().rewriteVersionPlaceholder(
 			wheelsSource = wheelsSource,
-			vendorDir = vendorDir
+			vendorDir = vendorDir,
+			cliVersion = version()
 		);
 		printCreated(appName & "/vendor/wheels/");
 	}

--- a/cli/lucli/services/FrameworkInstaller.cfc
+++ b/cli/lucli/services/FrameworkInstaller.cfc
@@ -13,32 +13,40 @@ component {
 
 	/**
 	 * Substitute the @build.version@ placeholder in a freshly-copied
-	 * vendor/wheels/box.json when the source is identifiable as a dev checkout
-	 * of the wheels-dev/wheels monorepo (GH ##2279).
+	 * vendor/wheels/box.json so the scaffolded app's homepage reports a
+	 * meaningful version instead of "0.0.0-dev".
 	 *
 	 * Released framework tarballs have the placeholder replaced at build time
 	 * by tools/build/scripts, so their box.json already carries a real version.
-	 * A dev checkout does not — the placeholder is literal. Copying that file
-	 * verbatim into a scaffolded app makes the homepage display "0.0.0-dev"
-	 * because $readFrameworkVersion()'s fallback can only identify the monorepo
-	 * when the enclosing box.json is the monorepo's own — never true inside a
-	 * generated app.
+	 * A dev checkout doesn't — the placeholder is literal. Some release-install
+	 * paths (e.g. the homebrew formula) also ship the framework with the
+	 * placeholder unsubstituted; those need a fallback too.
 	 *
-	 * When the source's enclosing root box.json identifies the monorepo
-	 * (slug="wheels" or name="Wheels.fw") and carries a real version, rewrite
-	 * the copy's placeholder to "<rootversion>-dev" so the new app reports a
-	 * meaningful version. Otherwise leave the placeholder alone — the
-	 * framework's runtime fallback still returns "0.0.0-dev", matching pre-fix
-	 * behavior for unusual third-party layouts.
+	 * Resolution order, highest priority first:
+	 *
+	 * 1. **Monorepo dev checkout** — when the source's enclosing root box.json
+	 *    identifies the monorepo (slug="wheels" or name="Wheels.fw"), use
+	 *    "<rootversion>-dev". (GH ##2279.)
+	 * 2. **CLI version fallback** — when no monorepo is identifiable but the
+	 *    caller passed `cliVersion`, use that. The brew/chocolatey formulas
+	 *    bundle the LuCLI module and the framework together at the same
+	 *    version, so the LuCLI's known version is the right answer for the
+	 *    framework too. (GH ##2333.)
+	 * 3. **Leave alone** — without either signal, the placeholder stays and
+	 *    `$readFrameworkVersion()`'s runtime fallback returns "0.0.0-dev".
 	 *
 	 * @wheelsSource Absolute path of the source vendor/wheels/ directory.
 	 * @vendorDir    Absolute path of the newly-written vendor/wheels/ directory
 	 *               inside the scaffolded app.
+	 * @cliVersion   Optional. The LuCLI module's own version, used as a fallback
+	 *               when the source isn't a monorepo checkout. Skipped if empty
+	 *               or equal to LuCLI's "Version not specified" sentinel.
 	 * @return       True if the placeholder was rewritten, false otherwise.
 	 */
 	public boolean function rewriteVersionPlaceholder(
 		required string wheelsSource,
-		required string vendorDir
+		required string vendorDir,
+		string cliVersion = ""
 	) {
 		var targetBox = arguments.vendorDir & "/box.json";
 		if (!fileExists(targetBox)) return false;
@@ -46,31 +54,52 @@ component {
 		var content = fileRead(targetBox);
 		if (!findNoCase("@build.version@", content)) return false;
 
-		// The source is a vendor/wheels/ directory; the monorepo root lives two
-		// levels up (repo-root/vendor/wheels/ -> repo-root/box.json).
+		// 1. Try monorepo dev checkout: the source is a vendor/wheels/ directory;
+		//    the monorepo root lives two levels up.
 		var File = createObject("java", "java.io.File");
 		var sourceCanonical = File.init(arguments.wheelsSource).getCanonicalPath();
 		var rootCandidate = File.init(sourceCanonical & "/../../box.json").getCanonicalPath();
-		if (!fileExists(rootCandidate)) return false;
 
-		try {
-			var rootBox = deserializeJSON(fileRead(rootCandidate));
-		} catch (any e) {
-			return false;
+		if (fileExists(rootCandidate)) {
+			try {
+				var rootBox = deserializeJSON(fileRead(rootCandidate));
+				var isMonorepo = isStruct(rootBox)
+					&& (
+						(structKeyExists(rootBox, "slug") && rootBox.slug == "wheels")
+						|| (structKeyExists(rootBox, "name") && rootBox.name == "Wheels.fw")
+					);
+				if (
+					isMonorepo
+					&& structKeyExists(rootBox, "version")
+					&& len(rootBox.version)
+					&& rootBox.version != "@build.version@"
+				) {
+					var devVersion = rootBox.version & "-dev";
+					fileWrite(targetBox, replace(content, "@build.version@", devVersion, "all"));
+					return true;
+				}
+			} catch (any e) {
+				// fall through to the CLI-version fallback
+			}
 		}
 
-		var isMonorepo = isStruct(rootBox)
-			&& (
-				(structKeyExists(rootBox, "slug") && rootBox.slug == "wheels")
-				|| (structKeyExists(rootBox, "name") && rootBox.name == "Wheels.fw")
-			);
-		if (!isMonorepo) return false;
-		if (!structKeyExists(rootBox, "version") || !len(rootBox.version)) return false;
-		if (rootBox.version == "@build.version@") return false;
+		// 2. Fall back to the CLI's own version. brew/chocolatey ship LuCLI +
+		//    framework at the same version, so this is the right answer for
+		//    release-install paths where the framework's box.json placeholder
+		//    wasn't substituted at packaging time.
+		var trimmedCli = trim(arguments.cliVersion);
+		if (
+			len(trimmedCli)
+			&& trimmedCli != "Version not specified"
+			&& trimmedCli != "@build.version@"
+		) {
+			fileWrite(targetBox, replace(content, "@build.version@", trimmedCli, "all"));
+			return true;
+		}
 
-		var devVersion = rootBox.version & "-dev";
-		fileWrite(targetBox, replace(content, "@build.version@", devVersion, "all"));
-		return true;
+		// 3. No usable signal — leave the placeholder so the framework's
+		//    runtime fallback path still produces "0.0.0-dev".
+		return false;
 	}
 
 }

--- a/cli/lucli/tests/specs/services/FrameworkInstallerSpec.cfc
+++ b/cli/lucli/tests/specs/services/FrameworkInstallerSpec.cfc
@@ -112,6 +112,52 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 				directoryDelete(root, true);
 			});
 
+			it("falls back to cliVersion when monorepo root is missing (##2333 brew/chocolatey path)", () => {
+				var f = buildFixture(
+					'{"name":"SomeUserApp","slug":"user-app","version":"2.1.0"}',
+					'{"version":"@build.version@"}'
+				);
+				var rewrote = installer.rewriteVersionPlaceholder(f.sourceWheels, f.targetWheels, "0.3.7");
+				var after = deserializeJSON(fileRead(f.targetWheels & "/box.json"));
+				expect(rewrote).toBeTrue();
+				expect(after.version).toBe("0.3.7");
+				directoryDelete(f.root, true);
+			});
+
+			it("prefers monorepo signal over cliVersion when both are available (##2333)", () => {
+				var f = buildFixture(
+					'{"name":"Wheels.fw","slug":"wheels","version":"4.2.0"}',
+					'{"version":"@build.version@"}'
+				);
+				var rewrote = installer.rewriteVersionPlaceholder(f.sourceWheels, f.targetWheels, "0.3.7");
+				var after = deserializeJSON(fileRead(f.targetWheels & "/box.json"));
+				expect(rewrote).toBeTrue();
+				expect(after.version).toBe("4.2.0-dev");
+				directoryDelete(f.root, true);
+			});
+
+			it("ignores the 'Version not specified' sentinel from BaseModule (##2333)", () => {
+				var f = buildFixture(
+					'{"name":"SomeUserApp","slug":"user-app","version":"2.1.0"}',
+					'{"version":"@build.version@"}'
+				);
+				var rewrote = installer.rewriteVersionPlaceholder(f.sourceWheels, f.targetWheels, "Version not specified");
+				expect(rewrote).toBeFalse();
+				expect(fileRead(f.targetWheels & "/box.json")).toInclude("@build.version@");
+				directoryDelete(f.root, true);
+			});
+
+			it("ignores cliVersion when it is itself the unsubstituted placeholder (##2333)", () => {
+				var f = buildFixture(
+					'{"name":"SomeUserApp","slug":"user-app","version":"2.1.0"}',
+					'{"version":"@build.version@"}'
+				);
+				var rewrote = installer.rewriteVersionPlaceholder(f.sourceWheels, f.targetWheels, "@build.version@");
+				expect(rewrote).toBeFalse();
+				expect(fileRead(f.targetWheels & "/box.json")).toInclude("@build.version@");
+				directoryDelete(f.root, true);
+			});
+
 		});
 
 	}


### PR DESCRIPTION
## Summary

On brew/chocolatey installs, the dev toolbar shows \"Wheels Version 0.0.0-dev\" even though \`wheels --version\` reports the real version (e.g. 0.3.7).

## Root cause chain

1. The framework's \`vendor/wheels/box.json\` ships with \`\"version\": \"@build.version@\"\`. The release pipeline is supposed to substitute this at build time, but the homebrew/chocolatey formula paths don't guarantee it — the framework tarball can ship with the placeholder intact.
2. \`\$readFrameworkVersion()\` (vendor/wheels/Global.cfc) has a fallback that walks two levels up from \`vendor/wheels/\` looking for the wheels-dev/wheels monorepo's root box.json (slug=\"wheels\" / name=\"Wheels.fw\"). For an installed app, that lookup never resolves.
3. \`FrameworkInstaller.rewriteVersionPlaceholder()\` (added in #2279) had the same monorepo-only limitation: if the source's enclosing root box.json identified the monorepo, substitute with \`<rootversion>-dev\`; otherwise no-op. For brew/chocolatey, source isn't inside the monorepo → no-op → placeholder persists → runtime returns \"0.0.0-dev\".

## Fix

Extend \`rewriteVersionPlaceholder\` with a \`cliVersion\` parameter. When the monorepo signal is missing but a usable \`cliVersion\` is passed in, write it directly. The brew/chocolatey formulas bundle LuCLI and the framework together at the same version, so the LuCLI's own version is the right answer for the framework too.

**Resolution order:**

| Priority | Source | When it applies |
|---|---|---|
| 1 | \`<rootversion>-dev\` | Source is a wheels-dev/wheels monorepo dev checkout |
| 2 | cliVersion (new) | Monorepo signal missing, LuCLI version usable |
| 3 | leave placeholder | Neither signal — runtime returns \"0.0.0-dev\" |

\`Module.cfc.copyFrameworkToVendor\` passes its \`version()\` (read from \`module.json\` by BaseModule) so the substitution happens transparently at \`wheels new\` time.

## Defenses against bad inputs

- \`\"Version not specified\"\` sentinel (BaseModule's default when \`module.json\` lacks a version) → ignored.
- Self-placeholder \`\"@build.version@\"\` in \`cliVersion\` → ignored. Prevents pathological propagation if the CLI itself was shipped with an unsubstituted version.

## Test plan

- [x] \`bash tools/test-cli-local.sh\` — 447 pass / 3 fail / 0 error. Three failures are pre-existing Doctor Service issues (#2260) unrelated.
- [x] **4 new FrameworkInstaller specs** cover:
  - "falls back to cliVersion when monorepo root is missing (#2333 brew/chocolatey path)"
  - "prefers monorepo signal over cliVersion when both are available (#2333)"
  - "ignores the 'Version not specified' sentinel from BaseModule (#2333)"
  - "ignores cliVersion when it is itself the unsubstituted placeholder (#2333)"
- [x] All existing #2279 specs still pass — the new fallback only fires when the monorepo path doesn't.
- [x] \`bash tools/test-onboarding.sh\` Phase 15 still PASSes (the harness's symlink mode satisfies the monorepo path; the new fallback only fires on installed-package layouts which aren't reproducible in symlink mode).

Closes #2333