### PR TITLE
feat(cli): wheels migrate rename-system-tables (F15 Phase 2)

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -168,7 +168,7 @@ component extends="modules.BaseModule" {
 		help &= "  generate            Generate model, controller, scaffold, migration, etc." & nl;
 		help &= "  destroy (or d)      Remove generated files" & nl & nl;
 		help &= "Database:" & nl;
-		help &= "  migrate             Run database migrations (latest, up, down, info)" & nl;
+		help &= "  migrate             Run database migrations (latest, up, down, info, rename-system-tables)" & nl;
 		help &= "  seed                Run database seeds" & nl;
 		help &= "  db                  Database management (reset, status, version)" & nl & nl;
 		help &= "Testing & Inspection:" & nl;
@@ -310,9 +310,23 @@ component extends="modules.BaseModule" {
 					out("Migration failed: #e.message#", "red");
 					return "";
 				}
+			case "rename-system-tables":
+				// F15 Phase 2: opt-in one-shot rename of legacy c_o_r_e_*
+				// system tables to wheels_*. Idempotent (no-op when nothing
+				// to rename); refuses to run on a partial-rename state.
+				var dryRun = false;
+				for (var i = 2; i <= arrayLen(args); i++) {
+					if (args[i] == "--dry-run") dryRun = true;
+				}
+				try {
+					return runRenameSystemTables(dryRun);
+				} catch (MigrationError e) {
+					out("Rename failed: #e.message#", "red");
+					return "";
+				}
 			default:
 				out("Unknown migration action: #action#", "red");
-				out("Usage: wheels migrate [latest|up|down|info]");
+				out("Usage: wheels migrate [latest|up|down|info|rename-system-tables]");
 				return "";
 		}
 	}
@@ -3135,6 +3149,69 @@ component extends="modules.BaseModule" {
 		} else {
 			out("Migration #action# completed.", "green");
 		}
+
+		return "";
+	}
+
+	private string function runRenameSystemTables(boolean dryRun = false) {
+		var serverPort = $requireRunningServer([
+			"Renaming system tables requires a running server.",
+			"Start one with: wheels start"
+		]);
+
+		out(arguments.dryRun ? "Previewing system-table rename..." : "Renaming legacy c_o_r_e_* system tables to wheels_*...", "cyan");
+
+		var renameUrl = "http://localhost:#serverPort#/wheels/cli?command=renameSystemTables&format=json"
+			& (arguments.dryRun ? "&dryRun=true" : "");
+
+		var httpResult = "";
+		try {
+			httpResult = makeHttpRequest(renameUrl);
+		} catch (any httpErr) {
+			throw(
+				type    = "MigrationError",
+				message = "Rename failed (connection error): #httpErr.message#",
+				detail  = httpErr.detail ?: ""
+			);
+		}
+
+		var parsed = isJSON(httpResult) ? deserializeJSON(httpResult) : {};
+		var success = parsed.success ?: false;
+		var message = parsed.message ?: "";
+		var renameResult = parsed.renameResult ?: {renamed: [], errors: [], sql: [], skipped: ""};
+
+		if (!success) {
+			out("Rename failed.", "red");
+			for (var err in (renameResult.errors ?: [])) {
+				out("  #err#", "red");
+			}
+			return "";
+		}
+
+		// No-op path: legacy tables not present.
+		if (Len(renameResult.skipped ?: "")) {
+			out(renameResult.skipped, "yellow");
+			return "";
+		}
+
+		// Dry-run path: print SQL.
+		if (arguments.dryRun) {
+			if (ArrayLen(renameResult.sql ?: [])) {
+				out("Would execute:");
+				for (var sql in renameResult.sql) {
+					out("  " & sql, "cyan");
+				}
+			}
+			return "";
+		}
+
+		// Success path: print what was renamed.
+		out("Renamed:", "green");
+		for (var rename in (renameResult.renamed ?: [])) {
+			out("  " & rename, "green");
+		}
+		out("");
+		out("Note: the foreign-key constraint name is still `fk_core_level`. Constraint names are scoped to their table and only rename via DROP/CREATE; this is cosmetic and will not affect functionality.", "yellow");
 
 		return "";
 	}

