### PR TITLE
ci: pin softprops/action-gh-release to v2.6.2 (dodge v3.0.0 regression)

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -240,8 +240,10 @@ jobs:
           echo "Release notes extracted to release-notes.md"
           cat release-notes.md
 
+      # Pinned to v2.6.2: see release.yml Create-GitHub-Release for the
+      # full v3.0.0 ArrayBuffer-regression rationale.
       - name: Create GitHub Prerelease
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@v2.6.2
         with:
           tag_name: v${{ env.WHEELS_VERSION }}
           name: Wheels ${{ env.WHEELS_VERSION }} (Release Candidate)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,16 +313,28 @@ jobs:
       # GitHub Actions artifact-upload flakes — observed pattern is
       # `##[error]other side closed` mid-stream after most assets upload
       # successfully (e.g. SNAPSHOT+1655 lost wheels-core-*.zip while 17/18
-      # other assets uploaded fine). softprops/action-gh-release@v3 is
-      # safe to retry because `overwrite_files: true` makes it idempotent:
-      # on retry it attaches to the existing release and only re-uploads
+      # other assets uploaded fine). softprops/action-gh-release is safe
+      # to retry because `overwrite_files: true` makes it idempotent: on
+      # retry it attaches to the existing release and only re-uploads
       # missing or stale assets. attempt_delay is in milliseconds.
+      #
+      # Pinned to v2.6.2: softprops/action-gh-release@v3.0.0 (released
+      # 2026-04-12) introduced a regression where `.zip.sha512` asset
+      # uploads fail deterministically with `##[error]The "chunk"
+      # argument must be of type string or an instance of Buffer,
+      # TypedArray, or DataView. Received an instance of ArrayBuffer`.
+      # Because the error is deterministic, the Wandalen retry-wrap
+      # above runs all 3 attempts with the same result and exits 1.
+      # First seen on SNAPSHOT+1656; same error on +1657. Re-pin to @v3
+      # once upstream ships a fix. v2.6.2 was cut on the same day as
+      # v3.0.0 and is the last known-good release for this repo's
+      # upload pattern.
       - name: Create GitHub Release
         if: github.ref == 'refs/heads/main'
         id: gh-release-final
         uses: Wandalen/wretry.action@v3
         with:
-          action: softprops/action-gh-release@v3
+          action: softprops/action-gh-release@v2.6.2
           attempt_limit: 3
           attempt_delay: 30000
           with: |
@@ -364,7 +376,7 @@ jobs:
         id: gh-release-snapshot
         uses: Wandalen/wretry.action@v3
         with:
-          action: softprops/action-gh-release@v3
+          action: softprops/action-gh-release@v2.6.2
           attempt_limit: 3
           attempt_delay: 30000
           with: |


### PR DESCRIPTION
## Summary

Pin `softprops/action-gh-release` from the floating `@v3` tag to `@v2.6.2` in three workflow steps. v3.0.0 (released 2026-04-12) introduced a deterministic regression that breaks every snapshot publish on develop.

## The bug

After PR #2381 merged to develop, `Wheels Snapshots` run [#1657](https://github.com/wheels-dev/wheels/actions/runs/25149990634) failed at `Create Snapshot Pre-Release` with:

```
##[error]The "chunk" argument must be of type string or an instance of
Buffer, TypedArray, or DataView. Received an instance of ArrayBuffer
```

The error fires three times in a row at exactly 30-second intervals, matching the `Wandalen/wretry.action@v3` cadence configured in #2380 — proving the retry-wrap **is** working as designed but cannot help because the error is deterministic, not transient. Same error pattern visible on the previous run [#1656](https://github.com/wheels-dev/wheels/actions/runs/25149242045) on commit `f791d404` (which was the #2380 merge itself).

## Root cause

`softprops/action-gh-release@v3.0.0` shipped on 2026-04-12. The repo pinned `@v3` (a floating major tag), so it auto-upgraded the moment v3.0.0 went live. The new release has a regression in how it streams asset uploads — passing an `ArrayBuffer` into Node's stream-write API where Node 20+ requires `Buffer`/`TypedArray`/`DataView`/`string`. Affects at minimum `.zip.sha512` files.

`v2.6.2` was cut the same day as `v3.0.0` and is the last known-good release for this repo's upload pattern. `overwrite_files: true` (which #2380 relies on for retry idempotency) exists in v2.x as well.

Upstream issue: https://github.com/softprops/action-gh-release/issues/790

## Changes

- `.github/workflows/release.yml:325` — `@v3` → `@v2.6.2` (Create GitHub Release, main only)
- `.github/workflows/release.yml:367` — `@v3` → `@v2.6.2` (Create Snapshot Pre-Release, develop only)
- `.github/workflows/release-candidate.yml:244` — `@v3` → `@v2.6.2` (Create GitHub Prerelease)
- Expanded the comment block above `Create GitHub Release` to capture the regression rationale so a future maintainer doesn't silently bump the major version back without checking that v3.x is healthy.

## Test plan

- [ ] CI: `Lucee 7 + SQLite (LuCLI)` passes (sanity).
- [ ] CI: `verify` and `Validate Commit Messages` pass.
- [ ] After merge to develop: next `Wheels Snapshots` run completes without the `ArrayBuffer` error and the snapshot release attaches all 18 assets cleanly.
- [ ] Once upstream ships v3.0.1 with the chunk-type fix, follow up to re-pin to `@v3` (or `@v3.0.1` if we want belt-and-suspenders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
