### PR TITLE
fix(controller): convert appendToKey to array before iterating (#2386)

### DIFF
--- a/vendor/wheels/controller/processing.cfc
+++ b/vendor/wheels/controller/processing.cfc
@@ -61,7 +61,7 @@ component {
 
 					// Evaluate variables and append to the cache key when specified.
 					if (Len(local.appendToKey)) {
-						for (local.item in local.appendToKey) {
+						for (local.item in ListToArray(local.appendToKey)) {
 							if (IsDefined(local.item)) {
 								scopeMap = {
 									"request": request,


### PR DESCRIPTION
## Summary
- Fixes [#2386](https://github.com/wheels-dev/wheels/issues/2386) reported by @zainforbjs.
- `caches(appendToKey=\"request.user,application.settings\")` stores `appendToKey` as a comma-delimited string. CFML's `for (item in stringList)` iterates **by character**, not list item, so the loop ran on `r`, `e`, `q`, ... instead of `request.user` and `application.settings`.
- `IsDefined(\"r\")` is usually false, so the loop quietly produced an unmodified cache key — every cached action that relied on `appendToKey` to shard by user/scope was hitting a single shared cache entry.
- One-character class of fix: wrap `local.appendToKey` in `ListToArray()`.

## Test plan
- [ ] Define a controller action with `caches(action=\"index\", appendToKey=\"session.userId\")`.
- [ ] Hit the action twice with different `session.userId` values.
- [ ] Before this PR: both requests hit the same cache key (the iteration over `\"session.userId\"` produced no scope/var lookups, so the key never changed).
- [ ] After this PR: `IsDefined(\"session.userId\")` runs once, the key is shard-suffixed with the session value, and the two requests cache independently.

## Notes
One-line surgical fix. No regression test added; the existing controller cache specs don't appear to exercise `appendToKey`. Happy to add one in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)