### PR TITLE
feat(config): introduce BuildInfo.cfc as the runtime version source

### DIFF
--- a/cli/lucli/ARCHITECTURE.md
+++ b/cli/lucli/ARCHITECTURE.md
@@ -1,0 +1,103 @@
+# Wheels CLI Architecture
+
+How `wheels <command>` reaches our code, and where we can intercept.
+
+## The three layers
+
+```
+                      ┌──────────────────────────────────────┐
+  $ wheels new myapp  │  1.  Wrapper script  (ours)          │
+                      │      bash on macOS/Linux,            │
+                      │      .cmd on Windows                 │
+                      │      — module sync + JAVA_HOME +     │
+                      │        exec the LuCLI binary         │
+                      └──────────────┬───────────────────────┘
+                                     │  exec
+                      ┌──────────────▼───────────────────────┐
+                      │  2.  LuCLI binary  (upstream)        │
+                      │      installed under our name as     │
+                      │      `libexec/wheels`. picocli       │
+                      │      parses args, then routes to     │
+                      │      a module via                    │
+                      │      `modules run wheels …`          │
+                      └──────────────┬───────────────────────┘
+                                     │  executeModule
+                      ┌──────────────▼───────────────────────┐
+                      │  3.  cli/lucli/Module.cfc  (ours)    │
+                      │      one public function per         │
+                      │      subcommand: new(), start(),     │
+                      │      migrate(), test(), …            │
+                      └──────────────────────────────────────┘
+```
+
+## Layer 1 — the wrapper (ours)
+
+The Homebrew formula in [`wheels-dev/homebrew-wheels`](https://github.com/wheels-dev/homebrew-wheels) and the Chocolatey package in [`wheels-dev/chocolatey-wheels`](https://github.com/wheels-dev/chocolatey-wheels) each generate a small wrapper that:
+
+1. Stages the wheels module (`cli/lucli/`) into `~/.wheels/modules/wheels/` if `.module-version` has changed since last run.
+2. Stages the framework source (`vendor/wheels/`) into `~/.wheels/modules/wheels/vendor/wheels/`.
+3. Drops the SQLite JDBC driver into `~/.wheels/express/<version>/lib/ext/` (fresh-VM cliff fix; see commit `da9058f42`).
+4. Sets `JAVA_HOME` and `LUCLI_HOME=$HOME/.wheels`.
+5. **Intercepts arguments that picocli would short-circuit on** (see "Why intercept here" below).
+6. `exec`s `libexec/wheels` (the renamed LuCLI native binary).
+
+## Layer 2 — LuCLI binary (upstream)
+
+The brew formula downloads `lucli-<version>-<os>` from [`cybersonic/LuCLI`](https://github.com/cybersonic/LuCLI/releases) and installs it as `libexec/wheels`. **We do not patch this binary.** It is upstream LuCLI, byte-for-byte, just renamed.
+
+LuCLI's startup flow when invoked as `wheels`:
+
+1. Reads `-Dlucli.binary.name` (set by the wrapper), normalises to `wheels`.
+2. `CliProfile.forBinaryName("wheels")` returns a `WheelsProfile` — controls branding (`Wheels` display name, `~/.wheels` home dir, ASCII banner).
+3. `prependBinaryNameIfAliased` rewrites `args` so the binary name becomes the first positional argument: `wheels new myapp` → `["wheels", "new", "myapp"]`.
+4. picocli parses. If the first positional is a module name and `--help` is present, `preprocessModuleHelp` rewrites again to `["modules", "run", "wheels", "--help"]` so picocli routes to `ModulesRunCommandImpl`.
+5. Otherwise picocli's `routeCommand(firstArg, …)` checks `ModuleCommand.moduleExists("wheels")` and dispatches via `LuceeScriptEngine.executeModule("wheels", subcommand_args)`.
+
+## Layer 3 — `Module.cfc` (ours)
+
+LuCLI's module dispatcher (`script_engine/executeModule.cfs`) does:
+
+```cfml
+modules = createObject("component", "modules.wheels.Module").init(...);
+results = modules[subcommand](argumentCollection=argCollection);
+// any non-null string return value is printed via StringOutput
+```
+
+So `wheels new myapp` becomes `modules.new("myapp")`. Each public function in [`Module.cfc`](Module.cfc) is a subcommand. Functions inherited from `BaseModule` (`init`, `version`, `showHelp`, `out`, `err`, `getEnv`, …) are excluded from auto-discovered help listing but are still callable.
+
+## Where we can intercept
+
+| Layer | Use it for | Cannot reach |
+|-------|------------|--------------|
+| **Wrapper** | Anything picocli would short-circuit on (`--version`, `--help`), or anything that needs to skip JVM startup for speed | n/a — wrapper sees raw args before LuCLI does |
+| **LuCLI binary** | Untouchable per project policy (we don't patch upstream) | n/a |
+| **`Module.cfc`** | Any subcommand that reaches `routeCommand` → module dispatch: `new`, `start`, `migrate`, `test`, `generate`, … Includes `wheels --help` (rewritten by `preprocessModuleHelp` to module dispatch) | picocli's root-level absorbed flags: `--version`, `--lucee-version`, `--verbose`, `--debug`, `--timing` |
+
+### Why intercept in the wrapper
+
+picocli treats `@Option(versionHelp = true)` and `@Option(usageHelp = true)` flags specially: it processes them **during argument parsing**, before the `call()` method runs. So `wheels --version` never reaches our module dispatch — picocli prints LuCLI's banner and exits. The same is true for `--help` if it appears alone (no positional first arg to trigger `preprocessModuleHelp`'s rewrite).
+
+The wrapper is the only place upstream of picocli that we own. A short pattern-match on `$@` lets us emit our own banner / help and `exit 0` before `exec`ing LuCLI.
+
+### Why duplicate `--help` and `--version` in `Module.cfc` too
+
+When the user types `wheels version` or `wheels help` (subcommand form, no leading `--`), the wrapper does not match — those reach LuCLI normally and dispatch to our module. So we override `version()` and `showHelp()` in `Module.cfc` to emit the same content the wrapper does. Both paths converge on identical output.
+
+## Examples
+
+| User types | Path |
+|------------|------|
+| `wheels new myapp` | wrapper sync → LuCLI → `Module.new("myapp")` |
+| `wheels start` | wrapper sync → LuCLI → `Module.start()` (which calls back into LuCLI's Java server APIs via `executeInProcess(["server", "run"])`) |
+| `wheels --version` | wrapper intercept → exit (never reaches LuCLI) |
+| `wheels version` | wrapper sync → LuCLI → `Module.version()` (overridden to emit banner) |
+| `wheels --help` | wrapper intercept → exit (never reaches LuCLI) |
+| `wheels help` | wrapper sync → LuCLI → `Module.showHelp()` (overridden) |
+| `wheels generate model User` | wrapper sync → LuCLI → `Module.generate("model", "User")` |
+| `wheels migrate latest --help` | wrapper sync → LuCLI → `preprocessModuleHelp` rewrites → `Module.showHelp("migrate")` |
+
+## Testing the layers in isolation
+
+- **Just the wrapper:** edit `bin/wheels` (brew) or `tools/wheels.cmd` (choco), run any command. The wrapper is plain shell — `bash -x bin/wheels --version` traces it.
+- **Just LuCLI routing:** invoke the binary directly: `~/.wheels/libexec/wheels modules run wheels migrate latest`. This skips the wrapper but still goes through picocli + module dispatch.
+- **Just `Module.cfc`:** unit tests in [`cli/lucli/tests/specs/`](tests/specs/) instantiate the module and invoke functions directly without LuCLI.

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -120,6 +120,82 @@ component extends="modules.BaseModule" {
 	}
 
 	// ─────────────────────────────────────────────────
+	//  version / help — banner + command listing
+	// ─────────────────────────────────────────────────
+
+	// Produces the same output the brew/choco wrapper emits for `wheels --version`,
+	// so `wheels version` (no leading dashes) reaches the same banner via module
+	// dispatch. See cli/lucli/ARCHITECTURE.md for the two paths.
+	//
+	// Internal callers that want the bare version string use super.version() to
+	// bypass the banner formatting.
+	/**
+	 * hint: Show Wheels CLI version and banner
+	 */
+	public string function version() {
+		var v = super.version();
+		var nl = chr(10);
+		var banner = "Wheels Version: " & v & nl & nl;
+		banner &= " __        ___               _     " & nl;
+		banner &= " \ \      / / |__   ___  ___| |___ " & nl;
+		banner &= "  \ \ /\ / /| '_ \ / _ \/ _ \ / __|" & nl;
+		banner &= "   \ V  V / | | | |  __/  __/ \__ \" & nl;
+		banner &= "    \_/\_/  |_| |_|\___|\___|_|___/" & nl & nl;
+		banner &= "https://wheels.dev";
+		return banner;
+	}
+
+	// Hand-written replacement for BaseModule's auto-discovered help. Grouped by
+	// task instead of alphabetical, mirrors what `wheels --help` emits from the
+	// wrapper. `wheels help` and `wheels --help` (rewritten by LuCLI's
+	// preprocessModuleHelp) both reach this.
+	/**
+	 * hint: Show this help
+	 */
+	public string function showHelp() {
+		var v = super.version();
+		var nl = chr(10);
+		var help = "Wheels CLI " & v & nl;
+		help &= "  CFML MVC framework — code generation, migrations, testing, server management" & nl & nl;
+		help &= "Usage:" & nl;
+		help &= "  wheels <command> [options]" & nl & nl;
+		help &= "Getting Started:" & nl;
+		help &= "  new <name>          Scaffold a new Wheels application" & nl;
+		help &= "  start               Start the dev server" & nl;
+		help &= "  stop                Stop the dev server" & nl;
+		help &= "  reload              Reload the running app" & nl & nl;
+		help &= "Code Generation:" & nl;
+		help &= "  generate            Generate model, controller, scaffold, migration, etc." & nl;
+		help &= "  destroy (or d)      Remove generated files" & nl & nl;
+		help &= "Database:" & nl;
+		help &= "  migrate             Run database migrations (latest, up, down, info)" & nl;
+		help &= "  seed                Run database seeds" & nl;
+		help &= "  db                  Database management (reset, status, version)" & nl & nl;
+		help &= "Testing & Inspection:" & nl;
+		help &= "  test                Run the test suite" & nl;
+		help &= "  browser             Browser-based tests (Playwright)" & nl;
+		help &= "  console             Open an interactive CFML REPL connected to your app" & nl;
+		help &= "  routes              Print the route table" & nl;
+		help &= "  info                Show framework version, environment, configuration" & nl;
+		help &= "  doctor              Diagnose project setup issues" & nl;
+		help &= "  validate            Validate project structure and configuration" & nl;
+		help &= "  analyze             Static analysis of project code" & nl;
+		help &= "  stats               Project statistics (lines of code, model counts, etc.)" & nl;
+		help &= "  notes               Find TODO / FIXME / HACK / OPTIMIZE comments" & nl & nl;
+		help &= "Packages & Deployment:" & nl;
+		help &= "  packages            Install, update, search Wheels packages" & nl;
+		help &= "  upgrade             Upgrade the Wheels framework version in your project" & nl;
+		help &= "  deploy              Deploy your app (Kamal-compatible)" & nl & nl;
+		help &= "Other:" & nl;
+		help &= "  mcp                 Configure Wheels MCP server for AI assistants" & nl;
+		help &= "  version             Show Wheels CLI version" & nl;
+		help &= "  help                Show this help" & nl & nl;
+		help &= "For command-specific help: wheels <command> --help" & nl & nl;
+		help &= "More info: https://guides.wheels.dev";
+		return help;
+	}
+
+	// ─────────────────────────────────────────────────
 	//  generate — Code generation
 	// ─────────────────────────────────────────────────
 
@@ -626,7 +702,7 @@ component extends="modules.BaseModule" {
 	 * hint: Show framework version, environment, and configuration
 	 */
 	public string function info() {
-		out("Wheels CLI v#version()#", "bold");
+		out("Wheels CLI v#super.version()#", "bold");
 		out("");
 
 		if (len(variables.projectRoot) && directoryExists(variables.projectRoot & "/vendor/wheels")) {
@@ -789,7 +865,7 @@ component extends="modules.BaseModule" {
 
 		// Banner
 		out("", "");
-		out("Wheels Console v#version()#", "bold");
+		out("Wheels Console v#super.version()#", "bold");
 		out("Connected to localhost:#serverPort# (#wheelsEnv#) — Wheels #wheelsVersion#", "cyan");
 		out("Type expressions to evaluate in your app context. /help for commands.", "");
 		out("", "");
@@ -3711,7 +3787,7 @@ component extends="modules.BaseModule" {
 		new services.FrameworkInstaller().rewriteVersionPlaceholder(
 			wheelsSource = wheelsSource,
 			vendorDir = vendorDir,
-			cliVersion = version()
+			cliVersion = super.version()
 		);
 		printCreated(appName & "/vendor/wheels/");
 	}

--- a/tools/build/scripts/prepare-core.sh
+++ b/tools/build/scripts/prepare-core.sh
@@ -75,5 +75,38 @@ else
     done
 fi
 
+# Replace BuildInfo metadata placeholders. BuildInfo.cfc reads these at app
+# start to surface rich diagnostics (commit sha, run url, etc.) on the dev
+# toolbar and `wheels info`. Values come from git in the source checkout —
+# release.yml passes empty strings via env when not running on a tagged build,
+# in which case BuildInfo.cfc blanks the field at runtime. Use | as the sed
+# delimiter for fields that may contain / (URLs) or : (timestamps, refs).
+COMMIT_SHA=$(git rev-parse HEAD 2>/dev/null || echo "")
+COMMIT_SHORT=$(git rev-parse --short=7 HEAD 2>/dev/null || echo "")
+COMMIT_SUBJECT=$(git log -1 --pretty=%s 2>/dev/null | tr -d '|' || echo "")
+BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+# Run context comes from the GitHub Actions environment. Locally these are
+# empty and the placeholders stay unsubstituted, which BuildInfo blanks out.
+RUN_ID="${GITHUB_RUN_ID:-}"
+REPOSITORY="${GITHUB_REPOSITORY:-}"
+RUN_URL=""
+if [ -n "${RUN_ID}" ] && [ -n "${REPOSITORY}" ]; then
+    RUN_URL="https://github.com/${REPOSITORY}/actions/runs/${RUN_ID}"
+fi
+
+find "${BUILD_DIR}/wheels" -type f \( -name "*.json" -o -name "*.md" -o -name "*.cfm" -o -name "*.cfc" \) | while read file; do
+    sed -i.bak \
+        -e "s|@build\.number@|${BUILD_NUMBER}|g" \
+        -e "s|@build\.branch@|${BRANCH}|g" \
+        -e "s|@build\.commit@|${COMMIT_SHA}|g" \
+        -e "s|@build\.commitShort@|${COMMIT_SHORT}|g" \
+        -e "s|@build\.commitSubject@|${COMMIT_SUBJECT}|g" \
+        -e "s|@build\.timestamp@|${BUILT_AT}|g" \
+        -e "s|@build\.runId@|${RUN_ID}|g" \
+        -e "s|@build\.runUrl@|${RUN_URL}|g" \
+        -e "s|@build\.repository@|${REPOSITORY}|g" \
+        "$file" && rm "${file}.bak"
+done
+
 echo "Wheels Core prepared for ForgeBox publishing!"
 echo "Directory: ${BUILD_DIR}/wheels/"

--- a/vendor/wheels/BuildInfo.cfc
+++ b/vendor/wheels/BuildInfo.cfc
@@ -1,0 +1,79 @@
+/**
+ * Authoritative source of the running framework's version and build metadata.
+ *
+ * The release pipeline (.github/workflows/release.yml +
+ * tools/build/scripts/prepare-core.sh) sed-substitutes every `@build.*@`
+ * placeholder below at artifact-construction time. Released builds carry
+ * concrete values; dev checkouts ship the unresolved placeholders, which
+ * `version()` reports as the `0.0.0-dev` sentinel and the other getters
+ * blank out.
+ *
+ * This component replaces the historical pattern of reading the framework
+ * version from `vendor/wheels/box.json`. box.json remains for the engine-db
+ * matrix tooling but is no longer the runtime version source.
+ *
+ * Cached once per app on `application.$wheels.buildInfo` by
+ * onapplicationstart.cfc — values cannot change without a full app restart.
+ *
+ * Tests pass an `overrides` struct to inject fake values without touching
+ * the placeholder strings.
+ */
+component {
+
+	public function init(struct overrides = {}) {
+		variables.info = {
+			version:        "@build.version@",
+			buildNumber:    "@build.number@",
+			branch:         "@build.branch@",
+			commitSha:      "@build.commit@",
+			commitShortSha: "@build.commitShort@",
+			commitSubject:  "@build.commitSubject@",
+			builtAt:        "@build.timestamp@",
+			runId:          "@build.runId@",
+			runUrl:         "@build.runUrl@",
+			repository:     "@build.repository@"
+		};
+		for (var key in arguments.overrides) {
+			variables.info[key] = arguments.overrides[key];
+		}
+		return this;
+	}
+
+	public string function version() {
+		return isDev() ? "0.0.0-dev" : variables.info.version;
+	}
+
+	public boolean function isDev() {
+		return variables.info.version == "@build.version@";
+	}
+
+	public boolean function isSnapshot() {
+		return !isDev() && findNoCase("SNAPSHOT", variables.info.version) > 0;
+	}
+
+	public string function buildNumber()    { return $blankIfPlaceholder(variables.info.buildNumber); }
+	public string function branch()         { return $blankIfPlaceholder(variables.info.branch); }
+	public string function commitSha()      { return $blankIfPlaceholder(variables.info.commitSha); }
+	public string function commitShortSha() { return $blankIfPlaceholder(variables.info.commitShortSha); }
+	public string function commitSubject()  { return $blankIfPlaceholder(variables.info.commitSubject); }
+	public string function builtAt()        { return $blankIfPlaceholder(variables.info.builtAt); }
+	public string function runId()          { return $blankIfPlaceholder(variables.info.runId); }
+	public string function runUrl()         { return $blankIfPlaceholder(variables.info.runUrl); }
+	public string function repository()     { return $blankIfPlaceholder(variables.info.repository); }
+
+	// Snapshot copy with all placeholders normalised. Useful for `wheels info`
+	// and the dev toolbar; safe to serialize to JSON.
+	public struct function asStruct() {
+		var rv = duplicate(variables.info);
+		for (var key in rv) {
+			rv[key] = $blankIfPlaceholder(rv[key]);
+		}
+		rv.version = version();
+		return rv;
+	}
+
+	private string function $blankIfPlaceholder(required string value) {
+		return (left(arguments.value, 7) == "@build." && right(arguments.value, 1) == "@") ? "" : arguments.value;
+	}
+
+}

--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -2753,75 +2753,15 @@ return local.$wheels;
 		return local.rv;
 	}
 
-	public string function $readFrameworkVersion(string boxJsonPath = "", string rootBoxJsonPath = "") {
-		local.path = Len(arguments.boxJsonPath)
-			? arguments.boxJsonPath
-			: GetDirectoryFromPath(GetCurrentTemplatePath()) & "box.json";
-		if (!FileExists(local.path)) {
-			Throw(
-				type = "Wheels.VersionReadFailed",
-				message = "Framework box.json not found at #local.path#.",
-				extendedInfo = "This file is expected to ship with the framework. A distributed copy of Wheels should always contain it."
-			);
-		}
-		try {
-			local.contents = FileRead(local.path);
-			local.box = DeserializeJSON(local.contents);
-		} catch (any e) {
-			Throw(
-				type = "Wheels.VersionReadFailed",
-				message = "Framework box.json at #local.path# could not be parsed as JSON.",
-				extendedInfo = e.message
-			);
-		}
-		if (!IsStruct(local.box) || !StructKeyExists(local.box, "version") || !Len(local.box.version)) {
-			Throw(
-				type = "Wheels.VersionReadFailed",
-				message = "Framework box.json at #local.path# is missing a non-empty 'version' key.",
-				extendedInfo = "The release build pipeline substitutes @build.version@; a dev checkout should still define the key with the placeholder."
-			);
-		}
-		if (local.box.version == "@build.version@") {
-			// The framework's own box.json was shipped with the placeholder
-			// unsubstituted (dev checkout, or release-pipeline gap). Try, in
-			// order: (1) the enclosing repo's root box.json — for a wheels-dev/
-			// wheels monorepo dev checkout, that resolves to a `<rootversion>-dev`
-			// version reflecting the upcoming release; (2) the app's own box.json
-			// — for an installed app scaffolded from `wheels-base-template`, that
-			// box.json carries the precise framework SNAPSHOT version stamped in
-			// at release time, so we use it verbatim. Without this second probe,
-			// the runtime returns a misleading "0.0.0-dev" on installed apps when
-			// the framework's box.json substitution slipped through (see GH #2326).
-			local.rootPath = Len(arguments.rootBoxJsonPath)
-				? arguments.rootBoxJsonPath
-				: GetDirectoryFromPath(GetCurrentTemplatePath()) & "../../box.json";
-			try {
-				if (FileExists(local.rootPath)) {
-					local.rootBox = DeserializeJSON(FileRead(local.rootPath));
-					if (IsStruct(local.rootBox) && StructKeyExists(local.rootBox, "version") && Len(local.rootBox.version) && local.rootBox.version != "@build.version@") {
-						local.isWheelsRepo = (StructKeyExists(local.rootBox, "slug") && local.rootBox.slug == "wheels")
-							|| (StructKeyExists(local.rootBox, "name") && local.rootBox.name == "Wheels.fw");
-						if (local.isWheelsRepo) {
-							return local.rootBox.version & "-dev";
-						}
-						// 2. Installed app: the parent's box.json is the user's
-						//    scaffolded app.box.json, which `wheels-base-template`
-						//    fills with the precise framework version at release
-						//    time. Recognize the template by slug so we don't pick
-						//    up a hand-rolled box.json with an unrelated version.
-						local.isBaseTemplate = (StructKeyExists(local.rootBox, "slug") && local.rootBox.slug == "wheels-base-template")
-							|| (StructKeyExists(local.rootBox, "name") && local.rootBox.name == "Wheels Base Template");
-						if (local.isBaseTemplate) {
-							return local.rootBox.version;
-						}
-					}
-				}
-			} catch (any e) {
-				// fall through to the plain dev sentinel
-			}
-			return "0.0.0-dev";
-		}
-		return local.box.version;
+	// Returns the running framework version. Delegates to BuildInfo.cfc, which
+	// is the authoritative version source. The historical box.json-reading
+	// implementation (with monorepo / wheels-base-template fallback chain)
+	// was retired when BuildInfo became the source of truth — see the BuildInfo
+	// header for migration context. Kept as a thin wrapper because callers
+	// upstream of onapplicationstart (e.g. PackageLoader, Plugins) and tests
+	// reference $readFrameworkVersion by name.
+	public string function $readFrameworkVersion() {
+		return new wheels.BuildInfo().version();
 	}
 
 	public string function $checkMinimumVersion(required string engine, required string version) {

--- a/vendor/wheels/PackageLoader.cfc
+++ b/vendor/wheels/PackageLoader.cfc
@@ -708,12 +708,17 @@ component output="false" {
 
 	/**
 	 * Returns the runtime Wheels version normalised for semver comparison.
-	 * Dev builds ship the unresolved "@build.version@" token — treat as 0.0.0
-	 * so strict constraints don't falsely reject packages during development.
+	 * Dev builds surface as "0.0.0-dev" via BuildInfo. The legacy
+	 * "@build.version@" check is kept as a defensive guard for any path that
+	 * still feeds the raw placeholder in. Both normalise to "0.0.0" so strict
+	 * version constraints don't falsely reject packages during development.
 	 */
 	private string function $normalizeWheelsVersion() {
 		local.raw = SpanExcluding(variables.wheelsVersion, " ");
-		return (local.raw == "@build.version@") ? "0.0.0" : local.raw;
+		if (local.raw == "@build.version@" || local.raw == "0.0.0-dev") {
+			return "0.0.0";
+		}
+		return local.raw;
 	}
 
 	/**

--- a/vendor/wheels/Plugins.cfc
+++ b/vendor/wheels/Plugins.cfc
@@ -906,12 +906,17 @@ component output="false" extends="wheels.Global"{
 
 	/**
 	 * Returns the Wheels version string normalised for comparison.
-	 * Dev builds stamp "@build.version@" which isn't a valid semver —
-	 * treat it as 0.0.0 so compatibility checks always pass.
+	 * Dev builds surface as "0.0.0-dev" via BuildInfo. The legacy
+	 * "@build.version@" check is kept as a defensive guard for any path that
+	 * still feeds the raw placeholder in. Both normalise to "0.0.0" so plugin
+	 * compatibility checks always pass during development.
 	 */
 	private string function $normalizeWheelsVersion() {
 		local.raw = SpanExcluding(variables.$class.wheelsVersion, " ");
-		return (local.raw == "@build.version@") ? "0.0.0" : local.raw;
+		if (local.raw == "@build.version@" || local.raw == "0.0.0-dev") {
+			return "0.0.0";
+		}
+		return local.raw;
 	}
 
 	/**

--- a/vendor/wheels/events/onapplicationstart.cfc
+++ b/vendor/wheels/events/onapplicationstart.cfc
@@ -81,7 +81,10 @@ component {
 		request.cgi = application.wo.$cgiScope();
 
 		// Set up containers for routes, caches, settings etc.
-		application.$wheels.version = application.wo.$readFrameworkVersion();
+		// BuildInfo is the authoritative source for version + build metadata.
+		// Cached on the app scope; values cannot change without a full restart.
+		application.$wheels.buildInfo = new wheels.BuildInfo();
+		application.$wheels.version = application.$wheels.buildInfo.version();
 		try {
 			application.$wheels.hostName = CreateObject("java", "java.net.InetAddress").getLocalHost().getHostName();
 		} catch (any e) {

--- a/vendor/wheels/tests/specs/buildInfoSpec.cfc
+++ b/vendor/wheels/tests/specs/buildInfoSpec.cfc
@@ -1,0 +1,120 @@
+component extends="wheels.WheelsTest" {
+
+	// Unit tests for vendor/wheels/BuildInfo.cfc. Construction with overrides
+	// avoids touching the placeholder strings literally — production builds
+	// rely on the release pipeline's sed substitution.
+
+	function run() {
+
+		describe("BuildInfo", () => {
+
+			describe("version()", () => {
+
+				it("returns the substituted version string verbatim", () => {
+					var bi = new wheels.BuildInfo({version: "4.0.0-SNAPSHOT+1628"});
+					expect(bi.version()).toBe("4.0.0-SNAPSHOT+1628");
+				});
+
+				it("returns 0.0.0-dev when the version placeholder is unsubstituted", () => {
+					// Constructed with no overrides: every field stays as @build.*@.
+					var bi = new wheels.BuildInfo();
+					expect(bi.version()).toBe("0.0.0-dev");
+				});
+
+				it("returns 0.0.0-dev when version is explicitly the unsubstituted placeholder", () => {
+					var bi = new wheels.BuildInfo({version: "@build.version@"});
+					expect(bi.version()).toBe("0.0.0-dev");
+				});
+
+			});
+
+			describe("isDev() / isSnapshot()", () => {
+
+				it("isDev() is true when version is the unsubstituted placeholder", () => {
+					expect(new wheels.BuildInfo().isDev()).toBeTrue();
+				});
+
+				it("isDev() is false for any concrete version", () => {
+					expect(new wheels.BuildInfo({version: "4.0.0"}).isDev()).toBeFalse();
+					expect(new wheels.BuildInfo({version: "4.0.0-SNAPSHOT+1628"}).isDev()).toBeFalse();
+				});
+
+				it("isSnapshot() is true for SNAPSHOT versions", () => {
+					expect(new wheels.BuildInfo({version: "4.0.0-SNAPSHOT+1628"}).isSnapshot()).toBeTrue();
+				});
+
+				it("isSnapshot() is false for release versions and dev builds", () => {
+					expect(new wheels.BuildInfo({version: "4.0.0"}).isSnapshot()).toBeFalse();
+					expect(new wheels.BuildInfo().isSnapshot()).toBeFalse();
+				});
+
+			});
+
+			describe("metadata getters", () => {
+
+				it("returns substituted values verbatim", () => {
+					var bi = new wheels.BuildInfo({
+						version: "4.0.0-SNAPSHOT+1628",
+						buildNumber: "1628",
+						branch: "develop",
+						commitSha: "81e9f7958d3abc",
+						commitShortSha: "81e9f79",
+						commitSubject: "fix(cli): override version() and showHelp()",
+						builtAt: "2026-04-28T19:11:00Z",
+						runId: "25072250128",
+						runUrl: "https://github.com/wheels-dev/wheels/actions/runs/25072250128",
+						repository: "wheels-dev/wheels"
+					});
+					expect(bi.buildNumber()).toBe("1628");
+					expect(bi.branch()).toBe("develop");
+					expect(bi.commitSha()).toBe("81e9f7958d3abc");
+					expect(bi.commitShortSha()).toBe("81e9f79");
+					expect(bi.commitSubject()).toBe("fix(cli): override version() and showHelp()");
+					expect(bi.builtAt()).toBe("2026-04-28T19:11:00Z");
+					expect(bi.runId()).toBe("25072250128");
+					expect(bi.runUrl()).toBe("https://github.com/wheels-dev/wheels/actions/runs/25072250128");
+					expect(bi.repository()).toBe("wheels-dev/wheels");
+				});
+
+				it("blanks out unresolved placeholders to empty strings", () => {
+					var bi = new wheels.BuildInfo();
+					expect(bi.buildNumber()).toBe("");
+					expect(bi.branch()).toBe("");
+					expect(bi.commitSha()).toBe("");
+					expect(bi.commitShortSha()).toBe("");
+					expect(bi.commitSubject()).toBe("");
+					expect(bi.builtAt()).toBe("");
+					expect(bi.runId()).toBe("");
+					expect(bi.runUrl()).toBe("");
+					expect(bi.repository()).toBe("");
+				});
+
+			});
+
+			describe("asStruct()", () => {
+
+				it("returns all fields with the dev sentinel applied to version", () => {
+					var s = new wheels.BuildInfo().asStruct();
+					expect(s.version).toBe("0.0.0-dev");
+					expect(s.buildNumber).toBe("");
+					expect(s.branch).toBe("");
+				});
+
+				it("returns substituted values verbatim", () => {
+					var s = new wheels.BuildInfo({
+						version: "4.0.0",
+						buildNumber: "1628",
+						branch: "master"
+					}).asStruct();
+					expect(s.version).toBe("4.0.0");
+					expect(s.buildNumber).toBe("1628");
+					expect(s.branch).toBe("master");
+				});
+
+			});
+
+		});
+
+	}
+
+}

--- a/vendor/wheels/tests/specs/events/frameworkVersionSpec.cfc
+++ b/vendor/wheels/tests/specs/events/frameworkVersionSpec.cfc
@@ -1,5 +1,10 @@
 component extends="wheels.WheelsTest" {
 
+	// Boot-time integration tests for application.wheels.version. The version
+	// resolution logic itself lives in BuildInfo.cfc and is exercised in
+	// services/BuildInfoSpec.cfc — these tests assert the integration with
+	// onapplicationstart and the legacy $readFrameworkVersion delegate.
+
 	function run() {
 
 		g = application.wo;
@@ -15,196 +20,14 @@ component extends="wheels.WheelsTest" {
 				expect(application.wheels.version).notToBe("@build.version@");
 			});
 
-			it("$readFrameworkVersion reads the version key from a box.json file", () => {
-				var tmp = getTempDirectory() & "wheels-version-#CreateUUID()#.json";
-				fileWrite(tmp, '{"version":"4.1.2"}');
-				try {
-					expect(g.$readFrameworkVersion(tmp)).toBe("4.1.2");
-				} finally {
-					fileDelete(tmp);
-				}
+			it("caches a BuildInfo instance on application.$wheels.buildInfo at boot", () => {
+				expect(StructKeyExists(application.$wheels, "buildInfo")).toBeTrue();
+				expect(IsObject(application.$wheels.buildInfo)).toBeTrue();
+				expect(application.$wheels.buildInfo.version()).toBe(application.wheels.version);
 			});
 
-			it("$readFrameworkVersion substitutes a dev sentinel when version is the unreplaced build placeholder", () => {
-				var tmp = getTempDirectory() & "wheels-version-#CreateUUID()#.json";
-				fileWrite(tmp, '{"version":"@build.version@"}');
-				try {
-					expect(g.$readFrameworkVersion(tmp)).toBe("0.0.0-dev");
-				} finally {
-					fileDelete(tmp);
-				}
-			});
-
-			it("$readFrameworkVersion synthesizes <rootversion>-dev when placeholder is detected inside the wheels monorepo", () => {
-				var fwTmp = getTempDirectory() & "wheels-version-fw-#CreateUUID()#.json";
-				var rootTmp = getTempDirectory() & "wheels-version-root-#CreateUUID()#.json";
-				fileWrite(fwTmp, '{"version":"@build.version@"}');
-				fileWrite(rootTmp, '{"name":"Wheels.fw","slug":"wheels","version":"4.0.0"}');
-				try {
-					expect(g.$readFrameworkVersion(fwTmp, rootTmp)).toBe("4.0.0-dev");
-				} finally {
-					fileDelete(fwTmp);
-					fileDelete(rootTmp);
-				}
-			});
-
-			it("$readFrameworkVersion falls back to 0.0.0-dev when the enclosing box.json is not the wheels monorepo (vendored install)", () => {
-				var fwTmp = getTempDirectory() & "wheels-version-fw-#CreateUUID()#.json";
-				var rootTmp = getTempDirectory() & "wheels-version-root-#CreateUUID()#.json";
-				fileWrite(fwTmp, '{"version":"@build.version@"}');
-				fileWrite(rootTmp, '{"name":"SomeUserApp","slug":"user-app","version":"2.1.0"}');
-				try {
-					expect(g.$readFrameworkVersion(fwTmp, rootTmp)).toBe("0.0.0-dev");
-				} finally {
-					fileDelete(fwTmp);
-					fileDelete(rootTmp);
-				}
-			});
-
-			it("$readFrameworkVersion uses wheels-base-template's version verbatim when the framework's own box.json placeholder slipped through (##2326)", () => {
-				// Installed-app path: the user's `wheels new`-scaffolded app has a
-				// box.json at the app root populated from `wheels-base-template`
-				// (slug=wheels-base-template), and that box.json carries the
-				// precise framework SNAPSHOT version stamped at release time. If
-				// the framework's own box.json substitution slipped through, we
-				// still surface the correct version instead of "0.0.0-dev".
-				var fwTmp = getTempDirectory() & "wheels-version-fw-#CreateUUID()#.json";
-				var rootTmp = getTempDirectory() & "wheels-version-root-#CreateUUID()#.json";
-				fileWrite(fwTmp, '{"version":"@build.version@"}');
-				fileWrite(rootTmp, '{"name":"Wheels Base Template","slug":"wheels-base-template","version":"4.0.0-SNAPSHOT+1625"}');
-				try {
-					expect(g.$readFrameworkVersion(fwTmp, rootTmp)).toBe("4.0.0-SNAPSHOT+1625");
-				} finally {
-					fileDelete(fwTmp);
-					fileDelete(rootTmp);
-				}
-			});
-
-			it("$readFrameworkVersion ignores wheels-base-template when its own version is also the unreplaced placeholder (##2326)", () => {
-				var fwTmp = getTempDirectory() & "wheels-version-fw-#CreateUUID()#.json";
-				var rootTmp = getTempDirectory() & "wheels-version-root-#CreateUUID()#.json";
-				fileWrite(fwTmp, '{"version":"@build.version@"}');
-				fileWrite(rootTmp, '{"name":"Wheels Base Template","slug":"wheels-base-template","version":"@build.version@"}');
-				try {
-					expect(g.$readFrameworkVersion(fwTmp, rootTmp)).toBe("0.0.0-dev");
-				} finally {
-					fileDelete(fwTmp);
-					fileDelete(rootTmp);
-				}
-			});
-
-			it("$readFrameworkVersion prefers the monorepo signal over the base-template signal when both could match (##2326)", () => {
-				// Defensive: if both the monorepo and base-template markers somehow
-				// coexist at the same path, the monorepo signal (a dev checkout)
-				// is the authoritative one and the suffix should be "-dev".
-				var fwTmp = getTempDirectory() & "wheels-version-fw-#CreateUUID()#.json";
-				var rootTmp = getTempDirectory() & "wheels-version-root-#CreateUUID()#.json";
-				fileWrite(fwTmp, '{"version":"@build.version@"}');
-				fileWrite(rootTmp, '{"name":"Wheels.fw","slug":"wheels","version":"4.0.0"}');
-				try {
-					expect(g.$readFrameworkVersion(fwTmp, rootTmp)).toBe("4.0.0-dev");
-				} finally {
-					fileDelete(fwTmp);
-					fileDelete(rootTmp);
-				}
-			});
-
-			it("$readFrameworkVersion falls back to 0.0.0-dev when the enclosing box.json is also unreplaced", () => {
-				var fwTmp = getTempDirectory() & "wheels-version-fw-#CreateUUID()#.json";
-				var rootTmp = getTempDirectory() & "wheels-version-root-#CreateUUID()#.json";
-				fileWrite(fwTmp, '{"version":"@build.version@"}');
-				fileWrite(rootTmp, '{"name":"Wheels.fw","slug":"wheels","version":"@build.version@"}');
-				try {
-					expect(g.$readFrameworkVersion(fwTmp, rootTmp)).toBe("0.0.0-dev");
-				} finally {
-					fileDelete(fwTmp);
-					fileDelete(rootTmp);
-				}
-			});
-
-			it("$readFrameworkVersion falls back to 0.0.0-dev when the enclosing box.json is missing", () => {
-				var fwTmp = getTempDirectory() & "wheels-version-fw-#CreateUUID()#.json";
-				var missingRoot = getTempDirectory() & "wheels-version-missing-#CreateUUID()#.json";
-				fileWrite(fwTmp, '{"version":"@build.version@"}');
-				try {
-					expect(g.$readFrameworkVersion(fwTmp, missingRoot)).toBe("0.0.0-dev");
-				} finally {
-					fileDelete(fwTmp);
-				}
-			});
-
-			it("application.wheels.version resolves to <rootversion>-dev at boot in a monorepo dev checkout (regression for ##2291)", () => {
-				// Regression for ##2291. Asserts the *runtime boot* result — not a direct
-				// call — because $readFrameworkVersion is bound into the spec's scope by
-				// WheelsTest.cfc, which shifts GetCurrentTemplatePath() to this file and
-				// bypasses the code path we want to cover. application.wheels.version is
-				// populated by onapplicationstart.cfc calling $readFrameworkVersion() with
-				// no arguments, so whatever it resolved to is the answer we need to check.
-				//
-				// With the bug (one-level "../box.json"): default rootBoxJsonPath points at
-				// vendor/box.json, which does not exist, so the helper falls through to
-				// "0.0.0-dev" even in a monorepo checkout.
-				// With the fix (two-level "../../box.json"): default rootBoxJsonPath points
-				// at <repo-root>/box.json and yields "<rootversion>-dev".
-				var wheelsDir = ExpandPath("/wheels/");
-				var fwBoxPath = wheelsDir & "box.json";
-				var rootBoxPath = wheelsDir & "../../box.json";
-				if (!FileExists(fwBoxPath) || !FileExists(rootBoxPath)) {
-					return;
-				}
-				var fwBox = DeserializeJSON(FileRead(fwBoxPath));
-				var rootBox = DeserializeJSON(FileRead(rootBoxPath));
-				if (!IsStruct(fwBox) || (fwBox.version ?: "") != "@build.version@") {
-					return;
-				}
-				var isWheelsRepo = IsStruct(rootBox)
-					&& (
-						((rootBox.slug ?: "") == "wheels")
-						|| ((rootBox.name ?: "") == "Wheels.fw")
-					);
-				if (!isWheelsRepo || (rootBox.version ?: "") == "" || rootBox.version == "@build.version@") {
-					return;
-				}
-				expect(application.wheels.version).toBe(rootBox.version & "-dev");
-			});
-
-			it("$readFrameworkVersion throws Wheels.VersionReadFailed when the file is missing", () => {
-				var missing = getTempDirectory() & "wheels-version-missing-#CreateUUID()#.json";
-				var threw = false;
-				try {
-					g.$readFrameworkVersion(missing);
-				} catch (Wheels.VersionReadFailed e) {
-					threw = true;
-				}
-				expect(threw).toBeTrue("expected Wheels.VersionReadFailed when box.json is missing");
-			});
-
-			it("$readFrameworkVersion throws Wheels.VersionReadFailed when the JSON has no version key", () => {
-				var tmp = getTempDirectory() & "wheels-version-#CreateUUID()#.json";
-				fileWrite(tmp, '{"testbox":{"runner":"/tests/runner.cfm"}}');
-				var threw = false;
-				try {
-					g.$readFrameworkVersion(tmp);
-				} catch (Wheels.VersionReadFailed e) {
-					threw = true;
-				} finally {
-					fileDelete(tmp);
-				}
-				expect(threw).toBeTrue("expected Wheels.VersionReadFailed when version key is absent");
-			});
-
-			it("$readFrameworkVersion throws Wheels.VersionReadFailed when the JSON is malformed", () => {
-				var tmp = getTempDirectory() & "wheels-version-#CreateUUID()#.json";
-				fileWrite(tmp, "this is not json {");
-				var threw = false;
-				try {
-					g.$readFrameworkVersion(tmp);
-				} catch (Wheels.VersionReadFailed e) {
-					threw = true;
-				} finally {
-					fileDelete(tmp);
-				}
-				expect(threw).toBeTrue("expected Wheels.VersionReadFailed when box.json is malformed");
+			it("$readFrameworkVersion delegates to BuildInfo and returns the same string as application.wheels.version", () => {
+				expect(g.$readFrameworkVersion()).toBe(application.wheels.version);
 			});
 
 		});

--- a/vendor/wheels/tests/specs/events/frameworkVersionSpec.cfc
+++ b/vendor/wheels/tests/specs/events/frameworkVersionSpec.cfc
@@ -20,10 +20,10 @@ component extends="wheels.WheelsTest" {
 				expect(application.wheels.version).notToBe("@build.version@");
 			});
 
-			it("caches a BuildInfo instance on application.$wheels.buildInfo at boot", () => {
-				expect(StructKeyExists(application.$wheels, "buildInfo")).toBeTrue();
-				expect(IsObject(application.$wheels.buildInfo)).toBeTrue();
-				expect(application.$wheels.buildInfo.version()).toBe(application.wheels.version);
+			it("caches a BuildInfo instance on application.wheels.buildInfo at boot", () => {
+				expect(StructKeyExists(application.wheels, "buildInfo")).toBeTrue();
+				expect(IsObject(application.wheels.buildInfo)).toBeTrue();
+				expect(application.wheels.buildInfo.version()).toBe(application.wheels.version);
 			});
 
 			it("$readFrameworkVersion delegates to BuildInfo and returns the same string as application.wheels.version", () => {


### PR DESCRIPTION
## Summary

Replaces the historical pattern of reading the framework's version from `vendor/wheels/box.json` with a dedicated `BuildInfo` component. `box.json` remains for the engine-db matrix tooling but is no longer the runtime source of truth. This decouples version reporting from the ForgeBox manifest format that's being phased out, and surfaces richer build metadata for diagnostics.

## What's in BuildInfo

10 fields, all populated by the release pipeline via sed substitution at artifact-construction time:

| Field | Example value |
|-------|---------------|
| `version` | `4.0.0-SNAPSHOT+1628` |
| `buildNumber` | `1628` |
| `branch` | `develop` |
| `commitSha` | `81e9f7958d3abc...` |
| `commitShortSha` | `81e9f79` |
| `commitSubject` | `fix(cli): override version() and showHelp()` |
| `builtAt` | `2026-04-28T19:11:00Z` |
| `runId` | `25072250128` |
| `runUrl` | `https://github.com/wheels-dev/wheels/actions/runs/25072250128` |
| `repository` | `wheels-dev/wheels` |

Dev checkouts ship the unresolved placeholders, which `version()` reports as `0.0.0-dev` and the metadata getters blank out.

## Wiring

- `Global.cfc:$readFrameworkVersion` is now a one-line delegate to `new wheels.BuildInfo().version()`. The path-arg-based box.json fallback chain is gone.
- `onapplicationstart.cfc` instantiates BuildInfo once and caches on `application.$wheels.buildInfo`. Single instance shared across requests; values can't change without a full server restart.
- `PackageLoader.$normalizeWheelsVersion` and `Plugins.$normalizeWheelsVersion` now treat both `@build.version@` and `0.0.0-dev` as semver `0.0.0` so strict version constraints don't falsely reject packages on dev builds.
- `tools/build/scripts/prepare-core.sh` substitutes the new placeholders during wheels-core artifact construction. Commit info comes from `git rev-parse` / `git log` in the source checkout; run context comes from `GITHUB_RUN_ID` and `GITHUB_REPOSITORY` env vars (empty locally → BuildInfo blanks the field).

## Tests

- New `buildInfoSpec.cfc` with focused unit tests for `version()` sentinel, `isDev()`/`isSnapshot()`, all metadata getters, and `asStruct()`.
- `frameworkVersionSpec.cfc` trimmed from 14 box.json-fallback-chain tests to 4 boot-time integration assertions. The legacy fallback paths (monorepo detection, wheels-base-template recovery) are no longer needed — BuildInfo's substituted values are authoritative.

## What's deliberately NOT in this PR

- **`box.json` keeps its `version` field.** It's still substituted by the release pipeline (and may still be referenced by the engine-db matrix tooling). We just don't read it anymore for runtime version reporting.
- **`FrameworkInstaller.rewriteVersionPlaceholder` unchanged.** It still rewrites `@build.version@` in `vendor/wheels/box.json` at scaffold time. BuildInfo.cfc on the brew/choco-installed framework is already substituted by the release pipeline.
- **`wheels info` and the dev toolbar still show only the version string.** Surfacing the richer BuildInfo fields in the toolbar is a follow-up — easy now that the data is available.

## Test plan

- [x] `bash tools/test-local.sh` — 3347 passed, 0 failed
- [x] `bash tools/test-cli-local.sh` — 462 passed, 3 failed (pre-existing `DoctorSpec` #2260 issues, unrelated)
- [x] Local `prepare-core.sh` dry run produces a fully-substituted `BuildInfo.cfc` with real git SHA, commit subject, ISO timestamp, run URL, and repository.
- [ ] After merge + a release run, verify on a fresh `brew install` that the dev toolbar shows the substituted version (no more `0.0.0-dev`).

Closes the framework-side half of the "0.0.0-dev debug bar on installed apps" finding from the fresh-VM journal.