### PR TITLE
docs: remove duplicate H1 from Blog 09 body

### DIFF
--- a/docs/releases/blog-skeletons/09-wheels-deploy.md
+++ b/docs/releases/blog-skeletons/09-wheels-deploy.md
@@ -18,12 +18,6 @@ excerpt: >-
 coverImage: null
 ---
 
-# Porting Kamal to CFML: How `wheels deploy` Ships 4.0 Apps Without Ruby
-
-_Peter Amiri, Wheels Core Team_
-
----
-
 You just finished a Wheels app. You have a Docker image. You have a Linux server. You want to ship.
 
 Before Wheels 4.0 the answer was whatever you had cobbled together — a shell script that SSHs in and runs `docker pull`, an Ansible playbook, maybe Capistrano if you had one lying around. The framework did not have an opinion about this step.

--- a/web/content/blog/posts/wheels-deploy-kamal-port.md
+++ b/web/content/blog/posts/wheels-deploy-kamal-port.md
@@ -19,12 +19,6 @@ excerpt: >-
 coverImage: null
 ---
 
-# Porting Kamal to CFML: How `wheels deploy` Ships 4.0 Apps Without Ruby
-
-_Peter Amiri, Wheels Core Team_
-
----
-
 You just finished a Wheels app. You have a Docker image. You have a Linux server. You want to ship.
 
 Before Wheels 4.0 the answer was whatever you had cobbled together — a shell script that SSHs in and runs `docker pull`, an Ansible playbook, maybe Capistrano if you had one lying around. The framework did not have an opinion about this step.


### PR DESCRIPTION
## Summary

Fix follow-up to #2434. The published post at https://blog.wheels.dev/posts/wheels-deploy-kamal-port/ rendered with **two `<h1>` elements**:

1. One auto-generated by [`PostLayout.astro:22`](https://github.com/wheels-dev/wheels/blob/develop/web/sites/blog/src/layouts/PostLayout.astro) from the frontmatter `title` field
2. One from the body's leading `# Porting Kamal to CFML...` heading

The body H1 was a duplicate. Removing it also drops the redundant `_Peter Amiri, Wheels Core Team_` byline and the trailing `---` divider, since `PostLayout` already renders author and date below the auto-generated title (`PostLayout.astro:24-29`).

Same edit applied to the source skeleton at `docs/releases/blog-skeletons/09-wheels-deploy.md` so future re-imports or re-exports of this post stay clean.

## Verification

```bash
$ curl -s https://blog.wheels.dev/posts/wheels-deploy-kamal-port/ | grep -oE '<h1' | wc -l
2   # current — duplicate H1
```

After merge:

```bash
$ curl -s https://blog.wheels.dev/posts/wheels-deploy-kamal-port/ | grep -oE '<h1' | wc -l
1   # expected — single H1 from PostLayout
```

## Diff

```
 docs/releases/blog-skeletons/09-wheels-deploy.md   | 6 ------
 web/content/blog/posts/wheels-deploy-kamal-port.md | 6 ------
 2 files changed, 12 deletions(-)
```

12 lines removed, 0 added. Each file loses the same 6-line block: the body H1, blank, `_byline_`, blank, `---` divider, blank.

## Out of scope

A spot-check of a handful of existing posts shows the duplicate-H1 pattern is inconsistent across the corpus:

| Post | `<h1>` count |
|---|---|
| `why-we-rebuilt-our-ci-pipeline` | 2 |
| `1-0-we-are-production-ready` | 1 |
| `wheels-vs-code-extension-supercharge-your-wheels-development` | 11 |

So there's no enforced convention. This PR only fixes Blog 09 — sweeping the other posts (and ideally adding a content-collection schema or remark plugin to prevent future duplication) is a separate cleanup. Worth filing as a follow-up.

## Test plan

- [ ] Commit-message lint passes (`docs:` type, no scope)
- [ ] CI `web-deploy.yml` builds `site-blog` cleanly (no Astro errors — same diff, just removing 6 lines of body)
- [ ] Visual regression: `blog.png` baseline captures the index, NOT the per-post page, so removing the body H1 should not require a baseline update. If it fails, the index card layout would have to be using post body content (worth investigating).
- [ ] After deploy, `curl https://blog.wheels.dev/posts/wheels-deploy-kamal-port/ | grep -c '<h1'` returns `1`