### PR TITLE
fix: tighten docs-validator prompt + raise turn budget + auto-finalize on edit

### DIFF
--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -104,6 +104,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           WHEELS_DOCS_MODEL: ${{ inputs.model }}
+          WHEELS_DOCS_MAX_TURNS: '24'
           LUCLI_HOME: ${{ runner.temp }}/.wheels
         run: |
           ARGS=(--section "${{ inputs.section }}")
@@ -146,7 +147,7 @@ jobs:
           Agent-driven docs validation for the **${{ inputs.section }}** section.
 
           - Snapshot: `docs/api/v4.0.0.json`
-          - Edits scoped to: `vendor/wheels/**/*.cfc` (docblocks + narrow body fixes) and `vendor/wheels/public/docs/reference/<scope>/<name>.txt`
+          - Edits scoped to: `vendor/wheels/**/*.cfc` (docblocks + narrow body fixes) and `vendor/wheels/public/docs/reference/{scope}/{name}.txt`
           - Per-function status tracked in `tools/docs-validation/state.json`
 
           ## Review checklist

--- a/tools/docs-validation/agent/prompt.md
+++ b/tools/docs-validation/agent/prompt.md
@@ -1,107 +1,164 @@
 # Wheels API Doc Validator
 
-You are validating one Wheels framework function at a time. Your job is to make
-the documentation match the code, write usage examples that actually work, and
-fix narrow code bugs when the function's behavior contradicts its documented
-contract.
+You are validating ONE Wheels framework function. Your output is one
+reference example file plus (rarely) a docblock or body fix in the CFC.
+Stay tight: most functions should finish in 6–10 turns.
 
-## Sources of truth
+## Critical: `wheels cfml` limits
 
-1. **Snapshot** (`docs/api/v4.0.0.json`) — what the framework's
-   self-introspection currently says about every public function. The user
-   message tells you which entry to work on.
-2. **CFC source** (`vendor/wheels/**/*.cfc`) — the actual implementation. The
-   docblock above the function is what the snapshot's `hint` and per-param
-   hints come from.
-3. **Reference examples** (`vendor/wheels/public/docs/reference/<scope>/<name>.txt`)
-   — usage examples that get rendered into the API docs site. May exist or
-   not.
+The `run_bash` tool can call `wheels cfml '<expr>'`, but **`wheels cfml`
+runs CFML in a bare Lucee context with no Wheels framework loaded**.
+That means:
+
+- `wheels cfml 'model("User").findAll()'` — FAILS with "No matching
+  function [MODEL] found". This is **expected**, not a bug. Don't try to
+  validate framework-level calls this way.
+- `wheels cfml 'x = {a:1}; writeOutput(StructKeyExists(x, "a"));'` —
+  WORKS. Plain CFML data structures, control flow, builtin functions.
+
+So `wheels cfml` is a CFML **syntax** validator, not a Wheels semantic
+validator. Use it once or twice at most, and only when you're checking
+that a non-framework expression you wrote (like a struct iteration or a
+CFML built-in call) parses and runs.
+
+**Don't burn turns trying to make `model()` or `findAll()` execute.**
+The reference examples are documentation, not tests — the existing
+ones in `vendor/wheels/public/docs/reference/<scope>/*.txt` aren't
+test-validated either. They demonstrate the API; that's the bar.
 
 ## Workflow per function
 
-1. **Locate the function in source.**
-   - Use `run_bash` with `grep -nR "function <name>(" vendor/wheels/ --include='*.cfc'`
-     to find the file. The function will live in a subdir matching one of its
-     `availableIn` scopes (`vendor/wheels/model/`, `vendor/wheels/controller/`,
-     `vendor/wheels/mapper/`, `vendor/wheels/migrator/`, etc.).
-   - `read_file` on the CFC, focusing on the function and its docblock.
+You're invoked once per function. The user message contains:
+- Source-file candidates (file path + line number — pre-located for you)
+- The existing reference example body, if any
+- The documented hint and parameters from the snapshot
 
-2. **Diff doc vs. code.** Compare the function's actual signature, parameters,
-   defaults, and behavior against the snapshot's `hint`/`parameters`. Look for:
-   - Parameters in code that aren't in the doc (or vice versa).
-   - Defaults that differ between code and docblock.
-   - Hint prose that misstates what the function does.
-   - Param hints that are stale, copy-pasted, or wrong.
+Aim for this turn budget:
 
