### PR TITLE
feat(cli): include simple.css in generated layout.cfm by default

### DIFF
--- a/cli/lucli/templates/app/app/views/layout.cfm
+++ b/cli/lucli/templates/app/app/views/layout.cfm
@@ -12,6 +12,13 @@
 			<meta name="viewport" content="width=device-width, initial-scale=1">
 			<title>{{appName}}</title>
 			<cfoutput>#csrfMetaTags()#</cfoutput>
+			<!--- Default styling: simple.css (https://simplecss.org/) — a classless
+			      stylesheet that gives plain semantic HTML a clean, modern look without
+			      any markup changes. Form helpers like #textField()# already emit the
+			      right tags, so scaffolded views render polished out of the box.
+			      Remove this line if you're bringing your own CSS, or swap for a richer
+			      component kit — e.g. `wheels packages install wheels-basecoat`. --->
+			<link rel="stylesheet" href="https://cdn.simplecss.org/simple.min.css">
 		</head>
 
 		<body>

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/01-hello-wheels.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/01-hello-wheels.mdx
@@ -130,7 +130,9 @@ Three directories matter right now:
 The other top-level `app/` directories (`events/`, `global/`, `jobs/`, `lib/`, `mailers/`, `migrator/`, `models/`, `plugins/`, `snippets/`) are scaffolding for features you'll meet later — background jobs, mailers, application events, model definitions, generator templates. Leave them alone for now. The remaining root-level files are framework configuration: `lucee.json` configures the Lucee runtime, `.env` holds environment variables (the dev server's reload password lives here), and `config/app.cfm` plus the rest of `config/` configure the framework itself.
 
 <Aside type="tip">
-  **On Hotwire and Basecoat:** a fresh `wheels new` ships with only the core framework. Turbo (for SPA-like page transitions) and Basecoat (for styled forms and components) arrive as packages later in the tutorial when you actually need them. For now, everything is plain server-rendered HTML.
+  **On styling:** the generated `app/views/layout.cfm` includes [simple.css](https://simplecss.org/) via CDN — a classless stylesheet that gives semantic HTML a clean, modern look without any markup changes. Wheels' form helpers (`#textField()#`, `#startFormTag()#`, etc.) already emit the right tags, so your scaffolded views render polished from the very first page. Remove the `<link>` if you're bringing your own CSS. For a fuller component kit with proper buttons, cards, and form helpers, install [`wheels-basecoat`](https://github.com/wheels-dev/wheels-basecoat) post-tutorial.
+
+  **On Turbo:** a fresh `wheels new` ships with only the core framework. Turbo (for SPA-like page transitions and inline form errors) lands in Part 4 via a CDN script tag. For now, everything is plain server-rendered HTML.
 </Aside>
 
 ## Add a `/hello` route


### PR DESCRIPTION
## Summary

Fresh `wheels new` apps now ship with [simple.css](https://simplecss.org/) linked from `app/views/layout.cfm`, so scaffolded views render with a clean, modern look out of the box — no markup changes, no build step, no class soup.

| Before | After |
|---|---|
| Stark unstyled `<h1>`, `<input>`, `<button>` (Times New Roman + browser defaults) | Modern typography, padded form fields, styled buttons, comfortable line-height |

## Why simple.css and not a fuller component kit

Discussed and chosen over `wheels-basecoat` for the **default** because:

- **Classless** — zero markup changes. The Getting Started tutorial chapters introducing models / Turbo / auth / tests don't have to also teach styling vocabulary.
- **6KB, one CDN file, no JS dependency.** No build step, no npm, no Tailwind compile.
- **Trivially removed or replaced** — one line in `layout.cfm`. The comment above it mentions `wheels packages install wheels-basecoat` as the natural next step for users who want components.

`wheels-basecoat` is still the right choice for users who want shadcn/ui-quality components, but it earns its own optional bonus chapter in a follow-up PR — both because installing it is itself a meaningful Wheels lesson (the package system) and because dropping it into the tutorial main path would dilute every chapter that follows.

## Files

- **`cli/lucli/templates/app/app/views/layout.cfm`** — adds the `<link>` and a comment block explaining what it is and how to swap.
- **`web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/01-hello-wheels.mdx`** — replaces the existing "On Hotwire and Basecoat" Aside with a factual "On styling" + "On Turbo" pair. The old Aside claimed Basecoat would arrive as a package later in the tutorial; that never happened in chapters 2-7. The new Aside points at the simple.css link as the actual default and at `wheels-basecoat` (linked to its repo) as the post-tutorial upgrade path.

## What's NOT in this PR

The tutorial has a handful of other places that reference Basecoat as if it were already part of the main flow:

- `tutorial/index.mdx` — "Styling: Basecoat UI on scaffolded forms and views. Arrives via the `basecoat` package."
- `tutorial/02-first-model.mdx` — "you'll also activate the Hotwire and Basecoat packages"
- `tutorial/03-crud-scaffold.mdx` — chapter description claims to "Activate Hotwire and Basecoat"
- `tutorial/07-testing-deploying.mdx` — recap claims "Full CRUD scaffold with Basecoat styling"

These will be fixed in the **bonus-chapter follow-up PR** that actually delivers the basecoat content. Fixing them here would leave the index pointing at no chapter; fixing them in the follow-up keeps the change coherent (a chapter that delivers basecoat goes in alongside the references that now point at it).

## Verification

End-to-end verified on a fresh VM:

```bash
wheels new simplecss-test
cd simplecss-test && wheels start
curl -s localhost:8080/ | grep simplecss
#   <link rel="stylesheet" href="https://cdn.simplecss.org/simple.min.css">

curl -I https://cdn.simplecss.org/simple.min.css
#   HTTP/2 200
#   content-type: text/css
```

Existing apps are unaffected — `layout.cfm` is only emitted by `wheels new`, never rewritten on framework upgrade.

## Test plan

- [ ] CI green (this is a template change + a docs change; only doc-build-related checks should be sensitive)
- [ ] `wheels new <app>` produces a `layout.cfm` containing the simple.css link
- [ ] First-load on the home page renders with simple.css applied (no FOUC)
- [ ] Removing the `<link>` line returns to the previous unstyled behavior

## Follow-up

- **PR (next): bonus chapter `08-bonus-basecoat.mdx`** — install via `wheels packages install wheels-basecoat`, serve `basecoat.min.css`, swap the simple.css link for `#basecoatIncludes()#`, convert the post show + comment form to use `uiCard()` / `uiField()` / `uiButton()`. Will also clean up the stale Basecoat references in `index.mdx`, ch.2, ch.3, ch.7 (now backed by an actual chapter to point at).