### PR TITLE
fix(cli): $detectRuntime reads .module-version, not unreachable wheels.Global

### DIFF
--- a/cli/lucli/services/packages/PackagesMainCli.cfc
+++ b/cli/lucli/services/packages/PackagesMainCli.cfc
@@ -285,14 +285,47 @@ component {
 	}
 
 	private string function $detectRuntime() {
+		// Three-tier fallback. The original implementation tried to
+		// instantiate `wheels.Global` and call `$readFrameworkVersion()`,
+		// but in the LuCLI context the only registered mapping for the
+		// framework is `modules.wheels.*` — `wheels.Global` doesn't
+		// resolve, so every CLI invocation fell through to the catch
+		// and returned the `0.0.0-dev` sentinel. That made the package
+		// system version-blind from the CLI: `wheels packages show`
+		// reported every released runtime as out-of-range for every
+		// published package's wheelsVersion constraint. See PR #XXXX.
+
+		// Tier 1 — read .module-version text file (brew/chocolatey
+		// installs write this at install time with the exact module
+		// version). Plain text; no CFML compilation, no mapping lookup,
+		// and immune to BuildInfo.cfc bugs like the self-substituting
+		// sentinel issue fixed in #2368.
 		try {
-			local.global = CreateObject("component", "wheels.Global");
-			return local.global.$readFrameworkVersion();
+			local.versionFile = ExpandPath("/modules/wheels/.module-version");
+			if (FileExists(local.versionFile)) {
+				local.v = Trim(FileRead(local.versionFile));
+				if (Len(local.v)) return local.v;
+			}
 		} catch (any e) {
-			// In test contexts the framework may not be discoverable from
-			// the webroot. Fall back to a permissive sentinel that matches
-			// any wheelsVersion constraint (SemVer's "*" behaviour).
-			return "0.0.0-dev";
+			// ExpandPath may throw in unusual contexts (e.g. the file
+			// system mapping isn't yet wired). Fall through.
 		}
+
+		// Tier 2 — instantiate the bundled BuildInfo.cfc directly via
+		// the `modules.wheels.*` mapping that LuCLI guarantees. This
+		// covers ForgeBox installs and dev checkouts where the
+		// .module-version marker isn't written.
+		try {
+			local.bi = new modules.wheels.vendor.wheels.BuildInfo();
+			local.v = local.bi.version();
+			if (Len(local.v) && local.v != "0.0.0-dev") return local.v;
+		} catch (any e) {
+			// BuildInfo unreachable; fall through.
+		}
+
+		// Tier 3 — sentinel. Matches "*" against any wheelsVersion
+		// constraint via the SemVer comparator (treated as a
+		// permissive dev build).
+		return "0.0.0-dev";
 	}
 }


### PR DESCRIPTION
## Summary

`PackagesMainCli.$detectRuntime()` tried to read the runtime version by instantiating `wheels.Global` and calling `$readFrameworkVersion()` on it. In the LuCLI CLI context the only registered framework mapping is `modules.wheels.*` — `wheels.Global` doesn't resolve, so every CLI invocation fell through the try/catch and returned the `0.0.0-dev` sentinel.

Visible symptom: every `wheels packages` command reported the runtime as `0.0.0-dev`, regardless of the actual installed version. The package system was version-blind from the CLI surface.

## Reproduction

On a fresh VM running brew-installed `4.0.0-SNAPSHOT+1644`:

```
$ wheels packages show wheels-basecoat
...
Compatible versions (runtime 0.0.0-dev):
  (none — this runtime is out of range for every published version)
```

…even though `wheels-basecoat 1.0.1` advertises `wheelsVersion: ">=4.0"` and `4.0.0-SNAPSHOT+1644` is well within range.

## Fix

Three-tier fallback chain in `$detectRuntime()`:

| Tier | Source | Why |
|---|---|---|
| 1 | `~/.wheels/modules/wheels/.module-version` (text file) | Brew/chocolatey write this at install time. Plain text — no CFML compilation, no mapping lookup, immune to BuildInfo.cfc bugs (e.g. the self-substituting sentinel issue fixed in #2368). |
| 2 | `new modules.wheels.vendor.wheels.BuildInfo()` | Covers ForgeBox installs and dev checkouts where `.module-version` isn't written. Uses the `modules.wheels.*` mapping that actually exists in the LuCLI context. |
| 3 | `"0.0.0-dev"` sentinel | Last resort. Preserves the previous "matches everything via SemVer's `*` behaviour" semantics. |

Tier 1 is the fast path on every brew/chocolatey install. Tier 2 is the right answer for source checkouts and ForgeBox-style consumers. Tier 3 keeps the "everything matches" behaviour of the previous catch block.

## Verified end-to-end

Same fresh VM, same brew-installed runtime, after scp'ing this fix to `~/.wheels/modules/wheels/services/packages/PackagesMainCli.cfc`:

```
$ wheels packages show wheels-basecoat
wheels-basecoat — Basecoat UI component helpers for Wheels...
...
Compatible versions (runtime 4.0.0-SNAPSHOT+1644):
  1.0.1   [wheelsVersion >=4.0]   published 2026-04-24T00:00:00Z
  1.0.0   [wheelsVersion >=4.0]   published 2026-04-23T00:00:00Z
```

`runtime 0.0.0-dev` → `runtime 4.0.0-SNAPSHOT+1644`. Both basecoat versions surface as compatible.

## Why tests didn't catch this

`PackagesMainCliSpec` injects `runtimeVersion` directly into the constructor, bypassing `$detectRuntime()`. The lookup-failure path was unexercised. Fixing the mock-vs-real gap is left as follow-up — integration-style tests against a sandbox-installed module are the right shape, not further unit-level injection.

## Why this matters

This is a prerequisite for the eventual wheels-basecoat tutorial bonus chapter — and for the package system being usable at all from the CLI on any released runtime. Without this fix, every package shows as out-of-range and `wheels packages install` (when its own routing bug is fixed) would refuse to install anything.

## Test plan

- [ ] CI green
- [ ] After merge + brew bump, `wheels packages show <any-package>` reports the actual installed runtime version, not `0.0.0-dev`.
- [ ] `wheels packages list` continues to function (tier 3 fallback preserves prior behaviour for any code path that hits it)

## Related

- #2368 — BuildInfo isDev() fix. The Tier 2 path here implicitly depends on #2368 being in the bundled `vendor/wheels/BuildInfo.cfc` for it to return a non-`0.0.0-dev` value; the Tier 1 `.module-version` path is independent.
- Follow-up PR (next): `wheels packages install` is intercepted by LuCLI's built-in extension installer (same trap that bit `wheels browser install` and was renamed to `wheels browser setup` in #2345). The `case "install"` route in `Module.cfc::packages()` is dead code today.