### PR TITLE
fix(controller): redirectTo() defaults to 303 after non-idempotent methods (F5)

### DIFF
--- a/vendor/wheels/controller/redirection.cfc
+++ b/vendor/wheels/controller/redirection.cfc
@@ -42,7 +42,31 @@ component {
 		boolean delay,
 		boolean encode
 	) {
+		// F5: capture whether the caller explicitly passed `statusCode` BEFORE
+		// $args copies the framework default (302) in. Used below to upgrade
+		// the default to 303 for non-idempotent request methods without
+		// overriding an explicit user choice.
+		local.userPassedStatusCode = StructKeyExists(arguments, "statusCode");
+
 		$args(name = "redirectTo", args = arguments);
+
+		// F5: When redirecting after a POST/PUT/PATCH/DELETE without an
+		// explicit statusCode, upgrade the default 302 ("Found", historically
+		// ambiguous on method handling) to 303 ("See Other", which always
+		// downgrades the next request to GET regardless of the original
+		// method). RFC 7231 §6.4.4 specifies 303 for the "redirect after
+		// POST" pattern. Browsers treat 302 as 303 for compat, but scripted
+		// clients (curl with -L, programmatic HTTP libs) follow the spec
+		// literally — so the upgrade makes scripted smoke tests work
+		// correctly without method-replay surprises.
+		if (
+			!local.userPassedStatusCode
+			&& StructKeyExists(request, "cgi")
+			&& StructKeyExists(request.cgi, "request_method")
+			&& ListFindNoCase("POST,PUT,PATCH,DELETE", request.cgi.request_method)
+		) {
+			arguments.statusCode = 303;
+		}
 
 		// Set flash if passed in.
 		// If more than the arguments listed in the function declaration was passed in it's possible that one of them is intended for the flash.

--- a/vendor/wheels/tests/specs/controller/redirectionSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/redirectionSpec.cfc
@@ -131,6 +131,64 @@ component extends="wheels.WheelsTest" {
 			})
 		})
 
