### PR TITLE
ci: wrap release-asset upload in Wandalen/wretry to recover from upload flakes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,69 +309,90 @@ jobs:
           echo "Release notes extracted to release-notes.md"
           cat release-notes.md
 
+      # Wrapped in Wandalen/wretry.action@v3 to recover from transient
+      # GitHub Actions artifact-upload flakes — observed pattern is
+      # `##[error]other side closed` mid-stream after most assets upload
+      # successfully (e.g. SNAPSHOT+1655 lost wheels-core-*.zip while 17/18
+      # other assets uploaded fine). softprops/action-gh-release@v3 is
+      # safe to retry because `overwrite_files: true` makes it idempotent:
+      # on retry it attaches to the existing release and only re-uploads
+      # missing or stale assets. attempt_delay is in milliseconds.
       - name: Create GitHub Release
         if: github.ref == 'refs/heads/main'
         id: gh-release-final
-        uses: softprops/action-gh-release@v3
+        uses: Wandalen/wretry.action@v3
         with:
-          tag_name: v${{ env.WHEELS_VERSION }}
-          name: Wheels ${{ env.WHEELS_VERSION }}
-          body_path: release-notes.md
-          draft: false
-          prerelease: ${{ env.WHEELS_PRERELEASE }}
-          files: |
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-base-template-*.zip
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-base-template-*.md5
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-base-template-*.sha512
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-core-*.zip
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-core-*.md5
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-core-*.sha512
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-cli-*.zip
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-cli-*.md5
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-cli-*.sha512
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-starter-app-*.zip
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-starter-app-*.md5
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-starter-app-*.sha512
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.tar.gz
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.tar.gz.md5
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.tar.gz.sha512
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip.md5
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip.sha512
+          action: softprops/action-gh-release@v3
+          attempt_limit: 3
+          attempt_delay: 30000
+          with: |
+            tag_name: v${{ env.WHEELS_VERSION }}
+            name: Wheels ${{ env.WHEELS_VERSION }}
+            body_path: release-notes.md
+            draft: false
+            prerelease: ${{ env.WHEELS_PRERELEASE }}
+            overwrite_files: true
+            files: |
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-base-template-*.zip
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-base-template-*.md5
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-base-template-*.sha512
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-core-*.zip
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-core-*.md5
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-core-*.sha512
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-cli-*.zip
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-cli-*.md5
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-cli-*.sha512
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-starter-app-*.zip
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-starter-app-*.md5
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-starter-app-*.sha512
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.tar.gz
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.tar.gz.md5
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.tar.gz.sha512
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip.md5
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip.sha512
 
       #############################################
       # Create Snapshot Pre-Release (develop only)
       #############################################
 
+      # Same retry-wrap rationale as the stable Create-GitHub-Release step
+      # above. Both branches need the wrap because the same flake fires on
+      # any release upload regardless of branch.
       - name: Create Snapshot Pre-Release
         if: github.ref != 'refs/heads/main'
         id: gh-release-snapshot
-        uses: softprops/action-gh-release@v3
+        uses: Wandalen/wretry.action@v3
         with:
-          tag_name: v${{ env.WHEELS_VERSION }}
-          name: Wheels ${{ env.WHEELS_VERSION }} (snapshot)
-          body: "Snapshot build from develop. Not for production use."
-          draft: false
-          prerelease: true
-          files: |
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-base-template-*.zip
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-base-template-*.md5
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-base-template-*.sha512
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-core-*.zip
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-core-*.md5
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-core-*.sha512
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-cli-*.zip
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-cli-*.md5
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-cli-*.sha512
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-starter-app-*.zip
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-starter-app-*.md5
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-starter-app-*.sha512
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.tar.gz
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.tar.gz.md5
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.tar.gz.sha512
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip.md5
-            artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip.sha512
+          action: softprops/action-gh-release@v3
+          attempt_limit: 3
+          attempt_delay: 30000
+          with: |
+            tag_name: v${{ env.WHEELS_VERSION }}
+            name: Wheels ${{ env.WHEELS_VERSION }} (snapshot)
+            body: "Snapshot build from develop. Not for production use."
+            draft: false
+            prerelease: true
+            overwrite_files: true
+            files: |
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-base-template-*.zip
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-base-template-*.md5
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-base-template-*.sha512
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-core-*.zip
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-core-*.md5
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-core-*.sha512
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-cli-*.zip
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-cli-*.md5
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-cli-*.sha512
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-starter-app-*.zip
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-starter-app-*.md5
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-starter-app-*.sha512
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.tar.gz
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.tar.gz.md5
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.tar.gz.sha512
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip.md5
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip.sha512
 
       #############################################
       # Dispatch downstream package managers


### PR DESCRIPTION
## Summary

Adds an automatic-retry wrap around the two `softprops/action-gh-release@v3` calls in `release.yml` so the next "other side closed" upload flake recovers without human intervention.

### Why

The Snapshots run for `develop@61c17d80` (the auto-PR baseline refresh that fired right after [#2378](https://github.com/wheels-dev/wheels/pull/2378) merged) failed at the artifact-upload step:

```
✅ Uploaded wheels-module-4.0.0-SNAPSHOT+1655.zip
✅ Uploaded wheels-module-4.0.0-SNAPSHOT+1655.tar.gz
##[error]other side closed             ← 2 minutes of silence, then failure
```

17 of 18 release assets uploaded fine; one (`wheels-core-4.0.0-SNAPSHOT+1655.zip`, 3.3 MB) dropped mid-stream. Manual `gh run rerun --failed` recovered it cleanly. This pattern is recurring on every package-registry baseline auto-refresh chain, so wrapping it in retry is the right shape.

### What changed

Two steps in `release.yml` are now wrapped:

- `Create GitHub Release` (main-branch stable releases, line 312)
- `Create Snapshot Pre-Release` (develop-branch snapshots, line 346)

Both wraps use `Wandalen/wretry.action@v3` (the right tool for retrying `uses:` action invocations — `nick-fields/retry@v3` only handles shell `run:` steps). Retry params:

- `attempt_limit: 3`
- `attempt_delay: 30000` (30s)

`overwrite_files: true` is now set explicitly on both wrapped invocations. It's already the action's v3 default, but the retry-safety property critically depends on this flag — making it explicit so a future default flip won't silently break retry semantics.

### How retry preserves correctness

`softprops/action-gh-release@v3` with `overwrite_files: true` is idempotent on retry:

1. If the release already exists (which it will after the first attempt creates it), it's reused.
2. For each file in the `files:` glob, the action upserts: missing assets get uploaded, existing ones get overwritten.

So a partial-upload failure on attempt 1 → attempt 2 finishes the job. No duplicate releases, no duplicate tag pushes, no torn state.

### Out of scope for this PR

- Migrating to a different release-publishing action (e.g. native `gh release` shell calls). The retry wrap is the smaller, more surgical change. If we ever want to drop the third-party action entirely, that's a separate refactor.
- Retrying other steps that occasionally flake (e.g. `actions/upload-artifact@v6`, the Java setup step). Each has its own failure characteristics; wrap them as needed when they bite.

### Test plan

- [ ] CI passes on this branch
- [ ] On merge, the next snapshot run fires normally — the wrap is transparent when the underlying action succeeds first try
- [ ] (Future, can't test without an actual flake) When a flake hits, log shows `Retrying...` from Wandalen/wretry rather than a job failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)