### PR TITLE
docs: tutorial accuracy sweep — chapters 1-6

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/01-hello-wheels.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/01-hello-wheels.mdx
@@ -71,6 +71,10 @@ You should see a Wheels version number. If not, revisit the install guide.
 
    The server boots in a few seconds and prints the URL it's listening on (default: `http://localhost:8080`).
 
+   <Aside type="note" title="First start downloads ~74 MB">
+     The very first `wheels start` on a fresh machine downloads Lucee Express (~74 MB). You'll see a progress bar; expect ~30 seconds on a typical connection. Subsequent starts skip the download and boot immediately.
+   </Aside>
+
 </Steps>
 
 Open `http://localhost:8080` in your browser. You'll see a welcome page: "Welcome to blog. Your Wheels application is running."
@@ -81,7 +85,6 @@ Open `http://localhost:8080` in your browser. You'll see a welcome page: "Welcom
 - blog
   - app
     - controllers
-      - Controller.cfc
       - Main.cfc
     - events
     - global
@@ -91,7 +94,6 @@ Open `http://localhost:8080` in your browser. You'll see a welcome page: "Welcom
     - migrator
       - migrations
     - models
-      - Model.cfc
     - plugins
     - snippets
     - views
@@ -116,6 +118,7 @@ Open `http://localhost:8080` in your browser. You'll see a welcome page: "Welcom
     - javascripts
     - miscellaneous
     - stylesheets
+  - rewrite.config
   - tests
     - specs
       - controllers

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/02-first-model.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/02-first-model.mdx
@@ -138,7 +138,7 @@ A few things to notice:
 
 - `up()` runs when applying the migration; `down()` reverses it.
 - `createTable(name="posts")` returns a builder. You add typed columns on it, then call `t.create()` to emit the DDL.
