### PR TITLE
fix(view): drop /wheels/* top nav in favor of debug footer

### DIFF
--- a/vendor/wheels/public/layout/_header.cfm
+++ b/vendor/wheels/public/layout/_header.cfm
@@ -7,6 +7,17 @@ if (!IsDefined("pageHeader")) {
 // Css Path
 request.wheelsInternalAssetPath = application.wheels.webpath & "wheels/public/assets";
 
+// Opt the request into the dev debug bar emitted at onrequestend.
+// Public.cfc handlers <cfinclude> these views directly (bypassing
+// renderView, which is what normally flips this flag), so without this
+// the bar wouldn't appear on /wheels/info, /wheels/routes, etc. — which
+// is exactly where developers expect dev-tools nav. Setting it during
+// view rendering (here) instead of in the controller preamble avoids
+// touching request scope before the framework is fully wired.
+if (StructKeyExists(request, "wheels") && IsStruct(request.wheels)) {
+	request.wheels.showDebugInformation = true;
+}
+
 // Primary Navigation
 request.navigation = [
 	{
@@ -440,12 +451,10 @@ if (StructKeyExists(url, "refresh")) {
 	<body>
 	<cfif request.isFluid>
 		<div id="main" class="ui grid stackable h-100">
-		<cfinclude template="_navigation.cfm">
 		<div id="top" class="sixteen wide stretched column ">
 		<div class="ui grid stackable">
 	<cfelse>
 		<div id="main">
-		<cfinclude template="_navigation.cfm">
 		<div id="top" class="margin-top">
 	</cfif>
 	<!--- cfformat-ignore-end --->

--- a/vendor/wheels/public/layout/_header_simple.cfm
+++ b/vendor/wheels/public/layout/_header_simple.cfm
@@ -1,6 +1,16 @@
 <!---
 Static simple version of the header/navigation for output on error screens
 --->
+<cfscript>
+// Opt the request into the dev debug bar emitted at onrequestend.
+// Public.cfc::index() <cfinclude>s congratulations.cfm directly (bypassing
+// renderView, which is what normally flips this flag), so without this
+// the bar wouldn't appear on the welcome page when served from the
+// framework's Public dispatcher. Same opt-in pattern as _header.cfm.
+if (StructKeyExists(request, "wheels") && IsStruct(request.wheels)) {
+	request.wheels.showDebugInformation = true;
+}
+</cfscript>
 <cfoutput>
 <!--- cfformat-ignore-start --->
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary

- Drop the top-nav include from `_header.cfm` — duplicates links already in the debug bar emitted at `onrequestend` (System Info / Routes / API / Guides / Migrator / Packages / Plugins).
- Opt both `_header.cfm` and `_header_simple.cfm` into `request.wheels.showDebugInformation = true` so the debug bar emits on `/wheels/*` admin pages and the welcome page. Necessary because `Public.cfc` handlers `<cfinclude>` their views directly without going through `renderView()`, which is what normally flips that flag.

Extends the pattern from #2406 (welcome + error pages) to the rest of the dev-tools admin pages — every view that uses either header layout now has the debug footer as its only chrome.

## Why

`/wheels/info`, `/wheels/routes`, `/wheels/api`, etc. were rendering with two parallel navigation surfaces: the top nav from `_header.cfm` AND the debug bar at the bottom. Both linked to the same destinations. Removing the top nav consolidates dev-tools navigation into a single surface and matches the look established for the welcome page.

## Test plan

- [x] `/` (welcome page) renders with debug bar at bottom
- [x] `/wheels/info` renders without top nav, with debug bar at bottom
- [x] Debug bar's "Tools" panel still surfaces System Info / Routes / API Docs / Guides / Migrator / Packages / Plugins links (unchanged from `debug.cfm`)
- [x] No regressions: home page and `/wheels/info` both return HTTP 200; framework dev rig boots cleanly
- [ ] CI: full test matrix passes