### PR TITLE
fix(controller): make $subscribe* public so $integrateComponents copies them (#2384)

### DIFF
--- a/vendor/wheels/controller/channels.cfc
+++ b/vendor/wheels/controller/channels.cfc
@@ -140,7 +140,7 @@ component {
 	 * Subscribes to the Channel singleton, buffers events in a synchronized
 	 * array, and streams them to the client via SSE.
 	 */
-	private void function $subscribeMemory(
+	public void function $subscribeMemory(
 		required string channel,
 		required array eventFilter,
 		required string lastEventId,
@@ -223,7 +223,7 @@ component {
 	 * Polls the DatabaseAdapter at regular intervals and streams
 	 * matching events to the client via SSE.
 	 */
-	private void function $subscribeDatabase(
+	public void function $subscribeDatabase(
 		required string channel,
 		required array eventFilter,
 		required string lastEventId,


### PR DESCRIPTION
## Summary
- Fixes [#2384](https://github.com/wheels-dev/wheels/issues/2384) reported by @zainforbjs.
- `$integrateComponents()` copies only **public** methods from mixin CFCs in `vendor/wheels/controller/` into the live controller object during boot.
- [vendor/wheels/controller/channels.cfc:143](vendor/wheels/controller/channels.cfc:143) and [:226](vendor/wheels/controller/channels.cfc:226) declared `$subscribeMemory` / `$subscribeDatabase` as `private`. The public `subscribeToChannel` (which **does** get integrated) calls these two helpers at lines 73 and 82 — so any controller invoking SSE channel subscription would die with a method-not-found error at runtime.

## Convention
This matches the project rule documented in [CLAUDE.md](CLAUDE.md):
> **`private` mixin functions not integrated**: `$integrateComponents()` only copies `public` methods into model/controller objects. ALL helper functions in mixin CFCs MUST use `public` access. Use `$` prefix for internal scope instead of `private` keyword.

The two methods already use the `$` prefix, so the surgical fix is just `private` → `public`.

## Test plan
- [ ] Wire a controller action that calls `subscribeToChannel(channel=\"test\")` against either the memory or database engine.
- [ ] Before this PR: action throws `variable [$subscribeMemory] doesn't exist` (or equivalent) once integration runs.
- [ ] After this PR: subscription proceeds normally; SSE stream opens.

## Notes
Two-line change. No behavior change for direct callers — `$` prefix still signals "framework-internal, do not call from app code." BoxLang may or may not enforce this differently per the CLAUDE.md note; the fix is correct on Lucee/Adobe regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)