### PR TITLE
fix(config): make BuildInfo.isDev() invariant under release-pipeline substitution

### DIFF
--- a/vendor/wheels/BuildInfo.cfc
+++ b/vendor/wheels/BuildInfo.cfc
@@ -44,7 +44,17 @@ component {
 	}
 
 	public boolean function isDev() {
-		return variables.info.version == "@build.version@";
+		// Detect dev checkouts by structural shape (prefix `@build.` + suffix
+		// `@`), NOT by literal equality with the version placeholder. The
+		// release pipeline (prepare-core.sh) does a global sed pass that
+		// rewrites every literal occurrence of the version placeholder in
+		// this file at artifact-construction time — if such a literal
+		// appeared inside a comparison here, it would be rewritten too,
+		// silently turning every released build into a self-reported dev
+		// build. (Even comments are not safe; sed is line-oriented text and
+		// does not respect CFML syntax.) Mirrors $blankIfPlaceholder() below.
+		var v = variables.info.version;
+		return left(v, 7) == "@build." && right(v, 1) == "@";
 	}
 
 	public boolean function isSnapshot() {

--- a/vendor/wheels/tests/specs/buildInfoSpec.cfc
+++ b/vendor/wheels/tests/specs/buildInfoSpec.cfc
@@ -39,6 +39,30 @@ component extends="wheels.WheelsTest" {
 					expect(new wheels.BuildInfo({version: "4.0.0-SNAPSHOT+1628"}).isDev()).toBeFalse();
 				});
 
+				it("source contains the @build.version@ sentinel exactly once (regression guard)", () => {
+					// The release pipeline (tools/build/scripts/prepare-core.sh) does a
+					// GLOBAL `sed s/@build.version@/<version>/g` over BuildInfo.cfc at
+					// artifact-construction time. If the sentinel appears anywhere
+					// other than the `version:` field of init()'s `variables.info`
+					// struct — say, inside isDev()'s equality comparison — that
+					// occurrence is rewritten too, silently turning every released
+					// build into a self-reported "0.0.0-dev" build. This test reads
+					// the source and asserts the structural invariant: exactly one
+					// literal occurrence, no more.
+					//
+					// If this fails, you almost certainly added a comparison like
+					//     return variables.info.version == "@build.version@";
+					// somewhere. Use the prefix/suffix structural check that
+					// $blankIfPlaceholder() uses instead.
+					var src = fileRead(expandPath("/wheels/BuildInfo.cfc"));
+					var token = "@" & "build.version" & "@"; // split so this file isn't itself a sentinel
+					var occurrences = (len(src) - len(replace(src, token, "", "all"))) / len(token);
+					expect(occurrences).toBe(
+						1,
+						"BuildInfo.cfc must contain exactly one '" & token & "' literal (found " & occurrences & "). A second occurrence is rewritten by prepare-core.sh's global sed and breaks dev detection on every released build."
+					);
+				});
+
 				it("isSnapshot() is true for SNAPSHOT versions", () => {
 					expect(new wheels.BuildInfo({version: "4.0.0-SNAPSHOT+1628"}).isSnapshot()).toBeTrue();
 				});


### PR DESCRIPTION
## Summary

Every snapshot since #2352 has been silently reporting itself as `0.0.0-dev` in the debug bar, `wheels info` output, and anywhere `application.wheels.version` flows. Surfaced by a fresh-VM tutorial run on `4.0.0-SNAPSHOT+1644` where the user expected `Wheels 4.0.0-SNAPSHOT+1644` in the debug bar but saw `Wheels 0.0.0-dev`.

## Root cause

`tools/build/scripts/prepare-core.sh` does a **global** `sed s/@build.version@/<version>/g` over `BuildInfo.cfc` at artifact-construction time. Before this fix, `isDev()` compared `variables.info.version` to the literal `"@build.version@"` string:

```cfml
public boolean function isDev() {
    return variables.info.version == "@build.version@";  // literal sentinel
}
```

The sed pass rewrote the sentinel-literal too, turning the comparison into:

```cfml
return variables.info.version == "4.0.0-SNAPSHOT+1644";  // post-substitution
```

…which is **always true** on every released build, since `variables.info.version` was substituted to the same value. Then `version()` does `isDev() ? "0.0.0-dev" : variables.info.version` → always returns `"0.0.0-dev"`.

This is a textbook *self-substituting sentinel*: the in-source value used for "this hasn't been rewritten yet" detection looks identical to the value being rewritten.

## Fix

Replace the literal-equality check with the structural prefix/suffix check that `$blankIfPlaceholder()` already uses in the same file:

```cfml
public boolean function isDev() {
    var v = variables.info.version;
    return left(v, 7) == "@build." && right(v, 1) == "@";
}
```

The matcher never embeds the full sentinel string `@build.version@`, so it's invariant under any single-token substitution.

## Regression guard

Adds a structural test in `buildInfoSpec.cfc` that reads the source and asserts the literal `@build.version@` appears **exactly once** (only in the `variables.info.version` field). A second occurrence anywhere — comments, comparison logic — is rewritten by the release pipeline and re-introduces the bug. This test would have caught the issue when #2352 first introduced BuildInfo.cfc.

The pre-existing tests run against the source (placeholder still literal), where the buggy `isDev()` happens to return the right answer; only post-substitution artifacts trigger the bug, which is why this slipped through.

## Verification

Verified end-to-end on a fresh-VM blog app running brew-installed `4.0.0-SNAPSHOT+1644`:

| | Before fix | After fix |
|---|---|---|
| `application.wheels.buildInfo.isDev()` | `true` | `false` |
| `application.wheels.buildInfo.version()` | `"0.0.0-dev"` | `"4.0.0-SNAPSHOT+1644"` |
| Debug bar | `Wheels 0.0.0-dev` | `Wheels 4.0.0-SNAPSHOT+1644` |

Reproduced by sed-substituting the fixed source locally (`sed 's/@build\.version@/4.0.0-SNAPSHOT+1644/g'`), scp'ing the result to the VM's `blog/vendor/wheels/BuildInfo.cfc`, restarting the server, and inspecting the rendered debug bar — exactly the artifact shape the release pipeline produces.

Unit-level verification via direct CFM probe:

```
== Structural test ==
@build.version@ literal occurrences in source: 1 (expected: 1)

== Behavioral test (concrete version) ==
isDev() with version=4.0.0-SNAPSHOT+9999: false (expected: false)
version() returns: 4.0.0-SNAPSHOT+9999 (expected: 4.0.0-SNAPSHOT+9999)

== Behavioral test (placeholder, dev checkout) ==
isDev() with no override: true (expected: true)
version() returns: 0.0.0-dev (expected: 0.0.0-dev)
```

## Test plan

- [ ] CI buildInfoSpec passes (existing 7 tests + 1 new structural-guard test = 8 total)
- [ ] After merge + next snapshot release, `wheels info` reports the concrete build version
- [ ] After merge + next snapshot release, debug bar shows the concrete build version
- [ ] After merge + next snapshot release, `BuildInfo.cfc` in `wheels-core-<v>.zip` artifact still has exactly one `@build.version@` literal pre-substitution and zero post-substitution

## Related

- #2352 (introduced BuildInfo.cfc and the substitution block in prepare-core.sh — the same PR introduced both halves of the bug)
- #2348 (closed an earlier `0.0.0-dev` display gap on installed apps; this is a regression of that fix that landed silently when the version source moved from box.json to BuildInfo.cfc)