### PR TITLE
fix(model): block SQL injection in legacy finders via adapter-side value validation

### DIFF
--- a/vendor/wheels/databaseAdapters/Base.cfc
+++ b/vendor/wheels/databaseAdapters/Base.cfc
@@ -472,6 +472,18 @@ component output=false extends="wheels.Global"{
 
 	/**
 	 * Internal function.
+	 *
+	 * For integer/float/boolean columns this returns the value unquoted so the
+	 * downstream WHERE-clause regex can re-extract bare numerics into
+	 * cfqueryparam placeholders. That contract is unsafe by itself — a string
+	 * like "0 OR 1=1" would land verbatim in the SQL — so we validate the value
+	 * shape here before passing it through. This closes SQL injection across
+	 * every caller (chainable QueryBuilder, $keyWhereString used by findByKey/
+	 * updateByKey/deleteByKey, dynamic finders findByX/findOneByX/findAllByX,
+	 * the uniqueness-check $buildWhereClausePart, and any future caller).
+	 *
+	 * String columns are unaffected — the adapter still wraps and escapes the
+	 * value, so classic single-quote payloads land harmlessly inside a literal.
 	 */
 	public string function $quoteValue(required string str, string sqlType = "CF_SQL_VARCHAR", string type) {
 		if (!StructKeyExists(arguments, "type")) {
@@ -480,9 +492,48 @@ component output=false extends="wheels.Global"{
 		if (!ListFindNoCase("integer,float,boolean", arguments.type) || !Len(arguments.str)) {
 			local.rv = "'#Replace(arguments.str, "'", "''", "all")#'";
 		} else {
+			$validateValueShape(arguments.str, arguments.type);
 			local.rv = arguments.str;
 		}
 		return local.rv;
+	}
+
+	/**
+	 * Validate that a value matches the shape this adapter expects for its
+	 * declared column type. Throws Wheels.InvalidValue when the shape doesn't
+	 * match — closing the SQL-injection vector through which strings like
+	 * "0 OR 1=1" would otherwise land in the unquoted numeric/boolean path.
+	 *
+	 * Intentionally narrow: only fires for integer/float/boolean columns,
+	 * which is exactly the set of types $quoteValue passes through unquoted.
+	 * String columns are wrapped + escaped above and don't need this check.
+	 */
+	public void function $validateValueShape(required string str, required string type) {
+		switch (arguments.type) {
+			case "integer":
+				if (!ReFind("^-?[0-9]+$", arguments.str)) {
+					$throwInvalidValue(arguments.str, "integer");
+				}
+				break;
+			case "float":
+				if (!ReFind("^-?[0-9]+(\.[0-9]+)?$", arguments.str)) {
+					$throwInvalidValue(arguments.str, "float");
+				}
+				break;
+			case "boolean":
+				if (!ListFindNoCase("0,1,true,false,yes,no", arguments.str)) {
+					$throwInvalidValue(arguments.str, "boolean");
+				}
+				break;
+		}
+	}
+
+	public void function $throwInvalidValue(required string str, required string expectedType) {
+		Throw(
+			type = "Wheels.InvalidValue",
+			message = "The value `#EncodeForHTML(arguments.str)#` is not a valid #arguments.expectedType#.",
+			extendedInfo = "Values bound to #arguments.expectedType# columns must be valid #arguments.expectedType# literals so they can be safely interpolated into the WHERE clause. This check protects every Wheels query path against SQL injection through typed-numeric/boolean payloads."
+		);
 	}
 
 	/**

--- a/vendor/wheels/tests/specs/security/LegacyFinderInjectionSpec.cfc
+++ b/vendor/wheels/tests/specs/security/LegacyFinderInjectionSpec.cfc
@@ -1,0 +1,134 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		g = application.wo
+
+		describe("Legacy finder SQL injection prevention", () => {
+
+			// PR #2416 closed the SQL-injection vector in the chainable QueryBuilder by
+			// validating typed values before they reach the adapter's $quoteValue. The
+			// same root-cause pattern existed in the legacy ORM paths that pre-date the
+			// chainable builder — findByKey / updateByKey / deleteByKey (which share the
+			// $keyWhereString sink in sql.cfc) and the dynamic finders (findByX /
+			// findOneByX / findAllByX) in onmissingmethod.cfc. Adapter-side validation
+			// in Base.$quoteValue closes those at the only sink they share.
+			//
+			// Tracking issue: #2417.
+
+			describe("$keyWhereString — findByKey / updateByKey / deleteByKey", () => {
+
+				it("findByKey rejects tautology injection on integer-keyed model", () => {
+					expect(function() {
+						g.model("post").findByKey("1 OR 1=1");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("findByKey rejects UNION SELECT injection", () => {
+					expect(function() {
+						g.model("post").findByKey("1 UNION SELECT password FROM c_o_r_e_users");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("findByKey rejects comment-truncation injection", () => {
+					expect(function() {
+						g.model("post").findByKey("1 --");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("findByKey rejects stacked-statement injection", () => {
+					expect(function() {
+						g.model("post").findByKey("1; DROP TABLE c_o_r_e_posts");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("updateByKey rejects tautology injection in key", () => {
+					expect(function() {
+						g.model("post").updateByKey(key = "1 OR 1=1", title = "hijacked");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("deleteByKey rejects tautology injection in key", () => {
+					expect(function() {
+						g.model("post").deleteByKey("1 OR 1=1");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("findByKey accepts a legitimate integer key", () => {
+					// Should not throw; the row may or may not exist depending on
+					// fixtures, but the value-shape gate must let integers through.
+					expect(function() {
+						g.model("post").findByKey(1);
+					}).notToThrow();
+				});
+
+				it("findByKey accepts an integer-shaped string key", () => {
+					expect(function() {
+						g.model("post").findByKey("1");
+					}).notToThrow();
+				});
+
+				it("findByKey accepts a negative integer key", () => {
+					// Negative integers are legitimate per the regex (^-?[0-9]+$).
+					// No row will match, but the gate must not throw.
+					expect(function() {
+						g.model("post").findByKey("-1");
+					}).notToThrow();
+				});
+
+			});
+
+			describe("dynamic finders — findByX / findOneByX / findAllByX", () => {
+
+				it("findAllByViews rejects tautology injection on integer column", () => {
+					expect(function() {
+						g.model("post").findAllByViews("0 OR 1=1");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("findOneByViews rejects UNION SELECT injection on integer column", () => {
+					expect(function() {
+						g.model("post").findOneByViews("0 UNION SELECT 1");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("findOneByViews rejects comment-truncation on integer column", () => {
+					expect(function() {
+						g.model("post").findOneByViews("0 --");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("findAllByAveragerating rejects injection on float column", () => {
+					expect(function() {
+						g.model("post").findAllByAveragerating("3.14 OR 1=1");
+					}).toThrow("Wheels.InvalidValue");
+				});
+
+				it("findAllByViews accepts legitimate integer value", () => {
+					expect(function() {
+						g.model("post").findAllByViews(0);
+					}).notToThrow();
+				});
+
+				it("findAllByAveragerating accepts legitimate float value", () => {
+					expect(function() {
+						g.model("post").findAllByAveragerating(3.14);
+					}).notToThrow();
+				});
+
+				it("findAllByTitle accepts ordinary string values (string column)", () => {
+					// String columns are quoted-and-escaped by the adapter; the
+					// numeric/boolean shape gate is skipped for them so legitimate
+					// string content (including spaces) passes through.
+					expect(function() {
+						g.model("post").findAllByTitle("any title here");
+					}).notToThrow();
+				});
+
+			});
+
+		});
+
+	}
+
+}


### PR DESCRIPTION
## Summary

Closes #2417. PR #2416 closed the SQL injection vector in the chainable QueryBuilder by validating typed values before they reach `$quoteValue`. The same root-cause pattern still existed in the legacy ORM paths that pre-date the chainable builder:

- `findByKey` / `updateByKey` / `deleteByKey` via `$keyWhereString` ([sql.cfc:1325](vendor/wheels/model/sql.cfc#L1325))
- `findByX` / `findOneByX` / `findAllByX` via dynamic finders ([onmissingmethod.cfc:165](vendor/wheels/model/onmissingmethod.cfc#L165))
- `$buildWhereClausePart` used by `validatesUniquenessOf` ([validations.cfc:774](vendor/wheels/model/validations.cfc#L774))

All three reach `Base.$quoteValue` ([databaseAdapters/Base.cfc:476](vendor/wheels/databaseAdapters/Base.cfc#L476)) with user-supplied values bound to integer/float/boolean columns. The adapter returns them **unquoted** (a known contract for the downstream `RESQLWhere` regex that re-extracts bare numerics into `cfqueryparam`). The post-hoc regex parameterizes what it sees, but doesn't strip injected `OR` / `UNION` / comment structure — so `/users/1%20OR%201%3D1` produced `WHERE id=1 OR 1=1`, a tautology returning the first row.

**Severity:** HIGH (framework-level, affects every downstream Wheels app following the canonical CRUD pattern documented in our guides).

## What changed

Push the validation into `Base.$quoteValue` itself (approach **B** from #2417 — the maintainer's recommended shape). One fix point, defense for any future caller.

- **[`vendor/wheels/databaseAdapters/Base.cfc`](vendor/wheels/databaseAdapters/Base.cfc):** new `$validateValueShape(str, type)` runs before the adapter passes integer/float/boolean values through unquoted. Same regex/allowlist as #2416 — `^-?[0-9]+$` for integer, `^-?[0-9]+(\.[0-9]+)?$` for float, `0,1,true,false,yes,no` for boolean. Mismatches throw `Wheels.InvalidValue`. String columns are untouched — the adapter still wraps and escapes them.
- **[`vendor/wheels/tests/specs/security/LegacyFinderInjectionSpec.cfc`](vendor/wheels/tests/specs/security/LegacyFinderInjectionSpec.cfc):** 16 regression tests covering tautology, UNION SELECT, comment-truncation, and stacked-statement payloads against `findByKey` / `updateByKey` / `deleteByKey` / `findAllByX` / `findOneByX` on integer + float columns, plus accept-cases for legitimate integer (positive, negative, integer-shaped string), float, and string values.

## Why adapter-side rather than caller-side

The issue flagged the audit risk for internal callers. Verified each:

| Internal caller | Trust | Effect of adapter validation |
|---|---|---|
| [`read.cfc:170`](vendor/wheels/model/read.cfc#L170) (pagination) | DB-round-tripped PK values | Always valid integers — no false positives |
| [`validations.cfc:774`](vendor/wheels/model/validations.cfc#L774) (`$buildWhereClausePart`) | Model property values | Non-numeric on integer column was already a DB error today; now a clearer `Wheels.InvalidValue` at the framework boundary |
| [`Base.cfc:66`](vendor/wheels/databaseAdapters/Base.cfc#L66) (`parameterize=false`) | Query plan params | Malformed numerics were already broken; same — earlier failure with explicit error |

No regressions in the suite (see Test plan).

## Test plan

- [x] Local Lucee 7 + SQLite via `tools/test-local.sh` (with port-collision workaround for the user's daily-driver server): **3413 passed, 0 failed, 0 errored** — the 9 non-passes are all in browser fixture-server specs unrelated to `$quoteValue`.
- [x] Docker Lucee 6 + SQLite, security suite: **173 passed, 0 failed, 0 errored** — including 16/16 on the new `LegacyFinderInjectionSpec`.
- [x] Docker Adobe 2025 + SQLite, model suite: **804 passed, 0 failed, 0 errored** (11 explicit skips for non-MySQL-only useIndex tests).
- [x] Docker Adobe 2025 + SQLite, security suite (with the pre-existing Adobe-incompatible `McpCommandInjectionSpec` temporarily set aside): **148 passed, 0 failed, 0 errored** — including 16/16 on the new spec.
- [x] CI: full test matrix on `pr.yml` (Lucee 5/6/7 + Adobe 2018/2021/2023/2025 + boxlang × SQLite/MySQL/Postgres/SQL Server)

### Side finding (separate fix, spawned)

`vendor/wheels/tests/specs/security/McpCommandInjectionSpec.cfc` calls `mid(s, 7)` on lines 105, 117, 133, 150 — Lucee accepts the 2-arg form, Adobe CF requires 3. Pre-existing since [PR #2083](https://github.com/wheels-dev/wheels/pull/2083) (commit `db722c713`); crashes the Adobe 2025 security suite at compile time. Spawned as a separate `fix(test)` task — out of scope for this PR.

## Cross-references

- Related fix on `develop`: [#2416](https://github.com/wheels-dev/wheels/pull/2416) — chainable QueryBuilder fix
- Tracking issue: [#2417](https://github.com/wheels-dev/wheels/issues/2417)

🤖 Generated with [Claude Code](https://claude.com/claude-code)