### PR TITLE
docs: switch Social 4 to canonical URLs and sweep one duplicate H1

### DIFF
--- a/docs/releases/blog-skeletons/social-announcements.md
+++ b/docs/releases/blog-skeletons/social-announcements.md
@@ -389,7 +389,7 @@ Wheels 4.0 brings a new command: `wheels deploy`.
 
 It's a port of Basecamp's Kamal into the Wheels CLI — zero-downtime Dockerized deploys to Linux servers over plain SSH. No Ruby runtime, no gem install, no second tool to learn.
 
-<https://github.com/wheels-dev/wheels/blob/develop/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/index.mdx|Deployment guide>
+<https://blog.wheels.dev/posts/wheels-deploy-kamal-port/|Read the full post> · <https://guides.wheels.dev/v4-0-0-snapshot/deployment/|Deployment guide>
 
 What you get:
 • One command from laptop to production: `wheels deploy`
@@ -420,8 +420,9 @@ What `wheels deploy` is not: it is not a Kubernetes integration, not a systemd-n
 
 If you're shipping a Dockerized Wheels app to one or more Linux hosts and you want zero-downtime rollover out of the box, this is the shortest path in 4.0.
 
-Guide: https://github.com/wheels-dev/wheels/blob/develop/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/index.mdx
-Migrating from Kamal: https://github.com/wheels-dev/wheels/blob/develop/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/migrating-from-kamal.mdx
+Read the full post: https://blog.wheels.dev/posts/wheels-deploy-kamal-port/
+Deployment guide: https://guides.wheels.dev/v4-0-0-snapshot/deployment/
+Migrating from Kamal: https://guides.wheels.dev/v4-0-0-snapshot/deployment/migrating-from-kamal/
 
 #CFML #Wheels #Kamal #DevOps #Deployment #OpenSource
 ```
@@ -469,8 +470,8 @@ No new syntax. Just ERB out — `${VAR}` is something Kamal already supports too
 
 Secret adapters: 1Password, Bitwarden, AWS, LastPass, Doppler.
 
-Guide:
-https://github.com/wheels-dev/wheels/blob/develop/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/index.mdx
+Full post:
+https://blog.wheels.dev/posts/wheels-deploy-kamal-port/
 ```
 
 ### GitHub Discussions
@@ -479,6 +480,8 @@ https://github.com/wheels-dev/wheels/blob/develop/web/sites/guides/src/content/d
 
 ```markdown
 Wheels 4.0 introduces a new built-in command: `wheels deploy`. It is a port of [Basecamp's Kamal](https://kamal-deploy.org/) — the container-based deployer — into the Wheels CLI. This post is for anyone currently running ad-hoc deploy scripts (or running Ruby Kamal alongside Wheels) who wants to understand what's shipping and what the contract is.
+
+> **Full blog post:** https://blog.wheels.dev/posts/wheels-deploy-kamal-port/
 
 ## Why a port, not a plugin
 
@@ -549,10 +552,10 @@ Every verb supports `--dry-run` — prints the exact shell commands that would r
 
 ## Docs
 
-- [Deployment landing page](https://github.com/wheels-dev/wheels/blob/develop/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/index.mdx) — start here for context and when-to-use guidance
-- [Your first deploy](https://github.com/wheels-dev/wheels/blob/develop/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/first-deploy.mdx) — hands-on walkthrough
-- [Migrating from Kamal](https://github.com/wheels-dev/wheels/blob/develop/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/migrating-from-kamal.mdx) — the full compatibility contract and switch-over checklist
-- [Config reference](https://github.com/wheels-dev/wheels/blob/develop/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/config-reference.mdx), [secrets](https://github.com/wheels-dev/wheels/blob/develop/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/secrets.mdx), [hooks](https://github.com/wheels-dev/wheels/blob/develop/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/hooks.mdx), [accessories](https://github.com/wheels-dev/wheels/blob/develop/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/accessories.mdx)
+- [Deployment landing page](https://guides.wheels.dev/v4-0-0-snapshot/deployment/) — start here for context and when-to-use guidance
+- [Your first deploy](https://guides.wheels.dev/v4-0-0-snapshot/deployment/first-deploy/) — hands-on walkthrough
+- [Migrating from Kamal](https://guides.wheels.dev/v4-0-0-snapshot/deployment/migrating-from-kamal/) — the full compatibility contract and switch-over checklist
+- [Config reference](https://guides.wheels.dev/v4-0-0-snapshot/deployment/config-reference/), [secrets](https://guides.wheels.dev/v4-0-0-snapshot/deployment/secrets/), [hooks](https://guides.wheels.dev/v4-0-0-snapshot/deployment/hooks/), [accessories](https://guides.wheels.dev/v4-0-0-snapshot/deployment/accessories/)
 
 ## Question for the thread
 

--- a/web/content/blog/posts/why-we-rebuilt-our-ci-pipeline.md
+++ b/web/content/blog/posts/why-we-rebuilt-our-ci-pipeline.md
@@ -15,12 +15,6 @@ coverImage: null
 legacyId: '1165378763664687105'
 ---
 
-# Why We Rebuilt Our CI Pipeline From 40 Minutes to 82 Seconds
-
-_April 9, 2026 — Peter Amiri, Wheels Core Team_
-
----
-
 For years, the Wheels CI pipeline ran every commit through a gauntlet: five CFML engines, seven databases, Docker Compose orchestrating it all. It was thorough. It was comprehensive. And it was killing our velocity.
 
 Today we shipped a fundamentally different approach. Our primary CI now runs in **82 seconds**. No Docker. No CommandBox. Just LuCLI, Lucee 7, and SQLite — the same tools a developer uses on their laptop.


### PR DESCRIPTION
## Summary

Two coordinated cleanups before tomorrow's Social 4 posting.

### 1. Switch Social 4 links to canonical surfaces

Every link in Post 4 across Slack / LinkedIn / X / GitHub Discussions used to point at `https://github.com/wheels-dev/wheels/blob/develop/web/sites/guides/src/content/docs/...mdx` — i.e. the GitHub source MDX, not the published docs. That's bad for SEO (no credit to guides.wheels.dev), bad UX (readers see raw markdown not styled docs), and brittle (the GitHub URL breaks if the file is ever renamed or moved).

