### PR TITLE
docs(cli): correct ARCHITECTURE.md per-subcommand --help routing (#2313)

### DIFF
--- a/cli/lucli/ARCHITECTURE.md
+++ b/cli/lucli/ARCHITECTURE.md
@@ -94,7 +94,9 @@ When the user types `wheels version` or `wheels help` (subcommand form, no leadi
 | `wheels --help` | wrapper intercept → exit (never reaches LuCLI) |
 | `wheels help` | wrapper sync → LuCLI → `Module.showHelp()` (overridden) |
 | `wheels generate model User` | wrapper sync → LuCLI → `Module.generate("model", "User")` |
-| `wheels migrate latest --help` | wrapper sync → LuCLI → `preprocessModuleHelp` rewrites → `Module.showHelp("migrate")` |
+| `wheels migrate --help` | wrapper intercept → exit (LuCLI's `preprocessModuleHelp` would otherwise drop "migrate" and route to top-level help — see [wheels#2313](https://github.com/wheels-dev/wheels/issues/2313)) |
+| `wheels migrate latest --help` | wrapper intercept → exit (`--help` detected anywhere in args; first arg routes to subcommand help) |
+| `wheels foo --help` (unknown sub) | wrapper sees `--help` but `case "$1"` has no match → falls through to LuCLI which reports the unknown subcommand |
 
 ## Testing the layers in isolation
 


### PR DESCRIPTION
## Summary

Cleanup PR coordinated with [homebrew-wheels#35](https://github.com/wheels-dev/homebrew-wheels/pull/35) and [chocolatey-wheels#41](https://github.com/wheels-dev/chocolatey-wheels/pull/41), both already merged.

The `cli/lucli/ARCHITECTURE.md` dispatch table claimed `wheels migrate latest --help` mapped to `Module.showHelp("migrate")`. That was aspirational — LuCLI's `preprocessModuleHelp` actually drops the subcommand name before dispatch, so `Module.showHelp()` only ever sees zero args.

After the two wrapper PRs, per-subcommand `--help` is intercepted in the wrapper script itself (before LuCLI runs). Updates the dispatch table to reflect the new wrapper-side behavior plus the unknown-subcommand fall-through path.

Resolves the `--help per subcommand` line in #2313.

## Test plan

- [x] No code paths touched — pure doc fix.
- [x] Companion wrapper PRs verified end-to-end (see homebrew-wheels#35 for the eight-case smoke test).