### PR TITLE
fix(cli): guard against duplicate 'create' lines in wheels new (#2311)

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -3573,6 +3573,19 @@ component extends="modules.BaseModule" {
 		// non-zero exit code instead of a silent success.
 		var wheelsSource = resolveFrameworkSourceOrFail(appName);
 
+		// Open a printCreated() dedup session for the duration of this
+		// scaffold. See issue #2311 — the duplicate
+		// "create blog/Application.cfc" line was a side-effect of the
+		// copyTemplateDir() recursion bug fixed in #2342, but the guard
+		// stays here so any future code path that double-emits the same
+		// path in one `wheels new` run surfaces as a verbose() diagnostic
+		// instead of a confusing user-visible duplicate. Cleanup runs in
+		// the finally below so generator commands later in the same
+		// process (MCP server, REPL) emit unconditionally.
+		variables.$createdPathTracker = {};
+
+		try {
+
 		out("Creating new Wheels application: #appName#...", "cyan");
 		out("");
 
@@ -3650,6 +3663,12 @@ component extends="modules.BaseModule" {
 		out("  cd #appName#");
 		out("  wheels start");
 		return "";
+
+		} finally {
+			// Always close the dedup session so subsequent commands in the
+			// same process (long-lived MCP / REPL contexts) emit normally.
+			structDelete(variables, "$createdPathTracker");
+		}
 	}
 
 	/**
@@ -4611,9 +4630,26 @@ component extends="modules.BaseModule" {
 	}
 
 	/**
-	 * Print a "create" action line with green formatting
+	 * Print a "create" action line with green formatting.
+	 *
+	 * When a tracking session is active (started by scaffoldNewApp via
+	 * `variables.$createdPathTracker`), duplicate emissions of the same path
+	 * are suppressed and surfaced as a verbose() diagnostic instead. This is
+	 * defense-in-depth for issue #2311 — the original duplicate
+	 * "create blog/Application.cfc" line was a side effect of the
+	 * copyTemplateDir() recursion bug fixed in #2342, but if any future
+	 * regression re-emits a path twice, users see one cosmetic line rather
+	 * than a confusing duplicate. Generator commands (which don't open a
+	 * tracking session) emit unconditionally.
 	 */
 	private void function printCreated(required string path) {
+		if (structKeyExists(variables, "$createdPathTracker")) {
+			if (structKeyExists(variables.$createdPathTracker, arguments.path)) {
+				verbose("printCreated: duplicate emit suppressed for #arguments.path#");
+				return;
+			}
+			variables.$createdPathTracker[arguments.path] = true;
+		}
 		out("  create  #path#", "green");
 	}
 

--- a/cli/lucli/tests/specs/commands/NewCommandTemplateSpec.cfc
+++ b/cli/lucli/tests/specs/commands/NewCommandTemplateSpec.cfc
@@ -49,6 +49,18 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 				expect(arrayToList(missing)).toBe("");
 			});
 
+			it("ships both public/Application.cfc and public/miscellaneous/Application.cfc", () => {
+				// Issue #2311 reported a duplicate "create blog/Application.cfc"
+				// line. The root cause was the copyTemplateDir() recursion bug
+				// fixed in #2342 — both files exist on purpose (the empty one
+				// in public/miscellaneous/ overrides the parent so requests to
+				// that subtree don't run through Wheels) but flattened paths
+				// printed both as the same string. This guards against a
+				// future "cleanup" that mistakenly deletes one as a duplicate.
+				expect(fileExists(templateRoot & "public/Application.cfc")).toBeTrue();
+				expect(fileExists(templateRoot & "public/miscellaneous/Application.cfc")).toBeTrue();
+			});
+
 		});
 
 	}


### PR DESCRIPTION
## Summary

- Verified that the duplicate `create blog/Application.cfc` line reported in #2311 no longer reproduces — the symptom was a side effect of the `copyTemplateDir()` recursion bug fixed in #2342, where both `public/Application.cfc` and `public/miscellaneous/Application.cfc` printed as the same flattened path.
- Added the defense-in-depth guard the issue itself suggested: `printCreated()` deduplicates within a per-scaffold tracking session opened by `scaffoldNewApp()` and closed in a `finally` block. A future regression that re-emits the same path now surfaces as a `verbose()` diagnostic instead of a confusing user-visible duplicate.
- The tracker is scoped to the scaffold call only — generator commands run later in the same long-lived process (MCP server, `wheels console`) emit unconditionally.
- Added a `NewCommandTemplateSpec` invariant asserting both `public/Application.cfc` and `public/miscellaneous/Application.cfc` exist. The empty `miscellaneous/Application.cfc` is an intentional override so requests under that subtree skip the parent Wheels app, and the test prevents a future maintainer from deleting it as the "duplicate".

Closes #2311.

## Test plan

- [x] `bash tools/test-cli-local.sh` — 474 pass / 3 fail (3 failures are pre-existing on develop in `DoctorSpec`, unrelated to this change). New `NewCommandTemplateSpec` case included.
- [x] Manual fresh-install `wheels new blog --no-open-browser` against the worktree: exit 0, 81 distinct `create` lines, `sort | uniq -d` returns nothing, both `Application.cfc` files emit at their full distinct paths.
- [x] Manual `wheels generate model Post title:string` after the scaffold: emits its `create` lines normally — tracker is correctly scoped via `try/finally` and doesn't leak across commands.
- [ ] CI: full compat matrix on PR.