### PR TITLE
docs: align tutorial styling/package references with chapter-1 reality

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/02-first-model.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/02-first-model.mdx
@@ -336,6 +336,6 @@ wheels reload
 
 ## What's next
 
-In [Part 3: CRUD Scaffold](/v4-0-0-snapshot/start-here/tutorial/03-crud-scaffold/) you'll throw most of Part 2's hand-written code away and let `wheels generate scaffold` produce the full create/read/update/delete stack. You'll also activate the Hotwire and Basecoat packages so the scaffold renders with styled forms and Turbo page transitions instead of plain HTML.
+In [Part 3: CRUD Scaffold](/v4-0-0-snapshot/start-here/tutorial/03-crud-scaffold/) you'll throw most of Part 2's hand-written code away and let `wheels generate scaffold` produce the full create/read/update/delete stack. You'll also tour the Wheels package system and get a first look at Hotwire ahead of Part 4, where Turbo Frames land for real.
 
 Want a reference-level tour of what you just built? See [Models and the ORM](/v4-0-0-snapshot/basics/models-and-the-orm/) and [Migrations](/v4-0-0-snapshot/basics/migrations/).

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/07-testing-deploying.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/07-testing-deploying.mdx
@@ -267,7 +267,7 @@ Quick recap of the feature list:
 
 - `Post` model with `title`, `body`, `status` (enum), `publishedAt`
 - Migrations and seeds
-- Full CRUD scaffold with Basecoat styling and Turbo Drive
+- Full CRUD scaffold rendered with simple.css default styling and Turbo Drive page transitions
 - Validations with inline errors via Turbo Frames
 - Comments via nested resources with Turbo Stream appends
 - User signup, login, and logout — hand-rolled and built-in `SessionStrategy` variants

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Tutorial: Build a Blog"
-description: A 7-part narrative tutorial. Build a complete Wheels 4.0 blog with Turbo, Basecoat, and built-in auth. Takes about 3.5 hours.
+description: A 7-part narrative tutorial. Build a complete Wheels 4.0 blog with Turbo and built-in auth. Takes about 3.5 hours.
 type: tutorial
 sidebar:
   order: 5
@@ -34,8 +34,8 @@ A blog for an individual author. The final app supports:
 
 - **Framework:** Wheels 4.0 on Lucee 7 (via the bundled `wheels` CLI)
 - **Database:** SQLite, zero setup. Same engine the tutorial runs against in CI.
