### PR TITLE
fix(controller): super.config() in chapter 6 + generator templates so CSRF inherits (F10)

### DIFF
--- a/cli/lucli/templates/app/app/snippets/ControllerContent.txt
+++ b/cli/lucli/templates/app/app/snippets/ControllerContent.txt
@@ -1,10 +1,17 @@
 |DescriptionComment|component extends="Controller" {
 
   /**
-	* Controller config settings
+	* Controller config settings.
+	*
+	* The `super.config()` call inherits CSRF protection (via
+	* `protectsFromForgery()`) and any other defaults set in
+	* `app/controllers/Controller.cfc`. Don't remove it unless
+	* you really mean to opt out of those defaults — without it,
+	* `startFormTag` will silently stop emitting the hidden
+	* `authenticityToken` input for this controller's forms.
 	**/
 	function config() {
-
+		super.config();
 	}
 |Actions|
 }

--- a/cli/lucli/templates/snippets/api-controller.txt
+++ b/cli/lucli/templates/snippets/api-controller.txt
@@ -1,6 +1,12 @@
 component extends="Controller" {
 
 	function config() {
+		// API controllers usually authenticate via API keys / bearer tokens
+		// rather than session cookies, so the session-based CSRF check from
+		// app/controllers/Controller.cfc doesn't apply. Either skip the
+		// super.config() call (as below) or call protectsFromForgery(with="ignore")
+		// to make the opt-out explicit.
+		protectsFromForgery(with="ignore");
 		provides("json");
 		verifies(params="key", paramsTypes="integer", only="show,update,delete");
 		filters(through="findRecord", only="show,update,delete");

--- a/cli/lucli/templates/snippets/api-controller.txt
+++ b/cli/lucli/templates/snippets/api-controller.txt
@@ -3,9 +3,10 @@ component extends="Controller" {
 	function config() {
 		// API controllers usually authenticate via API keys / bearer tokens
 		// rather than session cookies, so the session-based CSRF check from
-		// app/controllers/Controller.cfc doesn't apply. Either skip the
-		// super.config() call (as below) or call protectsFromForgery(with="ignore")
-		// to make the opt-out explicit.
+		// app/controllers/Controller.cfc doesn't apply. The explicit
+		// `protectsFromForgery(with="ignore")` call below opts out
+		// intentionally rather than relying on a missing super.config()
+		// call to drop the protection silently.
 		protectsFromForgery(with="ignore");
 		provides("json");
 		verifies(params="key", paramsTypes="integer", only="show,update,delete");

--- a/cli/lucli/templates/snippets/auth-sessions-controller.txt
+++ b/cli/lucli/templates/snippets/auth-sessions-controller.txt
@@ -1,6 +1,10 @@
 component extends="Controller" {
 
 	function config() {
+		// Inherit CSRF protection (and other defaults) from
+		// app/controllers/Controller.cfc. Login forms in particular need
+		// CSRF or they're trivially target-able.
+		super.config();
 		verifies(only="create", params="username,password");
 	}
 

--- a/cli/lucli/templates/snippets/crud-controller.txt
+++ b/cli/lucli/templates/snippets/crud-controller.txt
@@ -1,6 +1,10 @@
 component extends="Controller" {
 
 	function config() {
+		// Inherit CSRF protection (and any other defaults) from
+		// app/controllers/Controller.cfc. Skipping super.config() silently
+		// disables protectsFromForgery() for this controller.
+		super.config();
 		verifies(params="key", paramsTypes="integer", only="show,edit,update,delete");
 		filters(through="findRecord", only="show,edit,update,delete");
 	}

--- a/cli/src/templates/ControllerContent.txt
+++ b/cli/src/templates/ControllerContent.txt
@@ -1,10 +1,17 @@
 |DescriptionComment|component extends="Controller" {
 
   /**
-	* Controller config settings
+	* Controller config settings.
+	*
+	* The `super.config()` call inherits CSRF protection (via
+	* `protectsFromForgery()`) and any other defaults set in
+	* `app/controllers/Controller.cfc`. Don't remove it unless
+	* you really mean to opt out of those defaults — without it,
+	* `startFormTag` will silently stop emitting the hidden
+	* `authenticityToken` input for this controller's forms.
 	**/
 	function config() {
-
+		super.config();
 	}
 |Actions|
 }

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/06-authentication.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/06-authentication.mdx
@@ -312,7 +312,6 @@ Three actions, three responsibilities:
 The first line of `config()` is `super.config();`. If you skip it, you silently disable everything `app/controllers/Controller.cfc` does in *its* `config()` — most importantly, `protectsFromForgery()`, which makes Wheels reject `POST`/`PATCH`/`DELETE` requests that don't carry a valid CSRF token. Without that call, `startFormTag` won't emit the hidden `authenticityToken` input, and your forms silently lose CSRF protection. If you ever notice some forms have a hidden `authenticityToken` and others don't, this is the first thing to check.
 </Aside>
 
-
 The filter is `private`. This is critical: **public filter methods become routable actions**, which means Wheels would happily respond to `/posts/authenticate` and run the filter body as an action. Private filters are invisible to the router.
 
 `ownershipCheck` is called explicitly at the top of `edit`, `update`, and `delete`. It's not a filter because filters run on every matching action uniformly — ownership checks need the loaded post, which only the specific action has. A helper function keeps the three call sites from diverging.

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/06-authentication.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/06-authentication.mdx
@@ -241,6 +241,7 @@ Three actions, three responsibilities:
    ```cfm {test:compile}
    component extends="Controller" {
        function config() {
+           super.config();
            filters(through="authenticate", except="index,show");
        }
 
@@ -306,6 +307,11 @@ Three actions, three responsibilities:
 </Steps>
 
 `config()` runs once when the controller is instantiated. `filters(through="authenticate", except="index,show")` says: "run the `authenticate` method before every action, except `index` and `show`." So anyone can browse the blog, but only logged-in users can create, edit, or delete posts.
+
+<Aside type="caution" title="Always call `super.config()` when overriding">
+The first line of `config()` is `super.config();`. If you skip it, you silently disable everything `app/controllers/Controller.cfc` does in *its* `config()` — most importantly, `protectsFromForgery()`, which makes Wheels reject `POST`/`PATCH`/`DELETE` requests that don't carry a valid CSRF token. Without that call, `startFormTag` won't emit the hidden `authenticityToken` input, and your forms silently lose CSRF protection. If you ever notice some forms have a hidden `authenticityToken` and others don't, this is the first thing to check.
+</Aside>
+
 
 The filter is `private`. This is critical: **public filter methods become routable actions**, which means Wheels would happily respond to `/posts/authenticate` and run the filter body as an action. Private filters are invisible to the router.
 
@@ -624,6 +630,7 @@ One change from 6a: the post-save `session.userId = user.id;` line is replaced w
    ```cfm {test:compile}
    component extends="Controller" {
        function config() {
+           super.config();
            filters(through="authenticate", except="index,show");
        }
 


### PR DESCRIPTION
## Summary

F10 from the 2026-05-01 afternoon fresh-VM run. **Originally hypothesised** as a "CSRF flag never set in production" framework bug needing a new middleware; **actually** a chapter-6 paste-bug + generator-template defensiveness gap. The framework's CSRF wiring is intact — what was missing was \`super.config()\` calls in places where users override \`config()\`.

## Investigation that overturned the original diagnosis

Initial grep for \`request.\$wheelsProtectedFromForgery\` only found assignments in test fixtures. Conclusion: "the flag is never set in production." **Wrong.**

Closer reading: \`vendor/wheels/controller/csrf.cfc\` defines \`\$flagRequestAsProtected()\` which DOES set the flag, called from \`\$runCsrfProtection(action)\` which DOES run on every action via \`vendor/wheels/controller/processing.cfc:12\`. The chain only fires when \`variables.\$class.csrf\` is set, which only happens when the controller called \`protectsFromForgery()\` in \`config()\`.

**The generated \`app/controllers/Controller.cfc\` (project base, written by \`wheels new\`) calls \`protectsFromForgery()\` in its \`config()\`.** So new apps DO get protection — IF child controllers call \`super.config()\`.

The fresh-VM observation matches this exactly:

| Controller | \`config()\` override | \`super.config()\` called | Form has token |
|---|---|---|---|
| Chapter 6 \`Sessions.cfc\` | none | n/a (inherits) | ✓ |
| Chapter 6 \`Users.cfc\` | none | n/a (inherits) | ✓ |
| Chapter 6 \`Posts.cfc\` (6a) | yes (adds \`filters\`) | **no** | ✗ |
| Chapter 6 \`Posts.cfc\` (6b) | yes (adds \`filters\`) | **no** | ✗ |

Same code pasted twice in chapter 6 was the root cause. The signup/login forms had tokens because their controllers don't override \`config()\` at all. The post-create form didn't have a token because chapter 6's \`Posts.cfc\` paste broke the inheritance chain.

## Fixes

### Chapter 6 paste-bugs

Both \`Posts.cfc\` instances now call \`super.config();\` as the first line of \`config()\`. Plus a new \`<Aside type="caution">\` callout right after the controller walkthrough explaining the failure mode:

> The first line of \`config()\` is \`super.config();\`. If you skip it, you silently disable everything \`app/controllers/Controller.cfc\` does in *its* \`config()\` — most importantly, \`protectsFromForgery()\` …

### Generator templates

Four templates that were prone to the same trap now call \`super.config()\` with explanatory comments:

- \`cli/src/templates/ControllerContent.txt\` (legacy CommandBox)
- \`cli/lucli/templates/app/app/snippets/ControllerContent.txt\` (LuCLI app template)
- \`cli/lucli/templates/snippets/crud-controller.txt\` (CRUD snippet)
- \`cli/lucli/templates/snippets/auth-sessions-controller.txt\` (auth snippet)

The fifth template, \`cli/lucli/templates/snippets/api-controller.txt\`, is the deliberate exception. APIs usually authenticate via API keys / bearer tokens, not session cookies, so the session-CSRF check doesn't apply. Updated to call \`protectsFromForgery(with="ignore")\` explicitly so the opt-out is intentional rather than accidental.

## What this PR doesn't do

- **No framework code change.** The infrastructure is correct; the bug was upstream of it.
- **No new middleware.** My initial proposal involved a \`Csrf\` middleware that would have duplicated the existing controller-layer logic. Not needed.
- **No global default flip.** I considered adding \`application.wheels.csrfProtection = true\` as a framework-level setting that would force protection even when controllers forget \`super.config()\`. Decided against it for this PR — would require updating ~10 framework test fixtures (every \`vendor/wheels/tests/_assets/controllers/*.cfc\` that doesn't already call \`protectsFromForgery\`) since they'd suddenly start rejecting POSTs with no token. That's a separate larger PR if the team wants belt-and-braces protection against the super.config() footgun.

## Tests

Doc/template-only changes, no framework code touched.

- Full SQLite suite: 3377 passed, 0 failed (same baseline as [#2403](https://github.com/wheels-dev/wheels/pull/2403))
- The chapter 6 \`{test:compile}\` doctest annotation will validate that the new \`super.config();\` line compiles in CI.

## Memory note

The \`project_csrf_never_enforced.md\` memory entry has been corrected. The original misdiagnosis is preserved in the entry as a "lesson learned" anchor — a good example of why grep-based "never assigned" conclusions need a second pass for indirect setters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)