### PR TITLE
fix(cli): generate property passes column/table to correct params (#2355)

### DIFF
--- a/cli/src/commands/wheels/generate/property.cfc
+++ b/cli/src/commands/wheels/generate/property.cfc
@@ -84,8 +84,8 @@ component aliases='wheels g property'  extends="../base"  {
     	detailOutput.invoke("dbmigrate");
 		command('wheels dbmigrate create column')
 			.params(
-				name=obj.objectNamePlural,
-				columnName=lcase(arguments.columnName),
+				name=lcase(arguments.columnName),
+				tableName=obj.objectNamePlural,
 				dataType=arguments.dataType,
 				default=arguments.default,
 				allowNull=arguments.allowNull,


### PR DESCRIPTION
## Summary

Fixes [#2355](https://github.com/wheels-dev/wheels/issues/2355): `wheels generate property` produced a migration with garbage values for `table` and `columnName`.

**Root cause** — the legacy CommandBox command at [cli/src/commands/wheels/generate/property.cfc:85](https://github.com/wheels-dev/wheels/blob/develop/cli/src/commands/wheels/generate/property.cfc#L85) delegates to `wheels dbmigrate create column`, but the parameter names were transposed against the target's signature ([cli/src/commands/wheels/dbmigrate/create/column.cfc:39](https://github.com/wheels-dev/wheels/blob/develop/cli/src/commands/wheels/dbmigrate/create/column.cfc#L39)):

| Caller passed       | Target expected       | Effect                                           |
| ------------------- | --------------------- | ------------------------------------------------ |
| `name` ← plural     | `name` = column name  | Plural model name (`users`) became `columnName`  |
| `columnName` ← col  | (no such param)       | Silently dropped by `command().params()`         |
| (not passed)        | `tableName` (required)| CommandBox prompted invisibly; user typed `n`    |

That's exactly what produced the reporter's output:
```
addColumn(table = 'n', columnType = 'string', columnName = 'users', allowNull = true);
```

**Fix** — swap the two `params()` keys so `name` carries the column and `tableName` carries the table.

The LuCLI `generate property` path ([cli/lucli/Module.cfc:2463](https://github.com/wheels-dev/wheels/blob/develop/cli/lucli/Module.cfc#L2463)) writes the migration directly without delegating, so it does not share the bug.

## Test plan

- [ ] Run `wheels generate property name=User columnName=firstName` against a project with `app/models/User.cfc`
- [ ] Confirm the generated migration contains `addColumn(table = 'users', columnType = 'string', columnName = 'firstname', ...)`
- [ ] Run `wheels generate property name=User columnName=isActive dataType=boolean default=0` and confirm `default = 0` and the boolean type render correctly
- [ ] Verify `wheels dbmigrate latest` applies the migration cleanly