### PR TITLE
docs: spread companion blog posts to one-per-day cadence

### DIFF
--- a/docs/releases/blog-skeletons/social-announcements.md
+++ b/docs/releases/blog-skeletons/social-announcements.md
@@ -25,13 +25,15 @@
 |---|---|---|
 | 09 — `wheels deploy` (Kamal port) | 2026-05-06 | Social 4 |
 | 03 — Security hardening | 2026-05-07 | Social 5 |
-| 06 — Testing in 4.0 | 2026-05-09 | Social 7 |
-| 04 — Background jobs without Redis | 2026-05-10 | Social 8 |
-| 07 — Multi-tenancy built in | 2026-05-10 | Social 8 (same day, double pairing) |
+| 06 — Testing in 4.0 | 2026-05-08 | (Social 6 covers Data layer that day — slight topic mismatch) |
+| 04 — Background jobs without Redis | 2026-05-09 | (Social 7 covers Testing that day — slight topic mismatch) |
+| 07 — Multi-tenancy built in | 2026-05-10 | Social 8 (Multi-tenancy + background jobs) — partial match |
 | 05 — LuCLI zero-Docker DX | 2026-05-11 | Social 9 |
 | 01 — Closing the maturity gap (lead) | 2026-05-12 | Social 10 / GA |
-| 02 — Upgrading from 3.x | 2026-05-12 | Social 10 / GA |
-| 08 — WireBox → wheelsdi (contributor) | 2026-05-13 | Post-GA |
+| 02 — Upgrading from 3.x | 2026-05-13 | Post-GA migration companion |
+| 08 — WireBox → wheelsdi (contributor) | 2026-05-14 | Post-GA |
+
+**Note on the spread-out blog schedule:** the campaign was originally planned with same-day social/blog pairings (Social 8 paired with Blogs 04+07; Social 10 paired with Blogs 01+02). Spreading the blogs to one-per-day for clearer publishing cadence introduces social/blog topic mismatches on 2026-05-08 (Social=Data layer, Blog=Testing) and 2026-05-09 (Social=Testing, Blog=Background jobs). At post time, decide per-day whether to re-theme the social to the blog topic, swap social order, or accept the cross-pollination as feature-density evidence.
 
 **Framing:** 4.0 is *in the works* — release candidate, not GA. Phrasing throughout uses "coming" / "on the way" / "preview" rather than "shipped." Swap to present tense on GA day.
 

--- a/docs/releases/blog-skeletons/social-announcements.md
+++ b/docs/releases/blog-skeletons/social-announcements.md
@@ -13,8 +13,8 @@
 | 3 | 2026-04-25 | 3.0 → 4.0 delta | Existing users planning the upgrade. Posted. |
 | 4 | **2026-05-06** | `wheels deploy` | Marquee-feature spotlight; wholly new CLI surface. (Resume) |
 | 5 | 2026-05-07 | Security hardening | 40+ hardening PRs, "secure by default" story. |
-| 6 | 2026-05-08 | Data layer modernization | "Rails parity made concrete" for ORM-curious devs. |
-| 7 | 2026-05-09 | Testing | Browser testing + parallel runner + HTTP client + zero-Docker inner loop. |
+| 7 | 2026-05-08 | Testing | Browser testing + parallel runner + HTTP client + zero-Docker inner loop. |
+| 6 | 2026-05-09 | Data layer modernization | "Rails parity made concrete" for ORM-curious devs. |
 | 8 | 2026-05-10 | Multi-tenancy + background jobs | The "what makes Wheels different" beat. |
 | 9 | 2026-05-11 | LuCLI / zero-Docker DX | Inner-loop developer-experience closer. |
 | 10 | **2026-05-12 (GA)** | Release announcement | Recaps the arc, swap all "coming" → present tense. |
@@ -25,15 +25,15 @@
 |---|---|---|
 | 09 — `wheels deploy` (Kamal port) | 2026-05-06 | Social 4 |
 | 03 — Security hardening | 2026-05-07 | Social 5 |