-- `t.timestamps()` adds both `createdAt` and `updatedAt` as `datetime` columns — don't add them yourself.
+- `t.timestamps()` adds three `datetime` columns at once: `createdAt`, `updatedAt`, and `deletedAt`. The first two are obvious bookkeeping; `deletedAt` is the soft-delete marker (covered in [Part 5](/v4-0-0-snapshot/start-here/tutorial/05-comments-streams/#checkpoint)). Don't add any of them by hand.
 - `status` is stored as a short string matching the enum values. Wheels doesn't require a database-level enum type.
 - The `transaction { try ... catch ... }` shape looks verbose. It's what the generator produces too; it ensures partial schema changes roll back cleanly.
 
@@ -166,7 +166,16 @@ A few things to notice:
    wheels migrate latest
    ```
 
-   Expected output includes `Migrating up 20260419120000_create_posts_table.cfc` followed by `Migration complete.`
+   Expected output looks roughly like:
+
+   ```text
+   Migrating from 0 up to 20260419120000.
+
+   -------- 20260419120000_create_posts_table -----------------
+   Created table posts
+   ```
+
+   The exact wording can drift across snapshots; what matters is that you see `Created table posts`.
 
 </Steps>
 

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/03-crud-scaffold.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/03-crud-scaffold.mdx
@@ -96,9 +96,9 @@ wheels generate scaffold Post title:string body:text status:enum
 ```
 
 <Aside type="caution">
-  The scaffold generator skips files that already exist rather than failing the whole run. Since chapter 2 already wrote `app/models/Post.cfc` and the migration, you'll see `skip model: Model already exists` and `skip migration: create_posts_table already exists` in the output — but the controller, views, and tests will still be generated. The scaffold also appends `.resources("posts")` to `config/routes.cfm`; we'll replace the resulting routes file in a few steps anyway.
+  The scaffold generator skips files that already exist rather than failing the whole run. Since chapter 2 already wrote `app/models/Post.cfc` and the migration, you'll see `skip model: Model already exists` and `skip migration: create_posts_table already exists` in the output — but the controller, views, and tests will still be generated. The scaffold appends `.resources("posts")` to `config/routes.cfm` *only if no resources line for `posts` already exists* — chapter 2 added one, so the routes file is left alone. Either way, we'll replace `config/routes.cfm` in a few steps below.
 
-  The generator's emitted controller uses `findByKey(params.key)` everywhere and emits Bootstrap-flavored views — perfectly fine, but a different shape from this tutorial. Replace the scaffold's output with the code in the sections below to follow along; pass `--force` next time if you want the scaffold to overwrite. Or compare the two — generator vs. tutorial — to see two equally valid CRUD shapes.
+  The generator's emitted controller is the same shape as this tutorial's — it uses `params.post` (route model binding) on key-scoped actions and `findByKey(params.key)` only when binding isn't enabled. The cosmetic differences are extra javadoc-style comments and Bootstrap-flavored views. Replace the scaffold's output with the code in the sections below to follow along, or compare the two to see what convention drift looks like; pass `--force` next time if you want the scaffold to overwrite.
 </Aside>
 
 ### The controller

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/04-validations-frames.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/04-validations-frames.mdx
@@ -126,23 +126,17 @@ The form partial needs a `<turbo-frame>` with an `id` that the server will reuse
    <turbo-frame id="post_form">
        #errorMessagesFor("post")#
        #startFormTag(action=IsNumeric(post.id ?: "") ? "update" : "create", key=post.id ?: "")#
-           <label>Title<br>
-               #textField(objectName="post", property="title")#
-           </label>
-           <label>Body<br>
-               #textArea(objectName="post", property="body")#
-           </label>
-           <label>Status<br>
-               #select(objectName="post", property="status", options="draft,published,archived")#
-           </label>
-           <label>Published at<br>
-               #dateField(objectName="post", property="publishedAt")#
-           </label>
+           #textField(objectName="post", property="title", label="Title")#
+           #textArea(objectName="post", property="body", label="Body")#
+           #select(objectName="post", property="status", options="draft,published,archived", label="Status")#
+           #dateField(objectName="post", property="publishedAt", label="Published at")#
            <button type="submit">Save</button>
        #endFormTag()#
    </turbo-frame>
    </cfoutput>
    ```
+
+   Same shape as Part 3's `_form.cfm`, just wrapped in a `<turbo-frame>`. The form helpers emit their own `<label>` wrappers; passing `label="..."` sets the visible text. Don't add an outer `<label>` around them — that produces nested `<label>` elements (the gotcha called out in [Part 3](/v4-0-0-snapshot/start-here/tutorial/03-crud-scaffold/#the-form-partial)).
 
 </Steps>
 

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/06-authentication.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/06-authentication.mdx
@@ -484,9 +484,18 @@ Then walk through the flow in the browser:
 That's the hand-rolled version. Thirty-ish lines of logic total, no hidden machinery. Now let's see what the framework gives you for free.
 
 <Aside type="caution" title="Scripting smoke tests with curl? Read this first.">
-**CSRF token rotation**: Wheels rotates the CSRF token after each accepted POST. A scraped token is single-use — re-POSTing with the same token fails with `Wheels.InvalidAuthenticityToken`. To script a flow, fetch a fresh form before every write. The signup form has a hidden `authenticityToken` input you can scrape from the response body; the login form (which uses raw `<input>` tags rather than form helpers) doesn't, so scrape from the layout's `<meta name="csrf-token">` tag instead.
+**CSRF token rotation**: Wheels rotates the CSRF token after each accepted POST. A scraped token is single-use — re-POSTing with the same token fails with `Wheels.InvalidAuthenticityToken`. To script a flow, fetch a fresh form before every write. **Always scrape the token from the layout's `<meta name="csrf-token" content="...">` tag**, not from a form's hidden `authenticityToken` input. The meta tag is in the response on every page render and always carries the current token. Form-helper-emitted hidden inputs work too on signup, but other forms (login, post show with the comments form, the rewritten basecoat views in chapter 8) don't always include the input — scraping the meta tag uniformly avoids the special cases.
 
-**curl `--data-urlencode` and `@`**: `curl --data-urlencode "user[email]=test@example.com"` correctly URL-encodes the `@` to `%40`. But `curl --data-urlencode "user[email][test@example.com]"` (no `=` separator) gets misread by Lucee's form parser as a nested-bracket key path — `params.user.email` arrives as `{"test@example.com": ""}` instead of the string. The cause is curl + Lucee form encoding, not Wheels — but it surfaces as a confusing `Can't cast Complex Object Type Struct to String` error. Browsers always %-encode `@`, so this is curl-only. Always include the `=` and let `--data-urlencode` encode the value side: `--data-urlencode "user[email]=test@example.com"`.
+**curl `--data-urlencode` and `@`**: build the body with raw `--data` and pre-encode the brackets and the `@`. Lucee's form parser interprets any URL key with brackets as a nested-struct path — `user[email]=alice@example.com` arrives in your controller as `params.user.email = {"alice@example.com": ""}`, which then fails with the confusing `Can't cast Complex Object Type Struct to String` when Wheels' `normalizeEmail()` calls `LCase()` on it. The reliable shape is:
+
+```bash title="known-working signup smoke test"
+TOKEN=$(curl -s http://localhost:8080/signup | grep -oE 'name="csrf-token" content="[^"]+"' | sed 's/.*content="\([^"]*\)"/\1/')
+curl -s -X POST http://localhost:8080/signup \
+  -H "X-CSRF-Token: $TOKEN" \
+  --data "user%5Bemail%5D=alice%40example.com&user%5Bpassword%5D=secret123&user%5BpasswordConfirmation%5D=secret123"
+```
+
+Browsers always %-encode `@` and emit form bodies that Lucee parses correctly, so this is curl-only.
 </Aside>
 
 ---
@@ -517,9 +526,10 @@ The design is a registry: an `Authenticator` holds a list of named strategies. O
 
 `config/services.cfm` is loaded once at app init. Like every other file under `config/`, the body must be wrapped in `<cfscript>...</cfscript>` — without the wrapper, Lucee parses the file as markup and the `var di = ...` lines spill onto the page as literal text instead of executing. `injector()` returns the DI container; `.map("name").to("component.path").asSingleton()` registers a binding — one instance per app lifetime, resolved on demand. Any controller or view can ask for `service("authenticator")` and get the same instance back every time.
 
-Next, wire the session strategy into the authenticator so `authenticate(request)` has something to try. The cleanest place is wherever your app's init hook runs. If your app has a `config/app.cfm` (or equivalent on-init block), add:
+Next, wire the session strategy into the authenticator so `authenticate(request)` has something to try. This is `onApplicationStart` work — it only needs to happen once per app boot. The right file is `app/events/onapplicationstart.cfm`. If you don't already have one, create it; otherwise append to it:
 
-```cfm {test:compile}
+```cfm title="app/events/onapplicationstart.cfm" {test:compile}
+<cfscript>
 if (StructKeyExists(application, "wheelsdi") && application.wheelsdi.containsInstance("authenticator")) {
     var auth = application.wo.service("authenticator");
     var sessionStrategy = application.wo.service("sessionStrategy");
@@ -527,7 +537,10 @@ if (StructKeyExists(application, "wheelsdi") && application.wheelsdi.containsIns
         auth.registerStrategy(name="session", strategy=sessionStrategy);
     }
 }
+</cfscript>
 ```
+
+Don't put this in `config/app.cfm` — that file is for `Application.cfc` `this`-scope settings (`this.name`, `this.datasources`, `this.sessionTimeout`, etc.), not for init code. The DI container isn't initialized when `config/app.cfm` runs, so `application.wheelsdi` doesn't exist yet and the registration silently no-ops.
 
 On a *cold* reload — meaning `wheels stop` followed by `wheels start`, which re-fires `onApplicationStart` — this registers the strategy exactly once. (Plain `wheels reload` does **not** re-run `onApplicationStart`; if you edit init code, restart the server.) The `hasStrategy` check keeps a second cold reload from stacking duplicates.
 


### PR DESCRIPTION
## Summary
Bundles 9 fixes from the 2026-04-30 fresh-VM tutorial bake into a single doc-sweep PR (one CI run, one review pass). Each chapter is a focused edit; nothing touches code or tests.

## Findings addressed

| # | Chapter | Fix |
|---|---|---|
| 6 | 6b | Name `app/events/onapplicationstart.cfm` explicitly as the strategy-registration site; explain why `config/app.cfm` is wrong |
| 7 | 6 caution | Recommend `<meta name=\"csrf-token\">` scrape uniformly across all forms |
| 8 | 6 caution | Replace `--data-urlencode` recipe with a known-working raw `--data` form |
| 10 | 2 | Update Expected migration output to match current snapshot wording, with a \"format may drift\" note |
| 11 | 4 | Drop manual `<label>` wrappers; use helpers' `label=\"...\"` arg (no more nested `<label>` elements) |
| 13 | 3 | Phrase scaffold-resources behavior as conditional (\"only if no resources line exists\") |
| 14 | 3 | Update stale `findByKey(params.key)` claim — generator uses `params.post` like the tutorial |
| 15 | 1 | Drop non-existent `Controller.cfc` / `Model.cfc` from file tree; add real `rewrite.config` |
| 16 | 1 | Add \"First start downloads ~74 MB\" Aside before the boot step |

## Findings deliberately NOT in this PR

| # | Why |
|---|---|
| 9 | Verified `t.timestamps()` adds `deletedAt` (vendor/wheels/migrator/TableDefinition.cfc:372-376) and `softDeleteProperty=\"deletedAt\"` (vendor/wheels/events/init/orm.cfm:27). Chapter 5's callout matches current code; runner's snapshot-1660 observation predates the behavior. |
| 12 | Aligning docs to the generator's uglier emitted shape (`force='false', id='true'` triplet) is value-negative — either source can drift again. |
| 17 | Silent `brew tap` exits 0; adding a \"no output expected\" note is noise. |
| 19 | Chapter 6 Compare table markdown source is well-formed GFM. If rendered output is broken, it's a build/CSS issue (separate task). |

## Companion PRs

- [wheels-dev/wheels-basecoat#5](https://github.com/wheels-dev/wheels-basecoat/pull/5) — Finding #5 (basecoat 1.0.5)
- [wheels-dev/wheels#2392](https://github.com/wheels-dev/wheels/pull/2392) — Finding #4 (chapter 8 paste bugs) — merged
- [wheels-dev/wheels#2394](https://github.com/wheels-dev/wheels/pull/2394) — Finding #2, #1 partial (CLI test filter + packages help) — merged

## Test plan
- [ ] Snapshot CI green (visual regression catches Astro layout drift)
- [ ] Chapter 1 file tree matches reality on a fresh \`wheels new\`
- [ ] Chapter 4 form renders with single \`<label>\` per field (no nesting in DevTools)
- [ ] Chapter 6b registration code in \`app/events/onapplicationstart.cfm\` activates after \`wheels stop && wheels start\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)