-3. **Decide direction.** When code and doc disagree:
-   - **Doc wrong, code right** (most common): edit the docblock prose. Use
-     `edit_file` on the CFC. Touch only the docblock comment lines and the
-     `@param` hints — never the function signature or body for this case.
-   - **Doc right, code wrong AND the bug is small AND obvious AND fixable in
-     a few lines without changing the public contract**: edit the body. Then
-     run the relevant test suite (`bash tools/test-local.sh <scope>` where
-     scope is e.g. `model`, `controller`, `view`). If tests fail, revert the
-     edit (using another `edit_file` to put it back) and call
-     `report_outcome` with `status="needs_human"` and notes explaining the
-     suspected bug.
-   - **Both wrong, or unclear which is right, or behavior is intentional**:
-     `report_outcome` with `status="needs_human"`.
+1. **(1 turn)** Read the function source at the candidate path. The user
+   message gives you the line; jump there. If the function spans the
+   docblock + a few hundred lines, that's one `read_file`.
+2. **(0–1 turns)** If you've never seen a Wheels reference example, read
+   ONE for format reference (e.g. `reference/model/findall.txt`). Don't
+   read more than one.
+3. **(0 turns)** Skim the docblock vs. the snapshot's `hint`/`parameters`
+   for drift — you have both in context already, no tool call needed.
+4. **(0–2 turns)** If drift exists, decide direction:
+   - **Doc wrong, code right** (most common): `edit_file` on the CFC,
+     touching only the docblock comment lines or `@param` hints. Never
+     the signature.
+   - **Doc right, code wrong, fix is small (≤5 lines)**: `edit_file` the
+     body. Then run `bash tools/test-local.sh <scope>` (e.g. `model`).
+     If tests fail, revert with another `edit_file`, then
+     `report_outcome status="needs_human"` describing the bug.
+   - **Unclear / intentional / non-trivial**: skip the edit; make the
+     example pragmatic and mark `status="needs_human"` in your final
+     report if a doc/code conflict remains.
+5. **(1 turn)** Draft 1–3 examples. Format: numbered comment headings
+   (`// 1. Basic usage`), one CFML fragment per heading. Mimic the tone
+   of existing references — short, idiomatic, no `<cfcomponent>`
+   wrappers unless the example IS a component definition.
+6. **(0–1 turns, OPTIONAL)** If you're unsure about CFML syntax (not
+   framework calls), `wheels cfml '<expr>'` once to sanity-check. Skip
+   this entirely if the example is straightforward.
+7. **(1 turn)** `write_file` the reference. Path:
+   `vendor/wheels/public/docs/reference/<scope>/<funcname-lowercased>.txt`.
+   Pick the scope from the function's `availableIn` (most specific
+   first; if `availableIn` includes both `controller` and `model`, prefer
+   `controller`).
+8. **(1 turn)** `report_outcome` with `status="done"`. **DO THIS
+   IMMEDIATELY AFTER `write_file`. Do not validate further. Do not
+   re-read the file you just wrote.**
 
-4. **Write or refresh examples.** Read the existing reference body if any
-   (`vendor/wheels/public/docs/reference/<scope>/<name>.txt`). Then:
-   - If none exists, draft 1–3 short examples covering the common shapes
-     (basic usage; one option flag; one association/scope variation if
-     applicable).
-   - If one exists but it's stale (uses removed args, wrong association
-     style, mixed positional+named — see CLAUDE.md anti-patterns), rewrite.
-   - Format: numbered comment headings (`// 1. Basic usage`), one CFML
-     fragment per heading. Look at existing references for tone — short,
-     idiomatic, no boilerplate component wrappers unless needed.
+## Termination is the most important thing
 
-5. **Validate every example.** For each fragment, run
-   `wheels cfml '<expr>'` via `run_bash`. Exit code 0 = compiles. Non-zero =
-   broken example; revise and retry. If `wheels cfml` is not available in
-   the environment, fall back to a careful read-through and note the lack
-   of compile validation in your `report_outcome` notes.
+You have a hard turn budget. If you don't call `report_outcome`, your
+work is recorded as `failed` even when the file you wrote is good.
 
-6. **Write the reference file.** Use `write_file` to save the validated
-   examples to `vendor/wheels/public/docs/reference/<scope>/<name>.txt`.
-   Pick the scope from the function's `availableIn` (prefer the most
-   specific one if multiple).
+**Mandatory pattern at the end of every run:**
 
