### PR TITLE
fix(test): auto-merge.sh tolerates cosmetic local-git failures

### DIFF
--- a/tools/auto-merge.sh
+++ b/tools/auto-merge.sh
@@ -294,13 +294,34 @@ merge_pr() {
     fi
 
     info "merging PR #$pr ($tier tier)..."
-    if gh pr merge "$pr" "${merge_args[@]}" 2>&1; then
+    local merge_output
+    merge_output=$(gh pr merge "$pr" "${merge_args[@]}" 2>&1)
+    local merge_rc=$?
+
+    # `gh pr merge` can exit non-zero even when the server-side merge AND
+    # branch deletion both succeeded. The most common cause: gh's
+    # post-merge step that fast-forwards the local default branch fails
+    # because that branch is checked out in a sibling git worktree
+    # ("fatal: 'develop' is already used by worktree at..."). Treating
+    # that exit code as failure would break every cron-driven merge in
+    # any setup that uses worktrees. Disambiguate by re-querying state.
+    local actual_state
+    actual_state=$(gh pr view "$pr" --json state --jq .state 2>/dev/null)
+
+    if [[ "$actual_state" == "MERGED" ]]; then
         local sha
         sha=$(gh pr view "$pr" --json mergeCommit --jq '.mergeCommit.oid // ""' 2>/dev/null)
         ok "PR #$pr merged${sha:+ — $sha}"
+        if [[ "$merge_rc" -ne 0 ]]; then
+            # Surface the cosmetic error so the operator can see it, but
+            # don't treat the merge itself as failed.
+            warn "  gh exited $merge_rc (cosmetic local-git error; remote merge + branch delete succeeded):"
+            echo "$merge_output" | sed 's/^/    /' >&2
+        fi
         return 0
     else
-        warn "PR #$pr merge command failed"
+        warn "PR #$pr merge command failed (state=$actual_state, gh exit=$merge_rc):"
+        echo "$merge_output" | sed 's/^/    /' >&2
         return 1
     fi
 }


### PR DESCRIPTION
## Summary

`gh pr merge` exits non-zero when its post-merge step that fast-forwards the local default branch fails — even when the server-side merge and branch deletion both succeeded. The most common trigger: the default branch is checked out in a sibling git worktree, producing:

```
failed to run git: fatal: 'develop' is already used by worktree at '/path/to/main/clone'
```

This breaks the script's whole reason to exist when run from a worktree-based setup (which a cron task on a developer's machine typically is): every successful merge would be misreported as a failure, and the cron's exit code 1 would mix "actual failure" with "false-positive failure" indistinguishably.

## Discovery

Caught while dogfooding the script on its own merge (PR #2370):

```
· merging PR #2370 (code tier)...
failed to run git: fatal: 'develop' is already used by worktree at '/Users/peter/GitHub/wheels-dev/wheels'

! PR #2370 merge command failed                          ← FALSE NEGATIVE

---post-merge state---
{"mergeCommit":"5485b2e7b8808ee5663e8a71793e40b99b93cd26","mergedAt":"2026-04-29T19:04:00Z","state":"MERGED"}
                                                         ← but the merge actually succeeded
```

Server-side: merge ✓, branch deletion ✓, mergeCommit retrievable ✓. Script: reported failure, exit 1.

## Fix

After `gh pr merge` returns, re-query `PR.state`. If `MERGED`, treat as success regardless of `gh`'s exit code, and surface the cosmetic error to the operator as a warning rather than a hard failure. The actual merge-failure path (state != MERGED) still logs `gh`'s output and returns 1.

Code change is +23/-2 in `tools/auto-merge.sh::merge_pr`.

```diff
-    if gh pr merge "$pr" "${merge_args[@]}" 2>&1; then
-        local sha
-        sha=$(gh pr view "$pr" --json mergeCommit --jq '.mergeCommit.oid // ""' 2>/dev/null)
-        ok "PR #$pr merged${sha:+ — $sha}"
-        return 0
-    else
-        warn "PR #$pr merge command failed"
-        return 1
-    fi
+    local merge_output merge_rc actual_state
+    merge_output=$(gh pr merge "$pr" "${merge_args[@]}" 2>&1)
+    merge_rc=$?
+    actual_state=$(gh pr view "$pr" --json state --jq .state 2>/dev/null)
+
+    if [[ "$actual_state" == "MERGED" ]]; then
+        local sha; sha=$(gh pr view "$pr" --json mergeCommit --jq '.mergeCommit.oid // ""' 2>/dev/null)
+        ok "PR #$pr merged${sha:+ — $sha}"
+        if [[ "$merge_rc" -ne 0 ]]; then
+            warn "  gh exited $merge_rc (cosmetic local-git error; remote merge + branch delete succeeded):"
+            echo "$merge_output" | sed 's/^/    /' >&2
+        fi
+        return 0
+    else
+        warn "PR #$pr merge command failed (state=$actual_state, gh exit=$merge_rc):"
+        echo "$merge_output" | sed 's/^/    /' >&2
+        return 1
+    fi
```

## Why this should also dogfood through the script

If this PR's CI passes, running `tools/auto-merge.sh 2371` should:
1. Print all 8 gates green and `tier: code`.
2. Call `gh pr merge --squash --delete-branch`, which will produce the same cosmetic local-git error.
3. Re-query state, see MERGED, return 0.
4. Print the cosmetic warning to stderr but report success.

That's the validation: the script merges itself cleanly even from a worktree.

## Test plan

- [ ] CI green
- [ ] Run `tools/auto-merge.sh 2371` (this PR) — should report "merged" without false-failure
- [ ] If running from a non-worktree setup, the cosmetic warning should be absent (gh exit 0)

## Commit-scope note

Per `commitlint.config.js` `scope-enum`, scoped `test` following precedent for `tools/` scripts (e.g. #2366, #2334). `tools` itself isn't in the allowlist.