### PR TITLE
fix(docs): repair chapter 8 paste bugs that 500 the post show view

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/08-bonus-basecoat.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/08-bonus-basecoat.mdx
@@ -229,11 +229,12 @@ basecoat ships CFML view helpers — but the actual styling is provided by `base
        #uiCardHeader(title="Comments")#
        #uiCardContent()#
            <section id="comments">
-               <cfloop query="post.comments()">
+               <cfset comments = post.comments()>
+               <cfloop query="comments">
                    <article style="margin-bottom: 1em;">
-                       <strong>#post.comments.author#</strong>
-                       <span style="color: var(--bc-muted-foreground);">· #DateFormat(post.comments.createdAt, "mmm d")#</span>
-                       <p>#post.comments.body#</p>
+                       <strong>#comments.author#</strong>
+                       <span style="color: var(--bc-muted-foreground);">· #DateFormat(comments.createdAt, "mmm d")#</span>
+                       <p>#comments.body#</p>
                    </article>
                </cfloop>
            </section>
@@ -241,7 +242,7 @@ basecoat ships CFML view helpers — but the actual styling is provided by `base
    #uiCardEnd()#
 
    <turbo-frame id="new_comment">
-       #startFormTag(route="postComments", key=post.id)#
+       #startFormTag(route="postComments", postKey=post.id)#
            #uiField(label="Your name", name="comment[author]", type="text", required=true)#
            #uiField(label="Your comment", name="comment[body]", type="textarea", required=true, rows=4)#
            #uiButton(text="Post comment", variant="primary", type="submit")#


### PR DESCRIPTION
## Summary
- Fix two bugs in chapter 8's \"Replace \`app/views/posts/show.cfm\` entirely\" snippet that caused HTTP 500 when a tutorial follower pasted it verbatim
- Hoist \`post.comments()\` into a \`<cfset>\` before the \`<cfloop>\` (Lucee 7 rejects function-call expressions in \`query=\`); match chapter 5's working pattern
- Use \`postKey=post.id\` to satisfy chapter 5's nested-resource \`:postKey\` placeholder (was incorrectly \`key=post.id\`, which throws \`Wheels.IncorrectRoutingArguments\`)

## Source
Discovered during a Wheels Tutorial fresh-VM bake. Both bugs are doc-only — the framework is correct on both points and chapter 5's earlier \`_form.cfm\` already used the working forms. See onboarding report Finding #4.

The companion fix to make rendered output match the chapter's checkpoint #3 (`btn-primary` instead of bare `btn`) lands in [wheels-dev/wheels-basecoat#5](https://github.com/wheels-dev/wheels-basecoat/pull/5).

## Test plan
- [ ] Run chapter 8 verbatim against a fresh app and confirm \`/posts/:id\` returns HTTP 200 instead of 500
- [ ] Confirm the comments loop renders existing comments (column access via \`comments.author\` etc.)
- [ ] Confirm the comment form posts to \`/posts/:id/comments\` (no \`Wheels.IncorrectRoutingArguments\`)
- [ ] CI green on the snapshot pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)