+		describe("F5: 303 See Other after non-idempotent methods", () => {
+
+			beforeEach(() => {
+				params = {controller = "test", action = "testRedirect"};
+				_controller = application.wo.controller("test", params);
+				copies.request.cgi = request.cgi;
+				$origMethod_F5 = request.cgi.request_method ?: "GET";
+			});
+
+			afterEach(() => {
+				request.cgi = copies.request.cgi;
+				request.cgi.request_method = $origMethod_F5;
+			});
+
+			it("upgrades default 302 to 303 on POST", () => {
+				request.cgi.request_method = "POST";
+				_controller.redirectTo(action = "test");
+				expect(_controller.getRedirect().statusCode).toBe(303);
+			});
+
+			it("upgrades default 302 to 303 on PUT", () => {
+				request.cgi.request_method = "PUT";
+				_controller.redirectTo(action = "test");
+				expect(_controller.getRedirect().statusCode).toBe(303);
+			});
+
+			it("upgrades default 302 to 303 on PATCH", () => {
+				request.cgi.request_method = "PATCH";
+				_controller.redirectTo(action = "test");
+				expect(_controller.getRedirect().statusCode).toBe(303);
+			});
+
+			it("upgrades default 302 to 303 on DELETE", () => {
+				request.cgi.request_method = "DELETE";
+				_controller.redirectTo(action = "test");
+				expect(_controller.getRedirect().statusCode).toBe(303);
+			});
+
+			it("keeps default 302 on GET", () => {
+				request.cgi.request_method = "GET";
+				_controller.redirectTo(action = "test");
+				expect(_controller.getRedirect().statusCode).toBe(302);
+			});
+
+			it("respects an explicit statusCode override on POST", () => {
+				// User explicitly requested 302 — don't second-guess.
+				request.cgi.request_method = "POST";
+				_controller.redirectTo(action = "test", statusCode = 302);
+				expect(_controller.getRedirect().statusCode).toBe(302);
+			});
+
+			it("respects an explicit statusCode override on POST (301)", () => {
+				request.cgi.request_method = "POST";
+				_controller.redirectTo(action = "test", statusCode = 301);
+				expect(_controller.getRedirect().statusCode).toBe(301);
+			});
+		})
+
 		describe("Tests that redirectto prevents open redirect", () => {
 
 			beforeEach(() => {


### PR DESCRIPTION
## Summary

F5 from the 2026-05-01 afternoon fresh-VM run. Wheels' default post-create redirect uses HTTP 302 (\"Found\"), which has historically ambiguous method-handling semantics. Browsers treat it as 303 (\"See Other\") for compat, but scripted clients (curl with \`-L\`, programmatic HTTP libs) follow the spec literally and re-issue the redirect target with the original method.

The original report's exact symptom:

\`\`\`bash
\$ curl -X POST -d \"...\" -L http://localhost:8080/posts
HTTP/1.1 404 Not Found
Wheels.RouteNotFound — Incorrect HTTP Verb for route — The posts/3 path does not allow POST requests
\`\`\`

The redirect target is the show page (\`GET /posts/3\`), but \`-X POST -L\` re-POSTs to \`/posts/3\`, which routes-as-defined doesn't allow.

## Why 303

[RFC 7231 §6.4.4](https://tools.ietf.org/html/rfc7231#section-6.4.4) specifies 303 as the correct status for \"redirect after POST\" — clients **must** change to GET on 303 regardless of the original method. 302 is *technically allowed* but the spec only says \"clients MAY change the method\" (§6.4.3), and historically that ambiguity has caused exactly the kind of confusion this PR fixes.

| Method | Before | After |
|--------|--------|-------|
| GET    | 302    | 302   |
| POST   | 302    | **303** |
| PUT    | 302    | **303** |
| PATCH  | 302    | **303** |
| DELETE | 302    | **303** |

Explicit \`statusCode\` argument always wins regardless of method. Browser behavior is unchanged in practice (browsers were already treating 302 as 303 for redirect-after-POST).

## Implementation

The interesting part: \`\$args(name=\"redirectTo\", args=arguments)\` copies the framework default (302) into \`arguments.statusCode\` if the user didn't pass one. After that call, you can't tell whether the user explicitly passed 302 or just got the default. The fix captures intent **before** \`\$args\` runs:

\`\`\`cfc
local.userPassedStatusCode = StructKeyExists(arguments, \"statusCode\");
\$args(name = \"redirectTo\", args = arguments);
// ...
if (
    !local.userPassedStatusCode
    && StructKeyExists(request, \"cgi\")
    && StructKeyExists(request.cgi, \"request_method\")
    && ListFindNoCase(\"POST,PUT,PATCH,DELETE\", request.cgi.request_method)
) {
    arguments.statusCode = 303;
}
\`\`\`

Same \"capture state before the framework helper mutates it\" pattern used in F12 (TAP emitter closure) and F10 (CSRF detection probe) earlier in this fresh-VM batch.

## Tests

7 new specs in \`vendor/wheels/tests/specs/controller/redirectionSpec.cfc\`:

- POST/PUT/PATCH/DELETE without explicit \`statusCode\` → 303
- GET without explicit \`statusCode\` → 302 (unchanged)
- Explicit \`statusCode=302\` on POST → respects user choice (302)
- Explicit \`statusCode=301\` on POST → respects user choice (301)

## Coverage

- **Controller spec dir**: 422 passed (was 418, +4 RED → 0 fail; the other 3 new specs were always green)
- **Full SQLite suite**: 3384 passed (was 3377, zero regressions)

## Behavior change risk

- **Browsers**: zero user-visible change. Browsers were already treating 302 as 303 for redirect-after-POST.
- **API consumers / scripted clients**: this is the user-visible improvement. \`curl -L\` POSTs now work as expected.
- **Tests asserting status code**: any test asserting \`statusCode == 302\` after a POST/PUT/PATCH/DELETE redirect would break. The framework's own test suite has no such assertion (verified — only the explicit-pass case at line 51 of redirectionSpec.cfc tests a specific status, and it passes 301 explicitly). User app tests in the wild would need updating; documented in the migration guide.

## Test plan

- [x] Local migrator + controller + full SQLite suites green
- [ ] CI cross-engine matrix green
- [ ] (Future) Verify in fresh-VM run that the chapter 3 curl smoke test no longer needs the \`-X POST\` workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)