### PR TITLE
feat(migration): rename system tables to wheels_* with detection of legacy c_o_r_e_* (F15 Phase 1)

### DIFF
--- a/vendor/wheels/Migrator.cfc
+++ b/vendor/wheels/Migrator.cfc
@@ -406,6 +406,12 @@ component output="false" extends="wheels.Global"{
 	private string function $getVersionsPreviouslyMigrated() {
 		local.appKey = $appKey();
 
+		// F15 Phase 1: detect whether this app's system tables already exist
+		// under the legacy `c_o_r_e_*` names; if so, flip the configured names
+		// back so subsequent SQL targets the existing tables. New installs
+		// keep the `wheels_*` defaults from onapplicationstart.cfc.
+		$detectSystemTables(appKey = local.appKey);
+
 		/* Choose appropriate SQL syntax for LIMIT based on database engine */
 		local.info = $dbinfo(
 			type = "version",
@@ -413,12 +419,13 @@ component output="false" extends="wheels.Global"{
 			username = application.wheels.dataSourceUserName,
 			password = application.wheels.dataSourcePassword
 		);
+		local.levelsTable = application[local.appKey].levelsTableName;
 		if(FindNoCase("SQLServer", local.info.database_productname) || FindNoCase("SQL Server", local.info.database_productname)){
-			local.sql = "SELECT TOP 1 * FROM c_o_r_e_levels";
+			local.sql = "SELECT TOP 1 * FROM #local.levelsTable#";
 		} else if(FindNoCase("Oracle", local.info.database_productname)){
-			local.sql = "SELECT * FROM c_o_r_e_levels FETCH FIRST 1 ROWS ONLY";
+			local.sql = "SELECT * FROM #local.levelsTable# FETCH FIRST 1 ROWS ONLY";
 		} else{
-			local.sql = "SELECT * FROM c_o_r_e_levels LIMIT 1";
+			local.sql = "SELECT * FROM #local.levelsTable# LIMIT 1";
 		}
 
 		try {
@@ -430,15 +437,15 @@ component output="false" extends="wheels.Global"{
 			if (application[local.appKey].createMigratorTable) {
 				$query(
 					datasource = application[local.appKey].dataSourceName,
-					sql = "CREATE TABLE c_o_r_e_levels (id INT PRIMARY KEY, name VARCHAR(50) NOT NULL, description VARCHAR(255))"
+					sql = "CREATE TABLE #local.levelsTable# (id INT PRIMARY KEY, name VARCHAR(50) NOT NULL, description VARCHAR(255))"
 				);
 				$query(
 					datasource = application[local.appKey].dataSourceName,
-					sql = "INSERT INTO c_o_r_e_levels (id, name, description) VALUES (1, 'App', 'Application level migrations')"
+					sql = "INSERT INTO #local.levelsTable# (id, name, description) VALUES (1, 'App', 'Application level migrations')"
 				);
 				$query(
 					datasource = application[local.appKey].dataSourceName,
-					sql = "INSERT INTO c_o_r_e_levels (id, name, description) VALUES (2, 'Test', 'Test level migrations')"
+					sql = "INSERT INTO #local.levelsTable# (id, name, description) VALUES (2, 'Test', 'Test level migrations')"
 				);
 			}
 		}
@@ -456,6 +463,11 @@ component output="false" extends="wheels.Global"{
 			if (application[local.appKey].createMigratorTable) {
 				local.dbType = local.info.database_productname;
 				local.tableName = application[local.appKey].migratorTableName;
+				// FK constraint name follows the levels-table prefix so a
+				// fresh install gets `fk_wheels_level` and a legacy install
+				// keeps `fk_core_level`. Constraint names are scoped to
+				// their tables, so this only matters for new bootstraps.
+				local.fkName = (local.levelsTable == "c_o_r_e_levels") ? "fk_core_level" : "fk_wheels_level";
 
 				// SQLite: skip rename / ALTER, create table with constraint in one query
 				if (FindNoCase("SQLite", local.dbType)) {
@@ -463,7 +475,7 @@ component output="false" extends="wheels.Global"{
 						CREATE TABLE #local.tableName# (
 							version VARCHAR(25),
 							core_level INT NOT NULL DEFAULT 1,
-							CONSTRAINT fk_core_level FOREIGN KEY (core_level) REFERENCES c_o_r_e_levels(id)
+							CONSTRAINT #local.fkName# FOREIGN KEY (core_level) REFERENCES #local.levelsTable#(id)
 						)
 					";
 					$query(
@@ -492,32 +504,96 @@ component output="false" extends="wheels.Global"{
 							sql="SELECT version FROM migratorversions"
 						);
 						$query(
-							datasource=application[local.appKey].dataSourceName, 
+							datasource=application[local.appKey].dataSourceName,
 							sql=local.renameSQL
 						);
 						$query(
-							datasource=application[local.appKey].dataSourceName, 
+							datasource=application[local.appKey].dataSourceName,
 							sql=local.addColumnSQL
 						);
 						$query(
-							datasource=application[local.appKey].dataSourceName, 
-							sql="ALTER TABLE #local.tableName# ADD CONSTRAINT fk_core_level FOREIGN KEY (core_level) REFERENCES c_o_r_e_levels(id)"
+							datasource=application[local.appKey].dataSourceName,
+							sql="ALTER TABLE #local.tableName# ADD CONSTRAINT #local.fkName# FOREIGN KEY (core_level) REFERENCES #local.levelsTable#(id)"
 						);
 					} catch (any e) {
 						// If rename fails, create table instead
 						$query(
-							datasource=application[local.appKey].dataSourceName, 
+							datasource=application[local.appKey].dataSourceName,
 							sql=local.createSQL
 						);
 						$query(
-							datasource=application[local.appKey].dataSourceName, 
-							sql="ALTER TABLE #local.tableName# ADD CONSTRAINT fk_core_level FOREIGN KEY (core_level) REFERENCES c_o_r_e_levels(id)"
+							datasource=application[local.appKey].dataSourceName,
+							sql="ALTER TABLE #local.tableName# ADD CONSTRAINT #local.fkName# FOREIGN KEY (core_level) REFERENCES #local.levelsTable#(id)"
 						);
 					}
 				}
 			}
 			return 0;
 		}
+	}
+
+	/**
+	 * F15 Phase 1: detect which system-table naming family this app's database
+	 * already uses, and flip the configured names if needed.
+	 *
+	 * Decision tree:
+	 *   1. If `wheels_levels` exists, keep the new defaults (no-op).
+	 *   2. Else if `c_o_r_e_levels` exists, override application settings to
+	 *      point at the legacy names AND log a one-time deprecation warning.
+	 *   3. Else (neither exists, fresh DB), keep the new defaults — the
+	 *      bootstrap below will create `wheels_*` tables.
+	 *
+	 * Step 2 is the migration-friendly path: existing 4.0-SNAPSHOT apps that
+	 * already have `c_o_r_e_*` tables continue to read/write them without
+	 * any code or data changes. Phase 2 will ship a CLI command to do the
+	 * rename when the user is ready.
+	 *
+	 * Idempotent and stateless — re-runs every call. The probe is two cheap
+	 * SELECTs each returning 0 rows; per-request caching breaks test isolation
+	 * (the spec suite shares a request scope across tests) so we just don't.
+	 */
+	private void function $detectSystemTables(required string appKey) {
+		// Cache the datasource locally — the inline closure below uses its
+		// own `arguments` scope (CFML closures don't inherit the parent's
+		// `arguments` struct), so we need to pull the value out by reference
+		// before the closure sees it.
+		var dsn = application[arguments.appKey].dataSourceName;
+
+		// Always probe with a no-rows query so we don't load data unnecessarily.
+		// `WHERE 1=0` is portable across every adapter we support.
+		var probe = function(tableName) {
+			try {
+				$query(
+					datasource = dsn,
+					sql = "SELECT 1 FROM #arguments.tableName# WHERE 1=0"
+				);
+				return true;
+			} catch (any e) {
+				return false;
+			}
+		};
+
+		if (probe(application[arguments.appKey].levelsTableName)) {
+			// Configured name exists — nothing to do.
+			return;
+		}
+
+		if (probe("c_o_r_e_levels")) {
+			// Legacy install. Override settings to match what's actually on disk.
+			application[arguments.appKey].levelsTableName = "c_o_r_e_levels";
+			application[arguments.appKey].migratorTableName = "c_o_r_e_migrator_versions";
+			// Quiet stderr warning — fires once per migrator run, not per request.
+			if (StructKeyExists(server, "system") && StructKeyExists(server.system, "out")) {
+				server.system.out.println(
+					"[wheels] Legacy c_o_r_e_* migration tables detected. "
+					& "These will be renamed to wheels_* in a future Wheels release; "
+					& "see the upgrade guide for the rename procedure."
+				);
+			}
+		}
+
+		// If neither exists, we leave the configured `wheels_*` defaults in
+		// place; the bootstrap path below will create them.
 	}
 
 	/**

--- a/vendor/wheels/events/onapplicationstart.cfc
+++ b/vendor/wheels/events/onapplicationstart.cfc
@@ -245,7 +245,13 @@ component {
 
 		// Create migrations object and set default settings.
 		application.$wheels.autoMigrateDatabase = false;
-		application.$wheels.migratorTableName = "c_o_r_e_migrator_versions";
+		// New default names (F15 Phase 1). The migrator's $detectSystemTables()
+		// helper at runtime will flip these back to the legacy `c_o_r_e_*`
+		// names if it finds those tables already in the database, so existing
+		// 4.0-SNAPSHOT apps continue to work without manual intervention.
+		// New installs get the clean `wheels_*` prefix.
+		application.$wheels.migratorTableName = "wheels_migrator_versions";
+		application.$wheels.levelsTableName = "wheels_levels";
 		application.$wheels.createMigratorTable = true;
 		application.$wheels.writeMigratorSQLFiles = false;
 		// Preserve column / table / index name case as written in the migration.

--- a/vendor/wheels/public/views/info.cfm
+++ b/vendor/wheels/public/views/info.cfm
@@ -94,6 +94,7 @@ settings = [
 		values = [
 			'autoMigrateDatabase',
 			'migratorTableName',
+			'levelsTableName',
 			'createMigratorTable',
 			'writeMigratorSQLFiles',
 			'migratorObjectCase',

--- a/vendor/wheels/tests/specs/migrator/helperFunctions.cfm
+++ b/vendor/wheels/tests/specs/migrator/helperFunctions.cfm
@@ -1,16 +1,26 @@
 <cfscript>
 
 	public void function deleteMigratorVersions(required numeric levelId) {
-		queryExecute(
-			"DELETE FROM c_o_r_e_migrator_versions WHERE core_level = :levelId",
-			{
-				levelId = {
-					value      = arguments.levelId,
-					cfsqltype  = "cf_sql_integer"
-				}
-        	},
-			{ datasource = application.wheels.dataSourceName }
-		);
+		// Use the configured table name so the helper works regardless of
+		// whether this app is on the new `wheels_*` defaults or a legacy
+		// `c_o_r_e_*` install detected by Migrator's $detectSystemTables.
+		var tableName = application.wheels.migratorTableName;
+		try {
+			queryExecute(
+				"DELETE FROM #tableName# WHERE core_level = :levelId",
+				{
+					levelId = {
+						value      = arguments.levelId,
+						cfsqltype  = "cf_sql_integer"
+					}
+				},
+				{ datasource = application.wheels.dataSourceName }
+			);
+		} catch (any e) {
+			// Table may not exist yet on the very first migrator-spec run
+			// (the migrator creates it lazily on first migrateTo). The
+			// DELETE-against-nothing semantics are vacuously satisfied.
+		}
 	}
 
 	public any function $cleanSqlDirectory() {

--- a/vendor/wheels/tests/specs/migrator/migratorSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/migratorSpec.cfc
@@ -158,6 +158,83 @@ component extends="wheels.WheelsTest" {
 			})
 		})
 
+		describe("F15 Phase 1: system-table naming + legacy detection", () => {
+
+			beforeEach(() => {
+				origMigratorTableName_F15 = Duplicate(application.wheels.migratorTableName);
+				origLevelsTableName_F15 = StructKeyExists(application.wheels, "levelsTableName")
+					? Duplicate(application.wheels.levelsTableName)
+					: "wheels_levels";
+				origCreateMigratorTable_F15 = Duplicate(application.wheels.createMigratorTable);
+				// Wipe both naming families so detection runs from scratch.
+				for (local.t in ["wheels_migrator_versions", "c_o_r_e_migrator_versions", "wheels_levels", "c_o_r_e_levels"]) {
+					try { migration.dropTable(local.t); } catch (any e) {}
+				}
+			});
+
+			afterEach(() => {
+				application.wheels.migratorTableName = origMigratorTableName_F15;
+				application.wheels.levelsTableName = origLevelsTableName_F15;
+				application.wheels.createMigratorTable = origCreateMigratorTable_F15;
+				for (local.t in ["wheels_migrator_versions", "c_o_r_e_migrator_versions", "wheels_levels", "c_o_r_e_levels"]) {
+					try { migration.dropTable(local.t); } catch (any e) {}
+				}
+			});
+
+			it("creates wheels_levels and wheels_migrator_versions on a fresh DB", () => {
+				if (_isCockroachDB) return;
+				application.wheels.migratorTableName = "wheels_migrator_versions";
+				application.wheels.levelsTableName = "wheels_levels";
+				application.wheels.createMigratorTable = true;
+
+				// Trigger the migrator's bootstrap path (it lazy-creates the
+				// system tables when neither variant exists).
+				migrator.getCurrentMigrationVersion();
+
+				var info = g.$dbinfo(datasource = application.wheels.dataSourceName, type = "tables");
+				var tables = ValueList(info.table_name);
+
+				expect(ListFindNoCase(tables, "wheels_levels")).toBeGT(0);
+				expect(ListFindNoCase(tables, "wheels_migrator_versions")).toBeGT(0);
+				expect(ListFindNoCase(tables, "c_o_r_e_levels")).toBe(0);
+				expect(ListFindNoCase(tables, "c_o_r_e_migrator_versions")).toBe(0);
+			});
+
+			it("falls back to c_o_r_e_levels when only legacy tables exist", () => {
+				if (_isCockroachDB) return;
+				application.wheels.migratorTableName = "wheels_migrator_versions";
+				application.wheels.levelsTableName = "wheels_levels";
+				application.wheels.createMigratorTable = true;
+
+				// Pre-create the legacy table to simulate an existing 4.0-SNAPSHOT
+				// install. The framework's own bootstrap (Migrator.cfc:433) uses
+				// raw SQL with the same shape across adapters.
+				queryExecute(
+					"CREATE TABLE c_o_r_e_levels (id INT PRIMARY KEY, name VARCHAR(50) NOT NULL, description VARCHAR(255))",
+					{},
+					{ datasource = application.wheels.dataSourceName }
+				);
+				queryExecute(
+					"INSERT INTO c_o_r_e_levels (id, name, description) VALUES (1, 'App', 'Application level migrations')",
+					{},
+					{ datasource = application.wheels.dataSourceName }
+				);
+
+				migrator.getCurrentMigrationVersion();
+
+				// The detection helper should have flipped the application
+				// settings back to the legacy names.
+				expect(application.wheels.levelsTableName).toBe("c_o_r_e_levels");
+				expect(application.wheels.migratorTableName).toBe("c_o_r_e_migrator_versions");
+
+				// The new wheels_levels table should NOT have been created
+				// alongside the existing legacy table.
+				var info = g.$dbinfo(datasource = application.wheels.dataSourceName, type = "tables");
+				var tables = ValueList(info.table_name);
+				expect(ListFindNoCase(tables, "wheels_levels")).toBe(0);
+			});
+		})
+
 		describe("Tests that redomigration", () => {
 
 			beforeEach(() => {


### PR DESCRIPTION
## Summary

Phase 1 of F15 from the 2026-05-01 fresh-VM tutorial run. The migrator's internal tracking tables ship with awkward letter-spaced names (\`c_o_r_e_levels\`, \`c_o_r_e_migrator_versions\`) that show up alongside user tables in any schema introspection — \`sqlite3 .tables\`, DBA tools, BI exports. The fix is a phased migration; **this PR is the non-breaking first phase.**

## Phase plan

| Phase | When | What |
|-------|------|------|
| **1 (this PR)** | now, 4.0-SNAPSHOT | Rename defaults to \`wheels_*\`, add detection that flips back to \`c_o_r_e_*\` if legacy tables exist. **No breaking change.** |
| 2 | 4.1 / 4.2 | CLI command \`wheels migrate rename-system-tables\` for opt-in one-shot rename. Deprecation warning escalates to error after grace period. |
| 3 | 5.0 | Remove all \`c_o_r_e_*\`-aware code paths. |

## What this PR does

- **New defaults** in \`onapplicationstart.cfc\`:
  - \`migratorTableName = \"wheels_migrator_versions\"\` (was \`c_o_r_e_*\`)
  - \`levelsTableName = \"wheels_levels\"\` (newly configurable; was hardcoded everywhere)

- **\`Migrator.cfc\` threads \`levelsTableName\`** through every site that used to hardcode \`c_o_r_e_levels\` (3 SELECT-LIMIT branches per adapter, 3 CREATE/INSERT statements in the bootstrap, 2 FK constraint references in CREATE/ALTER paths).

- **New \`\$detectSystemTables()\` helper** runs at the top of \`\$getVersionsPreviouslyMigrated()\`. Probes the configured names first; if missing, probes legacy \`c_o_r_e_levels\`. When legacy is found, overrides \`application.wheels.{levelsTableName,migratorTableName}\` back to the legacy values and emits a one-line stderr deprecation warning. Idempotent and stateless (deliberately — see closure note below). Two cheap probes per migrator call.

- **FK constraint name follows the levels-table prefix**: fresh installs get \`fk_wheels_level\`, legacy installs keep \`fk_core_level\`. Constraint names are scoped to their tables, so this is a one-shot naming decision per table.

- **\`info.cfm\` exposes \`levelsTableName\`** alongside \`migratorTableName\`.

## What this PR doesn't do (deferred to Phase 2)

- No CLI command to actually rename \`c_o_r_e_*\` tables in existing user databases.
- No removal of \`c_o_r_e_*\`-aware code paths.

Users keep working without action thanks to the detection helper.

## Tests

- **Two new specs** in \`migratorSpec.cfc\` cover both branches of the detection helper:
  - Fresh DB → creates \`wheels_*\`, never \`c_o_r_e_*\`.
  - Legacy \`c_o_r_e_levels\` exists → detection flips back, no \`wheels_*\` table created.

- **\`helperFunctions.cfm:deleteMigratorVersions()\` now reads the configured name** dynamically instead of hardcoding \`c_o_r_e_*\`, so the helper works regardless of which family this app is on.

- **Full SQLite test suite**: 3373 passed, 0 failed (3371 baseline + 2 new specs, zero regressions).
- **Migrator-only suite**: 179 passed.

## Cross-engine note

CI matrix is the gate. The detection helper's probe (\`SELECT 1 FROM <table> WHERE 1=0\`) is portable across every adapter we support. The FK constraint syntax change uses the same per-adapter branches that already exist in the bootstrap.

## CFML closure gotcha

\`\$detectSystemTables\` uses an inline closure for the probe. CFML closures **don't inherit \`arguments\` from the parent function** — the closure's \`arguments\` scope is its own. Pulling \`dataSourceName\` into a \`var dsn\` before the closure is what makes the probe see the right datasource. Hit this bug during initial RED → GREEN; documented inline in the implementation.

## Test plan

- [x] Migrator suite green locally (179 passed)
- [x] Full SQLite suite green locally (3373 passed)
- [ ] CI cross-engine matrix green
- [ ] Verify \`/info\` endpoint shows \`levelsTableName\` post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)