-- **Frontend:** Turbo Drive for page transitions, Turbo Frames for inline errors, Turbo Streams for comment updates. All arrive via the `hotwire` package partway through.
-- **Styling:** Basecoat UI on scaffolded forms and views. Arrives via the `basecoat` package.
+- **Frontend:** Turbo Drive for page transitions, Turbo Frames for inline errors, Turbo Streams for comment updates. Loaded from a CDN script tag in Part 4; the `hotwire` package is the eventual canonical home.
+- **Styling:** [simple.css](https://simplecss.org/), wired into the generated `app/views/layout.cfm` by `wheels new`. Classless — semantic HTML renders polished without any markup changes. The [`wheels-basecoat`](https://github.com/wheels-dev/wheels-basecoat) package is available as an optional shadcn/ui-quality component-kit upgrade after the tutorial.
 - **Auth:** Wheels' built-in `SessionStrategy` for session cookies. Hand-rolled version shown first for understanding, built-in version shown second for shipping.
 - **Tests:** WheelsTest (BDD), plus one Playwright-driven browser spec.
 
@@ -45,7 +45,7 @@ A blog for an individual author. The final app supports:
 |------|-------|------|
 | [1. Hello, Wheels](/v4-0-0-snapshot/start-here/tutorial/01-hello-wheels/) | Scaffold an app. Add a route, a controller action, a view. | 20 min |
 | [2. Your First Model](/v4-0-0-snapshot/start-here/tutorial/02-first-model/) | Generate a Post model. Run a migration. Seed data. Build the index and show actions by hand. | 25 min |
-| [3. CRUD Scaffold](/v4-0-0-snapshot/start-here/tutorial/03-crud-scaffold/) | Throw it away. Run `wheels generate scaffold`. Activate Hotwire and Basecoat. Tour the generated files. | 25 min |
+| [3. CRUD Scaffold](/v4-0-0-snapshot/start-here/tutorial/03-crud-scaffold/) | Throw it away. Run `wheels generate scaffold`. Tour the generated files and meet Wheels' package system. | 25 min |
 | [4. Validations and Turbo Frames](/v4-0-0-snapshot/start-here/tutorial/04-validations-frames/) | Add model validations. Wrap the form in a `<turbo-frame>` so errors come back inline. | 30 min |
 | [5. Comments and Turbo Streams](/v4-0-0-snapshot/start-here/tutorial/05-comments-streams/) | Add a Comment model. Associate it with Post. Nested routes. Submit comments via Turbo Streams. | 35 min |
 | [6. Authentication](/v4-0-0-snapshot/start-here/tutorial/06-authentication/) | Hand-roll sessions first to understand the mental model. Then replace with `wheels.auth.SessionStrategy`. | 45 min |


### PR DESCRIPTION
## Summary

PR #2369 made simple.css the actual default styling and corrected chapter 1's misleading "Basecoat arrives later as a package" Aside. Three other places in the tutorial still claimed basecoat is part of the main flow even though chapters 2–7 never install or use it. This PR reconciles those references with what the tutorial actually delivers.

## What changed (3 files, 6 lines)

### `tutorial/index.mdx`

```diff
- description: A 7-part narrative tutorial. Build a complete Wheels 4.0 blog with Turbo, Basecoat, and built-in auth. Takes about 3.5 hours.
+ description: A 7-part narrative tutorial. Build a complete Wheels 4.0 blog with Turbo and built-in auth. Takes about 3.5 hours.
```

```diff
- - **Frontend:** Turbo Drive ... All arrive via the `hotwire` package partway through.
- - **Styling:** Basecoat UI on scaffolded forms and views. Arrives via the `basecoat` package.
+ - **Frontend:** Turbo Drive ... Loaded from a CDN script tag in Part 4; the `hotwire` package is the eventual canonical home.
+ - **Styling:** [simple.css](https://simplecss.org/), wired into the generated `app/views/layout.cfm` by `wheels new`. Classless — semantic HTML renders polished without any markup changes. The [`wheels-basecoat`](https://github.com/wheels-dev/wheels-basecoat) package is available as an optional shadcn/ui-quality component-kit upgrade after the tutorial.
```

```diff
- | [3. CRUD Scaffold] | Throw it away. Run `wheels generate scaffold`. Activate Hotwire and Basecoat. Tour the generated files. | 25 min |
+ | [3. CRUD Scaffold] | Throw it away. Run `wheels generate scaffold`. Tour the generated files and meet Wheels' package system. | 25 min |
```

### `tutorial/02-first-model.mdx`

```diff
- In Part 3 ... You'll also activate the Hotwire and Basecoat packages so the scaffold renders with styled forms and Turbo page transitions instead of plain HTML.
+ In Part 3 ... You'll also tour the Wheels package system and get a first look at Hotwire ahead of Part 4, where Turbo Frames land for real.
```

### `tutorial/07-testing-deploying.mdx`

```diff
- - Full CRUD scaffold with Basecoat styling and Turbo Drive
+ - Full CRUD scaffold rendered with simple.css default styling and Turbo Drive page transitions
```

## What did NOT change

`tutorial/03-crud-scaffold.mdx`'s "Three first-party packages ship today" catalog still lists `hotwire`, `basecoat`, and `sentry` — that section describes the package system generically and is factually correct. The chapter never claims to install any of them; it shows `gh repo clone` as an illustrative-only example for hotwire. This is the appropriate level of basecoat mention for the main tutorial.

## Why this isn't the bonus chapter

A real bonus chapter walking through `wheels packages install wheels-basecoat` is planned as a follow-up. Today's released runtime can't install the package end-to-end:

1. The `wheels packages install <name>` subcommand currently routes to LuCLI's package installer (which only handles git/extension deps from `lucee.json`), never reaching the Wheels module's `PackagesMainCli.cfc`.
2. Even when the package is dropped into `vendor/wheels-basecoat/` directly via `git clone`, the runtime self-reports as `0.0.0-dev` (the bug fixed in PR #2368, not yet propagated to brew), which fails wheels-basecoat's `wheelsVersion: ">=4.0"` SemVer check and the package never activates.

Once #2368 reaches a brew snapshot and the install path is verified end-to-end on a fresh VM, the bonus chapter follows. Doing it before then would mean shipping fictional install instructions.

## Test plan

- [ ] CI green (docs-build verify-docs check should be sensitive)
- [ ] Visually inspect the rendered tutorial index page for tone consistency

## Related

- #2369 — made simple.css the actual default and corrected chapter 1's Aside (this PR's anchor)
- #2368 — BuildInfo isDev() fix (blocker for the eventual basecoat bonus chapter)