### PR TITLE
fix(cli): scaffold merges hand-edited migration columns + uses string column for headings

### DIFF
--- a/cli/lucli/services/Scaffold.cfc
+++ b/cli/lucli/services/Scaffold.cfc
@@ -98,14 +98,29 @@ component {
 				throw(type="ScaffoldError", message="Controller: #controllerResult.error#");
 			}
 
-			// 4. Generate Views (unless API-only)
+			// 4. Generate Views (unless API-only).
+			// If a migration exists on disk, parse it for columns the CLI
+			// args don't know about (e.g. user followed chapter 2 to add
+			// `publishedAt` to the migration, then ran `generate scaffold`
+			// in chapter 3 with only the original `title:string body:text
+			// status:enum` args — without this merge, the form silently
+			// omits `publishedAt`). Onboarding F3.
+			var viewProps = props;
+			var existingMigration = findExistingMigration(arguments.name);
+			if (len(existingMigration)) {
+				var migrationCols = parseMigrationColumns(existingMigration);
+				if (arrayLen(migrationCols)) {
+					viewProps = mergePropsWithMigrationColumns(props, migrationCols);
+				}
+			}
+
 			if (!arguments.api) {
 				for (var action in ["index", "show", "new", "edit", "_form"]) {
 					var viewResult = variables.codeGenService.generateView(
 						name = pluralName,
 						action = action,
 						force = arguments.force,
-						properties = props,
+						properties = viewProps,
 						belongsTo = arguments.belongsTo,
 						hasMany = arguments.hasMany
 					);
@@ -167,12 +182,89 @@ component {
 	 * when a user re-runs scaffold over an existing model.
 	 */
 	private boolean function migrationAlreadyExists(required string name) {
+		return len(findExistingMigration(arguments.name)) > 0;
+	}
+
+	/**
+	 * Return the absolute path to the existing `_create_<plural>_table.cfc`
+	 * migration for this resource, or "" if none. Used to merge hand-edited
+	 * migration columns back into the scaffold's properties list.
+	 */
+	private string function findExistingMigration(required string name) {
 		var migrationDir = variables.projectRoot & "/app/migrator/migrations";
-		if (!directoryExists(migrationDir)) return false;
+		if (!directoryExists(migrationDir)) return "";
 		var tableName = variables.helpers.pluralize(lCase(arguments.name));
 		var suffix = "_create_" & tableName & "_table.cfc";
 		var existing = directoryList(migrationDir, false, "name", "*" & suffix);
-		return arrayLen(existing) > 0;
+		if (!arrayLen(existing)) return "";
+		return migrationDir & "/" & existing[1];
+	}
+
+	/**
+	 * Parse a migration file for `t.<type>(columnNames="<name>", ...)` calls
+	 * and return them as an array of {name, type} structs. Used to discover
+	 * columns added by hand-editing the migration after the original CLI
+	 * scaffold call. Onboarding F3.
+	 *
+	 * Recognized types match what `generateFormFieldsCode` knows how to render:
+	 * string / text / longtext / boolean / integer / float / decimal /
+	 * date / datetime / timestamp / time / binary / enum.
+	 *
+	 * Conservative parser — only matches lines that already use the
+	 * scaffold-generated shape (`t.string(columnNames="title", ...)`). Custom
+	 * column-construction patterns are silently skipped.
+	 */
+	private array function parseMigrationColumns(required string migrationPath) {
+		var result = [];
+		if (!fileExists(arguments.migrationPath)) return result;
+		var content = fileRead(arguments.migrationPath);
+
+		// Match `t.<type>(columnNames = "<name>"...` allowing optional whitespace
+		// and either single or double quotes around the column name.
+		var pattern = "t\.([a-zA-Z]+)\s*\(\s*columnNames\s*=\s*[""']([^""']+)[""']";
+		var pos = 1;
+		var match = reFindNoCase(pattern, content, pos, true);
+		while (isStruct(match) && arrayLen(match.pos) > 1 && match.pos[1] > 0) {
+			var fnType = lCase(mid(content, match.pos[2], match.len[2]));
+			var colName = mid(content, match.pos[3], match.len[3]);
+			// Skip the helper that doesn't take columnNames in the same way
+			// (we already filter via the regex requiring columnNames= but
+			// belt-and-braces if a future helper grows that arg).
+			if (
+				fnType != "timestamps"
+				&& fnType != "create"
+				&& fnType != "primarykey"
+				&& fnType != "references"
+			) {
+				arrayAppend(result, {name: colName, type: fnType});
+			}
+			pos = match.pos[1] + match.len[1];
+			match = reFindNoCase(pattern, content, pos, true);
+		}
+		return result;
+	}
+
+	/**
+	 * Merge migration-derived columns into the CLI-provided properties list.
+	 * CLI args win on name conflict (they may carry enum values etc. that the
+	 * parser can't recover). New columns from the migration are appended.
+	 */
+	private array function mergePropsWithMigrationColumns(
+		required array cliProps,
+		required array migrationCols
+	) {
+		var merged = duplicate(arguments.cliProps);
+		var seen = {};
+		for (var p in arguments.cliProps) {
+			seen[lCase(p.name)] = true;
+		}
+		for (var col in arguments.migrationCols) {
+			if (!structKeyExists(seen, lCase(col.name))) {
+				arrayAppend(merged, col);
+				seen[lCase(col.name)] = true;
+			}
+		}
+		return merged;
 	}
 
 	/**

--- a/cli/lucli/services/Templates.cfc
+++ b/cli/lucli/services/Templates.cfc
@@ -144,6 +144,18 @@ component {
 			processed = replace(processed, "|FormFields|", "", "all");
 		}
 
+		// Process |DisplayProperty| — the column name used for human-readable
+		// scaffold headings/links. Defaults to `id` (matches legacy behavior),
+		// but if the properties list contains a string column we use that
+		// instead so scaffolded show.cfm/index.cfm don't lead with a numeric
+		// primary key. Onboarding F4.
+		processed = replace(
+			processed,
+			"|DisplayProperty|",
+			pickDisplayProperty(arguments.context.properties ?: []),
+			"all"
+		);
+
 		// Process controller includes for associations
 		if (structKeyExists(arguments.context, "belongsTo") && len(arguments.context.belongsTo)) {
 			processed = addControllerIncludes(processed, arguments.context.belongsTo);
@@ -395,6 +407,34 @@ component {
 			}
 		}
 		return arrayToList(code, chr(10));
+	}
+
+	/**
+	 * Pick the best column to use as a human-readable display name in scaffold
+	 * views. Preference order:
+	 *   1. First property typed `string` (Rails-style — `title`, `name`, etc.)
+	 *   2. First property typed `text`
+	 *   3. Fallback to `id` so legacy templates without scaffold context still
+	 *      render (and so non-scaffold users of the placeholder don't break).
+	 */
+	private string function pickDisplayProperty(required array properties) {
+		// First pass: prefer a `string` column. Skip foreign-key-shaped names
+		// (ending in "Id") which are typically not user-facing labels.
+		for (var prop in arguments.properties) {
+			var t = lCase(prop.type ?: "string");
+			var n = prop.name ?: "";
+			if (t == "string" && right(n, 2) != "Id" && n != "id") {
+				return n;
+			}
+		}
+		// Second pass: text columns. Useful when the user only provides
+		// `body:text`-shaped scaffolds with no string column at all.
+		for (var prop in arguments.properties) {
+			if (lCase(prop.type ?: "string") == "text") {
+				return prop.name ?: "id";
+			}
+		}
+		return "id";
 	}
 
 	/**

--- a/cli/lucli/tests/specs/services/ScaffoldSpec.cfc
+++ b/cli/lucli/tests/specs/services/ScaffoldSpec.cfc
@@ -142,6 +142,80 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					expect(content).toInclude("hasMany");
 				});
 
+				it("show.cfm heading uses first string column, not id (F4)", () => {
+					// Scaffolding a model with a string column should put that
+					// column in the <h1> heading instead of the numeric primary
+					// key. Onboarding F4: scaffolded show.cfm previously rendered
+					// `<h1>#post.id#</h1>` even though `title` was available.
+					scaffold.generateScaffold(
+						name = "Headline",
+						properties = [{name: "title", type: "string"}, {name: "body", type: "text"}],
+						force = true
+					);
+					var showContent = fileRead(tempRoot & "/app/views/headlines/show.cfm");
+					expect(showContent).toInclude("##headline.title##");
+					expect(showContent).notToInclude("<h1>##headline.id##</h1>");
+				});
+
+				it("index.cfm link text uses first string column, not id (F4)", () => {
+					scaffold.generateScaffold(
+						name = "Tagline",
+						properties = [{name: "label", type: "string"}, {name: "weight", type: "integer"}],
+						force = true
+					);
+					var indexContent = fileRead(tempRoot & "/app/views/taglines/index.cfm");
+					expect(indexContent).toInclude("text=taglines.label");
+				});
+
+				it("falls back to id when no string column is provided (F4)", () => {
+					// Defensive fallback: a scaffold with only numeric/boolean
+					// columns has nothing user-facing to put in the heading,
+					// so we keep the legacy `id` behavior.
+					scaffold.generateScaffold(
+						name = "Counter",
+						properties = [{name: "value", type: "integer"}],
+						force = true
+					);
+					var showContent = fileRead(tempRoot & "/app/views/counters/show.cfm");
+					expect(showContent).toInclude("##counter.id##");
+				});
+
+				it("merges hand-edited migration columns into the form (F3)", () => {
+					// Scenario from chapter 2/3 of the tutorial: user creates
+					// a model with the generator, then hand-edits the migration
+					// to add `publishedAt`, then scaffolds with the original
+					// CLI args (no `publishedAt`). The form should still pick
+					// up `publishedAt` by parsing the existing migration.
+					var migrationDir = tempRoot & "/app/migrator/migrations";
+					if (!directoryExists(migrationDir)) directoryCreate(migrationDir, true);
+					var migrationPath = migrationDir & "/20260419120000_create_articulars_table.cfc";
+					fileWrite(migrationPath, '
+						component extends="wheels.migrator.Migration" {
+							function up() {
+								t = createTable(name="articulars");
+								t.string(columnNames="title", default="", allowNull=true, limit=255);
+								t.text(columnNames="body", default="", allowNull=true);
+								t.datetime(columnNames="publishedAt", allowNull=true);
+								t.timestamps();
+								t.create();
+							}
+						}
+					');
+
+					scaffold.generateScaffold(
+						name = "Articular",
+						properties = [{name: "title", type: "string"}, {name: "body", type: "text"}],
+						force = true
+					);
+
+					var formContent = fileRead(tempRoot & "/app/views/articulars/_form.cfm");
+					// CLI-arg columns still present
+					expect(formContent).toInclude('property="title"');
+					expect(formContent).toInclude('property="body"');
+					// Migration-only column merged in
+					expect(formContent).toInclude('property="publishedAt"');
+				});
+
 			});
 
 			describe("createMigrationWithProperties()", () => {

--- a/cli/src/templates/crud/index.txt
+++ b/cli/src/templates/crud/index.txt
@@ -4,7 +4,7 @@
 <p>#linkTo(route="new|ObjectNameSingularC|", text="New |ObjectNameSingular|")#</p>
 <cfloop query="|ObjectNamePlural|">
 	<article>
-		<h2>#linkTo(route="|ObjectNameSingular|", key=|ObjectNamePlural|.id, text=|ObjectNamePlural|.id)#</h2>
+		<h2>#linkTo(route="|ObjectNameSingular|", key=|ObjectNamePlural|.id, text=|ObjectNamePlural|.|DisplayProperty|)#</h2>
 		<!--- CLI-Appends-Here --->
 	</article>
 </cfloop>

--- a/cli/src/templates/crud/show.txt
+++ b/cli/src/templates/crud/show.txt
@@ -1,6 +1,6 @@
 <cfparam name="|ObjectNameSingular|" default="">
 <cfoutput>
-<h1>#|ObjectNameSingular|.id#</h1>
+<h1>#|ObjectNameSingular|.|DisplayProperty|#</h1>
 <!--- CLI-Appends-Here --->
 <p>
 	#linkTo(route="edit|ObjectNameSingularC|", key=|ObjectNameSingular|.id, text="Edit")# ·


### PR DESCRIPTION
## Summary

Two scaffold-output follow-ups from the 2026-05-01 fresh-VM tutorial run.

### F3 — scaffold silently dropped hand-edited migration columns

`wheels generate scaffold Post title:string body:text status:enum` only knew about the three columns in the CLI args. After the user followed chapter 2 to hand-edit the migration and add `publishedAt`, scaffolding the views in chapter 3 produced a `_form.cfm` with no `publishedAt` field — the form could never populate that column for new posts. Off-tutorial readers would silently ship a broken form.

**Fix**: `Scaffold.parseMigrationColumns()` reads the existing `*_create_<plural>_table.cfc` (when found) for `t.<type>(columnNames=...)` calls, and `Scaffold.mergePropsWithMigrationColumns()` folds those columns into the property list before view generation. CLI args still win on name conflicts (they may carry enum values the parser can't recover from raw migration text).

### F4 — scaffold show.cfm/index.cfm headings used the numeric primary key

```cfm
<h1>#post.id#</h1>
linkTo(route="post", key=posts.id, text=posts.id)
```

Tutorials, blogs, and any model with a `title`/`name`/`label` column read more naturally with that as the heading. Rails-style scaffolds do this; Wheels did not.

**Fix**: new `|DisplayProperty|` template placeholder, populated by `Templates.pickDisplayProperty()` with the first `string` column (or `text` fallback, then `id` fallback). Both `show.txt` and `index.txt` use it for headings/link text. The `id` fallback preserves legacy behavior for scaffolds with no human-readable column.

## Files

- `cli/lucli/services/Scaffold.cfc` — F3 migration parser + merger
- `cli/lucli/services/Templates.cfc` — F4 placeholder substitution + helper
- `cli/src/templates/crud/show.txt` — `id` → `|DisplayProperty|`
- `cli/src/templates/crud/index.txt` — `id` → `|DisplayProperty|` in link text
- `cli/lucli/tests/specs/services/ScaffoldSpec.cfc` — 4 new specs covering both findings end-to-end

## Coverage

- **30 ScaffoldSpec tests pass** (26 pre-existing + 4 new)
- **481 / 484 CLI tests pass** (the 3 failures are pre-existing in `DoctorSpec` for issue #2260, unrelated to this PR)

## Tutorial impact

Re-scaffolding chapter-3 after the chapter-2 hand-edit will now:
1. Pick up `publishedAt` automatically (F3) — the form has all four fields
2. Render `<h1>#post.title#</h1>` instead of `<h1>#post.id#</h1>` (F4) — the show page leads with the user-typed title

Both behaviors match what a Rails-from-2010 user would expect, and remove two paper-cut findings that affected first-time users.

## Test plan

- [x] All ScaffoldSpec + TemplatesSpec tests pass locally
- [ ] CI green
- [ ] Re-run fresh-VM tutorial post-merge to confirm both findings no longer surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)