### PR TITLE
docs: chapter 7 browser spec — explicit waits between submit and assertion (F14)

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/07-testing-deploying.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/07-testing-deploying.mdx
@@ -189,6 +189,7 @@ The installer downloads the JARs into `lib/`, Chromium into `~/Library/Caches` (
                        .fill("input[name='user[email]']", "alice@example.com")
                        .fill("input[name='user[password]']", "hunter2")
                        .click("button[type=submit]")
+                       .waitForUrl("**/posts")
                        .assertUrlContains("/posts");
 
                    this.browser
@@ -197,12 +198,14 @@ The installer downloads the JARs into `lib/`, Chromium into `~/Library/Caches` (
                        .fill("##post-title", "My first post")
                        .fill("##post-body", "Hello Wheels")
                        .click("button[type=submit]")
+                       .waitForText("My first post")
                        .assertSee("My first post");
 
                    this.browser
                        .fill("input[name='comment[author]']", "Bob")
                        .fill("textarea[name='comment[body]']", "Great post")
                        .click("turbo-frame##new_comment button[type=submit]")
+                       .waitForText("Great post")
                        .assertSee("Great post");
                });
            });
@@ -212,13 +215,14 @@ The installer downloads the JARs into `lib/`, Chromium into `~/Library/Caches` (
 
 </Steps>
 
-Four things to notice:
+Things to notice:
 
 - `browserDescribe` wraps `describe` with a `beforeEach`/`afterEach` pair that creates a fresh Playwright page for every `it`. Without it, one test's navigation state would leak into the next.
 - `##post-title` is CFML escaping a literal `#` inside a string. At runtime the selector is `#post-title` — the CSS id the `textField(objectName="post", property="title")` helper emits (Wheels joins object + property with a dash). Without the double `##`, CFML would try to evaluate `post-title` as an expression and throw.
 - `turbo-frame##new_comment button[type=submit]` is the same `##` escape applied to a frame-scoped selector. The post show page has two submit buttons — the `Delete` button and the `Post comment` button — so a bare `button[type=submit]` would match both and Playwright's strict-mode locator would refuse to act. Scoping to the new-comment frame makes the click unambiguous.
 - The signup form uses plain `<input name="user[email]">` without an id, so the spec targets it by attribute selector instead. Attribute selectors like `input[name='user[email]']` are robust against future form refactors.
-- The fluent DSL chains: `.visitRoute("signup").fill(...).click(...).assertUrlContains("/posts")` is one statement. Each method returns the browser object, so the chain keeps going until you call a terminal like `.assertSee(...)` or let the statement end.
+- The fluent DSL chains: `.visitRoute("signup").fill(...).click(...).waitForUrl("**/posts").assertUrlContains("/posts")` is one statement. Each method returns the browser object, so the chain keeps going until you call a terminal like `.assertSee(...)` or let the statement end.
+- `.waitForUrl("**/posts")` and `.waitForText("My first post")` are not optional — they bridge the async gap between `.click()` and the assertion. Submitting a form goes through Turbo Drive's `fetch` + `history.pushState`, which doesn't complete on the same tick as the click. `assertUrlContains` and `assertSee` read state synchronously, so without an explicit wait they'd fire before navigation lands and you'd see `Expected URL to contain '/posts', got 'http://localhost:8080/signup'`. `waitForUrl` accepts Playwright glob patterns; `waitForText` waits for visible text anywhere on the page (handy when a Turbo Stream appends content but the URL doesn't change).
 - `if (this.browserTestSkipped) return;` keeps the spec green on machines without Playwright installed — fresh CI runners before `wheels browser install`, for example. The flag is set by `beforeAll` when the JARs can't be loaded.
 
 ## Run the tests


### PR DESCRIPTION
## Summary

The canonical `SignupFlowSpec.cfc` paste from chapter 7 was failing on a fresh-VM tutorial run with:

```
FAIL: signs up, creates a post, adds a comment
  Expected URL to contain '/posts', got 'http://localhost:8080/signup'
```

`assertUrlContains` and `assertSee` read state synchronously — they don't auto-wait. Submitting a form goes through Turbo Drive's `fetch` + `history.pushState`, which doesn't complete on the same tick as `.click()`. The DSL already has `waitForUrl(glob)` and `waitForText(text)` for exactly this; the chapter just wasn't using them.

Three submission chains, three matching waits:

- signup → `waitForUrl("**/posts")` before `assertUrlContains`
- new post → `waitForText("My first post")` before `assertSee`
- new comment → `waitForText("Great post")` before `assertSee` (no URL change for the Turbo-Stream append)

Plus a prose bullet that explains the principle so future authors don't strip the waits thinking they're noise.

## Source
F14 from the 2026-05-01 fresh-VM tutorial run.

## Test plan
- [ ] Build the docs site and confirm chapter 7 renders cleanly
- [ ] Run `wheels test --filter=browser` against a fresh tutorial app and confirm `SignupFlowSpec` passes (canonical copy-paste flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)