### PR TITLE
fix(test): wire $wheelsTestRun in runner.cfm so flash cookie shim fires

### DIFF
--- a/vendor/wheels/controller/flash.cfc
+++ b/vendor/wheels/controller/flash.cfc
@@ -216,7 +216,7 @@ component {
 
 	/**
 	 * Internal function. Returns true when running inside the Wheels test
-	 * harness. Set by `Test.cfc::$wheelsRunner` for every core test request.
+	 * harness. Set by `wheels/tests/runner.cfm` for every core test request.
 	 * Pure CFML — no engine-specific Java calls — so it is safe on
 	 * Lucee 5/6/7, Adobe 2018-2025, and BoxLang.
 	 */

--- a/vendor/wheels/tests/runner.cfm
+++ b/vendor/wheels/tests/runner.cfm
@@ -1,5 +1,11 @@
 ﻿<cfsetting requestTimeOut="1800">
 <cfscript>
+    // Flag this request as a test harness run so framework internals
+    // (e.g. flash cookie writes) can short-circuit operations that are
+    // unsafe after the response buffer auto-commits mid-suite. Read by
+    // wheels.controller.flash::$inTestHarness().
+    request.$wheelsTestRun = true;
+
     // Define helper functions as variables-scoped closures to avoid Adobe CF's
     // DuplicateFunctionDefinitionException (this file can be included from multiple
     // CFC methods via different include paths)

--- a/vendor/wheels/tests/specs/controller/flashSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/flashSpec.cfc
@@ -7,6 +7,20 @@ component extends="wheels.WheelsTest" {
 
 	function run() {
 
+		describe("Test harness wiring", () => {
+
+			// Regression: the cookie-write shim in flash.cfc depends on
+			// request.$wheelsTestRun being set. It was originally set in
+			// Test.cfc::$wheelsRunner but the current TestBox pipeline runs
+			// through tests/runner.cfm instead and never invokes $wheelsRunner.
+			// The shim was dormant until the flag was wired into runner.cfm —
+			// the symptom was 9 IllegalStateException errors in the
+			// flashMessages describe (cookie writes after Undertow auto-commit).
+			it("flags the request as a test harness run for the cookie-write shim", () => {
+				expect(_controller.$inTestHarness()).toBeTrue();
+			});
+		})
+
 		describe("Tests that flashStorage", () => {
 
 			it("should be enabled in cookies", () => {


### PR DESCRIPTION
## Summary

PR #2204 added a test-harness shim in `controller/flash.cfc` that round-trips cookie flash writes through `request.$testCookieFlash` to dodge `IllegalStateException` once Undertow auto-commits the response buffer mid-suite. The shim is gated on `request.$wheelsTestRun`, supposedly set by `Test.cfc::$wheelsRunner`. **But `$wheelsRunner` is never called** — the active TestBox pipeline runs through `tests/runner.cfm` and never enters `Test.cfc`. The flag was never set, `$inTestHarness()` always returned false, the shim was dormant from day 1, and the `IllegalStateException` only surfaced on the 9 late-running `flashMessages` specs because Undertow doesn't auto-commit the response buffer until enough output has accumulated; early specs wrote cookies fine.

This PR sets `request.$wheelsTestRun = true` at the top of `runner.cfm`'s cfscript block (the actual entry point of the TestBox pipeline), adds a regression spec asserting `$inTestHarness()` returns true during test runs, and updates `flash.cfc`'s now-stale comment that pointed at the vestigial `$wheelsRunner`.

## Verification (Lucee 7 + SQLite, local Docker matrix)

| Run | Pass | Fail | Error |
|---|---|---|---|
| Before (current `develop`) | 3413 | 0 | 9 |
| After this PR | 3423 | 0 | 0 |

The +1 in pass count is the new regression spec. All 9 errors (`flashSpec.cfc` cookie-write failures in the `flashMessages` describe) resolve to passes.

## Test plan
- [x] `tools/test-matrix.sh lucee7 sqlite` — full suite green (3423 / 0 / 0)
- [x] `flashSpec.cfc` regression spec passes (`$inTestHarness()` returns true)
- [ ] CI: full `compat-matrix.yml` run (Lucee 6/7, Adobe 2023/2025, BoxLang × multiple DBs) — required-checks gate
- [ ] Adobe CF 2025 verification deferred — local image is broken on `graphqlclient` package; CI image may differ

## Notes for reviewers

- The fix is intentionally minimal: one line in `runner.cfm`, one doc-comment update, one regression spec. No behavior changes outside the test harness — the shim itself was already correct.
- `Test.cfc::$wheelsRunner` is now confirmed dead code on the TestBox pipeline. Cleanup of `$wheelsRunner` and its surrounding helpers (`$resolvePaths`, `$listTestPackages`, `$runTest` chain) is out of scope for this PR but would be a reasonable follow-up.
- The new regression spec is in `flashSpec.cfc` rather than a dedicated `TestRunnerSpec.cfc` because the flag's only consumer is `flash.cfc`'s shim. If we add more shim consumers, splitting into a dedicated runner spec would be the right move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)