### PR TITLE
docs: correct deploy.yml interpolation syntax and compress launch schedule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -864,12 +864,12 @@ Commands-are-strings invariant: every `*Commands.cfc` method returns a shell-com
 
 ### Critical gotchas
 
-1. **Kamal-compatible schema, ONE divergence.** ERB in `deploy.yml` is NOT supported. Use the restricted Mustache context `{{env.FOO}}`, `{{destination}}`, `{{hostname}}` instead. Everything else in `config/deploy.yml` is byte-identical to Kamal 2.4.0.
+1. **Kamal-compatible schema, ONE divergence.** ERB in `deploy.yml` is NOT supported (rendering it would require embedding a Ruby runtime). Kamal's native `${VAR}` env-var interpolation is preserved unchanged — uppercase-snake tokens resolve via `envOverride → .kamal/secrets → System.getenv → ""` (see `ConfigLoader.$interpolate`). Mustache (`{{...}}`) is used only by `wheels deploy init` to scaffold a fresh `deploy.yml`/`secrets`; it is NOT applied to `deploy.yml` at runtime. Everything else in `config/deploy.yml` is byte-identical to Kamal 2.4.0.
 2. **Hook env prefix is `KAMAL_`, not `WHEELS_`.** This is deliberate — it means Ruby Kamal users' existing `.kamal/hooks/` scripts work unchanged.
 3. **`app live` / `app maintenance` use a marker file** (`/tmp/kamal-maintenance-<svc>`) rather than kamal-proxy native maintenance mode. Phase 2 simplification; Phase 3 follow-up will align with Kamal's proxy-native semantics.
 4. **`wheels deploy remove` is destructive and requires `--confirm`.** Bare `wheels deploy remove` throws without touching anything.
 5. **Lucee reserved scope names in subagent-authored deploy code.** `client`, `session`, `application` — use `ssh`/`sc`, `sess`, `app` instead. Bit us multiple times during the port.
-6. **No `--dry-run` flag in Ruby Kamal 2.8.2.** The `tools/deploy-config-diff.sh` harness compares config-layer output only. Byte-identical command-string parity is aspirational; see `tools/deploy-dry-run-diff.sh` for the plan.
+6. **No `--dry-run` flag in Ruby Kamal 2.4.0.** The `tools/deploy-config-diff.sh` harness compares config-layer output only. Byte-identical command-string parity is aspirational; see `tools/deploy-dry-run-diff.sh` for the plan.
 
 ### Testing
 

--- a/cli/lucli/services/deploy/config/ConfigLoader.cfc
+++ b/cli/lucli/services/deploy/config/ConfigLoader.cfc
@@ -9,9 +9,14 @@
  *   5. wrap in typed Config object
  *
  * Interpolation is deliberately simple: only ${UPPER_SNAKE} tokens are
