### PR TITLE
fix(model): block SQL injection in chainable QueryBuilder via value-shape validation

### DIFF
--- a/vendor/wheels/model/query/QueryBuilder.cfc
+++ b/vendor/wheels/model/query/QueryBuilder.cfc
@@ -475,6 +475,13 @@ component output="false" {
 
 	/**
 	 * Quote a value using the model's adapter for SQL injection safety.
+	 *
+	 * For integer/float/boolean columns the adapter's $quoteValue passes the value
+	 * through unquoted (the downstream WHERE-clause regex re-extracts bare numerics
+	 * into cfqueryparam). That contract assumes the caller has already constrained
+	 * the value to a numeric/boolean shape — so we enforce that here at the only
+	 * untrusted entry point. String columns are wrapped and escaped by the adapter,
+	 * so they don't need this check.
 	 */
 	private string function $quoteValue(required string property, required any value) {
 		local.type = "string";
@@ -482,7 +489,47 @@ component output="false" {
 		if (StructKeyExists(local.classData.properties, arguments.property)) {
 			local.type = local.classData.properties[arguments.property].validationtype;
 		}
-		return local.classData.adapter.$quoteValue(str = ToString(arguments.value), type = local.type);
+		local.strValue = ToString(arguments.value);
+		$validateValueShape(arguments.property, local.strValue, local.type);
+		return local.classData.adapter.$quoteValue(str = local.strValue, type = local.type);
+	}
+
+	/**
+	 * Validate that a value matches the shape the adapter expects for its declared
+	 * column type. Throws Wheels.InvalidValue when the shape doesn't match — closing
+	 * the SQL-injection vector through which strings like "0 OR 1=1" would otherwise
+	 * land in the unquoted numeric/boolean path of the adapter.
+	 */
+	private void function $validateValueShape(required string property, required string value, required string type) {
+		// Empty values fall through to the adapter's empty-string quoting branch.
+		if (!Len(arguments.value)) {
+			return;
+		}
+		switch (arguments.type) {
+			case "integer":
+				if (!ReFind("^-?[0-9]+$", arguments.value)) {
+					$throwInvalidValue(arguments.property, arguments.value, "integer");
+				}
+				break;
+			case "float":
+				if (!ReFind("^-?[0-9]+(\.[0-9]+)?$", arguments.value)) {
+					$throwInvalidValue(arguments.property, arguments.value, "float");
+				}
+				break;
+			case "boolean":
+				if (!ListFindNoCase("0,1,true,false,yes,no", arguments.value)) {
+					$throwInvalidValue(arguments.property, arguments.value, "boolean");
+				}
+				break;
+		}
+	}
+
+	private void function $throwInvalidValue(required string property, required string value, required string expectedType) {
+		Throw(
+			type = "Wheels.InvalidValue",
+			message = "The value `#EncodeForHTML(arguments.value)#` for property `#EncodeForHTML(arguments.property)#` is not a valid #arguments.expectedType#.",
+			extendedInfo = "Values bound to #arguments.expectedType# columns must be valid #arguments.expectedType# literals so they can be safely interpolated into the WHERE clause. This check protects the chainable query builder against SQL injection through typed-numeric/boolean payloads."
+		);
 	}
 
 	/**

--- a/vendor/wheels/tests/specs/QueryBuilderSpec.cfc
+++ b/vendor/wheels/tests/specs/QueryBuilderSpec.cfc
@@ -265,6 +265,150 @@ component extends="wheels.WheelsTest" {
 
 			});
 
+			describe("value validation for typed columns rejects SQL injection", function() {
+
+				// The post model has integer columns (id, authorid, views) and a float column
+				// (averagerating). The adapter's $quoteValue passes integer/float/boolean values
+				// through unquoted, so without value-shape validation the QueryBuilder leaks
+				// injected SQL fragments into the WHERE clause. These tests pin down the fix.
+
+				it("rejects tautology injection on integer column via where(prop, op, val)", function() {
+					expect(function() {
+						qb.where("views", ">", "0 OR 1=1");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("rejects UNION SELECT injection on integer column", function() {
+					expect(function() {
+						qb.where("views", "=", "1 UNION SELECT password FROM c_o_r_e_users");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("rejects comment-truncation on integer column", function() {
+					expect(function() {
+						qb.where("views", "=", "1 --");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("rejects stacked-statement injection on integer column", function() {
+					expect(function() {
+						qb.where("views", "=", "1; DROP TABLE c_o_r_e_posts");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("rejects injection on float column", function() {
+					expect(function() {
+						qb.where("averagerating", ">", "3.14 OR 1=1");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("rejects injection in whereBetween low bound", function() {
+					expect(function() {
+						qb.whereBetween(property = "views", low = "0 OR 1=1", high = 10);
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("rejects injection in whereBetween high bound", function() {
+					expect(function() {
+						qb.whereBetween(property = "views", low = 0, high = "10 OR 1=1");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("rejects injection in whereIn list element", function() {
+					expect(function() {
+						qb.whereIn(property = "views", values = "1,2,3 OR 1=1");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("rejects injection in whereIn array element", function() {
+					expect(function() {
+						qb.whereIn(property = "views", values = [1, 2, "3 OR 1=1"]);
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("rejects injection in whereNotIn list element", function() {
+					expect(function() {
+						qb.whereNotIn(property = "views", values = "1,2,3 OR 1=1");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("rejects injection via two-argument where()", function() {
+					expect(function() {
+						qb.where("views", "0 OR 1=1");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("rejects injection via three-argument orWhere()", function() {
+					expect(function() {
+						qb.orWhere("views", ">", "0 OR 1=1");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("rejects injection via two-argument orWhere()", function() {
+					expect(function() {
+						qb.orWhere("views", "0 OR 1=1");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("accepts plain integer values", function() {
+					expect(function() {
+						qb.where("views", ">", 18);
+					}).notToThrow();
+				});
+
+				it("accepts integer-shaped strings", function() {
+					expect(function() {
+						qb.where("views", "=", "42");
+					}).notToThrow();
+				});
+
+				it("accepts negative integer values", function() {
+					expect(function() {
+						qb.where("views", ">=", "-1");
+					}).notToThrow();
+				});
+
+				it("accepts plain float values", function() {
+					expect(function() {
+						qb.where("averagerating", ">", 3.14);
+					}).notToThrow();
+				});
+
+				it("accepts float-shaped strings", function() {
+					expect(function() {
+						qb.where("averagerating", ">", "3.14");
+					}).notToThrow();
+				});
+
+				it("accepts negative float values", function() {
+					expect(function() {
+						qb.where("averagerating", ">", "-2.5");
+					}).notToThrow();
+				});
+
+				it("accepts integer values in whereBetween", function() {
+					expect(function() {
+						qb.whereBetween(property = "views", low = 1, high = 10);
+					}).notToThrow();
+				});
+
+				it("accepts integer values in whereIn", function() {
+					expect(function() {
+						qb.whereIn(property = "views", values = "1,2,3");
+					}).notToThrow();
+				});
+
+				it("does not validate string columns (adapter quotes them safely)", function() {
+					// String columns get quoted with single-quote escaping by the adapter,
+					// so classic value-injection payloads are rendered harmless without
+					// needing a regex check at the builder layer.
+					expect(function() {
+						qb.where("title", "=", "anything' OR '1'='1");
+					}).notToThrow();
+				});
+
+			});
+
 		});
 
 	}


### PR DESCRIPTION
## Summary

Pre-release security review for v4.0.0-rc1 surfaced a **HIGH-severity SQL injection** in the new chainable `QueryBuilder` — the API advertised in [CLAUDE.md](CLAUDE.md) and its own docblock as "injection-safe."

The adapter's `$quoteValue` returns integer/float/boolean values **unquoted**, on the assumption that callers have already constrained the value to a numeric/boolean shape. The QueryBuilder didn't enforce that constraint. A standard endpoint like:

```cfm
function index() {
    users = model("User").where("age", ">", params.age).get();
}
```

`/users?age=0%20OR%201%3D1` produced `WHERE age > 0 OR 1=1` — a tautology returning every row. The same defect affected `whereBetween` (per-bound), `whereIn` / `whereNotIn` (per-element), and the 2-arg `where()`/`orWhere()` forms.

## What changed

- **[QueryBuilder.cfc](vendor/wheels/model/query/QueryBuilder.cfc):** `$quoteValue` now calls `$validateValueShape` before delegating to the adapter. Integer values must match `^-?[0-9]+$`, floats must match `^-?[0-9]+(\.[0-9]+)?$`, booleans must be in `0,1,true,false,yes,no`. Mismatches throw `Wheels.InvalidValue`. String columns are unaffected — the adapter still quotes and escapes them.
- **[QueryBuilderSpec.cfc](vendor/wheels/tests/specs/QueryBuilderSpec.cfc):** 22 regression tests covering tautology, UNION SELECT, comment-truncation, stacked-statement, per-method coverage across `where`, `orWhere`, `whereBetween`, `whereIn`, `whereNotIn` — plus accept-cases for legitimate integer/float/string values.

## Out of scope (separate finding)

The same root-cause pattern exists in legacy paths that pre-date the chainable builder:

- `vendor/wheels/model/onmissingmethod.cfc:165` — dynamic finders (`findByViews(params.views)`)
- `vendor/wheels/model/sql.cfc:1325` — `$keyWhereString` used by `findByKey` / `updateByKey` / `deleteByKey`

These are vulnerable today (`findByKey("1 OR 1=1")` injects on integer-keyed models), but they ship in every Wheels release going back to before 4.0. Recommend tracking as a follow-up so the rc1 fix stays narrowly scoped to the new "injection-safe" surface.

## Test plan

- [ ] CI: full test matrix on `pr.yml` (Lucee 5/6/7 + Adobe 2018/2021/2023/2025 + boxlang × SQLite/MySQL/Postgres/SQL Server)
- [ ] Verify no regression in [model/queryBuilderSpec.cfc](vendor/wheels/tests/specs/model/queryBuilderSpec.cfc) integration tests (existing legitimate values: `where("views", ">", 0)`, `whereBetween("views", 1, 5)`, `whereIn("lastName", "Djurner,Petruzzi")` all match the new validation)
- [ ] New tests in `QueryBuilderSpec.cfc` pass on all engines

**Note on local verification:** I could not run the suite locally — LuCLI hardcodes shutdown port `8081`, which is held by another worktree's daily server. Did not bounce that server. Fix verified by close code review against the test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)