-7. **Report.** Call `report_outcome` exactly once with:
-   - `status="done"` — examples written and validated, doc agrees with code
-   - `status="needs_human"` — drift requires judgment beyond your scope
-   - `status="failed"` — your validation never passed; describe what broke
+```
+write_file(...)        // step 7
+report_outcome(...)    // step 8 — IMMEDIATELY after write_file
+```
+
+If you find yourself at turn ≥10 and you haven't written the file yet,
+**simplify**: write the smallest plausible idiomatic example you can
+defend and report `status="done"`. Don't pursue perfection at the cost
+of termination.
+
+If you find yourself wanting to re-read a file you've already read,
+**don't**. Trust your context. If you genuinely forgot specific content,
+`grep` for the exact phrase rather than re-reading the whole file.
 
 ## Hard rules
 
 - **Never edit anything outside `vendor/wheels/**/*.cfc` and
-  `vendor/wheels/public/docs/reference/<scope>/<name>.txt`.** The tool layer
-  enforces this; respect it.
+  `vendor/wheels/public/docs/reference/<scope>/<name>.txt`.** The tool
+  layer enforces this — don't fight it.
 - **Never change a function's signature** (name, parameter list, return
-  type). Signature changes are out of scope for this agent.
-- **Never widen behavior** (add new options, new defaults, new public
-  methods). Only narrow bug fixes are allowed.
+  type, default values).
+- **Never widen behavior.** No new options, no new public methods.
 - **No new dependencies, no new files outside the reference store.**
-- **One `report_outcome` call.** It's the terminal action.
-- **Stay tight on tokens.** Read only what you need. Don't dump entire CFCs
-  if you can grep for the function first.
+- **One `report_outcome` call.** It's terminal.
+- **Don't read CLAUDE.md** — the relevant conventions are below.
 
-## Wheels conventions cheat sheet (reference, not exhaustive)
+## Wheels conventions cheat sheet
 
-- Functions in mixin CFCs (e.g. `vendor/wheels/model/read.cfc`) use `public
-  function` access — never `private` (Lucee/Adobe `$integrateComponents()`
-  only copies public into model/controller). Internal helpers use `$` prefix
-  on a public function.
-- Validations and associations take all-named arguments when options are
-  provided: `hasMany(name="orders", dependent="delete")` not
-  `hasMany("orders", dependent="delete")`.
-- View helpers sit in the controller variables scope, so view-related
-  examples often look like controller method calls.
-- Migrations use `NOW()` for cross-database date defaults.
-- `t.timestamps()` adds `createdAt`, `updatedAt`, AND `deletedAt`.
-- Test framework is WheelsTest BDD (`describe`/`it`), NOT RocketUnit.
-- Soft deletes are on by default for models with `deletedAt`.
+Use this instead of reading CLAUDE.md.
 