- * expanded. ERB-style `<%= %>` tags (Kamal's native syntax) are NOT
- * supported — that's a deliberate divergence. Mustache-style `{{env.FOO}}`
- * is handled by the Mustache layer later, not here.
+ * expanded — same syntax Kamal supports natively, with the same lookup
+ * order (envOverride → .kamal/secrets → System.getenv → ""). ERB-style
+ * `<%= %>` tags are NOT supported; that's the one deliberate divergence
+ * from Ruby Kamal, since rendering ERB would require embedding a Ruby
+ * runtime in the CLI. The Mustache layer in this package is used only
+ * by `wheels deploy init` to scaffold the initial deploy.yml/secrets
+ * files (see DeployMainCli.$init); it is NOT applied to deploy.yml at
+ * runtime.
  */
 component {
 

--- a/docs/releases/blog-skeletons/09-wheels-deploy.md
+++ b/docs/releases/blog-skeletons/09-wheels-deploy.md
@@ -1,7 +1,7 @@
 ---
 title: 'Porting Kamal to CFML: How wheels deploy Ships 4.0 Apps Without Ruby'
 slug: wheels-deploy-kamal-port
-publishedAt: '2026-04-27T07:00:00.000Z'
+publishedAt: '2026-05-06T07:00:00.000Z'
 updatedAt: null
 author: Peter Amiri
 tags:
@@ -76,14 +76,18 @@ service: <%= ENV["APP_NAME"] %>
 image: <%= ENV["REGISTRY"] %>/<%= ENV["APP_NAME"] %>
 ```
 
-ERB is Ruby template code. The template engine runs arbitrary Ruby at render time. To support it, `wheels deploy` would need to embed a Ruby runtime — which is the thing the whole port exists to avoid. So we replaced ERB with a restricted Mustache context.
+ERB is Ruby template code. The template engine runs arbitrary Ruby at render time. To support it, `wheels deploy` would need to embed a Ruby runtime — which is the thing the whole port exists to avoid.
+
+What `wheels deploy` *keeps* is Kamal's other built-in interpolation syntax — `${UPPER_SNAKE}` env-var tokens — completely unchanged. Most ERB-using configs convert mechanically by stripping the `<%= ENV["..."] %>` wrapper:
 
 ```yaml
-service: {{env.APP_NAME}}
-image: {{env.REGISTRY}}/{{env.APP_NAME}}
+service: ${APP_NAME}
+image: ${REGISTRY}/${APP_NAME}
 ```
 
-The context is deliberately small: `{{env.FOO}}` for environment variables, `{{destination}}` for the destination name, `{{hostname}}` for the target hostname. No function calls, no conditionals, no interpolated Ruby. For most `deploy.yml` files in the wild the conversion is mechanical — `<%= ENV["X"] %>` becomes `{{env.X}}`. For the handful of cases that use ERB for control flow or computed values, the migration is more involved, and the [migrating-from-kamal guide](https://guides.wheels.dev/v4-0-0-snapshot/deployment/migrating-from-kamal/) walks through each pattern.
+`${VAR}` references resolve through the same lookup chain Kamal uses: CLI `--env` overrides → `.kamal/secrets` (with destination overlay) → `System.getenv` → empty string. Only uppercase-and-underscore tokens are expanded, so shell-style `${service}` placeholders elsewhere in the config aren't captured by accident. For the handful of cases that use ERB for control flow or computed values, the resolution moves into `.kamal/secrets` (or a `.kamal/secrets.<destination>` overlay) and the result is referenced back through `${VAR}`. The [migrating-from-kamal guide](https://guides.wheels.dev/v4-0-0-snapshot/deployment/migrating-from-kamal/) walks through each pattern.
+
+The net effect is that `wheels deploy` is *more* schema-compatible with Kamal than the "we replaced X with Y" framing would suggest. There is no new syntax to learn. The single change is a removal — ERB out, everything else identical.
 
 We considered preserving ERB by shelling out to a system Ruby. The problem is that it turns a single-binary install into a "works if you also have Ruby" story, and every user who does not have Ruby installed gets a cryptic error the first time they deploy. The divergence felt worth naming up front.
 
@@ -134,7 +138,7 @@ It is not Ruby-Kamal-plugin-compatible. Ruby plugins use `Kamal::Commands` exten
 
 A few details for readers curious about the port itself.
 
-The CFML code lives in `cli/lucli/services/deploy/`. Three required JARs — `snakeyaml` for YAML, `jmustache` for template rendering, `sshj` with BouncyCastle transitives for SSH — load through a URL-isolated classloader so they do not collide with the rest of the JVM. Every command is a plain string returned by a pure function; only the CLI layer and the orchestrator actually execute them. That is what makes `--dry-run` trivial and what lets the test suite run without network.
+The CFML code lives in `cli/lucli/services/deploy/`. Three direct dependencies — `snakeyaml` for YAML, `sshj` for SSH transport (with BouncyCastle and SLF4J transitives), and `jmustache` for `wheels deploy init` scaffolding — bundle as ten JARs total in `cli/lucli/lib/deploy/`. They all load through a URL-isolated classloader so they do not collide with whatever copies of those libraries the host CFML engine ships. Every command is a plain string returned by a pure function; only the CLI layer and the orchestrator actually execute them. That is what makes `--dry-run` trivial and what lets the test suite run without network.
 
 Tests live in `cli/lucli/tests/specs/deploy/` and extend the same `wheels.wheelstest` base class the rest of the framework uses. A `FakeSshPool` records every command for offline assertions. A real-SSH fixture (`tools/deploy-sshd-up.sh`) brings up a disposable sshd for the couple of specs that need to exercise real transport.
 

--- a/docs/releases/blog-skeletons/social-announcements.md
+++ b/docs/releases/blog-skeletons/social-announcements.md
@@ -2,36 +2,36 @@
 
 **Status:** Copy-paste ready. Ten posts, four channels each. Runs as a drumbeat from first pre-announce to GA day.
 
-**Campaign start:** 2026-04-21 (Post 1 posted). **GA target:** 2026-05-09.
+**Campaign start:** 2026-04-21 (Posts 1–3 posted). **GA target:** 2026-05-12.
 
-**Posting schedule (every 2 days, 2026-04-21 → 2026-05-09):**
+**Posting schedule:** Posts 1–3 ran on the original every-2-days cadence (2026-04-21 → 2026-04-25). Posts 4–10 were postponed for last-mile framework work and have been compressed to a daily cadence resuming **2026-05-06**, landing GA on **2026-05-12**.
 
 | # | Date | Post | Angle |
 |---|---|---|---|
 | 1 | 2026-04-21 | Parity story | Broadest audience. Posted. |
-| 2 | 2026-04-23 | The full audit | Spec-and-receipts crowd. |
-| 3 | 2026-04-25 | 3.0 → 4.0 delta | Existing users planning the upgrade. |
-| 4 | 2026-04-27 | `wheels deploy` | Marquee-feature spotlight; wholly new CLI surface. |
-| 5 | 2026-04-29 | Security hardening | 40+ hardening PRs, "secure by default" story. |
-| 6 | 2026-05-01 | Data layer modernization | "Rails parity made concrete" for ORM-curious devs. |
-| 7 | 2026-05-03 | Testing | Browser testing + parallel runner + HTTP client + zero-Docker inner loop. |
-| 8 | 2026-05-05 | Multi-tenancy + background jobs | The "what makes Wheels different" beat. |
-| 9 | 2026-05-07 | LuCLI / zero-Docker DX | Inner-loop developer-experience closer. |
-| 10 | **2026-05-09 (GA)** | Release announcement | Recaps the arc, swap all "coming" → present tense. |
+| 2 | 2026-04-23 | The full audit | Spec-and-receipts crowd. Posted. |
+| 3 | 2026-04-25 | 3.0 → 4.0 delta | Existing users planning the upgrade. Posted. |
+| 4 | **2026-05-06** | `wheels deploy` | Marquee-feature spotlight; wholly new CLI surface. (Resume) |
+| 5 | 2026-05-07 | Security hardening | 40+ hardening PRs, "secure by default" story. |
+| 6 | 2026-05-08 | Data layer modernization | "Rails parity made concrete" for ORM-curious devs. |
+| 7 | 2026-05-09 | Testing | Browser testing + parallel runner + HTTP client + zero-Docker inner loop. |
+| 8 | 2026-05-10 | Multi-tenancy + background jobs | The "what makes Wheels different" beat. |
+| 9 | 2026-05-11 | LuCLI / zero-Docker DX | Inner-loop developer-experience closer. |
+| 10 | **2026-05-12 (GA)** | Release announcement | Recaps the arc, swap all "coming" → present tense. |
 
 **Companion long-form blog posts** (in [docs/releases/blog-skeletons/](.) — drop `NN-` prefix on move to `web/content/blog/posts/`):
 
 | Blog post | Date | Paired with |
 |---|---|---|
-| 09 — `wheels deploy` (Kamal port) | 2026-04-27 | Social 4 |
-| 03 — Security hardening | 2026-04-29 | Social 5 |
-| 06 — Testing in 4.0 | 2026-05-03 | Social 7 |
-| 04 — Background jobs without Redis | 2026-05-05 | Social 8 |
-| 07 — Multi-tenancy built in | 2026-05-06 | Social 8 (day after) |
-| 05 — LuCLI zero-Docker DX | 2026-05-07 | Social 9 |
-| 01 — Closing the maturity gap (lead) | 2026-05-09 | Social 10 / GA |
-| 02 — Upgrading from 3.x | 2026-05-09 | Social 10 / GA |
-| 08 — WireBox → wheelsdi (contributor) | 2026-05-11 | Post-GA |
+| 09 — `wheels deploy` (Kamal port) | 2026-05-06 | Social 4 |
+| 03 — Security hardening | 2026-05-07 | Social 5 |
+| 06 — Testing in 4.0 | 2026-05-09 | Social 7 |
+| 04 — Background jobs without Redis | 2026-05-10 | Social 8 |
+| 07 — Multi-tenancy built in | 2026-05-10 | Social 8 (same day, double pairing) |
+| 05 — LuCLI zero-Docker DX | 2026-05-11 | Social 9 |
+| 01 — Closing the maturity gap (lead) | 2026-05-12 | Social 10 / GA |
+| 02 — Upgrading from 3.x | 2026-05-12 | Social 10 / GA |
+| 08 — WireBox → wheelsdi (contributor) | 2026-05-13 | Post-GA |
 
 **Framing:** 4.0 is *in the works* — release candidate, not GA. Phrasing throughout uses "coming" / "on the way" / "preview" rather than "shipped." Swap to present tense on GA day.
 
@@ -400,7 +400,7 @@ What you get:
 
 Byte-compatible with Ruby Kamal on the server side — container names, labels, Docker network, lock paths, `.kamal/secrets`, `.kamal/hooks/*` all match exactly. A host managed by Ruby Kamal can be taken over by `wheels deploy` without cleanup.
 
-One deliberate divergence: `deploy.yml` uses Mustache (`{{env.APP_NAME}}`) instead of ERB. We can't render Ruby from a CFML CLI.
+One deliberate divergence: `deploy.yml` does not support ERB. Kamal's native `${VAR}` env-var interpolation is preserved unchanged, so most ERB-using configs convert mechanically — `<%= ENV["APP_NAME"] %>` becomes `${APP_NAME}`.
 ```
 
 ### LinkedIn
@@ -412,7 +412,7 @@ It's a port of Basecamp's Kamal — the Ruby-world container deployer — into t
 
 The design goal was byte-compatibility with Ruby Kamal on the server side. Container names (`<service>-<role>-<version>`), labels, Docker network name (`kamal`), proxy config directory, lock file path, `.kamal/secrets`, `.kamal/hooks/*` — all match the Kamal 2.4.0 contract exactly. A host that has been managed by Ruby Kamal can be taken over by `wheels deploy` without any cleanup, and vice versa. Teams evaluating the switch can sit on both tools simultaneously.
 
-There is exactly one deliberate divergence: `config/deploy.yml` does not support ERB. ERB is Ruby template code, and rendering it would require embedding a Ruby runtime — which is the thing we were trying to avoid. Wheels uses a restricted Mustache context instead: `{{env.APP_NAME}}`, `{{destination}}`, `{{hostname}}`. The migration from ERB is mechanical for most `deploy.yml` files.
+There is exactly one deliberate divergence: `config/deploy.yml` does not support ERB. ERB is Ruby template code, and rendering it would require embedding a Ruby runtime — which is the thing we were trying to avoid. What Wheels keeps unchanged is Kamal's other built-in interpolation, the `${VAR}` env-var syntax. So `<%= ENV["APP_NAME"] %>` becomes `${APP_NAME}` — a strict subset of the syntax Kamal itself already supports. The migration from ERB is mechanical for most `deploy.yml` files.
 
 The subcommand surface mirrors Kamal's top-level verbs: `init`, `setup`, `rollback`, `config`, `app`, `proxy`, `accessory`, `build`, `registry`, `secrets`, `server`, `prune`, `lock`, `audit`, `details`, `remove`. Secret management ships with adapters for 1Password, Bitwarden, AWS Secrets Manager, LastPass, and Doppler.
 
@@ -450,17 +450,17 @@ A Kamal-managed host can be taken over by `wheels deploy` without cleanup. Sit o
 
 **Reply 2:**
 ```
-2/ One deliberate divergence: `deploy.yml` uses Mustache, not ERB.
+2/ One deliberate divergence: `deploy.yml` does not support ERB. Kamal's native `${VAR}` env-var interpolation is preserved.
 
 ```yaml
 # Kamal
 service: <%= ENV["APP_NAME"] %>
 
 # wheels deploy
-service: {{env.APP_NAME}}
+service: ${APP_NAME}
 ```
 
-We can't render Ruby from a CFML CLI without embedding a Ruby runtime — which defeats the point.
+No new syntax. Just ERB out — `${VAR}` is something Kamal already supports too.
 ```
 
 **Reply 3:**
@@ -505,14 +505,21 @@ A server managed by Ruby Kamal can be taken over by `wheels deploy` during evalu
 
 ## The one divergence
 
-`config/deploy.yml` does not support ERB. ERB is Ruby template code; rendering it from a CFML CLI would require embedding a Ruby runtime, which defeats the purpose of the port. Wheels uses a restricted Mustache context instead:
+`config/deploy.yml` does not support ERB. ERB is Ruby template code; rendering it from a CFML CLI would require embedding a Ruby runtime, which defeats the purpose of the port. What Wheels keeps unchanged is Kamal's other built-in interpolation — `${UPPER_SNAKE}` env-var tokens — so most ERB-using configs convert mechanically:
 
 ```yaml
-service: {{env.APP_NAME}}
-image: {{env.REGISTRY}}/{{env.APP_NAME}}
+# Ruby Kamal — NOT SUPPORTED
+service: <%= ENV["APP_NAME"] %>
+image: <%= ENV["REGISTRY"] %>/<%= ENV["APP_NAME"] %>
+
+# wheels deploy — and also valid Kamal syntax
+service: ${APP_NAME}
+image: ${REGISTRY}/${APP_NAME}
 ```
 
-Available context: `{{env.FOO}}`, `{{destination}}`, `{{hostname}}`. For most `deploy.yml` files the conversion is mechanical.
+`${VAR}` references resolve through the same lookup chain Kamal uses (CLI overrides → `.kamal/secrets` → `System.getenv` → empty string). For ERB blocks that did real logic — conditionals, ternaries, computed values — the resolution moves into `.kamal/secrets` (or a `.kamal/secrets.<destination>` overlay) and the result is referenced back through `${VAR}`.
+
+Net effect: there is no new syntax to learn. The single change is a removal — ERB out, everything else identical.
 
 ## Subcommand surface
 

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/architecture.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/architecture.mdx
@@ -1,6 +1,6 @@
 ---
 title: Architecture of wheels deploy
-description: How the wheels deploy CLI is structured — the port strategy, the byte-compatibility contract with Ruby Kamal, the commands-are-strings invariant that makes --dry-run and offline tests trivial, and the URLClassLoader-isolated JAR loading for snakeyaml, jmustache, and sshj.
+description: How the wheels deploy CLI is structured — the port strategy, the byte-compatibility contract with Ruby Kamal, the commands-are-strings invariant that makes --dry-run and offline tests trivial, and the URLClassLoader-isolated JAR loading for snakeyaml, sshj, and jmustache.
 type: reference
 sidebar:
   order: 13
@@ -14,7 +14,7 @@ This page is for readers who want to understand how `wheels deploy` is put toget
 
 - Why `wheels deploy` is a port of [Basecamp's Kamal](https://kamal-deploy.org/) rather than a new tool
 - The byte-compatibility contract that makes a Kamal-managed server takeoverable by `wheels deploy` without cleanup
-- The one deliberate divergence from Kamal's config schema (ERB → Mustache) and why
+- The one deliberate divergence from Kamal's config schema (ERB removed; `${VAR}` interpolation kept unchanged) and why
 - The commands-are-strings invariant that makes `--dry-run` trivial and lets the test suite run offline
 - How the three third-party JARs load in isolation so they don't collide with the rest of the JVM
 
@@ -55,7 +55,7 @@ If you have a working Ruby Kamal setup, you can run `wheels deploy config` again
 
 See [Migrating from Kamal](/v4-0-0-snapshot/deployment/migrating-from-kamal/) for the complete switch-over checklist.
 
-## The one divergence: ERB → Mustache
+## The one divergence: ERB removed
 
 `config/deploy.yml` does not support ERB. This is the only schema-level incompatibility with Ruby Kamal, and it's deliberate.
 
@@ -69,22 +69,29 @@ image: <%= ENV["REGISTRY"] %>/<%= ENV["APP_NAME"] %>
 
 ERB is a Ruby template language — it executes arbitrary Ruby at render time. To support it, `wheels deploy` would need to embed a Ruby runtime, which defeats the purpose of the port.
 
-`wheels deploy` replaces ERB with a restricted Mustache context:
+What `wheels deploy` keeps unchanged is Kamal's other built-in interpolation: `${UPPER_SNAKE}` env-var tokens. Most ERB-using configs convert mechanically by dropping the `<%= ENV["..."] %>` wrapper:
 
 ```yaml
-service: {{env.APP_NAME}}
-image: {{env.REGISTRY}}/{{env.APP_NAME}}
+service: ${APP_NAME}
+image: ${REGISTRY}/${APP_NAME}
 ```
 
-Available context is small on purpose:
+The interpolator (`ConfigLoader.$interpolate`) walks the parsed YAML tree and resolves each `${VAR}` token through this lookup chain:
 
-- `{{env.FOO}}` — environment variable `FOO`
-- `{{destination}}` — the destination name (e.g. `staging`, `production`)
-- `{{hostname}}` — the current target hostname during command execution
+1. CLI `--env` overrides (test/CI shims).
+2. `.kamal/secrets`, then `.kamal/secrets.<destination>` overlay if `--destination` is set.
+3. `System.getenv(VAR)` on the machine running `wheels deploy`.
+4. Empty string for unset vars (matching Kamal's behavior).
 
-No function calls, no conditionals, no computed expressions. For most `deploy.yml` files the conversion is mechanical: `<%= ENV["X"] %>` becomes `{{env.X}}`.
+Only uppercase-and-underscore tokens are expanded — the regex is `\$\{([A-Z_][A-Z0-9_]*)\}`. That keeps shell-style `${service}` placeholders elsewhere in the config from being captured by accident, the same rule Kamal applies.
 
-We considered preserving ERB by shelling out to a system Ruby. The problem is that it turns a single-binary install into a "works if you also have Ruby" story, and every user without Ruby installed gets a cryptic error on their first deploy. Naming the divergence up front is the honest trade-off.
+No conditionals, no method calls, no computed expressions. If your existing config uses ERB logic (`<%= ... if ENV["ROLE"] == "staging" %>`), move that logic into `.kamal/secrets` (or a `.kamal/secrets.<destination>` overlay) and reference the resolved value with `${VAR}`.
+
+We considered preserving ERB by shelling out to a system Ruby. The problem is that it turns a single-binary install into a "works if you also have Ruby" story, and every user without Ruby installed gets a cryptic error on their first deploy. Naming the divergence up front — and keeping Kamal's `${VAR}` syntax untouched — is the honest trade-off.
+
+<Aside type="note" title="Mustache is used elsewhere — not in deploy.yml at runtime">
+The `cli/lucli/services/deploy/lib/Mustache.cfc` wrapper is a thin facade over jmustache, but it is **not** applied to `deploy.yml` at runtime. It's used by `wheels deploy init` to render the initial scaffolding templates (`config/deploy.yml` and `.kamal/secrets`) when a project doesn't have one yet. Once those files exist, `${VAR}` is the only interpolation that runs.
+</Aside>
 
 ## Commands-are-strings invariant
 
@@ -128,8 +135,8 @@ The separation of `cli/` (user-facing orchestration) from `commands/` (pure comm
 `wheels deploy` depends on three third-party libraries:
 
 - **snakeyaml** — YAML parsing for `config/deploy.yml`
-- **jmustache** — Mustache template rendering for the restricted context in `deploy.yml` and the `wheels deploy init` scaffolding
 - **sshj** (with BouncyCastle transitives) — SSH transport
+- **jmustache** — template rendering for the `wheels deploy init` scaffolding (`deploy.yml.mustache`, `secrets.mustache`); not applied to `deploy.yml` at runtime
 
 These JARs load through a dedicated `URLClassLoader` isolated from the main JVM classpath. That isolation matters because CFML engines (Lucee, Adobe CF) ship their own copies of some transitive dependencies (older BouncyCastle versions, in particular). Without isolation, class-resolution order would be nondeterministic and you'd get obscure `NoSuchMethodError` failures depending on load order.
 

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/config-reference.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/config-reference.mdx
@@ -356,23 +356,24 @@ readiness_delay: 5
 
 ## Variable interpolation
 
-`deploy.yml` supports a restricted subset of Mustache. Three variables are exposed in the rendering context:
+`deploy.yml` supports a single, deliberately small interpolation form: `${UPPER_SNAKE}` env-var tokens. This is the same syntax Ruby Kamal supports natively, with the same lookup order:
 
-| Variable | Value |
-|----------|-------|
-| `env.*` | Any environment variable or `.kamal/secrets` entry. |
-| `destination` | Current `--destination` flag, or empty. |
-| `hostname` | Local hostname of the machine running `wheels deploy`. |
+1. CLI `--env` overrides (test/CI shims).
+2. `.kamal/secrets` (and `.kamal/secrets.<destination>` when `--destination` is set).
+3. `System.getenv(VAR)` on the machine running `wheels deploy`.
+4. Empty string for unset vars.
 
 ```yaml title="config/deploy.yml (illustrative — do not type)"
-service: {{env.APP_NAME}}
-image: {{env.REGISTRY}}/{{env.APP_NAME}}
+service: ${APP_NAME}
+image: ${REGISTRY}/${APP_NAME}
 ```
 
-No loops, conditionals, or method calls. If you need logic, resolve it in `.kamal/secrets` first and reference the result via `env.*`.
+Only uppercase-and-underscore tokens are expanded — `${APP_NAME}` matches; lowercase `${service}` is left alone, which keeps shell-style placeholders elsewhere in the config from being captured by accident.
+
+No loops, conditionals, or method calls. If you need logic (e.g. different values per destination), resolve it in `.kamal/secrets` or a `.kamal/secrets.<destination>` overlay first and reference the result with `${VAR}`.
 
 <Aside type="caution" title="No ERB">
-Ruby Kamal supports `<%= ... %>` ERB inside `deploy.yml`. Wheels does not — we substitute a restricted Mustache. This is the single schema divergence. See [Migrating from Kamal](/v4-0-0-snapshot/deployment/migrating-from-kamal/) for conversion patterns.
+Ruby Kamal supports `<%= ... %>` ERB inside `deploy.yml`. Wheels does not — rendering ERB would require embedding a Ruby runtime in the CFML CLI. This is the single schema divergence. Most ERB-using configs convert mechanically by replacing `<%= ENV["X"] %>` with `${X}`. See [Migrating from Kamal](/v4-0-0-snapshot/deployment/migrating-from-kamal/) for the full conversion patterns.
 </Aside>
 
 ## Destination overlays

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/index.mdx
@@ -23,7 +23,7 @@ A Wheels app in production is a Java webapp running on a CFML engine. That one f
 
 The port is byte-compatible with Ruby Kamal on the server side. Container names, labels, Docker network, lock-file paths, and the `.kamal/` directory layout all match exactly — a host managed by Ruby Kamal can be taken over by `wheels deploy` during evaluation, and vice versa. You don't need Ruby, a gem install, or a second CLI. The mirrored Kamal version is 2.4.0; the `kamal-proxy` image is pinned at v0.8.6.
 
-There is exactly one deliberate schema divergence: `deploy.yml` does not support ERB. Where Ruby Kamal writes `<%= ENV["APP_NAME"] %>`, Wheels writes `{{env.APP_NAME}}`. Everything else is identical. See [Migrating from Kamal](/v4-0-0-snapshot/deployment/migrating-from-kamal/) for the full story.
+There is exactly one deliberate schema divergence: `deploy.yml` does not support ERB. Where Ruby Kamal writes `<%= ENV["APP_NAME"] %>`, Wheels writes `${APP_NAME}` — the same `${VAR}` env-var interpolation Kamal supports natively. Everything else is identical. See [Migrating from Kamal](/v4-0-0-snapshot/deployment/migrating-from-kamal/) for the full story.
 
 ## When to reach for `wheels deploy`
 

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/migrating-from-kamal.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/migrating-from-kamal.mdx
@@ -13,12 +13,12 @@ This page is for teams already running Ruby Kamal who want to replace `kamal` wi
 **You'll learn:**
 
 - What `wheels deploy` keeps byte-compatible with Ruby Kamal
-- The one deliberate schema divergence (ERB → Mustache) and how to convert
+- The one deliberate schema divergence — ERB removed; Kamal's `${VAR}` interpolation kept unchanged
 - The coexistence guarantee — running both tools against the same host during evaluation
 - A concrete switch-over checklist
 
 <Aside type="caution" title="ERB is not supported">
-`deploy.yml` in Ruby Kamal supports embedded ERB. `wheels deploy` does not. This is the only schema-level incompatibility. If you use ERB anywhere in your deploy config, you will need to convert it to Mustache. See [The one divergence](#the-one-divergence) below.
+`deploy.yml` in Ruby Kamal supports embedded ERB. `wheels deploy` does not. This is the only schema-level incompatibility. If you use ERB anywhere in your deploy config, you will need to convert it to `${VAR}` env-var interpolation (which Kamal already supports too) or move the logic into `.kamal/secrets`. See [The one divergence](#the-one-divergence) below.
 </Aside>
 
 ## What's byte-compatible
@@ -54,31 +54,32 @@ image: <%= ENV["REGISTRY"] %>/<%= ENV["APP_NAME"] %>
 
 ERB is a Ruby template language — it calls into Ruby code at render time. We can't render ERB from a CFML CLI without embedding a Ruby runtime, which defeats the purpose of the port.
 
-`wheels deploy` replaces ERB with a restricted Mustache context:
+What `wheels deploy` keeps unchanged is Kamal's other built-in interpolation syntax — `${UPPER_SNAKE}` env-var tokens — so most ERB-using configs convert mechanically by dropping the `<%= ENV["..."] %>` wrapper and using a bare `${VAR}` reference:
 
 ```yaml title="config/deploy.yml (illustrative — do not type)"
-service: {{env.APP_NAME}}
-image: {{env.REGISTRY}}/{{env.APP_NAME}}
+service: ${APP_NAME}
+image: ${REGISTRY}/${APP_NAME}
 ```
 
-Three variables are available in the rendering context:
+`${VAR}` references resolve in this order:
 
-| Variable | Value |
-|----------|-------|
-| `env.*` | Any environment variable or `.kamal/secrets` entry. |
-| `destination` | Current `--destination` flag, or empty. |
-| `hostname` | Local hostname of the machine running `wheels deploy`. |
+1. CLI `--env` overrides (test/CI shims).
+2. `.kamal/secrets` (and the destination overlay `.kamal/secrets.<destination>` when `--destination` is set).
+3. `System.getenv(VAR)` on the machine running `wheels deploy`.
+4. Empty string (Kamal's behavior for unset vars).
 
-No loops, no conditionals, no method calls. If your existing config uses ERB logic — `<%= "blue" if ENV["ROLE"] == "staging" %>` — move that logic into a shell wrapper or into `.kamal/secrets` first, and reference the resolved value via `{{env.*}}`.
+Only uppercase-and-underscore tokens are expanded — `${APP_NAME}` matches; lowercase `${service}` is left alone (this prevents accidental capture of shell-style placeholders elsewhere in the config). This is the same rule Kamal applies.
 
-### Common ERB → Mustache conversions
+If your existing config uses ERB logic — `<%= "blue" if ENV["ROLE"] == "staging" %>` — move that logic into `.kamal/secrets` (or a `.kamal/secrets.<destination>` overlay), or into a shell wrapper that exports the resolved value, then reference the result with `${ROLE}`.
 
-| Ruby Kamal ERB | `wheels deploy` Mustache |
-|----------------|--------------------------|
-| `<%= ENV["FOO"] %>` | `{{env.FOO}}` |
-| `<%= ENV.fetch("FOO", "bar") %>` | `{{env.FOO}}` (set `FOO=bar` in `.kamal/secrets` for the default) |
-| `<%= `git rev-parse --short HEAD`.chomp %>` | pass `--version=$(git rev-parse --short HEAD)` on the CLI, or set `VERSION` in `.kamal/secrets` and use `{{env.VERSION}}` |
-| `<%= ENV["STAGE"] == "prod" ? 1 : 0 %>` | Set the resolved value in `.kamal/secrets.production` or `.kamal/secrets.staging` — destination overlays replace in-file logic |
+### Common ERB → `${VAR}` conversions
+
+| Ruby Kamal ERB | `wheels deploy` |
+|----------------|-----------------|
+| `<%= ENV["FOO"] %>` | `${FOO}` |
+| `<%= ENV.fetch("FOO", "bar") %>` | `${FOO}` — set `FOO=bar` in `.kamal/secrets` for the default |
+| `<%= `git rev-parse --short HEAD`.chomp %>` | pass `--version=$(git rev-parse --short HEAD)` on the CLI, or set `VERSION` in `.kamal/secrets` and use `${VERSION}` |
+| `<%= ENV["STAGE"] == "prod" ? 1 : 0 %>` | set the resolved value in `.kamal/secrets.production` or `.kamal/secrets.staging` — destination overlays replace in-file logic |
 
 ## What changes in the CLI
 
@@ -139,7 +140,7 @@ These Ruby Kamal features have no `wheels deploy` equivalent and won't get one:
   <LinkCard
     title="deploy.yml Reference"
     href="/v4-0-0-snapshot/deployment/config-reference/"
-    description="Every key in the schema, with the Mustache interpolation rules."
+    description="Every key in the schema, with the ${VAR} interpolation rules."
   />
   <LinkCard
     title="Your First Deploy"


### PR DESCRIPTION
## Summary

Two coordinated fixes uncovered while validating Blog 09 (`wheels deploy`) and Social Post 4 for accuracy before publication today.

### 1. Correct `deploy.yml` interpolation syntax across the doc cascade

The campaign artifacts and the v4 deployment guides described the ERB divergence as if `{{env.X}}` Mustache was the `deploy.yml` replacement. Reality: `ConfigLoader.$interpolate` only handles `${UPPER_SNAKE}` env-var tokens (regex `\$\{([A-Z_][A-Z0-9_]*)\}`) — the same syntax Kamal supports natively. Mustache (`jmustache`) is invoked **only** by `wheels deploy init` to render scaffold templates (`deploy.yml.mustache`, `secrets.mustache`); it is not applied to `deploy.yml` at runtime.

A user following the original migration guide who wrote `service: {{env.APP_NAME}}` would have seen that string passed literally to `docker run`.

The truer story: `wheels deploy` is *more* schema-compatible with Kamal than the "we replaced X with Y" framing suggested. There is no new syntax to learn — the single change is a removal: ERB out, everything else identical.

**Affected files:**
- `docs/releases/blog-skeletons/09-wheels-deploy.md` — "The one divergence" section + JAR-count claim
- `docs/releases/blog-skeletons/social-announcements.md` — Post 4 across Slack, LinkedIn, X reply 2, GitHub Discussions
- `web/sites/guides/.../deployment/migrating-from-kamal.mdx` — full ERB → \${VAR} conversion table + paragraph
- `web/sites/guides/.../deployment/config-reference.mdx` — Variable interpolation section + No-ERB Aside
- `web/sites/guides/.../deployment/architecture.mdx` — divergence section, frontmatter description, JAR description, added clarifying Aside
- `web/sites/guides/.../deployment/index.mdx` — landing-page one-line divergence claim
- `CLAUDE.md` — deploy critical-gotcha #1; also corrects stray "Ruby Kamal 2.8.2" reference (deploy code targets and version-prints 2.4.0)
- `cli/lucli/services/deploy/config/ConfigLoader.cfc` — fixes the upstream docstring that seeded the cascade ("Mustache layer later, not here" was misleading)

### 2. Compress remaining launch schedule to daily cadence

Posts 1–3 ran on the original every-2-days cadence (2026-04-21 → 2026-04-25). Posts 4–10 were postponed for last-mile framework work. Compressed to daily cadence resuming **2026-05-06**, landing GA on **2026-05-12** (was 2026-05-09). Blog 09 `publishedAt` frontmatter updated to match.

| # | New date | Social | Companion blog |
|---|---|---|---|
| 4 | 2026-05-06 | wheels deploy | 09 |
| 5 | 2026-05-07 | Security hardening | 03 |
| 6 | 2026-05-08 | Data layer | — |
| 7 | 2026-05-09 | Testing | 06 |
| 8 | 2026-05-10 | Multi-tenancy + jobs | 04 + 07 (double) |
| 9 | 2026-05-11 | LuCLI | 05 |
| 10 | **2026-05-12 (GA)** | Release announcement | 01 + 02 |
| — | 2026-05-13 | — | 08 (post-GA) |

## No code changes

`ConfigLoader.cfc` edit is comment-only — replaces the misleading "Mustache layer later" docstring with the truth (Mustache is `init`-only). Diff stat: +88 / −63 lines, all prose/comment.

## Test plan

- [ ] CI commit-message lint passes (`docs:` type, no scope, header < 100 chars)
- [ ] Astro build succeeds for the four edited deployment guides (`pnpm --filter @wheels-dev/site-guides build`)
- [ ] Spot-read the rewritten "The one divergence" sections in `09-wheels-deploy.md`, `migrating-from-kamal.mdx`, `architecture.mdx`, `config-reference.mdx` for clarity
- [ ] Spot-read Post 4 across all four social channels in `social-announcements.md`
- [ ] Confirm `wheels deploy version` still prints `wheels-deploy mirrors kamal 2.4.0 / kamal-proxy v0.8.6` (unchanged — no code touched)