### PR TITLE
feat(cli): issue-resolver orchestrator using Managed Agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ settings.xml
 
 # Node.js (dev tooling: husky, commitlint)
 node_modules/
+
+# Issue-resolver — local resource IDs from setup.ts
+tools/issue-resolver/.env.local
 # CLI test output (but track spec sources)
 cli/tests/*
 !cli/tests/specs/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,42 @@
 {
   "name": "wheels",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wheels",
-      "version": "3.1.0",
+      "version": "4.0.0",
       "devDependencies": {
+        "@anthropic-ai/sdk": "^0.88.0",
         "@commitlint/cli": "^19.0.0",
         "@commitlint/config-conventional": "^19.0.0",
         "@playwright/test": "^1.58.2",
         "@types/node": "^25.5.0",
+        "dotenv": "^17.4.1",
         "husky": "^9.0.0",
-        "dotenv": "^17.4.1"
+        "tsx": "^4.19.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.88.0.tgz",
+      "integrity": "sha512-QQOtB5U9ZBJQj6y1ICmDZl14LWa4JCiJRoihI+0yuZ4OjbONrakP0yLwPv4DJFb3VYCtQM31bTOpCBMs2zghPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -35,6 +58,16 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -296,6 +329,448 @@
       },
       "engines": {
         "node": ">=v18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@playwright/test": {
@@ -580,6 +1055,7 @@
       "version": "17.4.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
       "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -613,6 +1089,48 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -690,6 +1208,19 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/git-raw-commits": {
@@ -867,6 +1398,20 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -1154,6 +1699,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -1233,6 +1788,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -5,14 +5,18 @@
   "type": "module",
   "description": "Wheels CFML MVC Framework — dev tooling only",
   "scripts": {
-    "prepare": "husky"
+    "prepare": "husky",
+    "issue-resolver:setup": "tsx tools/issue-resolver/setup.ts",
+    "issue-resolver:run": "tsx tools/issue-resolver/run.ts"
   },
   "devDependencies": {
+    "@anthropic-ai/sdk": "^0.88.0",
     "@commitlint/cli": "^19.0.0",
     "@commitlint/config-conventional": "^19.0.0",
     "@playwright/test": "^1.58.2",
     "@types/node": "^25.5.0",
     "husky": "^9.0.0",
-    "dotenv": "^17.4.1"
+    "dotenv": "^17.4.1",
+    "tsx": "^4.19.0"
   }
 }

--- a/tools/issue-resolver/.env.example
+++ b/tools/issue-resolver/.env.example
@@ -1,0 +1,26 @@
+# Required — Anthropic + GitHub credentials
+ANTHROPIC_API_KEY=sk-ant-...
+GITHUB_TOKEN=ghp_...                 # needs Contents: Read+Write on the repo, plus PRs: Write
+
+# Optional — repo overrides (defaults are wheels-dev/wheels)
+# GITHUB_OWNER=wheels-dev
+# GITHUB_REPO=wheels
+# BASE_BRANCH=develop
+
+# Optional — model overrides (read by setup.ts only)
+# FIXER_MODEL=claude-opus-4-7
+# REVIEWER_MODEL=claude-sonnet-4-6
+
+# Optional — loop limits
+# MAX_REVIEW_CYCLES=3
+# MAX_CI_FIX_ATTEMPTS=2
+# CI_POLL_INTERVAL_SEC=30
+# CI_POLL_TIMEOUT_SEC=1800
+
+# The following are populated by setup.ts into .env.local — do not set manually:
+# RESOLVER_ENVIRONMENT_ID=env_...
+# RESOLVER_MEMORY_STORE_ID=memstore_...
+# RESOLVER_FIXER_AGENT_ID=agent_...
+# RESOLVER_FIXER_AGENT_VERSION=1
+# RESOLVER_REVIEWER_AGENT_ID=agent_...
+# RESOLVER_REVIEWER_AGENT_VERSION=1

--- a/tools/issue-resolver/lib/config.ts
+++ b/tools/issue-resolver/lib/config.ts
@@ -1,0 +1,41 @@
+import "dotenv/config";
+import { config as loadEnv } from "dotenv";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ENV_LOCAL = join(__dirname, "..", ".env.local");
+
+if (existsSync(ENV_LOCAL)) {
+  loadEnv({ path: ENV_LOCAL, override: false });
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v)
+    throw new Error(
+      `Missing env var ${name}. Run \`npm run issue-resolver:setup\` to create resources, or set the var manually.`,
+    );
+  return v;
+}
+
+export const config = {
+  anthropicApiKey: required("ANTHROPIC_API_KEY"),
+  githubToken: required("GITHUB_TOKEN"),
+  githubOwner: process.env.GITHUB_OWNER || "wheels-dev",
+  githubRepo: process.env.GITHUB_REPO || "wheels",
+  baseBranch: process.env.BASE_BRANCH || "develop",
+
+  environmentId: required("RESOLVER_ENVIRONMENT_ID"),
+  memoryStoreId: required("RESOLVER_MEMORY_STORE_ID"),
+  fixerAgentId: required("RESOLVER_FIXER_AGENT_ID"),
+  reviewerAgentId: required("RESOLVER_REVIEWER_AGENT_ID"),
+
+  maxReviewCycles: Number(process.env.MAX_REVIEW_CYCLES || 3),
+  maxCiFixAttempts: Number(process.env.MAX_CI_FIX_ATTEMPTS || 2),
+  ciPollIntervalSec: Number(process.env.CI_POLL_INTERVAL_SEC || 30),
+  ciPollTimeoutSec: Number(process.env.CI_POLL_TIMEOUT_SEC || 1800),
+};
+
+export type Config = typeof config;

--- a/tools/issue-resolver/lib/github.ts
+++ b/tools/issue-resolver/lib/github.ts
@@ -1,0 +1,165 @@
+import { config } from "./config.js";
+
+const BASE = "https://api.github.com";
+
+async function gh<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    ...init,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${config.githubToken}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "wheels-issue-resolver",
+      ...(init?.headers || {}),
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GitHub ${init?.method || "GET"} ${path} → ${res.status}: ${text}`);
+  }
+  if (res.status === 204) return undefined as T;
+  return res.json() as Promise<T>;
+}
+
+const repoPath = `/repos/${config.githubOwner}/${config.githubRepo}`;
+
+export interface Issue {
+  number: number;
+  title: string;
+  body: string | null;
+  labels: { name: string }[];
+  state: string;
+}
+
+export interface PullRequest {
+  number: number;
+  html_url: string;
+  state: string;
+  draft: boolean;
+  head: { sha: string; ref: string };
+  base: { ref: string };
+  node_id: string;
+}
+
+export interface CheckRun {
+  name: string;
+  status: "queued" | "in_progress" | "completed";
+  conclusion:
+    | "success"
+    | "failure"
+    | "neutral"
+    | "cancelled"
+    | "skipped"
+    | "timed_out"
+    | "action_required"
+    | null;
+  details_url: string;
+}
+
+export async function listOpenIssues(): Promise<Issue[]> {
+  const issues = await gh<Issue[]>(
+    `${repoPath}/issues?state=open&per_page=100`,
+  );
+  // GitHub returns PRs in /issues — filter them out via the pull_request property.
+  return issues.filter(
+    (i) => !(i as Issue & { pull_request?: unknown }).pull_request,
+  );
+}
+
+export async function findExistingPrForBranch(
+  branch: string,
+): Promise<PullRequest | null> {
+  const prs = await gh<PullRequest[]>(
+    `${repoPath}/pulls?head=${config.githubOwner}:${branch}&state=open`,
+  );
+  return prs[0] ?? null;
+}
+
+export async function createDraftPr(args: {
+  title: string;
+  head: string;
+  body: string;
+}): Promise<PullRequest> {
+  return gh<PullRequest>(`${repoPath}/pulls`, {
+    method: "POST",
+    body: JSON.stringify({
+      title: args.title,
+      head: args.head,
+      base: config.baseBranch,
+      body: args.body,
+      draft: true,
+    }),
+  });
+}
+
+export async function postPrReview(args: {
+  prNumber: number;
+  event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT";
+  body: string;
+  comments?: { path: string; line: number; body: string }[];
+}): Promise<void> {
+  await gh(`${repoPath}/pulls/${args.prNumber}/reviews`, {
+    method: "POST",
+    body: JSON.stringify({
+      event: args.event,
+      body: args.body,
+      comments: args.comments,
+    }),
+  });
+}
+
+export async function markPrReadyForReview(prNodeId: string): Promise<void> {
+  // GraphQL — REST has no first-class "ready for review" endpoint.
+  const query = `
+    mutation($prId: ID!) {
+      markPullRequestReadyForReview(input: { pullRequestId: $prId }) {
+        pullRequest { id }
+      }
+    }
+  `;
+  const res = await fetch(`${BASE}/graphql`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${config.githubToken}`,
+      "Content-Type": "application/json",
+      "User-Agent": "wheels-issue-resolver",
+    },
+    body: JSON.stringify({ query, variables: { prId: prNodeId } }),
+  });
+  if (!res.ok) {
+    throw new Error(`markPrReadyForReview failed: ${res.status} ${await res.text()}`);
+  }
+  const json = (await res.json()) as { errors?: unknown[] };
+  if (json.errors)
+    throw new Error(`markPrReadyForReview GraphQL: ${JSON.stringify(json.errors)}`);
+}
+
+export async function getCheckRuns(sha: string): Promise<CheckRun[]> {
+  const res = await gh<{ check_runs: CheckRun[] }>(
+    `${repoPath}/commits/${sha}/check-runs?per_page=100`,
+  );
+  return res.check_runs;
+}
+
+export interface CiStatus {
+  state: "pending" | "success" | "failure";
+  failed: CheckRun[];
+  inProgress: CheckRun[];
+}
+
+export function summarizeChecks(checks: CheckRun[]): CiStatus {
+  const inProgress = checks.filter((c) => c.status !== "completed");
+  if (inProgress.length > 0) {
+    return { state: "pending", failed: [], inProgress };
+  }
+  const failed = checks.filter(
+    (c) =>
+      c.conclusion === "failure" ||
+      c.conclusion === "timed_out" ||
+      c.conclusion === "action_required",
+  );
+  if (failed.length > 0) {
+    return { state: "failure", failed, inProgress: [] };
+  }
+  return { state: "success", failed: [], inProgress: [] };
+}

--- a/tools/issue-resolver/lib/session.ts
+++ b/tools/issue-resolver/lib/session.ts
@@ -1,0 +1,116 @@
+import type Anthropic from "@anthropic-ai/sdk";
+
+type AnyEvent = { id: string; type: string; [k: string]: unknown };
+
+export interface RunTurnResult {
+  finalText: string;
+  events: AnyEvent[];
+  status: "idle" | "terminated";
+  stopReason?: string;
+}
+
+/**
+ * Run one turn of a session: send a user message, drain the SSE stream until
+ * the agent goes idle with a terminal stop_reason or terminates. Reuses the
+ * same session across calls — each call is one user/assistant exchange.
+ *
+ * Stream-first: opens the SSE stream before sending the user message so we
+ * don't miss the early events. (See managed-agents-events.md → Stream-first.)
+ *
+ * Idle gate: breaks on session.status_terminated, or on session.status_idle
+ * unless stop_reason.type === "requires_action" (transient; agent is waiting
+ * on a client-side response).
+ */
+export async function runTurn(
+  client: Anthropic,
+  sessionId: string,
+  message: string,
+  options: {
+    onText?: (delta: string) => void;
+    onEvent?: (event: AnyEvent) => void;
+  } = {},
+): Promise<RunTurnResult> {
+  const events: AnyEvent[] = [];
+
+  // Stream-first ordering — open before send.
+  const stream = await client.beta.sessions.events.stream(sessionId);
+
+  await client.beta.sessions.events.send(sessionId, {
+    events: [
+      {
+        type: "user.message",
+        content: [{ type: "text", text: message }],
+      },
+    ],
+  });
+
+  let status: "idle" | "terminated" = "idle";
+  let stopReason: string | undefined;
+  const turnTextParts: string[] = [];
+
+  for await (const event of stream as unknown as AsyncIterable<AnyEvent>) {
+    events.push(event);
+    options.onEvent?.(event);
+
+    if (event.type === "agent.message") {
+      const blocks = (event as { content?: { type: string; text?: string }[] })
+        .content;
+      if (blocks) {
+        for (const b of blocks) {
+          if (b.type === "text" && b.text) {
+            turnTextParts.push(b.text);
+            options.onText?.(b.text);
+          }
+        }
+      }
+    }
+
+    if (event.type === "session.status_terminated") {
+      status = "terminated";
+      break;
+    }
+    if (event.type === "session.status_idle") {
+      const sr = (event as { stop_reason?: { type?: string } }).stop_reason;
+      const reason = sr?.type;
+      if (reason !== "requires_action") {
+        status = "idle";
+        stopReason = reason;
+        break;
+      }
+      // requires_action — agent is waiting on a client-side response
+      // (tool confirmation or custom tool result). We don't wire those up,
+      // so this is a configuration bug; surface it.
+      throw new Error(
+        `Session ${sessionId} idle with requires_action — neither tool confirmations nor custom tools are wired up in this orchestrator.`,
+      );
+    }
+  }
+
+  return {
+    finalText: turnTextParts.join(""),
+    events,
+    status,
+    stopReason,
+  };
+}
+
+/**
+ * Wait for a session's queryable status to settle. The SSE stream emits
+ * status_idle slightly before sessions.retrieve() reflects it, so calls that
+ * mutate the session (delete/archive) can race. Returns the final status.
+ */
+export async function waitForSessionToSettle(
+  client: Anthropic,
+  sessionId: string,
+  maxWaitMs = 5000,
+): Promise<string> {
+  const deadline = Date.now() + maxWaitMs;
+  let status = "running";
+  while (Date.now() < deadline) {
+    const s = await client.beta.sessions.retrieve(sessionId);
+    status = s.status;
+    if (status !== "running") return status;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return status;
+}

--- a/tools/issue-resolver/run.ts
+++ b/tools/issue-resolver/run.ts
@@ -1,0 +1,420 @@
+import "dotenv/config";
+import Anthropic from "@anthropic-ai/sdk";
+import { config } from "./lib/config.js";
+import { runTurn } from "./lib/session.js";
+import {
+  createDraftPr,
+  findExistingPrForBranch,
+  getCheckRuns,
+  listOpenIssues,
+  markPrReadyForReview,
+  postPrReview,
+  summarizeChecks,
+  type Issue,
+  type PullRequest,
+} from "./lib/github.js";
+
+interface ReviewerVerdict {
+  verdict: "approve" | "request_changes";
+  comments: { path: string; line: number; body: string }[];
+  general_feedback: string;
+}
+
+const client = new Anthropic({ apiKey: config.anthropicApiKey });
+
+async function main(): Promise<void> {
+  const filterArg = process.argv[2];
+  const filter = filterArg ? new Set(filterArg.split(",").map(Number)) : null;
+
+  console.log("Listing open issues...");
+  const allIssues = await listOpenIssues();
+  const issues = filter
+    ? allIssues.filter((i) => filter.has(i.number))
+    : allIssues;
+  console.log(
+    `${issues.length} issue(s) to process${filter ? ` (filtered)` : ""}.`,
+  );
+
+  const summary: { issue: number; result: string }[] = [];
+
+  for (const issue of issues) {
+    const branch = `claude/issue-${issue.number}`;
+    console.log(`\n${"━".repeat(70)}`);
+    console.log(`#${issue.number}: ${issue.title}`);
+    console.log(`${"━".repeat(70)}`);
+
+    const existing = await findExistingPrForBranch(branch);
+    if (existing) {
+      console.log(
+        `  ↳ Existing PR #${existing.number} for ${branch} — skipping to avoid stomping.`,
+      );
+      summary.push({
+        issue: issue.number,
+        result: `skipped (existing PR #${existing.number})`,
+      });
+      continue;
+    }
+
+    try {
+      const result = await processIssue(issue, branch);
+      summary.push({ issue: issue.number, result });
+    } catch (err) {
+      console.error(`  ✗ ${(err as Error).message}`);
+      summary.push({
+        issue: issue.number,
+        result: `error: ${(err as Error).message}`,
+      });
+    }
+  }
+
+  console.log(`\n${"═".repeat(70)}\nSummary\n${"═".repeat(70)}`);
+  for (const row of summary) {
+    console.log(`  #${row.issue}: ${row.result}`);
+  }
+}
+
+async function processIssue(issue: Issue, branch: string): Promise<string> {
+  // 1. Create fixer session with develop checked out, memory attached.
+  const fixerSession = await client.beta.sessions.create({
+    agent: config.fixerAgentId,
+    environment_id: config.environmentId,
+    title: `Fix issue #${issue.number}`,
+    resources: [
+      {
+        type: "github_repository",
+        url: `https://github.com/${config.githubOwner}/${config.githubRepo}`,
+        authorization_token: config.githubToken,
+        checkout: { type: "branch", name: config.baseBranch },
+      },
+      {
+        type: "memory_store",
+        memory_store_id: config.memoryStoreId,
+        access: "read_write",
+        instructions:
+          "Cross-issue knowledge. Read /conventions.md and /gotchas.md before starting. After completing the fix, append to /issues-completed.md (issue, branch, files, learning). If you discover anything tricky, add it to /gotchas.md.",
+      },
+    ],
+  });
+  console.log(`  fixer session: ${fixerSession.id}`);
+
+  // 2. Initial fix turn.
+  const issueBody = (issue.body || "").trim() || "(no body)";
+  const fixKickoff = `Resolve issue #${issue.number}.
+
+Title: ${issue.title}
+
+Body:
+${issueBody}
+
+Branch to use: ${branch}
+
+Working directory: /workspace/wheels (already on ${config.baseBranch}).
+
+Steps:
+1. Read /workspace/wheels/CLAUDE.md if you haven't already.
+2. Investigate the issue, find affected files.
+3. Create branch \`${branch}\` from ${config.baseBranch}.
+4. Make the smallest change that resolves the issue.
+5. Commit with conventional format and push the branch.
+6. Output a final summary: branch, commit SHA(s), files changed, what you did.
+
+If too complex (multi-day, design needed, spans many subsystems), output a final message starting with "SKIP:" and explain.`;
+
+  console.log("  → fixer working...");
+  const initial = await runTurn(client, fixerSession.id, fixKickoff, {
+    onText: (t) => process.stdout.write(t),
+  });
+  process.stdout.write("\n");
+
+  if (initial.status === "terminated") {
+    return `failed (fixer session terminated: ${initial.stopReason || "unknown"})`;
+  }
+
+  if (initial.finalText.trimStart().startsWith("SKIP:")) {
+    console.log(`  ↳ Fixer skipped this issue.`);
+    return `skipped by fixer`;
+  }
+
+  // 3. Confirm the branch was pushed.
+  await new Promise((r) => setTimeout(r, 3000)); // brief grace for GitHub indexing
+  const branchCheck = await fetch(
+    `https://api.github.com/repos/${config.githubOwner}/${config.githubRepo}/branches/${branch}`,
+    {
+      headers: {
+        Authorization: `Bearer ${config.githubToken}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "wheels-issue-resolver",
+      },
+    },
+  );
+  if (!branchCheck.ok) {
+    return `fixer ran but branch ${branch} not found on origin (status ${branchCheck.status})`;
+  }
+
+  // 4. Create the draft PR.
+  console.log(`  → creating draft PR...`);
+  const pr = await createDraftPr({
+    title: `Fix #${issue.number}: ${issue.title}`,
+    head: branch,
+    body: buildPrBody(issue, initial.finalText),
+  });
+  console.log(`  ↳ PR #${pr.number}: ${pr.html_url}`);
+
+  // 5. Review cycle.
+  let reviewVerdict: ReviewerVerdict | null = null;
+  for (let cycle = 1; cycle <= config.maxReviewCycles; cycle++) {
+    console.log(`  → review cycle ${cycle}/${config.maxReviewCycles}...`);
+    const verdict = await reviewPr(pr, branch);
+
+    if (verdict.verdict === "approve") {
+      await postPrReview({
+        prNumber: pr.number,
+        event: "APPROVE",
+        body: `Automated review (cycle ${cycle}): ${verdict.general_feedback}`,
+      });
+      reviewVerdict = verdict;
+      console.log(`  ↳ approved on cycle ${cycle}.`);
+      break;
+    }
+
+    await postPrReview({
+      prNumber: pr.number,
+      event: "REQUEST_CHANGES",
+      body: `Automated review (cycle ${cycle}): ${verdict.general_feedback}`,
+      comments: verdict.comments,
+    });
+
+    if (cycle === config.maxReviewCycles) {
+      console.log(
+        `  ↳ review cycles exhausted; leaving PR for human attention.`,
+      );
+      return `review exhausted (PR #${pr.number} left as draft with REQUEST_CHANGES)`;
+    }
+
+    // Send feedback to fixer session for revision.
+    const reviewMsg = `The reviewer requested changes. General feedback:
+
+${verdict.general_feedback}
+
+Specific comments:
+${verdict.comments
+  .map((c) => `- ${c.path}:${c.line} — ${c.body}`)
+  .join("\n")}
+
+Please address these and push another commit. Output a final summary of what you changed.`;
+
+    console.log(`  → fixer addressing feedback...`);
+    const revision = await runTurn(client, fixerSession.id, reviewMsg, {
+      onText: (t) => process.stdout.write(t),
+    });
+    process.stdout.write("\n");
+
+    if (revision.status === "terminated") {
+      return `failed (fixer terminated during review cycle ${cycle})`;
+    }
+  }
+
+  if (!reviewVerdict) {
+    return `review cycle ended without approval`;
+  }
+
+  // 6. Wait for CI.
+  console.log(`  → polling CI...`);
+  const ciOk = await waitForCiAndFix(pr, fixerSession.id);
+
+  if (!ciOk) {
+    return `CI fix attempts exhausted (PR #${pr.number} left as draft)`;
+  }
+
+  // 7. Mark ready for review.
+  console.log(`  → marking PR ready for review...`);
+  await markPrReadyForReview(pr.node_id);
+
+  return `ready for human merge (PR #${pr.number})`;
+}
+
+async function reviewPr(
+  pr: PullRequest,
+  branch: string,
+): Promise<ReviewerVerdict> {
+  // Fresh reviewer session, scoped to this PR.
+  const reviewSession = await client.beta.sessions.create({
+    agent: config.reviewerAgentId,
+    environment_id: config.environmentId,
+    title: `Review PR #${pr.number}`,
+    resources: [
+      {
+        type: "github_repository",
+        url: `https://github.com/${config.githubOwner}/${config.githubRepo}`,
+        authorization_token: config.githubToken,
+        checkout: { type: "branch", name: branch },
+      },
+      {
+        type: "memory_store",
+        memory_store_id: config.memoryStoreId,
+        access: "read_write",
+        instructions:
+          "Cross-PR review knowledge. Read /review-patterns.md and /gotchas.md before reviewing. Append any new patterns you notice to /review-patterns.md.",
+      },
+    ],
+  });
+
+  const reviewMsg = `Review PR #${pr.number} (branch ${branch}, base ${pr.base.ref}).
+
+The branch is checked out at /workspace/wheels.
+
+Run \`git diff ${pr.base.ref}...HEAD\` to see the changes. Read affected files in full for context.
+
+Apply the review checklist from your system prompt. End your response with the JSON verdict block as specified.`;
+
+  const result = await runTurn(client, reviewSession.id, reviewMsg, {
+    onText: (t) => process.stdout.write(t),
+  });
+  process.stdout.write("\n");
+
+  const verdict = extractVerdict(result.finalText);
+  if (!verdict) {
+    console.warn(
+      `  ⚠ reviewer output had no parseable JSON verdict — treating as request_changes.`,
+    );
+    return {
+      verdict: "request_changes",
+      comments: [],
+      general_feedback:
+        "Reviewer output had no parseable JSON verdict block. Please fix the JSON output format.",
+    };
+  }
+  return verdict;
+}
+
+async function waitForCiAndFix(
+  pr: PullRequest,
+  fixerSessionId: string,
+): Promise<boolean> {
+  let headSha = pr.head.sha;
+
+  for (let attempt = 0; attempt <= config.maxCiFixAttempts; attempt++) {
+    const status = await pollCiUntilDone(headSha);
+    if (status.state === "success") {
+      console.log(`  ↳ CI green (attempt ${attempt}).`);
+      return true;
+    }
+    if (status.state !== "failure") {
+      console.log(`  ↳ CI ${status.state} — bailing.`);
+      return false;
+    }
+    if (attempt === config.maxCiFixAttempts) {
+      console.log(`  ↳ CI fix attempts exhausted.`);
+      return false;
+    }
+
+    const failedSummary = status.failed
+      .map(
+        (c) =>
+          `- ${c.name} (${c.conclusion})${c.details_url ? ` — ${c.details_url}` : ""}`,
+      )
+      .join("\n");
+
+    console.log(`  → fixer addressing CI failures (attempt ${attempt + 1})...`);
+    const ciMsg = `CI is failing on the PR. Failed checks:
+
+${failedSummary}
+
+Please:
+1. Investigate the failures (read CI logs if accessible, otherwise reason from check names).
+2. Make the smallest fix that resolves the failures.
+3. Commit and push to the same branch.
+4. Output a summary of what you fixed.
+
+If the failure is a flake (transient, infrastructure), say "FLAKE:" in your response and the orchestrator will retry without changes.`;
+
+    const fixTurn = await runTurn(client, fixerSessionId, ciMsg, {
+      onText: (t) => process.stdout.write(t),
+    });
+    process.stdout.write("\n");
+
+    if (fixTurn.status === "terminated") {
+      console.log(`  ↳ fixer terminated during CI fix.`);
+      return false;
+    }
+
+    // Refetch the PR to get the new head SHA after the push.
+    await new Promise((r) => setTimeout(r, 5000));
+    const refreshed = await fetch(
+      `https://api.github.com/repos/${config.githubOwner}/${config.githubRepo}/pulls/${pr.number}`,
+      {
+        headers: {
+          Authorization: `Bearer ${config.githubToken}`,
+          Accept: "application/vnd.github+json",
+          "User-Agent": "wheels-issue-resolver",
+        },
+      },
+    );
+    if (!refreshed.ok) {
+      console.warn(`  ⚠ couldn't refetch PR; staying on old SHA.`);
+      continue;
+    }
+    const json = (await refreshed.json()) as { head: { sha: string } };
+    headSha = json.head.sha;
+  }
+  return false;
+}
+
+async function pollCiUntilDone(sha: string): Promise<ReturnType<typeof summarizeChecks>> {
+  const deadline = Date.now() + config.ciPollTimeoutSec * 1000;
+  while (Date.now() < deadline) {
+    const checks = await getCheckRuns(sha);
+    if (checks.length === 0) {
+      // Checks not yet posted; wait briefly.
+      await new Promise((r) => setTimeout(r, config.ciPollIntervalSec * 1000));
+      continue;
+    }
+    const status = summarizeChecks(checks);
+    if (status.state !== "pending") return status;
+    process.stdout.write(
+      `    ⏳ ${status.inProgress.length} checks in progress…\r`,
+    );
+    await new Promise((r) => setTimeout(r, config.ciPollIntervalSec * 1000));
+  }
+  return { state: "failure", failed: [], inProgress: [] };
+}
+
+function extractVerdict(text: string): ReviewerVerdict | null {
+  const fenced = text.match(/```json\s*\n([\s\S]*?)\n```/);
+  if (fenced) {
+    try {
+      return JSON.parse(fenced[1]) as ReviewerVerdict;
+    } catch {
+      // fall through
+    }
+  }
+  // Fallback: look for the last { ... "verdict" ... } object in the text.
+  const lastObj = text.match(/\{[\s\S]*"verdict"[\s\S]*\}/);
+  if (lastObj) {
+    try {
+      return JSON.parse(lastObj[0]) as ReviewerVerdict;
+    } catch {
+      // fall through
+    }
+  }
+  return null;
+}
+
+function buildPrBody(issue: Issue, fixerSummary: string): string {
+  return [
+    `Resolves #${issue.number}.`,
+    "",
+    "## Fixer summary",
+    "",
+    fixerSummary.trim(),
+    "",
+    "---",
+    "",
+    "_This PR was opened by the issue-resolver orchestrator. It will go through automated review and CI checks before being marked ready for review._",
+  ].join("\n");
+}
+
+main().catch((err) => {
+  console.error("Run failed:", err);
+  process.exit(1);
+});

--- a/tools/issue-resolver/setup.ts
+++ b/tools/issue-resolver/setup.ts
@@ -1,0 +1,193 @@
+import "dotenv/config";
+import Anthropic from "@anthropic-ai/sdk";
+import { existsSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ENV_FILE = join(__dirname, ".env.local");
+
+const FIXER_MODEL = process.env.FIXER_MODEL || "claude-opus-4-7";
+const REVIEWER_MODEL = process.env.REVIEWER_MODEL || "claude-sonnet-4-6";
+
+const FIXER_SYSTEM = `You are a Wheels framework engineer resolving GitHub issues. The repo is mounted at /workspace/wheels with a feature branch already checked out.
+
+ALWAYS read /workspace/wheels/CLAUDE.md first. It contains anti-patterns and conventions you must follow strictly. Pay particular attention to:
+- The Top-10 Anti-Patterns (mixed positional/named args, query vs array in views, etc.)
+- Cross-engine compatibility notes (.ai/wheels/cross-engine-compatibility.md) — Lucee/Adobe CF differences are common bug sources
+- Commit message format (commitlint rules in CLAUDE.md)
+
+Workflow:
+1. Read the issue body and any referenced files. Use grep/glob to find related code.
+2. Make the smallest change that resolves the issue. No refactoring of surrounding code, no scope creep, no speculative abstractions.
+3. If a quick relevant test exists, run it (e.g. bash tools/test-local.sh model). Skip heavy matrix tests — CI handles those.
+4. Commit using the conventional format \`type(scope): subject\` from CLAUDE.md. The branch is already \`claude/issue-<NUMBER>\`.
+5. Push the branch with \`git push -u origin <branch>\`.
+6. Output a final message stating: branch name, commit SHA(s), files changed, brief summary.
+
+If the issue is too complex (multi-day work, requires design discussion, spans many subsystems), output a final message that STARTS with "SKIP:" and explains why. The orchestrator will move on.
+
+Do not open PRs — the orchestrator handles that. Do not merge.
+
+A memory store is attached for cross-issue knowledge. Read /conventions.md and /gotchas.md inside it for accumulated context before working. After finishing, append a brief note to /issues-completed.md (issue number, branch, files, key learning) and update /gotchas.md if you discovered anything tricky.`;
+
+const REVIEWER_SYSTEM = `You are a senior code reviewer for Wheels (CFML MVC framework). The PR branch is checked out at /workspace/wheels.
+
+Read /workspace/wheels/CLAUDE.md for the anti-patterns list. Then review the diff (\`git diff develop...HEAD\`) against:
+1. Does the change actually resolve the linked issue?
+2. CLAUDE.md anti-patterns: mixed positional/named args, query-vs-array in views, route ordering, public mixin functions, etc.
+3. Cross-engine compatibility (.ai/wheels/cross-engine-compatibility.md): private mixin functions, struct.map() resolution, application scope, bracket-notation calls in closures, array-by-value in struct literals.
+4. Scope creep: was anything changed beyond what the issue requires?
+5. Test coverage: new behavior should have tests; bug fixes should have a regression test where feasible.
+6. Commit message format: \`type(scope): subject\` with valid types/scopes from CLAUDE.md.
+
+Read affected files in full for context, not just the diff.
+
+End your response with a JSON block (the orchestrator parses this — no other JSON in your response):
+
+\`\`\`json
+{"verdict": "approve" | "request_changes", "comments": [{"path": "<file>", "line": <number>, "body": "<actionable feedback>"}], "general_feedback": "<one paragraph summary>"}
+\`\`\`
+
+If verdict is "approve", \`comments\` may be empty. If "request_changes", every comment must be actionable and specific. Don't nitpick style if commitlint and tests pass — focus on correctness, framework conventions, and cross-engine concerns.
+
+A memory store is attached. Read /review-patterns.md for accumulated reviewer notes from prior PRs.`;
+
+const SEED_CONVENTIONS = `# Wheels Conventions Cheat Sheet
+
+This file accumulates framework-specific conventions discovered while resolving issues. Initial seed:
+
+- Models extend "Model"; controllers extend "Controller"; new tests extend "wheels.WheelsTest" (BDD).
+- All associations/validations/callbacks go in the model's config() function.
+- Function-call rule: NEVER mix positional and named arguments in Wheels framework calls. Use all named when passing options.
+- Migrations: use NOW() for timestamps (database-agnostic), use direct SQL for seed inserts (parameter binding is unreliable in execute()).
+- View variables must be cfparam'd at the top of every view file.
+- Filter functions in controllers must be declared private.
+- timestamps() in migrations adds createdAt, updatedAt, AND deletedAt (three columns, not two).
+
+Update this file when you discover a new convention or framework idiom.
+`;
+
+const SEED_ISSUES_COMPLETED = `# Completed Issues
+
+Append entries as issues are resolved. Format:
+
+## #NNN — <title>
+- Branch: claude/issue-NNN
+- Files: <list>
+- Resolution: <one-paragraph summary>
+- Learning: <key takeaway, if any>
+`;
+
+const SEED_GOTCHAS = `# Recurring Gotchas
+
+Cross-engine, framework, and tooling pitfalls discovered while fixing issues. Append findings here so future runs benefit.
+
+- Lucee/Adobe CF: \`obj.map()\` resolves to the built-in struct member function, not a CFC method. Use a wrapper instead.
+- Adobe CF: \`obj["key"]()\` crashes the parser inside closures. Split into two statements.
+- Lucee 7: \`Left(str, 0)\` crashes. Use a ternary guard.
+- Test infrastructure: HTML entities like \`&#111;\` contain \`#\` which CFML interprets as expression delimiters — escape as \`&##111;\` in string literals.
+- \`private\` mixin functions are not integrated into model/controller objects. Use \`public\` access with a \`$\` prefix for internal scope.
+`;
+
+const SEED_REVIEW_PATTERNS = `# Reviewer Patterns
+
+Notes accumulated across PR reviews — recurring issues, false positives, framework-specific concerns the reviewer should weight heavily.
+
+- Always check \`vendor/wheels/\` changes for cross-engine compatibility (Lucee 6/7, Adobe 2023/2025, BoxLang).
+- New CFC files: confirm \`extends="..."\` is correct and matches the CLAUDE.md convention.
+- Routes: order matters; resources before custom-named before root before wildcard.
+- Migrations: use \`NOW()\` not database-specific timestamp functions.
+`;
+
+async function main() {
+  if (existsSync(ENV_FILE)) {
+    console.error(
+      `Refusing to overwrite ${ENV_FILE}.\n` +
+        `If you want to recreate resources, delete this file first (the old Anthropic-side resources will become orphans you can clean up via the \`ant\` CLI).`,
+    );
+    process.exit(1);
+  }
+
+  const client = new Anthropic();
+  const ts = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+
+  console.log("Creating environment...");
+  const environment = await client.beta.environments.create({
+    name: `wheels-issue-resolver-${ts}`,
+    config: {
+      type: "cloud",
+      networking: { type: "unrestricted" },
+    },
+  });
+  console.log(`  ${environment.id}`);
+
+  console.log("Creating memory store...");
+  const memory = await client.beta.memoryStores.create({
+    name: `wheels-issue-resolver-${ts}`,
+    description:
+      "Cross-issue knowledge for Wheels framework: conventions, gotchas, completed-issue log, reviewer patterns. Read before starting any task; append findings after.",
+  });
+  console.log(`  ${memory.id}`);
+
+  console.log("Seeding memory store...");
+  for (const [path, content] of [
+    ["/conventions.md", SEED_CONVENTIONS],
+    ["/issues-completed.md", SEED_ISSUES_COMPLETED],
+    ["/gotchas.md", SEED_GOTCHAS],
+    ["/review-patterns.md", SEED_REVIEW_PATTERNS],
+  ] as const) {
+    await client.beta.memoryStores.memories.create(memory.id, {
+      path,
+      content,
+    });
+    console.log(`  ${path}`);
+  }
+
+  console.log(`Creating fixer agent (model: ${FIXER_MODEL})...`);
+  const fixer = await client.beta.agents.create({
+    name: `Wheels Issue Fixer (${ts})`,
+    model: FIXER_MODEL,
+    system: FIXER_SYSTEM,
+    tools: [
+      { type: "agent_toolset_20260401", default_config: { enabled: true } },
+    ],
+    description:
+      "Resolves Wheels framework issues by reading the issue, making the smallest change, and pushing a branch.",
+  });
+  console.log(`  ${fixer.id} (version ${fixer.version})`);
+
+  console.log(`Creating reviewer agent (model: ${REVIEWER_MODEL})...`);
+  const reviewer = await client.beta.agents.create({
+    name: `Wheels PR Reviewer (${ts})`,
+    model: REVIEWER_MODEL,
+    system: REVIEWER_SYSTEM,
+    tools: [
+      { type: "agent_toolset_20260401", default_config: { enabled: true } },
+    ],
+    description:
+      "Reviews Wheels PRs for issue resolution, anti-pattern compliance, and cross-engine compatibility. Outputs structured JSON verdict.",
+  });
+  console.log(`  ${reviewer.id} (version ${reviewer.version})`);
+
+  const env =
+    [
+      `# Generated by tools/issue-resolver/setup.ts at ${new Date().toISOString()}`,
+      `# Delete this file to force recreate Anthropic-side resources (the old ones become orphans).`,
+      `RESOLVER_ENVIRONMENT_ID=${environment.id}`,
+      `RESOLVER_MEMORY_STORE_ID=${memory.id}`,
+      `RESOLVER_FIXER_AGENT_ID=${fixer.id}`,
+      `RESOLVER_FIXER_AGENT_VERSION=${fixer.version}`,
+      `RESOLVER_REVIEWER_AGENT_ID=${reviewer.id}`,
+      `RESOLVER_REVIEWER_AGENT_VERSION=${reviewer.version}`,
+    ].join("\n") + "\n";
+
+  writeFileSync(ENV_FILE, env);
+  console.log(`\nWrote ${ENV_FILE}`);
+  console.log(`Run \`npm run issue-resolver:run\` to start resolving issues.`);
+}
+
+main().catch((err) => {
+  console.error("Setup failed:", err);
+  process.exit(1);
+});

--- a/tools/issue-resolver/tsconfig.json
+++ b/tools/issue-resolver/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": false,
+    "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds a TypeScript orchestrator under `tools/issue-resolver/` that drives Anthropic Managed Agents to triage and fix open GitHub issues. Two persisted agents (fixer + reviewer) share a workspace-scoped memory store for cross-issue learnings.

## Architecture

- **`setup.ts`** — one-time. Creates a cloud environment, a memory store seeded with conventions/gotchas/completed-issues/review-patterns, a fixer agent (Opus 4.7), and a reviewer agent (Sonnet 4.6). Writes IDs to `.env.local` (gitignored).
- **`run.ts`** — per-run. Lists open issues, processes sequentially.
- **`lib/session.ts`** — session lifecycle: stream-first ordering, idle-break gate that distinguishes terminal `stop_reason` from `requires_action`.
- **`lib/github.ts`** — REST + GraphQL helpers for PR creation, review posting, ready-for-review marking, and check-run polling.
- **`lib/config.ts`** — env loader with required-var validation.

## Per-issue flow

1. Fixer session: `github_repository` mounted on `develop` + memory store (read/write).
2. Initial fix turn — agent investigates, makes minimal change, commits, pushes `claude/issue-<N>`.
3. Orchestrator creates draft PR.
4. Review cycle (≤ `MAX_REVIEW_CYCLES`, default 3): fresh reviewer session per cycle, structured JSON verdict parsed from final message, `REQUEST_CHANGES` fed back to the same fixer session.
5. CI poll on the head SHA. On failure, fixer addresses (≤ `MAX_CI_FIX_ATTEMPTS`, default 2).
6. On CI green: PR marked ready for review. **Never auto-merges** — human merge gate by design.

## Memory store

Workspace-scoped, attached to every session. Seeded with framework conventions and gotchas; agents append to `/issues-completed.md` and `/gotchas.md` so later runs benefit from earlier learnings.

## Run

```sh
cp tools/issue-resolver/.env.example tools/issue-resolver/.env
# fill in ANTHROPIC_API_KEY and GITHUB_TOKEN
npm install
npm run issue-resolver:setup        # once — writes .env.local with resource IDs
npm run issue-resolver:run          # iterates all open issues
npm run issue-resolver:run -- 2433  # or filter by issue number(s)
```

## Test plan

- [ ] `npm install` succeeds with new `@anthropic-ai/sdk` + `tsx` deps
- [ ] `npm run issue-resolver:setup` creates env/agents/memory store and writes `.env.local`
- [ ] Run against a single low-risk issue (e.g. a docs/typo) end-to-end: branch pushed, draft PR opened, review verdict parsed, CI polled, PR marked ready
- [ ] Re-running picks up via "skipped (existing PR)" rather than stomping
- [ ] Fixer `SKIP:` path bails cleanly on a deliberately complex issue
- [ ] Review cycles exhaust correctly when reviewer keeps requesting changes

## Notes / known limits

- Sequential by design; parallelizing would require concurrent session quotas + careful per-issue cost caps.
- Agents are persisted, versioned objects — created once at setup, referenced by ID at runtime. Re-running setup after deleting `.env.local` creates fresh resources (orphans are reclaimable via the `ant` CLI).
- Reviewer outputs a JSON verdict block; if parsing fails the orchestrator treats it as `request_changes` (safe default).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_