All 11 occurrences across the four channels remapped to `https://guides.wheels.dev/v4-0-0-snapshot/deployment/...`. Each canonical URL verified HTTP 200.

| Channel | Before | After |
|---|---|---|
| Slack | 1 GH-blob link | 1 blog-canonical + 1 guides-canonical |
| LinkedIn | 2 GH-blob links | 1 blog-canonical + 2 guides-canonical |
| X reply 3 | 1 GH-blob link | 1 blog-canonical (replaced — X favors single canonical) |
| GitHub Discussions | 7 GH-blob links | 7 guides-canonical + 1 blog-canonical (blockquote at top) |

Also added the canonical blog-post URL `https://blog.wheels.dev/posts/wheels-deploy-kamal-port/` prominently in each channel — readers can now click to the full styled post in one hop, instead of having to navigate from a docs link.

Third-party references (kamal-deploy.org, basecamp/kamal-proxy) left alone — those are correctly pointing at upstream.

### 2. Strip duplicate H1 from `why-we-rebuilt-our-ci-pipeline.md`

Same pattern that bit Blog 09 in #2435. The body opened with `# Why We Rebuilt Our CI Pipeline From 40 Minutes to 82 Seconds` + `_byline_` + `---` divider — all redundant with what `PostLayout.astro` auto-renders from frontmatter. Result: two `<h1>` elements on the live page.

Verified via corpus-wide sweep with a conservative fuzzy-match rule (only strip when body H1 ≈ frontmatter title):

| Result | Count |
|---|---|
| Modified | **1** (`why-we-rebuilt-our-ci-pipeline.md`) |
| Already clean | 140 |
| Section-style H1 — correctly skipped | 9 (`wheels-cli-*`, screencast posts) |
| **Total tracked posts scanned** | **150** |

The 9 section-style H1 posts (`wheels-cli-asset-commands`, `wheels-cli-config-commands`, etc.) use `# Introduction` as a section heading, NOT a title duplicate — those need a separate, more deliberate downgrade pass and are tracked in #2436.

**Loss in this commit:** the body H1's longer "From 40 Minutes to 82 Seconds" subtitle is no longer a heading. The "82 seconds" claim itself is still in the second paragraph of the body, so the rhetorical hook is preserved — just not as bold.

## Test plan

- [ ] Commit-message lint passes (`docs:` type, no scope, both subjects under 100 chars)
- [ ] CI `web-deploy.yml` succeeds — Astro builds blog (note: this PR's `social-announcements.md` change does NOT affect the Astro build since that file is in `docs/`, only the why-we-rebuilt change does)
- [ ] After merge + deploy: `curl -s https://blog.wheels.dev/posts/why-we-rebuilt-our-ci-pipeline/ | grep -c '<h1'` returns `1` (was `2`)
- [ ] Spot-check the live `why-we-rebuilt` post — first paragraph is "For years, the Wheels CI pipeline ran every commit through a gauntlet..."
- [ ] Visual regression: `blog.png` baseline screenshots the index, NOT per-post pages — the index card for `why-we-rebuilt` still shows the same excerpt (excerpt is from frontmatter), so no baseline update should be needed. If visual regression trips, that's a useful signal that the index card uses body content I missed; let me know.

## Out of scope (tracked in #2436)

- Sweeping the 9 section-style H1 posts to downgrade their H1s to H2/H3
- Building enforcement (Astro schema validation / remark plugin) so future posts can't reintroduce duplicate H1s