### PR TITLE
docs: chapter 2/6 + install page follow-ups (csrf regex, posts migration rename, headless brew)

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
@@ -55,6 +55,16 @@ Install the `wheels` CLI. Five minutes.
     On Intel, replace `/opt/homebrew` with `/usr/local`.
 
   Confirm with `brew --version` before continuing to step 1 below.
+
+  <Aside type="caution" title="Headless / non-interactive installs">
+    The official installer requires a TTY: it shells out to `sudo -n true` to check admin rights, which always prompts for a password and never succeeds in a non-interactive context (CI runners, provisioning scripts, agent shells, packer builds). Setting `NONINTERACTIVE=1` doesn't help — the sudo gate still fires. If you need to install Homebrew without a human at the keyboard, the supported options are:
+
+    - **User-prefix install (no sudo)**: `git clone https://github.com/Homebrew/brew ~/homebrew`, then add `~/homebrew/bin` to your `PATH`. Officially "unsupported" by the Homebrew team but works fine — the trade-off is no pre-built bottles, so every install becomes a source build (slower, sometimes much slower).
+    - **Pre-bake the image**: install Homebrew once interactively on a base image (Vagrant / Packer / Tart / Anka / VM template) and clone from there for headless work.
+    - **Provisioning frameworks**: Ansible's `community.general.homebrew` module and similar can drive an `expect`-style password prompt if you have a way to feed sudo credentials.
+
+    On a fresh agent/CI VM with no admin access, the path of least resistance is the user-prefix `git clone` install.
+  </Aside>
 </Aside>
 
 <Steps>

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/02-first-model.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/02-first-model.mdx
@@ -98,7 +98,11 @@ The generator already wrote a migration for you with `title` and `body` columns.
 
 <Steps>
 