--- a/vendor/wheels/Migrator.cfc
+++ b/vendor/wheels/Migrator.cfc
@@ -597,6 +597,153 @@ component output="false" extends="wheels.Global"{
 	}
 
 	/**
+	 * F15 Phase 2: rename legacy `c_o_r_e_*` system tables to `wheels_*`.
+	 *
+	 * Public API for the `wheels migrate rename-system-tables` CLI command.
+	 * Reads the current schema, generates per-adapter rename SQL, and
+	 * (unless `dryRun` is true) executes it inside a transaction. After
+	 * a successful rename, updates `application.wheels.{levelsTableName,
+	 * migratorTableName}` to the new names so the running app picks them
+	 * up without a restart.
+	 *
+	 * Result struct:
+	 *   - success: boolean
+	 *   - renamed: array of "old -> new" strings (empty if no-op)
+	 *   - skipped: human message when there's nothing to do
+	 *   - errors: array of error messages (when success=false)
+	 *   - sql: array of SQL statements that would run / did run
+	 *
+	 * Refuses to run (returns success=false) when both `c_o_r_e_*` AND
+	 * `wheels_*` versions of either table coexist — that's a partial-
+	 * rename state which warrants manual cleanup, not silent destruction.
+	 *
+	 * @dryRun When true, returns the SQL that would run without executing.
+	 *
+	 * [section: Migrator]
+	 * [category: General Functions]
+	 */
+	public struct function renameSystemTables(boolean dryRun = false) {
+		var rv = {
+			success: true,
+			renamed: [],
+			skipped: "",
+			errors: [],
+			sql: []
+		};
+		var appKey = $appKey();
+		var dsn = application[appKey].dataSourceName;
+
+		// Inline probe (CFML closures don't inherit parent `arguments`, so
+		// `dsn` is captured via lexical scope — see $detectSystemTables for
+		// the same pattern).
+		var probe = function(tableName) {
+			try {
+				$query(datasource = dsn, sql = "SELECT 1 FROM #arguments.tableName# WHERE 1=0");
+				return true;
+			} catch (any e) {
+				return false;
+			}
+		};
+
+		var hasLegacyLevels   = probe("c_o_r_e_levels");
+		var hasLegacyVersions = probe("c_o_r_e_migrator_versions");
+		var hasNewLevels      = probe("wheels_levels");
+		var hasNewVersions    = probe("wheels_migrator_versions");
+
+		// Nothing to rename — already on `wheels_*` or fresh DB.
+		if (!hasLegacyLevels && !hasLegacyVersions) {
+			rv.skipped = "Nothing to rename. Legacy c_o_r_e_* tables are not present.";
+			return rv;
+		}
+
+		// Refuse on partial-rename state. Renaming `c_o_r_e_levels` →
+		// `wheels_levels` when `wheels_levels` already exists would either
+		// fail with a "table exists" error mid-transaction or silently
+		// corrupt one of them depending on adapter. Better to stop and let
+		// the user reconcile manually.
+		if (
+			(hasLegacyLevels && hasNewLevels)
+			|| (hasLegacyVersions && hasNewVersions)
+		) {
+			rv.success = false;
+			ArrayAppend(
+				rv.errors,
+				"Both legacy c_o_r_e_* and new wheels_* system tables exist. "
+				& "Manual cleanup required to avoid data loss — drop whichever set is empty before re-running."
+			);
+			return rv;
+		}
+
+		// Build per-adapter rename SQL. The migrator-versions table is
+		// renamed first so any FK constraint pointing at c_o_r_e_levels
+		// follows naturally when levels is renamed last (every supported
+		// engine auto-updates FK references on table rename).
+		var info = $dbinfo(
+			type = "version",
+			datasource = dsn,
+			username = application.wheels.dataSourceUserName,
+			password = application.wheels.dataSourcePassword
+		);
+		var dbType = info.database_productname;
+
+		if (FindNoCase("MySQL", dbType)) {
+			// MySQL atomic multi-rename — both pairs in one statement.
+			var pairs = [];
+			if (hasLegacyVersions) ArrayAppend(pairs, "c_o_r_e_migrator_versions TO wheels_migrator_versions");
+			if (hasLegacyLevels)   ArrayAppend(pairs, "c_o_r_e_levels TO wheels_levels");
+			ArrayAppend(rv.sql, "RENAME TABLE " & ArrayToList(pairs, ", "));
+		} else if (FindNoCase("SQLServer", dbType) || FindNoCase("SQL Server", dbType)) {
+			if (hasLegacyVersions) ArrayAppend(rv.sql, "EXEC sp_rename 'c_o_r_e_migrator_versions', 'wheels_migrator_versions'");
+			if (hasLegacyLevels)   ArrayAppend(rv.sql, "EXEC sp_rename 'c_o_r_e_levels', 'wheels_levels'");
+		} else if (FindNoCase("Oracle", dbType)) {
+			if (hasLegacyVersions) ArrayAppend(rv.sql, "RENAME c_o_r_e_migrator_versions TO wheels_migrator_versions");
+			if (hasLegacyLevels)   ArrayAppend(rv.sql, "RENAME c_o_r_e_levels TO wheels_levels");
+		} else {
+			// SQLite, PostgreSQL, H2, CockroachDB
+			if (hasLegacyVersions) ArrayAppend(rv.sql, "ALTER TABLE c_o_r_e_migrator_versions RENAME TO wheels_migrator_versions");
+			if (hasLegacyLevels)   ArrayAppend(rv.sql, "ALTER TABLE c_o_r_e_levels RENAME TO wheels_levels");
+		}
+
+		// Dry-run returns the plan without executing.
+		if (arguments.dryRun) {
+			return rv;
+		}
+
+		// Execute. Wrap in a transaction so a partial failure rolls back
+		// rather than leaving a half-renamed schema. Note: DDL inside a
+		// transaction is a no-op on Oracle (auto-commits) and MSSQL has
+		// adapter-specific behavior, but on the engines that DO honor it
+		// (Postgres, SQLite via SAVEPOINT, MySQL on InnoDB) we get atomicity.
+		try {
+			transaction action="begin" {
+				try {
+					for (var sql in rv.sql) {
+						$query(datasource = dsn, sql = sql);
+					}
+					transaction action="commit";
+				} catch (any e) {
+					transaction action="rollback";
+					rethrow;
+				}
+			}
+
+			if (hasLegacyLevels)   ArrayAppend(rv.renamed, "c_o_r_e_levels -> wheels_levels");
+			if (hasLegacyVersions) ArrayAppend(rv.renamed, "c_o_r_e_migrator_versions -> wheels_migrator_versions");
+
+			// Update in-memory settings so the running app uses the new names
+			// without a restart. (Settings are reloaded from
+			// onapplicationstart on next reload anyway.)
+			application[appKey].levelsTableName    = "wheels_levels";
+			application[appKey].migratorTableName  = "wheels_migrator_versions";
+		} catch (any e) {
+			rv.success = false;
+			ArrayAppend(rv.errors, e.message);
+		}
+
+		return rv;
+	}
+
+	/**
 	 * Ensures a version as user input is numeric.
 	 */
 	private string function $sanitiseVersion(required string version) {

--- a/vendor/wheels/public/views/cli.cfm
+++ b/vendor/wheels/public/views/cli.cfm
@@ -45,6 +45,21 @@ try {
 			case "migrateToLatest":
 				data.message = migrator.migrateToLatest();
 				break;
+			case "renameSystemTables":
+				// F15 Phase 2: opt-in rename of legacy c_o_r_e_* system tables.
+				// Returns the full result struct (success/renamed/skipped/errors/sql)
+				// rather than a flat message — the CLI decodes and prints each field.
+				local.dryRun = (StructKeyExists(request.wheels.params, "dryRun") && request.wheels.params.dryRun == "true");
+				data.renameResult = migrator.renameSystemTables(dryRun = local.dryRun);
+				data.success = data.renameResult.success;
+				if (Len(data.renameResult.skipped)) {
+					data.message = data.renameResult.skipped;
+				} else if (ArrayLen(data.renameResult.renamed)) {
+					data.message = "Renamed: " & ArrayToList(data.renameResult.renamed, "; ");
+				} else if (local.dryRun && ArrayLen(data.renameResult.sql)) {
+					data.message = "Dry run — SQL that would execute:" & Chr(10) & ArrayToList(data.renameResult.sql, ";" & Chr(10)) & ";";
+				}
+				break;
 			case "diff":
 				try {
 					local.autoMigrator = CreateObject("component", "wheels.migrator.AutoMigrator");

--- a/vendor/wheels/tests/specs/migrator/migratorSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/migratorSpec.cfc
@@ -235,6 +235,129 @@ component extends="wheels.WheelsTest" {
 			});
 		})
 
