### PR TITLE
docs(tutorial): add upgrade tip to chapter 1 install section

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/01-hello-wheels.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/01-hello-wheels.mdx
@@ -28,6 +28,15 @@ This is Part 1. You're starting with nothing. By the end, you'll have a working 
 
 If you haven't yet, see [Installing Wheels](/v4-0-0-snapshot/start-here/installing/) for macOS, Windows, and Linux.
 
+<Aside type="tip" title="Already installed? Make sure you're on the latest snapshot.">
+  Wheels 4.0 ships frequent snapshot releases — the tutorial assumes you're on the current one. If you installed a while back, refresh first:
+
+  - **macOS / Linux (Homebrew):** `brew update && brew upgrade wheels`
+  - **Windows / other:** see [Installing → Upgrading](/v4-0-0-snapshot/start-here/installing/#upgrading)
+
+  Then re-run `wheels --version` and confirm the version matches the [latest release](https://github.com/wheels-dev/wheels/releases).
+</Aside>
+
 Verify:
 
 ```bash {test:cli cmd="wheels --version" asserts-stdout="Wheels"}


### PR DESCRIPTION
## Summary

Adds an \`<Aside type=\"tip\">\` to the \"Install the Wheels CLI\" subsection of Part 1, pointing readers with an existing install at the upgrade flow before they invest time in the tutorial.

## Why

Today on a fresh-VM walkthrough I had Wheels \`4.0.0-SNAPSHOT+1652\` from a prior session, opened the tutorial, and was about to start without realizing how far behind I was. Snapshot numbers carry no semver meaning so \"is this current?\" isn't visible without a side-trip to GitHub Releases. A 30-second nudge before the 3.5-hour tutorial is high-leverage.

## Placement choice

| Page | Add aside? | Why |
|---|---|---|
| \`installing.mdx\` | No | Already has a full Upgrading section. Aside would be redundant. |
| \`tutorial/index.mdx\` | No | Meta-content (chapter list, conventions). Actionable moment is in chapter 1. |
| \`tutorial/01-hello-wheels.mdx\` | **Yes** | The existing \"Install the Wheels CLI\" subsection is the natural anchor — sits right above \`wheels --version\` so the verify command becomes the immediate confirmation that the upgrade worked. |

## Diff

```diff
 ## Install the Wheels CLI

 If you haven't yet, see [Installing Wheels](...) for macOS, Windows, and Linux.

+<Aside type=\"tip\" title=\"Already installed? Make sure you're on the latest snapshot.\">
+  Wheels 4.0 ships frequent snapshot releases — the tutorial assumes you're on the current one. If you installed a while back, refresh first:
+
+  - **macOS / Linux (Homebrew):** \`brew update && brew upgrade wheels\`
+  - **Windows / other:** see [Installing → Upgrading](.../#upgrading)
+
+  Then re-run \`wheels --version\` and confirm the version matches the [latest release](https://github.com/wheels-dev/wheels/releases).
+</Aside>

 Verify:
```

Single-source linking: cross-link to \`installing.mdx#upgrading\` rather than inlining commands keeps the upgrade story in one place. When the v2 Chocolatey package ships and Windows gets a one-liner, only \`installing.mdx\` needs updating and this aside inherits the change.

## Test plan

- [ ] CI: \`Deploy guides\` builds cleanly (Astro/Starlight parses the new Aside).
- [ ] CI: \`Visual regression\` passes — only the guides homepage is screenshotted, not chapter 1, so this change shouldn't trigger a baseline diff.
- [ ] Manual: Cloudflare Pages preview renders the tip box correctly above the \`wheels --version\` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)