-| 06 — Testing in 4.0 | 2026-05-08 | (Social 6 covers Data layer that day — slight topic mismatch) |
-| 04 — Background jobs without Redis | 2026-05-09 | (Social 7 covers Testing that day — slight topic mismatch) |
+| 06 — Testing in 4.0 | 2026-05-08 | Social 7 (Testing) — match |
+| 04 — Background jobs without Redis | 2026-05-09 | Social 6 (Data layer) — distinct topics, parallel "ground gained" beats |
 | 07 — Multi-tenancy built in | 2026-05-10 | Social 8 (Multi-tenancy + background jobs) — partial match |
 | 05 — LuCLI zero-Docker DX | 2026-05-11 | Social 9 |
 | 01 — Closing the maturity gap (lead) | 2026-05-12 | Social 10 / GA |
 | 02 — Upgrading from 3.x | 2026-05-13 | Post-GA migration companion |
 | 08 — WireBox → wheelsdi (contributor) | 2026-05-14 | Post-GA |
 
-**Note on the spread-out blog schedule:** the campaign was originally planned with same-day social/blog pairings (Social 8 paired with Blogs 04+07; Social 10 paired with Blogs 01+02). Spreading the blogs to one-per-day for clearer publishing cadence introduces social/blog topic mismatches on 2026-05-08 (Social=Data layer, Blog=Testing) and 2026-05-09 (Social=Testing, Blog=Background jobs). At post time, decide per-day whether to re-theme the social to the blog topic, swap social order, or accept the cross-pollination as feature-density evidence.
+**Note on the swapped social order on 2026-05-08 / 09:** Social 7 (Testing) and Social 6 (Data layer modernization) had their dates swapped from the original campaign plan so Social 7 lands on the same day as Blog 06 (Testing), giving 5/8 a clean topic match. 5/9 then has Social 6 (Data layer) firing alongside Blog 04 (Background jobs) — two unrelated-but-related "ground gained in 4.0" beats, different audience angles. The social copy itself is unchanged from the original plan; only the dates moved.
 
 **Framing:** 4.0 is *in the works* — release candidate, not GA. Phrasing throughout uses "coming" / "on the way" / "preview" rather than "shipped." Swap to present tense on GA day.
 


### PR DESCRIPTION
## Summary

Aligns the source-of-truth campaign doc with the one-per-day blog schedule the admin tool's DB now reflects. The original compressed schedule (set in #2430) had two doubled-up days; this spreads them so each blog post has its own publishing window and feed slot.

## Schedule changes

| Blog | Old date | New date |
|---|---|---|
| 06 — Testing in 4.0 | 2026-05-09 | **2026-05-08** |
| 04 — Background jobs without Redis | 2026-05-10 | **2026-05-09** |
| 07 — Multi-tenancy built in | 2026-05-10 (07:05) | **2026-05-10 (07:00)** — lost the +5 min offset |
| 05 — LuCLI zero-Docker DX | 2026-05-11 | unchanged |
| 01 — Closing the maturity gap (lead) | 2026-05-12 | unchanged — anchors GA day alone |
| 02 — Upgrading from 3.x | 2026-05-12 | **2026-05-13** — post-GA migration companion |
| 08 — WireBox → wheelsdi | 2026-05-13 | **2026-05-14** |

GA day stays **2026-05-12**, but anchored by the lead post only (`wheels-4-closing-the-maturity-gap`). Blog 02 (Upgrading from 3.x) ships the day after as a "what to do tomorrow" companion — readers absorb the GA framing on day 0, then get specific upgrade guidance on day +1 when they're ready to act.

## Side effect — social/blog topic mismatches

Spreading the blogs while keeping the social drumbeat in place introduces two days of cross-pollination:

| Date | Social topic | Blog topic |
|---|---|---|
| 2026-05-08 | Data layer modernization | Testing in 4.0 |
| 2026-05-09 | Testing | Background jobs without Redis |

Documented as a "Note on the spread-out blog schedule" below the companion table. Resolution is left to per-day editorial judgment at post time — re-theme the social, swap social order, or accept the cross-pollination as a feature-density signal.

## DB state

The 8 staged posts in the local blog admin tool DB have already had their `publishedAt` timestamps updated to match this schedule. This PR aligns the public-facing campaign doc.

## Test plan

- [ ] Commit-message lint passes (`docs:` type, no scope)
- [ ] Spot-read the updated table for clarity
- [ ] No code paths affected — purely campaign-comms doc

## Out of scope

- Re-aligning the SOCIAL drumbeat dates to match the new blog dates (would require also re-mapping Social 6 / 7 / 8 / 10 timing — separate decision).
- Cutting Social 6 (Data layer modernization) which has no companion blog under either schedule.