### PR TITLE
docs(migration): note that t.timestamps() also adds deletedAt (#2313)

### DIFF
--- a/web/sites/guides/src/content/docs/v3-0-0/command-line-tools/cli-guides/migrations.md
+++ b/web/sites/guides/src/content/docs/v3-0-0/command-line-tools/cli-guides/migrations.md
@@ -103,7 +103,7 @@ function up() {
         t.uniqueidentifier(columnNames="uniqueId");
         
         // Special columns
-        t.timestamps(); // Creates createdAt and updatedAt
+        t.timestamps(); // Creates createdAt, updatedAt, and deletedAt (soft-delete marker)
         t.references(referenceNames="user"); // Creates userId foreign key
         
         // Create the table

--- a/web/sites/guides/src/content/docs/v3-0-0/command-line-tools/commands/generate/migration.md
+++ b/web/sites/guides/src/content/docs/v3-0-0/command-line-tools/commands/generate/migration.md
@@ -383,7 +383,7 @@ Common column types available in migrations:
 | `t.datetime()` | DATETIME | `t.datetime(columnNames='registeredAt')` |
 | `t.time()` | TIME | `t.time(columnNames='startTime')` |
 | `t.binary()` | BLOB | `t.binary(columnNames='avatar')` |
-| `t.timestamps()` | DATETIME | Creates createdAt and updatedAt |
+| `t.timestamps()` | DATETIME | Creates createdAt, updatedAt, and deletedAt (soft-delete marker) |
 
 ## Best Practices
 

--- a/web/sites/guides/src/content/docs/v3-0-0/database-interaction-through-models/using-sqlite.md
+++ b/web/sites/guides/src/content/docs/v3-0-0/database-interaction-through-models/using-sqlite.md
@@ -288,7 +288,7 @@ component extends="wheels.migrator.Migration" {
         t.string("email", limit=100, null=false);
         t.boolean("active", default=true);
         t.datetime("lastLoginAt");  // Stored as TEXT
-        t.timestamps();  // Creates createdAt and updatedAt as TEXT
+        t.timestamps();  // Creates createdAt, updatedAt, and deletedAt as TEXT
         t.create();
 
         // Indexes work normally


### PR DESCRIPTION
## Summary

- Three v3-0-0 doc spots described `t.timestamps()` as creating only `createdAt` and `updatedAt`. The implementation in [vendor/wheels/migrator/TableDefinition.cfc:372](vendor/wheels/migrator/TableDefinition.cfc:372) actually adds three columns; the third is `deletedAt`, the soft-delete marker.
- The v4-0-0-snapshot guide and the v3 database-migrations index already say "createdAt, updatedAt and deletedAt" — this PR aligns the remaining three v3 spots so the picture is consistent.
- Resolves the `t.timestamps()` line in #2313.

## Why docs and not opt-in

The issue explicitly recommends the docs path:

> Make the soft-delete column opt-in (`t.timestamps(softDelete=true)`), or update the docs to accurately describe the three-column behavior. (Note: the project's own CLAUDE.md anti-pattern #7 already documents the three-column behavior, so the docs side may be the right move.)

Making the soft-delete column opt-in would silently change the migration output for every existing Wheels app on disk — a backward-compat break for cosmetic gain. Documenting the existing behavior is the right move.

## Files changed

| File | Before | After |
|------|--------|-------|
| `using-sqlite.md` | `// Creates createdAt and updatedAt as TEXT` | `// Creates createdAt, updatedAt, and deletedAt as TEXT` |
| `cli-guides/migrations.md` | `// Creates createdAt and updatedAt` | `// Creates createdAt, updatedAt, and deletedAt (soft-delete marker)` |
| `commands/generate/migration.md` (table row) | `Creates createdAt and updatedAt` | `Creates createdAt, updatedAt, and deletedAt (soft-delete marker)` |

## Test plan

- [x] No code paths touched — pure doc fix.
- [x] Wording matches the existing accurate references in v4-0-0-snapshot/glossary.mdx and v4-0-0-snapshot/basics/migrations.mdx.