### PR TITLE
fix(cli): rename packages install verb to add to dodge LuCLI interceptor

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -1855,7 +1855,7 @@ component extends="modules.BaseModule" {
 	 *   wheels packages list [--tag=<tag>]
 	 *   wheels packages search <query>
 	 *   wheels packages show <name>
-	 *   wheels packages install <name>[@<version>] [--force]
+	 *   wheels packages add <name>[@<version>] [--force]
 	 *   wheels packages update <name> --yes
 	 *   wheels packages update --all --yes
 	 *   wheels packages remove <name>
@@ -1886,13 +1886,27 @@ component extends="modules.BaseModule" {
 				opts.name = positional[2];
 				var mainCli = new modules.wheels.services.packages.PackagesMainCli();
 				return mainCli.show(opts);
-			case "install":
+			case "add":
 				if (arrayLen(positional) < 2) {
-					throw(message="install requires a name: wheels packages install <name>[@<version>]");
+					throw(message="add requires a name: wheels packages add <name>[@<version>]");
 				}
 				opts.target = positional[2];
 				var mainCli = new modules.wheels.services.packages.PackagesMainCli();
-				return mainCli.install(opts);
+				return mainCli.add(opts);
+			case "install":
+				// Dead code on the CLI surface: LuCLI's built-in extension
+				// installer intercepts the literal verb `install` across
+				// all modules before dispatch reaches Module.cfc — the
+				// same trap that bit `wheels browser install` (renamed
+				// to `wheels browser setup` in #2345). Kept as a
+				// documentation marker for future maintainers; if LuCLI
+				// ever stops intercepting, this case keeps a friendly
+				// redirect for users still typing the historic verb.
+				out("'wheels packages install' is intercepted by LuCLI's", "yellow");
+				out("built-in extension installer and won't reach this module.", "yellow");
+				out("Use:", "yellow");
+				out("  wheels packages add " & (arrayLen(positional) >= 2 ? positional[2] : "<name>"), "bold");
+				return "";
 			case "update":
 				opts.target = arrayLen(positional) >= 2 ? positional[2] : "";
 				var mainCli = new modules.wheels.services.packages.PackagesMainCli();

--- a/cli/lucli/services/packages/PackagesMainCli.cfc
+++ b/cli/lucli/services/packages/PackagesMainCli.cfc
@@ -5,10 +5,18 @@
  *   list [--tag=<tag>]
  *   search <query>
  *   show <name>
- *   install <name>[@<version>] [--force]
+ *   add <name>[@<version>] [--force]
  *   update <name> [--yes]
  *   update --all --yes
  *   remove <name>
+ *
+ * `add` (not `install`!) is the install verb because LuCLI's built-in
+ * extension installer intercepts the literal subcommand `install`
+ * across all modules — same trap that bit `wheels browser install`
+ * (renamed to `wheels browser setup` in #2345). User input
+ * `wheels packages install <name>` never reaches Module.cfc; LuCLI
+ * runs its own dependency installer against `lucee.json` instead and
+ * prints "No git or extension dependencies to install".
  *
  * Outputs plain text suitable for a terminal. Exit-code semantics are
  * the caller's job (Module.cfc throws to signal non-zero on fatal error;
@@ -140,14 +148,24 @@ component {
 		return ArrayToList(local.buf, Chr(10)) & Chr(10);
 	}
 
-	public string function install(struct opts = {}) {
+	public string function add(struct opts = {}) {
 		local.target = Trim(arguments.opts.target ?: "");
 		if (!Len(local.target)) {
-			Throw(type = "Wheels.Packages.BadInput", message = "install requires a package name: wheels packages install <name>[@<version>]");
+			Throw(type = "Wheels.Packages.BadInput", message = "add requires a package name: wheels packages add <name>[@<version>]");
 		}
 		local.parsed = $parseTarget(local.target);
 		local.force = arguments.opts.force ?: false;
 		return $doInstall(local.parsed.name, local.parsed.pin, local.force);
+	}
+
+	// `install` is preserved as an alias for any in-process callers
+	// (specs, scripted clients) that haven't migrated to `add`. Note
+	// that the public CLI surface — `wheels packages install <name>` —
+	// never reaches this method because LuCLI's built-in extension
+	// installer intercepts the literal `install` subcommand before
+	// Module.cfc dispatches. See the component header.
+	public string function install(struct opts = {}) {
+		return add(argumentCollection = arguments);
 	}
 
 	public string function update(struct opts = {}) {
@@ -161,7 +179,7 @@ component {
 		if (!variables.installer.isInstalled(local.name)) {
 			Throw(
 				type = "Wheels.Packages.NotInstalled",
-				message = "Package '#local.name#' is not installed. Use `wheels packages install #local.name#`."
+				message = "Package '#local.name#' is not installed. Use `wheels packages add #local.name#`."
 			);
 		}
 		if (!(arguments.opts.yes ?: false)) {
@@ -258,7 +276,7 @@ component {
 			// rather than crashing on Left(str, 0) (a documented Lucee 7 hazard).
 			Throw(
 				type = "Wheels.Packages.BadInput",
-				message = "Package name is required before '@'. Use: wheels packages install <name>[@<version>]"
+				message = "Package name is required before '@'. Use: wheels packages add <name>[@<version>]"
 			);
 		}
 		if (local.at > 1) {

--- a/cli/lucli/templates/app/app/views/layout.cfm
+++ b/cli/lucli/templates/app/app/views/layout.cfm
@@ -17,7 +17,7 @@
 			      any markup changes. Form helpers like #textField()# already emit the
 			      right tags, so scaffolded views render polished out of the box.
 			      Remove this line if you're bringing your own CSS, or swap for a richer
-			      component kit — e.g. `wheels packages install wheels-basecoat`. --->
+			      component kit — e.g. `wheels packages add wheels-basecoat`. --->
 			<link rel="stylesheet" href="https://cdn.simplecss.org/simple.min.css">
 		</head>
 

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/digging-deeper/packages.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/digging-deeper/packages.mdx
@@ -35,7 +35,7 @@ Packages are distributed as standalone Git repositories, indexed by the [`wheels
 Install a package:
 
 ```bash title="your shell"
-wheels packages install wheels-hotwire
+wheels packages add wheels-hotwire
 wheels reload
 ```
 
@@ -45,7 +45,7 @@ Browse, search, inspect, update, or remove:
 wheels packages list                    # installed packages with versions
 wheels packages search hotwire          # match name/description/tags
 wheels packages show wheels-sentry      # registry detail page
-wheels packages install wheels-sentry@1.2.0   # pin a specific version
+wheels packages add wheels-sentry@1.2.0   # pin a specific version
 wheels packages update wheels-sentry --yes
 wheels packages update --all --yes
 wheels packages remove wheels-hotwire
@@ -295,7 +295,7 @@ Submission flow:
 4. CI validates schema, name uniqueness, that the source repo and tag resolve, the file-type allowlist, and the size cap.
 5. A maintainer reviews — they confirm the author's repo looks real and the package fits the ecosystem, then merge.
 6. The `mirror-tarball` workflow clones the tagged source, builds a deterministic tarball, uploads it to a release on the registry repo, computes a sha256, and bot-commits both back into your manifest.
-7. Users install via `wheels packages install wheels-foo`.
+7. Users install via `wheels packages add wheels-foo`.
 
 Publishing a new version is the same PR flow — append to the `versions[]` array, don't mutate previous entries. `wheels packages update` is explicit; users opt in to version bumps.
 
@@ -303,9 +303,11 @@ Publishing a new version is the same PR flow — append to the `versions[]` arra
 
 The install/update surface is covered by the commands shown earlier under [The activation model](#the-activation-model). The full set (see `wheels packages --help`):
 
-- `wheels packages list | search | show | install | update | remove` — day-to-day install and lifecycle operations.
-- `wheels packages install <name>@<version>` — pin a specific version; omit for the latest compatible.
-- `wheels packages install <name> --force` — overwrite an existing `vendor/<name>/`.
+- `wheels packages list | search | show | add | update | remove` — day-to-day install and lifecycle operations.
+- `wheels packages add <name>@<version>` — pin a specific version; omit for the latest compatible.
+- `wheels packages add <name> --force` — overwrite an existing `vendor/<name>/`.
+
+The install verb is `add`, not `install`, because LuCLI's built-in extension installer intercepts `install` across all modules — typing `wheels packages install foo` runs LuCLI's own `lucee.json` dependency resolver and never reaches the Wheels package handler. (Same trap that earlier renamed `wheels browser install` to `wheels browser setup`.) `add` is the canonical verb across the docs.
 - `wheels packages update --all --yes` — bulk-update every installed package, no prompt.
 - `wheels packages registry refresh | info` — manage the 24-hour registry cache.
 


### PR DESCRIPTION
## Summary

`wheels packages install <name>` doesn't reach `Module.cfc::packages()` — LuCLI's built-in extension installer intercepts the literal verb `install` across all modules and runs its own `lucee.json` dependency resolver instead, which has no awareness of the `wheels-packages` registry. The user sees `[INFO] No git or extension dependencies to install` and concludes the install failed (which it did, just for a non-obvious reason).

Same trap that bit `wheels browser install` (renamed to `wheels browser setup` in #2345).

## Fix

Rename the canonical install verb from `install` to `add`:

```
wheels packages add wheels-basecoat            # latest compat
wheels packages add wheels-basecoat@1.0.1      # pin a version
wheels packages add wheels-basecoat --force    # overwrite existing vendor/
```

`add` follows the npm/yarn/bundle/cargo convention. It dodges LuCLI's interceptor cleanly.

### Module.cfc switch

| Case | Behaviour |
|---|---|
| `add` | New canonical. Dispatches to `PackagesMainCli.add()`. |
| `install` | Documentation marker. Prints a friendly redirect to `add`. **Dead code on the CLI today** (LuCLI intercepts before this fires) but a useful in-source signal for future maintainers and a friendly fallback if LuCLI stops intercepting in some future version. |

### PackagesMainCli

- `install()` renamed to `add()`.
- `install()` preserved as an alias that delegates to `add()`. Keeps backward compatibility for in-process callers (specs, scripted clients) that haven't migrated. Existing `PackagesMainCliSpec` tests pass unchanged because they call `.install()` in-process — never go through the LuCLI dispatch table.

### Docs

- `web/sites/guides/.../digging-deeper/packages.mdx` — all examples switched to `add`; added an explanatory paragraph about why the verb is `add`, not `install`.
- `cli/lucli/templates/app/app/views/layout.cfm` — the comment recommending `wheels packages add wheels-basecoat` as the upgrade-from-simple.css path now uses the correct verb.

Internal error messages in `PackagesMainCli.cfc` also updated.

## Verified end-to-end

Fresh VM running `4.0.0-SNAPSHOT+1644`, with #2373's `$detectRuntime` fix also patched in (so the runtime version is correctly detected):

```
Before:
  $ wheels packages install wheels-basecoat
  [INFO]  Reading lucee.json...
  [INFO]  Resolving dependencies...
  ℹ️  No git or extension dependencies to install
  $ ls vendor/
  wheels                                            # nothing installed

After:
  $ wheels packages add wheels-basecoat
  Installed wheels-basecoat@1.0.1 → /Users/peter/ws/blog/vendor/wheels-basecoat
  Run `wheels reload` to activate it.
  $ ls vendor/
  wheels  wheels-basecoat                           # ✓
```

The install/extract path is now end-to-end functional.

## ⚠ Known follow-up: activation still blocked

Package **install** works after this PR + #2373. Package **activation** (mixin injection into controllers and views) is still blocked by a separate, deeper bug:

> `application.wheels.failedPackages` contains: `error: invalid component definition, can't find component [vendor.wheels-basecoat.Basecoat]`

Lucee 7 cannot resolve component paths containing a hyphen — `createObject("component", "vendor.wheels-basecoat.Basecoat")` fails even though `vendor/wheels-basecoat/Basecoat.cfc` exists on disk and the `/vendor` mapping is correctly set in `Application.cfc`. Affects every package with a hyphen in its directory name, which is the entire `wheels-*` registry today.

`PackageLoader.cfc:404` does:
```cfml
local.componentPath = "#variables.componentPrefix#.#arguments.dirName#.#local.cfcName#";
local.pkg = CreateObject("component", local.componentPath).init();
```

A fix likely involves registering a per-package Lucee mapping with a hyphen-free key (e.g. `application.this.mappings["/__pkg_wheels_basecoat"] = ...`) so the entry CFC can be loaded by a path the parser accepts. That's a non-trivial PackageLoader change and out of scope for this PR — file as a separate issue/PR.

## What this unblocks (and what it doesn't)

| Step | Before #2373 | After #2373 | After #2373 + this PR | After all three fixes (incl. the hyphen one) |
|---|---|---|---|---|
| `wheels packages show <name>` reports correct runtime | ❌ | ✓ | ✓ | ✓ |
| `wheels packages add <name>` extracts to vendor/ | ❌ | ❌ | ✓ | ✓ |
| Helpers activate, `#uiButton(...)#` renders in views | ❌ | ❌ | ❌ | ✓ |
| Tutorial bonus chapter shippable | ❌ | ❌ | ❌ | ✓ |

This PR is step 2 of 3.

## Test plan

- [ ] CI green
- [ ] After merge + brew bump, `wheels packages add wheels-basecoat` extracts the package successfully
- [ ] `wheels packages install wheels-basecoat` continues to be intercepted by LuCLI (the dead-code redirect won't fire there)
- [ ] Existing `PackagesMainCliSpec` tests pass unchanged (they call `.install()` in-process; the alias preserves them)

## Related

- #2373 — `$detectRuntime` fix (prerequisite; this PR depends on the runtime version being detectable to pass the manifest's `wheelsVersion` constraint check during install).
- #2345 — same trap, fixed for `wheels browser install` → `wheels browser setup`.
- Follow-up: `PackageLoader` cannot load CFCs at hyphenated paths in Lucee 7. Separate investigation needed.