+		describe("F15 Phase 2: renameSystemTables() opt-in rename", () => {
+
+			beforeEach(() => {
+				origMigratorTableName_F15P2 = Duplicate(application.wheels.migratorTableName);
+				origLevelsTableName_F15P2 = StructKeyExists(application.wheels, "levelsTableName")
+					? Duplicate(application.wheels.levelsTableName)
+					: "wheels_levels";
+				for (local.t in ["wheels_migrator_versions", "c_o_r_e_migrator_versions", "wheels_levels", "c_o_r_e_levels"]) {
+					try { migration.dropTable(local.t); } catch (any e) {}
+				}
+			});
+
+			afterEach(() => {
+				application.wheels.migratorTableName = origMigratorTableName_F15P2;
+				application.wheels.levelsTableName = origLevelsTableName_F15P2;
+				for (local.t in ["wheels_migrator_versions", "c_o_r_e_migrator_versions", "wheels_levels", "c_o_r_e_levels"]) {
+					try { migration.dropTable(local.t); } catch (any e) {}
+				}
+			});
+
+			it("returns a no-op result when neither legacy nor new tables exist", () => {
+				if (_isCockroachDB) return;
+				application.wheels.levelsTableName = "wheels_levels";
+				application.wheels.migratorTableName = "wheels_migrator_versions";
+
+				var result = migrator.renameSystemTables();
+				expect(result.success).toBeTrue();
+				expect(arrayLen(result.renamed)).toBe(0);
+				expect(result.skipped).toInclude("Nothing to rename");
+			});
+
+			it("renames c_o_r_e_levels -> wheels_levels and c_o_r_e_migrator_versions -> wheels_migrator_versions", () => {
+				if (_isCockroachDB) return;
+
+				// Pre-create both legacy tables so renameSystemTables has work to do.
+				queryExecute(
+					"CREATE TABLE c_o_r_e_levels (id INT PRIMARY KEY, name VARCHAR(50) NOT NULL, description VARCHAR(255))",
+					{},
+					{ datasource = application.wheels.dataSourceName }
+				);
+				queryExecute(
+					"INSERT INTO c_o_r_e_levels (id, name, description) VALUES (1, 'App', 'Application level migrations')",
+					{},
+					{ datasource = application.wheels.dataSourceName }
+				);
+				queryExecute(
+					"CREATE TABLE c_o_r_e_migrator_versions (version VARCHAR(25), core_level INT NOT NULL DEFAULT 1)",
+					{},
+					{ datasource = application.wheels.dataSourceName }
+				);
+				application.wheels.levelsTableName = "c_o_r_e_levels";
+				application.wheels.migratorTableName = "c_o_r_e_migrator_versions";
+
+				var result = migrator.renameSystemTables();
+				expect(result.success).toBeTrue();
+				expect(arrayLen(result.renamed)).toBe(2);
+
+				var info = g.$dbinfo(datasource = application.wheels.dataSourceName, type = "tables");
+				var tables = ValueList(info.table_name);
+				expect(ListFindNoCase(tables, "wheels_levels")).toBeGT(0);
+				expect(ListFindNoCase(tables, "wheels_migrator_versions")).toBeGT(0);
+				expect(ListFindNoCase(tables, "c_o_r_e_levels")).toBe(0);
+				expect(ListFindNoCase(tables, "c_o_r_e_migrator_versions")).toBe(0);
+
+				// And application settings should now point at the new names.
+				expect(application.wheels.levelsTableName).toBe("wheels_levels");
+				expect(application.wheels.migratorTableName).toBe("wheels_migrator_versions");
+			});
+
+			it("refuses to rename when both legacy and new tables exist (partial-rename safeguard)", () => {
+				if (_isCockroachDB) return;
+
+				// Simulate a half-renamed state: both versions of the levels
+				// table coexist. This shouldn't happen in practice but guards
+				// against silent data loss if a previous rename was interrupted.
+				queryExecute(
+					"CREATE TABLE c_o_r_e_levels (id INT PRIMARY KEY, name VARCHAR(50))",
+					{},
+					{ datasource = application.wheels.dataSourceName }
+				);
+				queryExecute(
+					"CREATE TABLE wheels_levels (id INT PRIMARY KEY, name VARCHAR(50))",
+					{},
+					{ datasource = application.wheels.dataSourceName }
+				);
+
+				var result = migrator.renameSystemTables();
+				expect(result.success).toBeFalse();
+				expect(arrayLen(result.errors)).toBeGT(0);
+				// Both tables should still exist — no destructive change.
+				var info = g.$dbinfo(datasource = application.wheels.dataSourceName, type = "tables");
+				var tables = ValueList(info.table_name);
+				expect(ListFindNoCase(tables, "c_o_r_e_levels")).toBeGT(0);
+				expect(ListFindNoCase(tables, "wheels_levels")).toBeGT(0);
+			});
+
+			it("dryRun=true returns the SQL list without executing", () => {
+				if (_isCockroachDB) return;
+
+				queryExecute(
+					"CREATE TABLE c_o_r_e_levels (id INT PRIMARY KEY, name VARCHAR(50))",
+					{},
+					{ datasource = application.wheels.dataSourceName }
+				);
+				queryExecute(
+					"CREATE TABLE c_o_r_e_migrator_versions (version VARCHAR(25), core_level INT)",
+					{},
+					{ datasource = application.wheels.dataSourceName }
+				);
+
+				var result = migrator.renameSystemTables(dryRun = true);
+				expect(result.success).toBeTrue();
+				expect(arrayLen(result.sql)).toBeGT(0);
+
+				// Tables should remain untouched.
+				var info = g.$dbinfo(datasource = application.wheels.dataSourceName, type = "tables");
+				var tables = ValueList(info.table_name);
+				expect(ListFindNoCase(tables, "c_o_r_e_levels")).toBeGT(0);
+				expect(ListFindNoCase(tables, "c_o_r_e_migrator_versions")).toBeGT(0);
+				expect(ListFindNoCase(tables, "wheels_levels")).toBe(0);
+			});
+		})
+
 		describe("Tests that redomigration", () => {
 
 			beforeEach(() => {


### PR DESCRIPTION
## Summary

Phase 2 of F15. [Phase 1 (#2402)](https://github.com/wheels-dev/wheels/pull/2402) shipped the new \`wheels_*\` defaults plus runtime detection that flips back to \`c_o_r_e_*\` when legacy tables exist. Phase 2 ships the opt-in tooling that actually does the rename when the user is ready.

## What's new

### Framework

- **\`Migrator.renameSystemTables(boolean dryRun = false)\`** — new public method that probes for legacy and new system tables, generates the per-adapter rename SQL, and (unless \`dryRun\`) executes it inside a transaction. Returns \`{success, renamed, skipped, errors, sql}\`.

- **Per-adapter SQL**:
  | Adapter | Rename syntax |
  |---|---|
  | MySQL | atomic \`RENAME TABLE old1 TO new1, old2 TO new2\` |
  | SQL Server | \`EXEC sp_rename\` (one per table) |
  | Oracle | \`RENAME old TO new\` |
  | SQLite / PostgreSQL / H2 / CockroachDB | \`ALTER TABLE old RENAME TO new\` |

- **Partial-rename safeguard**: refuses to run when both \`c_o_r_e_*\` AND \`wheels_*\` versions of a table coexist. The user must drop whichever is empty and re-run — better than silent destruction.

### HTTP / CLI

- **\`/wheels/cli?command=renameSystemTables[&dryRun=true]\`** — HTTP endpoint that calls the method and returns the result struct as JSON.

- **\`wheels migrate rename-system-tables [--dry-run]\`** — new CLI command:
  - **default mode**: idempotent rename. No-op when legacy tables don't exist. Reports each table renamed.
  - **\`--dry-run\`**: prints the per-adapter SQL without executing.

## Tests

- **Four new specs** in \`migratorSpec.cfc\`:
  - No-op when neither family exists.
  - Happy path: \`c_o_r_e_*\` → \`wheels_*\` rename + settings flip.
  - Refuses on partial state (both exist).
  - \`--dry-run\` returns SQL without executing.

- **Migrator suite**: 183 passed (was 179, +4 new)
- **Full SQLite suite**: 3377 passed, 0 failed (was 3373, +4 new)

## Note on FK constraint name

The \`fk_core_level\` constraint on \`wheels_migrator_versions\` is **NOT** renamed by this PR. Constraint names are scoped to their table; renaming them requires DROP/CREATE which is more invasive. Cosmetic blemish only — the constraint still correctly references \`wheels_levels.id\` because every supported engine auto-updates FK target references on table rename.

Phase 3 (5.0) will drop/recreate the constraint with the new name as part of the final cleanup pass alongside removing all \`c_o_r_e_*\`-aware code paths.

## Usage

```bash
# After upgrading to a Wheels version with both Phase 1 and Phase 2:
wheels migrate rename-system-tables --dry-run    # preview
wheels migrate rename-system-tables              # do it
```

The detection helper from Phase 1 keeps existing apps working without action; this command is purely opt-in.

## Test plan

- [x] Migrator suite green locally (183 passed)
- [x] Full SQLite suite green locally (3377 passed)
- [ ] CI cross-engine matrix green
- [ ] Manual test on a fresh-VM Wheels install: create app, run \`wheels migrate latest\`, verify \`c_o_r_e_*\` exists, run \`wheels migrate rename-system-tables\`, verify \`wheels_*\` exists and migrations still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)