-When in doubt about idiom, `read_file` `CLAUDE.md` for the canonical style.
+**Naming**
+- Models: singular PascalCase (`User.cfc`); table name plural lowercase (`users`)
+- Controllers: plural PascalCase (`Users.cfc`)
+- Reference file paths: lowercased (`reference/model/findall.txt`)
+
+**Argument styles** (the #1 source of bugs)
+- Mixing positional and named in framework helpers fails. Either all
+  positional, or all named once any option is given:
+  - `hasMany("comments")` ✓
+  - `hasMany(name="comments", dependent="delete")` ✓
+  - `hasMany("comments", dependent="delete")` ✗ MIXED — broken
+  - `validatesPresenceOf("name")` ✓
+  - `validatesPresenceOf(properties="name", message="Required")` ✓
+
+**Model finders**
+- `model("User").findAll()` returns a query object by default; pass
+  `returnAs="objects"` for an array of model objects.
+- Loop in views: `<cfloop query="users">#users.firstName#</cfloop>` —
+  query, not array.
+
+**Controller / view shape**
+- View helpers run in the controller's variables scope. Examples that
+  call `linkTo()`, `emailField()` etc. are valid in views and in
+  controller-context expressions.
+
+**Migrations**
+- Use `NOW()` for cross-database date defaults (works on MySQL,
+  Postgres, SQL Server, H2, SQLite).
+- `t.timestamps()` adds three columns: `createdAt`, `updatedAt`,
+  `deletedAt`. Don't add separate datetime columns for those.
+- Bulk seed data: use literal SQL, not parameterized
+  (`execute("INSERT INTO ... VALUES ('admin', NOW(), NOW())")`).
+
+**Routes**
+- Order: MCP → resources → custom named → root → wildcard (last).
+- Nested resources via callback or `nested=true ... .end()` — never
+  Rails-style inline blocks.
+
+**Test framework**
+- Tests use WheelsTest BDD (`describe(...)`, `it(...)`). Tests extend
+  `wheels.WheelsTest`. The legacy RocketUnit (`assert()`,
+  `function test_...`) is gone.
+
+**Soft deletes**
+- Models with a `deletedAt` column are soft-deleted by default;
+  `findAll()` excludes them. Pass `includeSoftDeletes=true` to fetch
+  them.
+
+**Filters**
+- Controller filters (auth, data loading) declared in `config()` MUST
+  be `private` — public filter functions become routable actions by
+  accident.
+
+If a convention you need isn't here, prefer reading 1–2 sentences from
+an existing reference file in the same `<scope>` rather than CLAUDE.md.

--- a/tools/docs-validation/lib/agent.mjs
+++ b/tools/docs-validation/lib/agent.mjs
@@ -80,7 +80,7 @@ export async function runAgentForFunction(fn, { logger = console.log } = {}) {
   const client = new Anthropic();
   const system = await getSystemPrompt();
   const outcome = { value: null };
-  const runState = { filesChanged: new Set() };
+  const runState = { filesChanged: new Set(), referencesWritten: new Set() };
   const exec = makeExecutor({ outcome, runState });
 
   const messages = [{ role: 'user', content: await userPayload(fn) }];
@@ -133,17 +133,30 @@ export async function runAgentForFunction(fn, { logger = console.log } = {}) {
 
   if (!outcome.value) {
     const filesChanged = [...runState.filesChanged];
-    if (filesChanged.length > 0) {
+    const refsWritten = [...runState.referencesWritten];
+    const exhausted = turn >= MAX_TURNS;
+    const cause = exhausted
+      ? `exhausted turn budget (${MAX_TURNS})`
+      : `stopped at turn ${turn}/${MAX_TURNS} (model returned no tool_use)`;
+
+    if (refsWritten.length > 0) {
       outcome.value = {
         status: 'done',
-        summary: `Auto-finalized: agent wrote ${filesChanged.length} file(s) but exhausted turn budget (${MAX_TURNS}) before calling report_outcome.`,
+        summary: `Auto-finalized: agent wrote ${refsWritten.length} reference file(s) but ${cause} before calling report_outcome.`,
         files_changed: filesChanged,
-        notes: 'auto_finalized=true; review the diff carefully — agent did not self-validate before timing out.',
+        notes: `auto_finalized=true; review the diff carefully — agent did not self-validate before stopping. references=${refsWritten.join(',')}`,
+      };
+    } else if (filesChanged.length > 0) {
+      outcome.value = {
+        status: 'needs_human',
+        summary: `Edits made to ${filesChanged.length} file(s) but no reference example was written; ${cause} before report_outcome.`,
+        files_changed: filesChanged,
+        notes: `auto_finalized=true; CFC-only edits without a reference write. Possible causes: edit→revert flow, partial work, or agent stopped early. Review and decide.`,
       };
     } else {
       outcome.value = {
         status: 'failed',
-        summary: `Agent did not call report_outcome within ${MAX_TURNS} turns and produced no file edits.`,
+        summary: `Agent did not call report_outcome and produced no file edits; ${cause}.`,
         files_changed: [],
         notes: '',
       };

--- a/tools/docs-validation/lib/agent.mjs
+++ b/tools/docs-validation/lib/agent.mjs
@@ -80,7 +80,8 @@ export async function runAgentForFunction(fn, { logger = console.log } = {}) {
   const client = new Anthropic();
   const system = await getSystemPrompt();
   const outcome = { value: null };
-  const exec = makeExecutor({ outcome });
+  const runState = { filesChanged: new Set() };
+  const exec = makeExecutor({ outcome, runState });
 
   const messages = [{ role: 'user', content: await userPayload(fn) }];
   let turn = 0;
@@ -131,12 +132,22 @@ export async function runAgentForFunction(fn, { logger = console.log } = {}) {
   }
 
   if (!outcome.value) {
-    outcome.value = {
-      status: 'failed',
-      summary: `Agent did not call report_outcome within ${MAX_TURNS} turns.`,
-      files_changed: [],
-      notes: '',
-    };
+    const filesChanged = [...runState.filesChanged];
+    if (filesChanged.length > 0) {
+      outcome.value = {
+        status: 'done',
+        summary: `Auto-finalized: agent wrote ${filesChanged.length} file(s) but exhausted turn budget (${MAX_TURNS}) before calling report_outcome.`,
+        files_changed: filesChanged,
+        notes: 'auto_finalized=true; review the diff carefully — agent did not self-validate before timing out.',
+      };
+    } else {
+      outcome.value = {
+        status: 'failed',
+        summary: `Agent did not call report_outcome within ${MAX_TURNS} turns and produced no file edits.`,
+        files_changed: [],
+        notes: '',
+      };
+    }
   }
 
   return { outcome: outcome.value, usage, turns: turn };

--- a/tools/docs-validation/lib/tools.mjs
+++ b/tools/docs-validation/lib/tools.mjs
@@ -123,7 +123,10 @@ export function makeExecutor({ outcome, runState }) {
     if (name === 'read_file') return doRead(input.path);
     if (name === 'write_file') {
       const r = await doWrite(input.path, input.content);
-      if (r.ok && runState) runState.filesChanged.add(r.path);
+      if (r.ok && runState) {
+        runState.filesChanged.add(r.path);
+        runState.referencesWritten.add(r.path);
+      }
       return r;
     }
     if (name === 'edit_file') {

--- a/tools/docs-validation/lib/tools.mjs
+++ b/tools/docs-validation/lib/tools.mjs
@@ -118,11 +118,19 @@ export const TOOLS = [
   },
 ];
 
-export function makeExecutor({ outcome }) {
+export function makeExecutor({ outcome, runState }) {
   return async function execute(name, input) {
     if (name === 'read_file') return doRead(input.path);
-    if (name === 'write_file') return doWrite(input.path, input.content);
-    if (name === 'edit_file') return doEdit(input.path, input.old_string, input.new_string);
+    if (name === 'write_file') {
+      const r = await doWrite(input.path, input.content);
+      if (r.ok && runState) runState.filesChanged.add(r.path);
+      return r;
+    }
+    if (name === 'edit_file') {
+      const r = await doEdit(input.path, input.old_string, input.new_string);
+      if (r.ok && runState) runState.filesChanged.add(r.path);
+      return r;
+    }
     if (name === 'run_bash') return doBash(input.command, input.timeout_seconds);
     if (name === 'report_outcome') {
       outcome.value = {


### PR DESCRIPTION
## Summary

The first real agent run (PR #2446) produced a usable reference example but failed at turn 16 without calling `report_outcome`. The 16-turn transcript broke down as:

| Turns | What happened |
| --- | --- |
| 1–9 | Read source, list/read existing examples — productive |
| **10** | **`wheels cfml 'info = model("user").associationInfo();'` → "No matching function [MODEL] found"** |
| 11–14 | Burned 4 turns trying to validate by hand-simulating the return value (clever but wasteful) |
| 15 | Re-read example files it had already read |
| 16 | Wrote the reference file — no budget left for `report_outcome` |

This PR fixes the three contributing causes.

### 1. Prompt: clarify what `wheels cfml` can and can't do

The existing `verify-docs` harness uses `wheels cfml` as a CFML **syntax** validator. It can't run framework functions (`model()`, `findAll()`, etc.) because there's no Wheels app loaded. Old prompt told the agent to "validate every example" via `wheels cfml`. New prompt:

- Calls out the limitation explicitly with examples of what works and what doesn't
- Demotes `wheels cfml` to "optional CFML-syntax sanity check, max once"
- Notes that existing reference examples in `vendor/wheels/public/docs/reference/` aren't test-validated either — they're documentation
- Adds a "termination is the most important thing" section forcing `write_file → report_outcome` as a mandatory pattern
- Adds a "if you find yourself wanting to re-read a file, don't" rule
- Bakes the relevant CLAUDE.md conventions inline so the agent doesn't burn a turn on a 51KB read

### 2. Turn budget 16 → 24

Env var bump in the workflow. Headroom for safety, not because the loop should need it after the prompt fixes (target is 6–10 turns per function).

### 3. Auto-finalize fallback in `agent.mjs`

When the turn budget runs out, check whether the agent wrote/edited any files via the tool layer. If yes, auto-record `status="done"` with `notes: "auto_finalized=true; review the diff carefully — agent did not self-validate before timing out."` instead of `failed`. This salvages real work in the case PR #2446 hit.

### Cosmetic

PR-body template substitutes `{scope}/{name}` placeholders instead of `<scope>/<name>`, since GitHub's markdown renderer strips the angle brackets even inside backticks.

## Test plan

- [ ] After merge, redispatch on `Model Class` with `limit=1`. Expect `associationInfo` to retry (it's marked `failed` on develop's empty state.json — wait, actually develop's state.json is empty since #2446 didn't merge, so the rerun starts fresh).
- [ ] Verify the agent finishes in ≤10 turns and calls `report_outcome` with `status="done"`.
- [ ] Verify cost per function drops below $0.30.
- [ ] If the agent still times out for some reason, confirm `state.json` records `status: done` with `auto_finalized=true` notes — not `failed`.

https://claude.ai/code/session_014puccJJixwdjRgMx7mPLmz

---
_Generated by [Claude Code](https://claude.ai/code/session_014puccJJixwdjRgMx7mPLmz)_