### PR TITLE
docs: chapter 2 tree no longer pretends Controller.cfc/Model.cfc are scaffolded

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/02-first-model.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/02-first-model.mdx
@@ -31,12 +31,10 @@ At the end of Part 1 you had a running `blog` app with a `/hello` route. There's
 - blog
   - app
     - controllers
-      - Controller.cfc
       - Main.cfc
     - migrator
       - migrations
-    - models
-      - Model.cfc
+    - models/
     - views
       - helpers.cfm
       - layout.cfm
@@ -54,6 +52,8 @@ At the end of Part 1 you had a running `blog` app with a `/hello` route. There's
 </FileTree>
 
 `Main.cfc` has `index` and `hello` actions. `config/routes.cfm` has a `/hello` named route alongside the wildcard and root. The SQLite database file exists but has no application tables. You'll fix all of that here.
+
+The `Controller` and `Model` base classes that your code extends (e.g. `component extends="Controller"`) live under `vendor/wheels/`, not in `app/`. They're framework files; `wheels new` doesn't put them in your project tree. You won't need to touch them.
 
 ## Generate the Post model
 


### PR DESCRIPTION
## Summary

F2 from the 2026-05-01 fresh-VM tutorial run.

Chapter 2's \"Where we left off\" tree showed `app/controllers/Controller.cfc` and `app/models/Model.cfc` as if `wheels new` had placed them on disk. They don't exist there — they're framework base classes that live under `vendor/wheels/` and resolve via `extends=\"Controller\"` / `extends=\"Model\"`.

New users would `ls app/controllers/` looking for `Controller.cfc` and worry they were missing a file.

This PR:
- Removes both phantom entries from the tree
- Adds a one-paragraph note explaining where the base classes actually live, so the question doesn't recur the next time someone reads `extends=\"Controller\"` and wonders

## Test plan

- [x] Doc-only — visual baseline should still match (Aside structure unchanged, just the tree contents)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)