### PR TITLE
docs(installing): add Homebrew install step to macOS tab

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
@@ -28,6 +28,35 @@ Install the `wheels` CLI. Five minutes.
 
 <TabItem label="macOS" icon="apple">
 
+<Aside type="tip" title="Don't have Homebrew yet?">
+  The macOS steps below assume [Homebrew](https://brew.sh/) is installed. Check with:
+
+  ```bash title="your shell"
+  brew --version
+  ```
+
+  If you see "command not found", install Homebrew first using the official installer:
+
+  ```bash title="your shell"
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  ```
+
+  Heads-up while it runs:
+
+  - The installer asks for your account password — it needs `sudo` to create `/opt/homebrew` (Apple Silicon) or `/usr/local` (Intel).
+  - If Xcode Command Line Tools aren't already installed, the installer triggers them. That opens a system dialog and takes ~5–10 minutes before the brew install resumes.
+  - When the installer finishes, it prints a "Next steps" block with two commands you must run so `brew` lands on your `PATH`. On Apple Silicon those are:
+
+    ```bash title="your shell"
+    echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+    ```
+
+    On Intel, replace `/opt/homebrew` with `/usr/local`.
+
+  Confirm with `brew --version` before continuing to step 1 below.
+</Aside>
+
 <Steps>
 
 1. Tap the Wheels Homebrew repo:


### PR DESCRIPTION
## Summary
The macOS install path silently assumed Homebrew was already present. The 2026-04-30 fresh-VM bake report explicitly flagged this gap. This PR adds a precondition Aside to the macOS tab covering brew install, the Xcode CLT trigger, the sudo prompt, and the \`brew shellenv\` PATH setup.

## Source
2026-04-30 fresh-VM tutorial bake. Direct quote from the runner's report:
> Guide does not say how to install Homebrew itself. New macOS user without brew would need to go elsewhere. Minor.

The existing top-of-page Aside already says \"On macOS: \`brew install openjdk@21\`\" — implicitly requiring brew without ever telling readers how to get it. This Aside fills that gap.

## What this enables
The next fresh-VM bake can run the install page verbatim from a truly fresh macOS — no out-of-band Homebrew install needed. The runner-prompt for the bake will be updated separately to point at this page from the very first step.

## Test plan
- [ ] Snapshot CI green (visual regression catches Astro layout drift)
- [ ] On a fresh macOS without brew, following the macOS tab top-to-bottom installs brew → openjdk@21 → wheels with no missing-dependency surprises
- [ ] On a macOS with brew already installed, \`brew --version\` returns immediately and the user proceeds straight to step 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)