### PR TITLE
fix(di): scope the circular-dependency guard per-request, not application

### DIFF
--- a/vendor/wheels/Injector.cfc
+++ b/vendor/wheels/Injector.cfc
@@ -31,9 +31,6 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 		// Track which mappings are request-scoped
 		variables.requestScopedFlags = {};
 
-		// Circular dependency guard during resolution
-		variables.resolving = {};
-
 		// Track the current mapping being built (for fluent API)
 		variables.currentMapping = "";
 
@@ -143,15 +140,23 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 			}
 		}
 
-		// Circular dependency guard
-		if (structKeyExists(variables.resolving, arguments.name)) {
+		// Circular dependency guard. The resolving struct is request-scoped —
+		// it tracks "what this thread is currently resolving" — so concurrent
+		// requests don't trip each other's guard. Application-scoping it (the
+		// previous behavior) caused spurious self-loop errors when two
+		// requests near-simultaneously hit getInstance for the same controller
+		// on a cold framework, before Lucee had compiled the CFC. The chain
+		// "X -> X" in the error message was thread A's in-flight entry being
+		// observed by thread B before B even started. See issue #2331.
+		var resolving = $getResolvingStack();
+		if (structKeyExists(resolving, arguments.name)) {
 			throw(
 				type="Wheels.DI.CircularDependency",
-				message="Circular dependency detected while resolving '#arguments.name#'. Resolution chain: #structKeyList(variables.resolving)# -> #arguments.name#"
+				message="Circular dependency detected while resolving '#arguments.name#'. Resolution chain: #structKeyList(resolving)# -> #arguments.name#"
 			);
 		}
 
-		variables.resolving[arguments.name] = true;
+		resolving[arguments.name] = true;
 
 		try {
 			// Create the component instance
@@ -188,11 +193,28 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 				local.requestCache[arguments.name] = local.instance;
 			}
 		} finally {
-			// Clean up resolving guard
-			structDelete(variables.resolving, arguments.name);
+			// Clean up resolving guard. Even on success this runs to keep the
+			// per-request stack tidy for subsequent getInstance calls in the
+			// same request.
+			var resolvingForCleanup = $getResolvingStack();
+			structDelete(resolvingForCleanup, arguments.name);
 		}
 
 		return local.instance;
