### PR TITLE
fix(migration): preserve column case as written by default (#2313 F19)

### DIFF
--- a/vendor/wheels/events/onapplicationstart.cfc
+++ b/vendor/wheels/events/onapplicationstart.cfc
@@ -248,7 +248,14 @@ component {
 		application.$wheels.migratorTableName = "c_o_r_e_migrator_versions";
 		application.$wheels.createMigratorTable = true;
 		application.$wheels.writeMigratorSQLFiles = false;
-		application.$wheels.migratorObjectCase = "lower";
+		// Preserve column / table / index name case as written in the migration.
+		// Set to "lower" or "upper" to fold names. Issue #2313 (F19): the
+		// previous "lower" default silently rewrote `t.string("publishedAt")`
+		// into a `publishedat` column on case-preserving engines (notably
+		// SQLite), which surprised users. Apps that depended on the old
+		// behavior can opt back in via `set("migratorObjectCase", "lower")`
+		// in `config/settings.cfm`.
+		application.$wheels.migratorObjectCase = "";
 		application.$wheels.allowMigrationDown = false;
 		application.$wheels.migrationLevel = 1;
 		if (application.$wheels.environment == "development") {

--- a/vendor/wheels/tests/specs/migrator/migrationSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/migrationSpec.cfc
@@ -649,6 +649,31 @@ component extends="wheels.WheelsTest" {
 
 				expect(ListFindNoCase(actual, expected)).toBeTrue()
 			})
+
+			// Issue 2313 F19: the framework default used to be "lower", silently
+			// rewriting `t.string("publishedAt")` into `publishedat` on case-
+			// preserving engines (notably SQLite). Default is now "" (preserve).
+			it("ships migratorObjectCase = '' as the framework default (issue 2313 F19)", () => {
+				// originalMigratorObjectCase is captured in beforeAll() at line 7
+				// before any test in this spec mutates the application setting.
+				// If a future change reverts the default to "lower" or "upper",
+				// this assertion fails immediately.
+				expect(originalMigratorObjectCase).toBe("")
+			})
+
+			it("preserves column case in DDL with default migratorObjectCase (issue 2313 F19)", () => {
+				// Companion to the assertion above — verifies the case-
+				// preservation BEHAVIOR end-to-end at the SQL-emission layer.
+				// Engine-independent because we inspect the generated DDL
+				// string, not the actual storage.
+				application.wheels.migratorObjectCase = ""
+				adapter = migration.adapter
+				col = CreateObject("component", "wheels.migrator.ColumnDefinition")
+					.init(adapter = adapter, name = "publishedAt", type = "datetime")
+				// toIncludeWithCase is case-sensitive — fails if the column
+				// name was folded to "publishedat" anywhere in the DDL.
+				expect(col.toSQL()).toIncludeWithCase("publishedAt")
+			})
 		})
 
 		describe("Tests addForeignKey", () => {


### PR DESCRIPTION
## Summary

Resolves the SQLite column case-folding line in #2313:

> **Migration column names get silently lower-cased on SQLite.** A migration that declares `columnNames="publishedAt"` produces a column called `publishedat` in the resulting sqlite schema. Hard to reproduce on case-sensitive databases. **Fix:** preserve column case as written in the migration; only normalize for case-insensitive engines that need it.

The framework default for `migratorObjectCase` was `"lower"`, which folded every column / table / index name through `LCase` before emitting DDL. On case-preserving engines (notably SQLite) the lowered names ended up literally in the schema, so a migration written with `t.string("publishedAt")` produced a column named `publishedat`. Most users never noticed on case-insensitive engines (MySQL, SQL Server with default collation) because reads worked either way, but the schema diverged from the migration source.

Default is now `""` (preserve case as written).

## Backward compat

Apps that depended on the old lowercased behavior can opt back in:

```cfm
// config/settings.cfm
set(migratorObjectCase = "lower");
```

Existing column data is unaffected — only **new** migrations created after this change will preserve case. Old columns in already-applied migrations stay lowercase. The ORM layer matches column names case-insensitively, so apps with mixed lower-case (old) and mixed-case (new) columns continue to work.

## Files

- [vendor/wheels/events/onapplicationstart.cfc:251](vendor/wheels/events/onapplicationstart.cfc:251) — flip the default + comment explaining the change.
- [vendor/wheels/tests/specs/migrator/migrationSpec.cfc](vendor/wheels/tests/specs/migrator/migrationSpec.cfc) — two new guard tests.

## Test plan

Two guard tests added:

1. **Shipped default test** — asserts `originalMigratorObjectCase` (captured in `beforeAll` before any test in the spec mutates it) equals `""`. Catches a regression if anyone reverts the default.
2. **Behavior test** — creates a `ColumnDefinition` with name `publishedAt` and asserts `toSQL()` contains `publishedAt` with case preserved. Engine-independent (inspects DDL string, not storage). Catches a regression in the case-folding logic itself.

Verified locally on Lucee 7 + SQLite:

- [x] migrator suite: **175 pass / 0 fail** (baseline 173, two new tests).
- [x] Full core suite: **3354 pass / 0 fail** (baseline 3352, two new tests; full run when server has memory headroom).
- [x] Temporarily reverting the default to `"lower"` makes the shipped-default test fail with `Expected [] but received [lower]` — confirming the test correctly guards.

CI will run the same suite across the full engine matrix.