-1. Open the migration file the generator created (it's the most recent one in `app/migrator/migrations/`, named `<timestamp>_create_posts_table.cfc`) and replace its contents with the version below. We're using a fixed timestamp here (`20260419120000`) so the filename in the rest of this tutorial matches what you have on disk — feel free to keep the generator's timestamp instead.
+1. Open the migration file the generator created (it's the most recent one in `app/migrator/migrations/`, named `<timestamp>_create_posts_table.cfc`). Rename it to `20260419120000_create_posts_table.cfc` and replace its contents with the version below.
+
+   <Aside type="caution" title="Why rename, not just use the generator timestamp?">
+     Later chapters add more migrations with hardcoded timestamps that *follow* `20260419120000`: chapter 5 adds comments at `20260419130000`, chapter 6 adds users at `20260419140000` and `add_user_to_posts` at `20260419150000`. Migrations apply in timestamp order, and `add_user_to_posts` references the `posts` table — so the posts migration **must** sort before all of them. Keeping the generator's current timestamp (e.g. May 2026) sneaks past chapter 5 and 6 because the dev DB applies migrations incrementally as you write them, but it bites in chapter 7 when the *test* DB runs them all from scratch in timestamp order and `add_user_to_posts` blows up against a non-existent `posts` table.
+   </Aside>
 
    ```cfm {test:compile}
    component extends="wheels.migrator.Migration" hint="Create posts table" {

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/06-authentication.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/06-authentication.mdx
@@ -489,11 +489,13 @@ That's the hand-rolled version. Thirty-ish lines of logic total, no hidden machi
 **curl `--data-urlencode` and `@`**: build the body with raw `--data` and pre-encode the brackets and the `@`. Lucee's form parser interprets any URL key with brackets as a nested-struct path — `user[email]=alice@example.com` arrives in your controller as `params.user.email = {"alice@example.com": ""}`, which then fails with the confusing `Can't cast Complex Object Type Struct to String` when Wheels' `normalizeEmail()` calls `LCase()` on it. The reliable shape is:
 
 ```bash title="known-working signup smoke test"
-TOKEN=$(curl -s http://localhost:8080/signup | grep -oE 'name="csrf-token" content="[^"]+"' | sed 's/.*content="\([^"]*\)"/\1/')
+TOKEN=$(curl -s http://localhost:8080/signup | grep -oE 'content="[^"]+" name="csrf-token"' | sed -E 's/.*content="([^"]+)".*/\1/')
 curl -s -X POST http://localhost:8080/signup \
   -H "X-CSRF-Token: $TOKEN" \
   --data "user%5Bemail%5D=alice%40example.com&user%5Bpassword%5D=secret123&user%5BpasswordConfirmation%5D=secret123"
 ```
+
+The regex matches `content="..." name="csrf-token"` — Wheels' `$tag` helper sorts attributes alphabetically for deterministic test output, so `content` comes before `name` even though the framework code constructs the struct in the opposite order. Earlier drafts of this chapter assumed `name`-first; if your scraped `$TOKEN` is ever empty, attribute order is the first thing to check.
 
 Browsers always %-encode `@` and emit form bodies that Lucee parses correctly, so this is curl-only.
 </Aside>


### PR DESCRIPTION
## Summary

Three carry-over findings from the 2026-05-01 fresh-VM tutorial run that survived the recent doc sweeps in [#2395](https://github.com/wheels-dev/wheels/pull/2395) and [#2396](https://github.com/wheels-dev/wheels/pull/2396).

### F8 — chapter 6 csrf scrape regex matches the wrong attribute order

The "known-working signup smoke test" used:

```bash
grep -oE 'name="csrf-token" content="[^"]+"'
```

…but `vendor/wheels/view/miscellaneous.cfc:404` deliberately **sorts attributes alphabetically** before emitting (the comment says: *"since the order of a struct can differ we sort the attributes in alphabetical order before placing them in the HTML tag (we could just place them in random order in the HTML but that would complicate testing for example)"*). So the actual emit is `content="..." name="csrf-token"`. The old regex returned an empty `TOKEN` and POSTs silently failed with `Wheels.InvalidAuthenticityToken`.

Fix: swap regex to match the actual order. Patching `$tag`'s emit order would have been cleaner from the chapter's perspective but would break visual baselines and downstream tests across the entire view layer for one tutorial recipe — wrong scope.

### F7 — chapter 2 "feel free to keep the generator's timestamp" is a hidden footgun

Sounds permissive but breaks chapter 7. Chapters 5/6 hardcode migration timestamps `20260419130000`, `20260419140000`, `20260419150000` for `comments` / `users` / `add_user_to_posts`. If the posts migration sorts *after* them (e.g. a May-2026 timestamp from a current-day generator), the **dev** DB still works because migrations apply incrementally as files land — but the **test** DB in chapter 7 runs all four from scratch in timestamp order, hits `add_user_to_posts` before `posts` exists, and bails out. Result: `posts` table missing from the test DB, controller specs run against an empty schema.

Fix: rename is now mandatory with a `<Aside type="caution">` explaining the dependency chain.

### F1 — install page didn't cover headless Homebrew install

The official `curl | bash` installer requires a TTY: it shells out to `sudo -n true` which always prompts even when the user is an admin (`peter` here is in the `admin` group, but `sudo -n` returns non-zero without a password). Setting `NONINTERACTIVE=1` doesn't help — the sudo gate still fires. This is a hard wall for any non-interactive context (CI, agent shells, packer, provisioning scripts).

Fix: added a `<Aside type="caution" title="Headless / non-interactive installs">` callout with three concrete options:
- **User-prefix `git clone`** install (officially "unsupported" but works; trade-off is no bottles)
- **Pre-bake the image** (Vagrant / Packer / Tart / Anka)
- **Provisioning frameworks** (Ansible's `community.general.homebrew` module)

Plus a recommendation: for fresh agent/CI VMs, the user-prefix `git clone` is the path of least resistance.

## Files changed

- `web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx` — F1 callout
- `web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/02-first-model.mdx` — F7 mandatory rename
- `web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/06-authentication.mdx` — F8 regex + explanatory paragraph

## Notes

- F9 (curl `--data-urlencode "[email protected]"` mangling) was already addressed by [#2395](https://github.com/wheels-dev/wheels/pull/2395) — chapter 6 now uses raw `--data` with `%40`/`%5B`/`%5D` pre-encoding. Dropped from this PR.
- This is a follow-up batch to the 16-finding fresh-VM run; the framework-side bug from the same run (F6 — SQLite datetime quote-wrapping) shipped in [#2397](https://github.com/wheels-dev/wheels/pull/2397).

## Test plan

- [x] All three changes are prose-only — no compile-tested code blocks touched
- [ ] CI matrix green
- [ ] Re-run fresh-VM tutorial post-merge to confirm the three findings no longer surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)