### PR TITLE
fix(cli): surface browser-test errors, wire test reporter flag, fix install/migrate output

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -3532,7 +3532,22 @@ component extends="modules.BaseModule" {
 				var resolvedDir = len(filter)
 					? filter
 					: (coreTests ? "wheels.tests.specs" : "tests.specs");
-				displayTestResults(result, verboseOutput, resolvedDir);
+
+				// Reporter dispatch. `--reporter=json` and `--reporter=tap` are
+				// the CI-friendly modes; `simple` (default) keeps the colorful
+				// human-readable rollup. Without this branch the reporter flag
+				// was parsed and passed in but never used (onboarding F12).
+				switch (lCase(arguments.reporter)) {
+					case "json":
+						out(httpResult);
+						break;
+					case "tap":
+						emitTapResults(result);
+						break;
+					case "simple":
+					default:
+						displayTestResults(result, verboseOutput, resolvedDir);
+				}
 			} else {
 				// Could be an HTML error page
 				if (reFindNoCase("<html", httpResult)) {
@@ -3548,6 +3563,95 @@ component extends="modules.BaseModule" {
 		}
 
 		return "";
+	}
+
+	/**
+	 * Emit results in TAP (Test Anything Protocol) v13 format. Used by CI
+	 * tooling that consumes a flat list of `ok`/`not ok` lines plus an
+	 * optional YAML diagnostic block per failure.
+	 *
+	 * Spec: https://testanything.org/tap-version-13-specification.html
+	 */
+	private void function emitTapResults(required any result) {
+		if (!isStruct(arguments.result)) {
+			out("TAP version 13");
+			out("1..0");
+			out("##  Bail out! Test runner returned non-struct payload.");
+			return;
+		}
+
+		// Flatten: walk every spec across every bundle/suite into a sequential
+		// list. TAP requires monotonically-numbered tests starting at 1.
+		// Mutable state lives on a parent struct so the recursive walker sees
+		// it by reference on Adobe CF (closures capture struct refs reliably
+		// but plain `var` captures can copy on Adobe — see CLAUDE.md).
+		var ctx = {tests: []};
+		var walkSuite = function(suite) {
+			for (var sp in (suite.specStats ?: [])) {
+				arrayAppend(ctx.tests, {
+					name: sp.name ?: "(unnamed)",
+					status: sp.status ?: "Failed",
+					failMessage: sp.failMessage ?: "",
+					failOrigin: sp.failOrigin ?: "",
+					skipped: (sp.status ?: "") == "Skipped"
+				});
+			}
+			// Suite-level errors (e.g. spec-file failed to compile, beforeAll
+			// threw) are reported on the suite itself with empty specStats —
+			// surface them as a synthetic test so they don't disappear.
+			if (
+				arrayIsEmpty(suite.specStats ?: [])
+				&& listFindNoCase("Failed,Error", suite.status ?: "")
+			) {
+				arrayAppend(ctx.tests, {
+					name: (suite.name ?: "(unnamed suite)") & " (suite-level)",
+					status: suite.status,
+					failMessage: suite.globalException ?: "",
+					failOrigin: "",
+					skipped: false
+				});
+			}
+			for (var inner in (suite.suiteStats ?: [])) {
+				walkSuite(inner);
+			}
+		};
+		for (var bundle in (arguments.result.bundleStats ?: [])) {
+			for (var suite in (bundle.suiteStats ?: [])) {
+				walkSuite(suite);
+			}
+		}
+
+		out("TAP version 13");
+		out("1..#arrayLen(ctx.tests)#");
+		var i = 0;
+		for (var t in ctx.tests) {
+			i++;
+			var ok = (t.status == "Passed") ? "ok" : "not ok";
+			var directive = t.skipped ? " ## SKIP" : "";
+			out("#ok# #i# - #t.name##directive#");
+			if (t.status != "Passed" && !t.skipped && len(t.failMessage)) {
+				// YAML diagnostic block, indented per TAP spec.
+				out("  ---");
+				out("  message: " & tapEscapeYaml(t.failMessage));
+				if (len(t.failOrigin)) {
+					out("  origin: " & tapEscapeYaml(t.failOrigin));
+				}
+				out("  ...");
+			}
+		}
+	}
+
+	/**
+	 * Quote a string for safe inclusion in a TAP YAML diagnostic block.
+	 * Single-quoted YAML escapes `'` as `''` and forbids unescaped newlines,
+	 * so we collapse them to spaces — TAP consumers don't render block scalars.
+	 */
+	private string function tapEscapeYaml(required string value) {
+		var v = replace(arguments.value, chr(13) & chr(10), " ", "all");
+		v = replace(v, chr(10), " ", "all");
+		v = replace(v, chr(13), " ", "all");
+		v = replace(v, "'", "''", "all");
+		return "'" & v & "'";
 	}
 
 	private void function displayTestResults(
@@ -5074,21 +5178,82 @@ component extends="modules.BaseModule" {
 			out("Pass: #totalPass#  Fail: #totalFail#  Error: #totalError#");
 			out("");
 
-			for (var bundle in (data.bundleStats ?: [])) {
-				for (var suite in (bundle.suiteStats ?: [])) {
-					for (var spec in (suite.specStats ?: [])) {
-						if (listFindNoCase("Failed,Error", spec.status ?: "")) {
-							out("  #spec.status ?: ''#: #spec.name ?: 'unknown'#", "red");
-							if (verboseOutput && len(spec.failMessage ?: "")) {
-								out("    #left(spec.failMessage, 200)#", "yellow");
+			// Recursive walk so we catch nested suites and surface failures
+			// at the suite level (empty specStats but status == Failed/Error)
+			// as well as per-spec failures. Playwright failures often error
+			// out before any `it` runs — the only artifact is on the suite,
+			// which the previous loop ignored. Onboarding F13.
+			// Mutable state on a parent struct so closures see it by reference
+			// on Adobe CF — see CLAUDE.md cross-engine notes.
+			var ctx = {failureCount: 0, verbose: verboseOutput};
+			var walkSuite = function(suite) {
+				var specs = suite.specStats ?: [];
+				for (var sp in specs) {
+					if (listFindNoCase("Failed,Error", sp.status ?: "")) {
+						ctx.failureCount++;
+						out("  #sp.status ?: ''#: #sp.name ?: 'unknown'#", "red");
+						var msg = sp.failMessage ?: "";
+						if (len(msg)) {
+							// Print failMessage by default. Without --verbose
+							// truncate to 400 chars (enough to see the
+							// assertion + selector context). With --verbose
+							// dump the whole thing.
+							var shown = ctx.verbose ? msg : left(msg, 400);
+							out("    #shown#", "yellow");
+							if (!ctx.verbose && len(msg) > 400) {
+								out("    (truncated; pass --verbose for full output)", "yellow");
 							}
 						}
+						if (len(sp.failOrigin ?: "")) {
+							out("    at: #sp.failOrigin#", "yellow");
+						}
+					}
+				}
+				// Suite-level errors (no spec ever ran — e.g. compile error,
+				// beforeAll threw, Playwright init blew up).
+				if (
+					arrayIsEmpty(specs)
+					&& listFindNoCase("Failed,Error", suite.status ?: "")
+				) {
+					ctx.failureCount++;
+					out("  #suite.status#: #suite.name ?: '(unnamed suite)'# (suite-level)", "red");
+					var sg = suite.globalException ?: "";
+					if (len(sg)) {
+						var shown = ctx.verbose ? sg : left(sg, 400);
+						out("    #shown#", "yellow");
+						if (!ctx.verbose && len(sg) > 400) {
+							out("    (truncated; pass --verbose for full output)", "yellow");
+						}
+					}
+				}
+				for (var inner in (suite.suiteStats ?: [])) {
+					walkSuite(inner);
+				}
+			};
+			for (var bundle in (data.bundleStats ?: [])) {
+				for (var suite in (bundle.suiteStats ?: [])) {
+					walkSuite(suite);
+				}
+				// Bundle-level error (compile error in spec file).
+				if (len(bundle.globalException ?: "")) {
+					ctx.failureCount++;
+					out("  Bundle error: #bundle.name ?: '(unnamed)'#", "red");
+					var bg = bundle.globalException;
+					var shown = ctx.verbose ? bg : left(bg, 400);
+					out("    #shown#", "yellow");
+					if (!ctx.verbose && len(bg) > 400) {
+						out("    (truncated; pass --verbose for full output)", "yellow");
 					}
 				}
 			}
 
 			if (totalFail == 0 && totalError == 0) {
 				out("All browser tests passed.", "green");
+			} else if (ctx.failureCount > 0 && (totalError + totalFail) > 0) {
+				out("");
+				out("If failure messages above don't show selector/Playwright detail,", "yellow");
+				out("the BrowserTest spec may need explicit try/catch around .click() /", "yellow");
+				out(".fill() to surface Playwright exceptions into failMessage.", "yellow");
 			}
 		} catch (any e) {
 			out("Failed to parse test results: #e.message#", "red");

--- a/cli/lucli/services/packages/PackagesMainCli.cfc
+++ b/cli/lucli/services/packages/PackagesMainCli.cfc
@@ -208,8 +208,13 @@ component {
 		local.manifest = variables.registry.fetchManifest(arguments.name);
 		local.picked = variables.resolver.pick(local.manifest, variables.runtime, arguments.pin);
 		local.vendor = variables.installer.install(arguments.name, local.picked, arguments.force);
+		// Activation requires a cold restart, not a soft reload: PackageLoader
+		// runs in onApplicationStart and `wheels reload` doesn't re-fire that
+		// hook. Telling users to `wheels reload` here directly contradicts
+		// the chapter-8 caveat and produces "uiCard not defined"-style errors
+		// when the helper resolution fails. Onboarding F14.
 		return "Installed " & arguments.name & "@" & local.picked.version & " → " & local.vendor & Chr(10)
-			& "Run `wheels reload` to activate it." & Chr(10);
+			& "Run `wheels stop && wheels start` to activate it." & Chr(10);
 	}
 
 	private string function $updateAll(struct opts) {

--- a/vendor/wheels/Migrator.cfc
+++ b/vendor/wheels/Migrator.cfc
@@ -81,6 +81,15 @@ component output="false" extends="wheels.Global"{
 				if(arguments.missingMigFlag){
 					local.rv = "Migrating remaining migrations till #arguments.version#.#Chr(13) & Chr(10)#";
 					$removeVersionAsMigrated(local.currentVersion);
+				} else if (local.currentVersion gte arguments.version && local.hasPendingMigrations) {
+					// Out-of-order pending migrations: a migration with a
+					// timestamp earlier than currentVersion is still pending
+					// (e.g. tutorial chapter 5 hardcodes 20260419130000 while
+					// the user's chapter 2 posts migration sits at the
+					// generator's current-day timestamp). The "from N up to N"
+					// framing reads as a no-op even though new migrations are
+					// about to run, so emit a clearer message. Onboarding F16.
+					local.rv = "Applying pending migration(s) up to #arguments.version#.#Chr(13) & Chr(10)#";
 				} else {
 					local.rv = "Migrating from #local.currentVersion# up to #arguments.version#.#Chr(13) & Chr(10)#";
 				}


### PR DESCRIPTION
## Summary

Four CLI-output follow-ups from the 2026-05-01 fresh-VM tutorial run. These are the surviving CLI/framework findings after [#2397](https://github.com/wheels-dev/wheels/pull/2397) (framework F6) and [#2398](https://github.com/wheels-dev/wheels/pull/2398) (docs F1+F7+F8).

### F12 — `wheels test --reporter=json|tap` was a no-op

The flag was parsed into `runTests()` and threaded all the way through, then **ignored** — every invocation called `displayTestResults()` regardless. Now there's a reporter switch:

- `simple` (default): existing colorful rollup
- `json`: dump the raw JSON envelope returned by `/wheels/{app,core}/tests`
- `tap`: emit TAP v13 with per-failure YAML diagnostic blocks. Walks suite-level errors as synthetic `not ok` tests so compile-failures and Playwright-init failures aren't lost (TestBox only populates `specStats` for specs that reach the body)

### F13 — `wheels browser test` failure output was opaque

Two reasons the previous diagnostic walk produced just `Error: signs up, creates a post, adds a comment`:

1. **The walk only iterated `suite.specStats[]`.** Playwright failures that error out before any `it` runs land at the *suite* level (`status=Error`, `specStats=[]`, `globalException` set). The loop saw nothing.
2. **`failMessage` was gated on `--verbose`.** By default users got the spec name and zero detail.

Now the walk recurses through nested suites, surfaces suite-level errors and bundle-level `globalException`, and **prints `failMessage` by default** (truncated to 400 chars; `--verbose` dumps the full message). Added a hint pointing readers at try/catch wrapping in the spec when no Playwright detail is available.

Fixing the underlying "WheelsTest BrowserTest doesn't propagate Playwright exceptions into `failMessage`" is out of scope here (framework change), but this CLI fix makes whatever IS in `failMessage` visible.

### F14 — `wheels packages add` printed the wrong restart command

```
Installed [email protected] → vendor/wheels-basecoat
Run `wheels reload` to activate it.
```

…but `PackageLoader` runs inside `onApplicationStart` and `wheels reload` doesn't re-fire that hook. Chapter 8 of the tutorial body says exactly that. The CLI's own success message was directly contradicting the chapter. Now: `Run \`wheels stop && wheels start\` to activate it.`

### F16 — `wheels migrate latest` reported "from N up to N" for out-of-order pending migrations

When the user has `currentVersion = 20260501081758` (their generator-timestamped chapter-2 posts migration) and a *pending* `20260419130000_create_comments_table` (chapter 5's hardcoded timestamp, earlier than current), `wheels migrate latest` resolves "latest" to the maximum-on-disk timestamp = 20260501081758, then emits:

```
Migrating from 20260501081758 up to 20260501081758.
-------- 20260419130000_create_comments_table -----------------
Created table comments
```

The "from N up to N" framing reads as a no-op even though new work is about to run. Added a branch that emits `Applying pending migration(s) up to <version>.` when `currentVersion >= arguments.version` AND there are still pending migrations. The migration loop itself is unchanged — only the human-facing announcement.

## Files

- `cli/lucli/Module.cfc` — F12 reporter dispatch + new `emitTapResults` / `tapEscapeYaml` helpers; F13 recursive walk in `browserTest()` with parent-struct mutable state
- `cli/lucli/services/packages/PackagesMainCli.cfc` — F14 message swap
- `vendor/wheels/Migrator.cfc` — F16 new branch for the "current >= target with pending" case

## Cross-engine safety

The new closure-based walks in `Module.cfc` keep mutable state on a parent struct (`ctx.tests`, `ctx.failureCount`, `ctx.verbose`) so Adobe CF's array-by-value-on-closure-capture gotcha (CLAUDE.md) doesn't bite. CLI runs only on Lucee but the parent-struct pattern matches the codebase's existing convention and is cheap insurance.

## F11 was already addressed

The fresh-VM run hit `--filter`/`--directory` non-functional, but [#2394](https://github.com/wheels-dev/wheels/pull/2394) had already shipped `\$normalizeTestFilter` (Module.cfc:418). The run was probably against a homebrew binary built before that PR's release tag rolled out. No fix needed here.

## Test plan

- [x] Migrator suite green (177 passed) — F16 framework change doesn't regress migration tests
- [ ] CI matrix green
- [ ] Smoke test the four findings post-merge against a fresh-VM run

🤖 Generated with [Claude Code](https://claude.com/claude-code)