### PR TITLE
docs(docs): address fresh-VM doc-only findings 11/13/14 in tutorial

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/03-crud-scaffold.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/03-crud-scaffold.mdx
@@ -314,6 +314,10 @@ wheels reload
 2. Visit `http://localhost:8080/posts/1` in a browser — shows one post, with Edit, Delete, and back buttons.
 3. From the index, click "New post", fill the form, submit — a third post appears on the index page.
 
+<Aside type="note" title="CSRF protection blocks bare-curl POSTs">
+The first `curl` smoke-test is fine because it's a GET. Form-driven POST/PUT/DELETE from a browser also works — the layout exposes `<meta name="csrf-token">` and Turbo attaches the token to every write request. But a bare `curl -X POST` from your shell is rejected with `Wheels.InvalidAuthenticityToken` — that's [CSRF protection](/v4-0-0-snapshot/security/csrf-protection/) doing its job, not a bug. Use the browser for the write steps in the tutorial; if you script smoke tests later, scrape the token from a `GET /posts/new` first.
+</Aside>
+
 ## Troubleshooting
 
 **`Route 'editPost' not found`** — you dropped `only="index,show"` from `.resources("posts")` but didn't reload. Run `wheels reload`.

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/04-validations-frames.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/04-validations-frames.mdx
@@ -206,7 +206,7 @@ wheels reload
 
 Open `http://localhost:8080/posts/new` in your browser. Clear the Title field and click Save. The form reappears with "Title can't be empty" above the fields — the URL hasn't changed, the page didn't flash, and any text you typed in Body is still there. That's the Turbo Frame swap.
 
-Now put the title back, paste 200 characters into it, and submit again. You'll see "Title is too long (maximum is 120 characters)" — same inline replacement, no full reload.
+Now put the title back, paste 200 characters into it, and submit again. You'll see "Title is the wrong length" — same inline replacement, no full reload. (You can override the default message by passing `message="Title is too long (maximum is 120 characters)"` to `validatesLengthOf` if you want the constraint number in the error.)
 
 Fix both fields and save. Redirect to `/posts/:id`, same as before. The failure path and success path diverge only in what the controller renders; the rest is Turbo doing its job.
 
@@ -221,7 +221,7 @@ wheels --version
 Three things to verify in the browser:
 
 1. Submitting the form with an empty Title shows "Title can't be empty" inline. No page flash, URL unchanged.
-2. Submitting with a 200-character Title shows "Title is too long (maximum is 120 characters)" inline. Same behavior.
+2. Submitting with a 200-character Title shows "Title is the wrong length" inline. Same behavior.
 3. A valid submission redirects to `/posts/:id` and displays the new post.
 
 ## Troubleshooting

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/05-comments-streams.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/05-comments-streams.mdx
@@ -346,7 +346,11 @@ Three things to verify in the browser:
 
 1. `/posts/1` renders the post, an empty `<section id="comments">`, and the comment form below it.
 2. Filling in the comment form and clicking "Post comment" causes a new comment `<article>` to appear inside the comments section. The URL doesn't change, the rest of the page doesn't flicker, and the form inputs clear.
-3. Clicking Delete on the post removes both the post and its comments — no stale `comments.postId` rows left behind.
+3. Clicking Delete on the post removes both the post and its comments — no stale `comments.postId` rows visible to your controller's `findAll()` queries.
+
+<Aside type="note" title="Soft-delete is on by default">
+`wheels generate model/scaffold` writes a `deletedAt` column on every table, so `post.delete()` actually stamps `deletedAt = now()` instead of issuing a `DELETE FROM`. The cascade does the same to `comments`. Wheels finders (`model("Post").findAll()`, `model("Comment").findAll()`) hide soft-deleted rows automatically — that's why item 3 above feels like a hard delete from the app's perspective. If you connect to the SQLite file with `sqlite3 db/development.sqlite` and run `SELECT * FROM posts`, you'll see the row is still there with `deletedAt` set. To include soft-deleted records in finder results, pass `includeSoftDeletes=true` (e.g. `findAll(includeSoftDeletes=true)`); to actually remove a row from the table, call `post.delete(softDelete=false)`.
+</Aside>
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Three corrections from the 2026-04-27 fresh-VM tutorial run — flagged as doc-only (no framework/CLI fix needed) but never tracked as issues. Bundling them into one PR since each is a few lines and they share scope (\`web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/\`).

This is a **trivia-tier change** — only \`.mdx\` files under \`web/sites/guides/\`, no executable code paths, no test changes.

## Findings addressed

### 11. CSRF on bare-curl POSTs (chapter 3 Checkpoint)

The journal user encountered \`Wheels.InvalidAuthenticityToken\` when trying to script a smoke-test \`curl POST\`. The browser-driven steps in the tutorial work fine because Turbo attaches the CSRF token automatically. Added an \`<Aside type=\"note\">\` clarifying that GETs work but write requests need a token, and pointing scripters at the \"scrape from a GET first\" workaround.

### 13. validation message wording (chapter 4 \"Try it\" + Checkpoint)

Tutorial promised \"Title is too long (maximum is 120 characters)\" but the framework's default \`validatesLengthOf\` message (per \`vendor/wheels/events/init/functions.cfm:720\`) is \`[property] is the wrong length\`. Updated both references to match reality, with a parenthetical showing how to override via the \`message=\` argument if a more specific error is wanted.

### 14. soft-delete is on by default (chapter 5 Checkpoint)

Tutorial claimed deleting a post \"removes both the post and its comments — no stale \`comments.postId\` rows left behind.\" That's true at the application layer (finders hide them) but misleading at the database layer — \`wheels generate model/scaffold\` writes a \`deletedAt\` column on every table, so \`post.delete()\` stamps \`deletedAt = now()\` instead of \`DELETE FROM\`. A reader running raw \`sqlite3\` queries sees the row is still there. Added an \`<Aside>\` explaining soft-delete is the default, with the \`findAll(includeSoftDeletes=true)\` and \`delete(softDelete=false)\` escape hatches verified against \`vendor/wheels/model/read.cfc\` and \`vendor/wheels/model/delete.cfc\`.

## Skipped from the journal

| Finding | Why not in this PR |
|---|---|
| 12 — Cloudflare email-protection mangles \`turbo@8.0.0\` URL | guides-site Cloudflare config, not a code change in this repo. The \`@\` in the source is correct; the issue is the rendered page on \`guides.wheels.dev\` having Email Obfuscation enabled at the Cloudflare dashboard level. |
| 16 — Java 21 keg-only doc note | Already addressed: \`installing.mdx\` line 22 mentions keg-only and links to the Troubleshooting section's JAVA_HOME snippet. |

## Test plan

- [x] All three Aside blocks use the existing \`<Aside type=\"note\" title=\"...\">\` convention. Both touched chapters already import \`Aside\` (verified at lines 9 of each MDX file).
- [x] No code/CLI changes — onboarding harness state remains at **44 pass / 0 fail / 1 skip / 45 total**.