+	}
+
+	/**
+	 * Per-request resolving stack. Tracks which names are currently being
+	 * resolved in THIS thread/request, so the circular-dependency guard
+	 * doesn't see entries from concurrent requests.
+	 *
+	 * Lazy-creates request.$wheelsDIResolving on first access.
+	 */
+	private struct function $getResolvingStack() {
+		if (!structKeyExists(request, "$wheelsDIResolving")) {
+			request.$wheelsDIResolving = {};
+		}
+		return request.$wheelsDIResolving;
 	}
 
 	/**

--- a/vendor/wheels/tests/specs/di/InjectorSpec.cfc
+++ b/vendor/wheels/tests/specs/di/InjectorSpec.cfc
@@ -153,6 +153,39 @@ component extends="wheels.WheelsTest" {
 					}).toThrow("Wheels.DI.CircularDependency");
 				});
 
+				it("resolving stack is request-scoped, not application-scoped (##2331)", () => {
+					// Regression: previously the resolving guard lived on the
+					// Injector instance (application scope), so concurrent
+					// requests could trip each other's guard with a spurious
+					// self-loop ("X -> X" in the chain). Verify the resolving
+					// struct is now stored on the request scope.
+					di.map("simpleService").to("wheels.tests._assets.di.SimpleService");
+					di.getInstance("simpleService");
+					// After a successful resolve, the request scope key should
+					// exist (created lazily on first getInstance) — and the
+					// instance should NOT be tracked on the Injector itself.
+					expect(structKeyExists(request, "$wheelsDIResolving")).toBeTrue();
+					// The resolved name should have been cleaned up from the
+					// stack on success, leaving an empty struct.
+					expect(structKeyExists(request.$wheelsDIResolving, "simpleService")).toBeFalse();
+				});
+
+				it("resolving stack recovers cleanly after a circular-dep error (##2331)", () => {
+					// Throwing the CircularDependency error must still pop the
+					// outer entry from the resolving stack (via the finally
+					// block) so subsequent getInstance calls in the same
+					// request can resolve the same name without false alarms.
+					di.map("circularServiceA").to("wheels.tests._assets.di.CircularServiceA");
+					di.map("circularServiceB").to("wheels.tests._assets.di.CircularServiceB");
+					di.map("simpleService").to("wheels.tests._assets.di.SimpleService");
+					try { di.getInstance("circularServiceA"); } catch (any e) {}
+					// After the error, the stack should be empty (cleanup ran)
+					// and an unrelated resolve should still work.
+					expect(structKeyExists(request.$wheelsDIResolving, "circularServiceA")).toBeFalse();
+					var svc = di.getInstance("simpleService");
+					expect(svc).notToBeNull();
+				});
+
 			});
 
 			// ===========================================================


### PR DESCRIPTION
## Summary

The very first HTTP request to a freshly-created Wheels app rendered a 1MB error page —

\`\`\`
Wheels.DI.CircularDependency
Circular dependency detected while resolving 'app.controllers.Main'.
Resolution chain: app.controllers.Main -> app.controllers.Main
\`\`\`

— with HTTP 200. Workaround was \`wheels reload\` then refresh; the error never reappeared on subsequent boots.

## Root cause

\`variables.resolving\` lived on the Injector instance, which is stored at \`application.wheelsdi\`. That makes the resolving struct **application-scoped** — shared across all concurrent request threads.

On a cold framework, when Lucee was still compiling \`app/controllers/Main.cfc\` and two requests near-simultaneously hit \`getInstance(\"app.controllers.Main\")\`:

| Thread A | Thread B |
|---|---|
| \`getInstance(\"X\")\` enters | |
| adds \`X\` to \`variables.resolving\` | |
| starts \`createObject\` (slow first compile) | \`getInstance(\"X\")\` enters |
|  | checks \`variables.resolving\` → sees A's entry |
|  | throws \"Circular dependency: X -> X\" |

The \`X -> X\` chain in the error message is exactly what the journal saw — Thread B's resolution chain was just Thread A's in-flight entry being read across the thread boundary.

The \`wheels reload\` workaround works because reload clears Lucee's CFC class cache, but more importantly the SECOND attempt finds the class already compiled — the compile window closes and the race narrows to nothing. The journal's note that \"the error never reappeared\" matches.

## Fix

Store the resolving stack on \`request.\$wheelsDIResolving\` instead of \`variables.resolving\`. Each request thread gets its own struct, so concurrent calls don't trip each other's guard.

- \`\$getResolvingStack()\` lazy-creates \`request.\$wheelsDIResolving\` on first access.
- The \`finally\` block still pops the entry on both success and failure, so subsequent \`getInstance\` calls in the same request work as expected.
- Within a single request, true circular dependencies (A → B → A) still throw correctly — the guard's intra-request semantics are unchanged.

## Tests

Two new \`InjectorSpec\` regressions:

- \`resolving stack is request-scoped, not application-scoped (#2331)\` — verifies \`request.\$wheelsDIResolving\` is created and that the struct stays clean after a successful resolve.
- \`resolving stack recovers cleanly after a circular-dep error (#2331)\` — verifies the \`finally\` cleanup runs even when a \`CircularDependency\` is thrown, and that subsequent unrelated resolves still work.

The existing \`throws on circular dependency\` spec still passes — intra-request circular detection is unchanged.

## Test plan

- [x] \`bash tools/test-local.sh\` — **3330 passed** (was 3328; 2 new specs).
- [x] \`bash tools/test-cli-local.sh\` — 452 pass / 3 fail. The 3 failures are pre-existing Doctor Service issues (#2260) unrelated.
- [x] Harness Phase 3 still PASSes (the bug doesn't reproduce in symlink mode anyway, so the harness can't actively verify the fix — but it confirms no regression).

Closes #2331