### PR TITLE
fix(config): include config/app.cfm after this.env is initialized (#2325)

### DIFF
--- a/public/Application.cfc
+++ b/public/Application.cfc
@@ -30,13 +30,6 @@ component output="false" {
 	// symlink, brew bottle, choco package). See PR #2309 for context.
 	this.mappings["/modules/wheels"] = expandPath("../cli/lucli/");
 
-	// Load app-level configuration (datasources, custom settings, etc.)
-	// This is the recommended place for developers to define this.datasources,
-	// this.sessionManagement overrides, and other Application.cfc-level config.
-	if (FileExists(expandPath("../config/app.cfm"))) {
-		include "../config/app.cfm";
-	}
-
 	// We turn on "sessionManagement" by default since the Flash uses it.
 	this.sessionManagement = true;
 
@@ -103,6 +96,9 @@ component output="false" {
 
 	function onServerStart() {}
 
+	// Load app-level configuration (datasources, custom settings, etc.). This
+	// must run AFTER this.env is initialized above so user code in
+	// config/app.cfm can reference this.env safely (issue #2325).
 	include "../config/app.cfm";
 
 	function onApplicationStart() {


### PR DESCRIPTION
## Summary

- Removes a premature, duplicate `include "../config/app.cfm"` at the top of `public/Application.cfc` that ran *before* `this.env` was initialized, causing `Component [Application] has no accessible Member with name [ENV]` whenever user code in `config/app.cfm` referenced `this.env`.
- The surviving include further down already runs in the correct lifecycle position (after `this.env` is built from `.env` / `.env.<env>` files) and matches the pattern used in the LuCLI scaffold template, `examples/starter-app`, and `examples/tweet`.
- Adds a one-line load-order comment near the surviving include so this regression doesn't return.

## Root cause

Commit d26fe1b91 (`fix: rebrand CFWheels to Wheels, move CI datasources to config/app.cfm`) introduced an early `include "../config/app.cfm"` at line 36 to host CI datasources, not realizing the file already had an include at line 106. The early include sat *above* the `this.env` initialization block (lines 65–102), so any reference to `this.env` from `config/app.cfm` blew up before that struct existed.

## Test plan

- [x] `bash tools/test-local.sh` — 3347 pass, 0 fail (Lucee 7 + SQLite)
- [x] Targeted regression repro: temporarily injected `if (structKeyExists(this.env, "WHEELS_ENV")) {}` at the top of `config/app.cfm`, reloaded the framework webroot, and confirmed no `no accessible Member with name [ENV]` error.
- [x] Confirmed the surviving include is consistent with `cli/lucli/templates/app/public/Application.cfc:89`, `examples/starter-app/public/Application.cfc:91`, and `examples/tweet/public/Application.cfc:91` (single include, after env init).
- [ ] CI: full compat matrix across engines / databases.

Closes #2325