### PR TITLE
docs: align commit-message section with commitlint.config.js

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -993,13 +993,70 @@ Deeper documentation lives in `.ai/` — Claude will search it automatically whe
 
 ## Commit Message Conventions
 
-This repo uses commitlint. Commit messages must follow: `type(scope): lowercase subject`
+This repo uses commitlint. The canonical rules live in `commitlint.config.js`; this section reflects them. If the two ever disagree, the config wins — open a PR updating this section to match.
 
-**Valid scopes:** `model`, `controller`, `view`, `router`, `middleware`, `migration`, `cli`, `test`, `config`, `di`, `job`, `mailer`, `plugin`, `sse`, `seed`, `docs`
+### Format
 
-**Invalid scope:** `security` — use the layer it touches (e.g., `model` for SQL injection fix, `view` for XSS fix, `config` for consoleeval hardening, `cli` for MCP server fixes).
+`type(scope): subject`
 
-**Subject must be lowercase.** No sentence-case, start-case, or pascal-case. Write `fix(model): validate index names` not `fix(model): Validate index names`.
+- **type** is required.
+- **scope** is optional. Omit it when no allowed scope fits cleanly (this is normal — many commits don't need one).
+- **subject** is required, must not be empty, and must not be ALL-CAPS.
+
+### Valid types
+
+`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
+
+### Valid scopes (full list)
+
+Framework layers:
+`model`, `controller`, `view`, `router`, `middleware`, `migration`, `cli`, `test`, `config`, `di`, `job`, `mailer`, `plugin`, `sse`, `seed`, `docs`
+
+Static-site monorepo (under `web/`):
+`web`, `web/ui`, `web/landing`, `web/blog`, `web/guides`, `web/api`, `web/starlight`
+
+When a change spans multiple layers or doesn't map cleanly, **use no scope** — `docs: …`, `fix: …`, `ci: …` are all valid bare forms. Prefer no scope over guessing.
+
+### Common scope choices by file path
+
+| You touched | Scope to use |
+|---|---|
+| `web/sites/guides/...` (tutorial, guides content) | `docs` (preferred for prose) or `web/guides` (preferred for site infra) |
+| `web/sites/landing/...` | `web/landing` |
+| `web/sites/blog/...` | `web/blog` |
+| `web/sites/api/...` | `web/api` |
+| `web/sites/packages/...` | `web` |
+| `web/tests/visual-baselines/...` | `web` |
+| `app/views/...`, `vendor/wheels/view/...` | `view` |
+| `app/models/...`, `vendor/wheels/model/...` | `model` |
+| `cli/...`, `vendor/wheels/cli/...` | `cli` |
+| `config/...` | `config` |
+| `tests/...` | `test` |
+| `.github/workflows/...` | type `ci`, no scope (e.g. `ci: pin softprops…`) |
+| `CLAUDE.md`, `README.md`, root docs | type `docs`, no scope |
+
+### Invalid scopes
+
+- `security` — use the layer it touches (e.g., `model` for SQL injection fix, `view` for XSS fix, `config` for consoleeval hardening).
+- Anything not in the lists above. Specifically **do not invent scopes** like `tutorial`, `package`, `release` — commitlint will reject them.
+
+### Subject rules
+
+- Must not be empty.
+- Must not be ALL-CAPS (e.g., `fix: FIX BUG` is rejected).
+- Sentence-case, start-case, and pascal-case **are allowed** — proper nouns like `Giscus`, `CockroachDB`, `Buttondown` may keep their canonical capitalization.
+- Header (`type(scope): subject`) capped at 100 chars.
+
+### When you forget and CI rejects the commit
+
+`gh pr checks <PR>` shows `Validate Commit Messages | fail`. The fix:
+
+```bash
+git commit --amend -m "<corrected message>"
+git push --force-with-lease origin <branch>
+```
+
+CI re-runs on the new commit. No need for a separate "fix commit message" commit on a single-commit PR.
 
 ## Branding
 


### PR DESCRIPTION
## Summary

The \"Commit Message Conventions\" section in CLAUDE.md drifted from the actual \`commitlint.config.js\` rules in two ways, and we kept tripping over both. This PR re-syncs the section and adds enough structure that contributors (and Claude Code agents) stop guessing.

## What was wrong

### 1. Seven \`web/*\` scopes were missing from the docs

The config allows 23 scopes; CLAUDE.md only listed 16. The static-site monorepo's \`web\`, \`web/ui\`, \`web/landing\`, \`web/blog\`, \`web/guides\`, \`web/api\`, \`web/starlight\` scopes were added to commitlint but never mirrored into the docs. So when picking a scope for a \`web/sites/guides/...\` change, the visible options didn't include anything obviously matching — leading to either invented scopes (\`tutorial\`, \`package\`) that get rejected, or falling back to \`docs\` and losing the more specific signal.

### 2. The subject-case rule was stricter than reality

CLAUDE.md said:
> **Subject must be lowercase.** No sentence-case, start-case, or pascal-case.

The config actually only forbids ALL-CAPS:
```js
'subject-case': [2, 'never', ['upper-case']]
```
With an explicit comment that sentence-case, start-case, and pascal-case are allowed for proper nouns like \`Giscus\`, \`CockroachDB\`, \`Buttondown\`. Over-strict docs led to unnecessary downcasing of legitimate proper nouns.

## What this changes

- **Adds the full 23-scope list**, split into framework layers vs. web monorepo for navigability.
- **Adds a \"Common scope choices by file path\" table** — the answer to \"what scope do I use here?\" is now a two-step lookup instead of guessing.
- **Fixes the subject-case rule** to match the config (only ALL-CAPS forbidden).
- **Adds a \"scope is optional\" call-out** — many commits don't need one, and \"no scope\" is preferable to guessing.
- **Adds a recovery footnote** — when CI rejects a commit message, amend + force-push fixes it without a separate commit.
- **Names \`commitlint.config.js\` as the source of truth** so future drift can be resolved by re-syncing this section to the config, not the other way around.

## How this surfaced

PR #2390 (\"add upgrade tip to chapter 1 install section\") used \`docs(tutorial):\` and was rejected by \`Validate Commit Messages\`. The CLAUDE.md section listed no obvious scope for tutorial content, so I reached for one that seemed semantically reasonable. The actual valid choice was \`docs:\` (no scope) or \`docs(web/guides):\` — neither was clearly indicated by the docs at the time.

## Test plan

- [ ] CI: \`Validate Commit Messages\` passes on this PR (header is now \`docs: align commit-message section with commitlint.config.js\` — type \`docs\`, no scope, lowercase subject, under 100 chars).
- [ ] Manual: skim the rendered CLAUDE.md and confirm the table reads sensibly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)