### PR TITLE
fix(cli): wheels destroy accepts <type> <name> order (#2313 F16)

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -1329,7 +1329,8 @@ component extends="modules.BaseModule" {
 			else { arrayAppend(positional, a); }
 		}
 		if (!arrayLen(positional)) {
-			out("Usage: wheels destroy <name> [type]", "yellow");
+			out("Usage: wheels destroy <type> <name>", "yellow");
+			out("       wheels destroy <name>          (type defaults to 'resource')", "yellow");
 			out("");
 			out("Types:", "bold");
 			out("  resource    Remove model + controller + views + tests + route + migration (default)");
@@ -1338,16 +1339,38 @@ component extends="modules.BaseModule" {
 			out("  view        Remove view directory (or single file with controller/view syntax)");
 			out("");
 			out("Examples:", "bold");
-			out("  wheels destroy User");
-			out("  wheels destroy Products controller");
-			out("  wheels destroy Product model");
-			out("  wheels destroy products/index view");
+			out("  wheels destroy User                   (remove the User resource)");
+			out("  wheels destroy controller Products    (remove just the Products controller)");
+			out("  wheels destroy model Product          (remove just the Product model)");
+			out("  wheels destroy view products/index    (remove a single view)");
 			return "";
 		}
-		var name = trim(positional[1]);
-		var type = arrayLen(positional) > 1 ? lCase(trim(positional[2])) : "resource";
 
-		if (!listFindNoCase("resource,model,controller,view", type)) {
+		// Smart-parse positionals to support both orderings:
+		//   `<type> <name>` — preferred, matches `wheels generate <type> <name>` and v3 docs index
+		//   `<name> [type]` — legacy form documented in earlier CLI builds
+		// Issue #2313 (F16): users following the docs hit "Unknown type: posts" before this.
+		var validTypes = "resource,model,controller,view";
+		var name = "";
+		var type = "resource";
+		if (arrayLen(positional) == 1) {
+			name = trim(positional[1]);
+		} else {
+			var firstArg = trim(positional[1]);
+			var secondArg = trim(positional[2]);
+			if (listFindNoCase(validTypes, firstArg)) {
+				type = lCase(firstArg);
+				name = secondArg;
+			} else if (listFindNoCase(validTypes, secondArg)) {
+				name = firstArg;
+				type = lCase(secondArg);
+			} else {
+				name = firstArg;
+				type = lCase(secondArg);
+			}
+		}
+
+		if (!listFindNoCase(validTypes, type)) {
 			out("Unknown type: #type#. Valid types: resource, model, controller, view", "red");
 			return "";
 		}

--- a/cli/lucli/tests/specs/commands/DestroyCommandSpec.cfc
+++ b/cli/lucli/tests/specs/commands/DestroyCommandSpec.cfc
@@ -91,6 +91,29 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 				expect(fileExists(tempRoot & "/app/models/Destroyable.cfc")).toBeTrue();
 			});
 
+			// Issue #2313 (F16): the v3 docs index and `wheels generate` both use
+			// `<type> <name>` order. The CLI used to reject this form with
+			// "Unknown type: ...". These specs guard the smart-parse fix.
+			it("accepts <type> <name> order (matches wheels generate)", () => {
+				mod.__arguments = ["model", "Destroyable", "--force"];
+				mod.destroy();
+				expect(fileExists(tempRoot & "/app/models/Destroyable.cfc")).toBeFalse();
+			});
+
+			it("accepts <type> <name> for controller", () => {
+				mod.__arguments = ["controller", "Destroyable", "--force"];
+				mod.destroy();
+				expect(fileExists(tempRoot & "/app/controllers/Destroyables.cfc")).toBeFalse();
+			});
+
+			it("accepts <type> <name> for resource", () => {
+				mod.__arguments = ["resource", "Destroyable", "--force"];
+				mod.destroy();
+				expect(fileExists(tempRoot & "/app/models/Destroyable.cfc")).toBeFalse();
+				expect(fileExists(tempRoot & "/app/controllers/Destroyables.cfc")).toBeFalse();
+				expect(directoryExists(tempRoot & "/app/views/destroyables")).toBeFalse();
+			});
+
 		});
 
 	}


### PR DESCRIPTION
## Summary

- Smart-parse `wheels destroy` positionals so `wheels destroy <type> <name>` works (the form the v3 docs and `wheels generate` both use).
- Legacy `wheels destroy <name> [type]` order still recognized — no breaking change.
- Updated inline help to lead with the preferred `<type> <name>` form.

Closes the F16 line in #2313:

> **`wheels destroy <type> <name>` rejects the documented argument order.** The CLI is treating the second positional as the type, so `wheels destroy controller Posts` errors with "Unknown type: posts. Valid types: resource, model, controller, view". (Tutorial currently falls back to manual `rm` so this is cosmetic.)

The CLI used to greet users with `Unknown type: posts` when they followed the docs. Now both orderings dispatch correctly:

```
==> Test 1: 'wheels destroy controller Posts' (was broken)
The following will be deleted:
  app/controllers/Posts.cfc
  ...
==> Test 2: legacy 'wheels destroy Post model'
The following will be deleted:
  app/models/Post.cfc
  ...
```

## How the parse works

If the first positional matches a known type (`resource`/`model`/`controller`/`view`), treat it as the type; otherwise fall through to the legacy `<name> [type]` ordering. The only ambiguity case is "first arg matches a known type" — in which case there's a single sensible interpretation. Existing tests using `<name> [type]` keep passing because `Destroyable` doesn't match any known type.

## Bonus catch

The first cut used inline `# explanation` comments in help-text examples. CFML treats `#` as an expression delimiter inside double-quoted strings, which crashes the whole CFC at parse time (the dreaded `Invalid Syntax Closing [#] not found` from the project's CLAUDE.md gotcha list). Live-loading the patched module into `~/.wheels/modules/wheels/Module.cfc` surfaced this immediately — the unit-test path can't, since a broken file fails to load at all. Switched to parenthetical notes.

## Test plan

- [x] `wheels destroy` (no args) prints help with new `<type> <name>` synopsis.
- [x] `wheels destroy controller Posts --force` removes `app/controllers/Posts.cfc` (was rejected before).
- [x] `wheels destroy Post model --force` (legacy form) still removes `app/models/Post.cfc`.
- [x] `wheels destroy User --force` (single arg) still defaults to `resource`.
- [x] Three new specs in `DestroyCommandSpec.cfc` covering the new order.
- [x] Full CLI test suite: 474 pass, 3 pre-existing fails in `DoctorSpec > checkMixinCollisions` (unrelated, predates this change).

## Out of scope

The v3-0-0 destroy guide at `web/sites/guides/.../core/destroy.md` has separate stale issues (claims there is no `--force` flag, never mentions a `[type]` argument). Worth a dedicated docs PR alongside the broader [guides rewrite](docs/superpowers/plans/2026-04-18-guides-rewrite-phase-1.md) — kept out of this scope to keep the diff minimal.

Other items in #2313 still outstanding (separate PRs):
- `wheels start` from a non-Wheels dir creates phantom servers (#2313 F18 partial — `stop` already shipped via 5e47c61d2).
- `--help` per subcommand prints top-level help (#2313 F18).
- SQLite migrator lower-cases column names (#2313 F19).
- `t.timestamps()` adds `deletedAt` without an explicit opt-in (docs vs implementation question).