### PR TITLE
fix(model): use local.key in UUID collision check (#2387)

### DIFF
--- a/vendor/wheels/model/create.cfc
+++ b/vendor/wheels/model/create.cfc
@@ -263,7 +263,7 @@ component {
 
 				while (true) {
 					local.exists = this.findOne(
-						where = "#local.primaryKey# = '#local.newUUID#'"
+						where = "#local.key# = '#local.newUUID#'"
 					);
 
 					if (!local.exists) {


### PR DESCRIPTION
## Summary
- Fixes [#2387](https://github.com/wheels-dev/wheels/issues/2387) reported by @zainforbjs.
- The UUID auto-generation block in [vendor/wheels/model/create.cfc:266](vendor/wheels/model/create.cfc:266) iterates `local.uuidBasedKeys` with `local.key`, but the collision-check `WHERE` clause referenced an undefined `local.primaryKey`. Any model with a UUID-based primary key that wasn't explicitly set would crash on `create()` / `save()`.
- One-character fix: `#local.primaryKey#` → `#local.key#`.

## Test plan
- [ ] Define a model with a UUID-typed primary key column (e.g. `t.string("id", limit=36, default=NullValue())`).
- [ ] Call `model("X").create({...})` without supplying the PK.
- [ ] Before this PR: throws `Variable LOCAL.PRIMARYKEY is undefined`.
- [ ] After this PR: row is created with a generated UUID; collision-check loop runs without error.

## Notes
This is a one-line surgical fix. No tests added — the existing test suite doesn't appear to exercise UUID-PK auto-generation; happy to add a regression spec in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)