### PR TITLE
fix: prefix reference-examples path with slash so /wheels mapping resolves

### DIFF
--- a/vendor/wheels/public/helpers.cfm
+++ b/vendor/wheels/public/helpers.cfm
@@ -472,7 +472,7 @@ struct function $parseMetaData(required struct meta, required string doctype, re
 		}
 	}
 	// Check for extended documentation: note this is not looked for by slug, i.e. controller/humanize.txt
-	local.rv["extended"] = $getExtendedCodeExamples("wheels/public/docs/reference/", local.rv.slug);
+	local.rv["extended"] = $getExtendedCodeExamples("/wheels/public/docs/reference/", local.rv.slug);
 	return local.rv;
 }
 


### PR DESCRIPTION
## Summary

`$getExtendedCodeExamples()` at `vendor/wheels/public/helpers.cfm:475` was called with `"wheels/public/docs/reference/"` — no leading slash. Without it, `ExpandPath()` resolves relative to the currently-executing template instead of going through the `/wheels` mapping, so `FileExists()` returns false for every reference file. Result: every v4 function gets `extended.hasExtended: false` in the API JSON snapshot, and `api.wheels.dev/v4-0-0-snapshot/*` renders Signature / Description / Parameters but never Examples — even though 245 reference `.txt` files exist under `vendor/wheels/public/docs/reference/`.

The v3 snapshot wasn't affected because its MD pages were generated once and committed at v3 release time. The v4-snapshot is regenerated on every push to develop and depends on the live snapshot pipeline picking up the examples — which it can't, due to this path resolution bug.

The leading slash forces Lucee to honor the `/wheels` mapping defined in `tools/ci/lucee.ci.json` (and equivalent mappings in user apps).

## Evidence

```bash
$ jq '[.functions[] | {name, hasExt: .extended.hasExtended}] | group_by(.hasExt) | map({key: .[0].hasExt, count: length})' docs/api/v3.0.0.json
[{"key": false, "count": 2}, {"key": true, "count": 307}]

$ jq '...' docs/api/v2.5.0.json
[{"key": false, "count": 74}, {"key": true, "count": 235}]

$ jq '...' docs/api/v4.0.0.json
[{"key": false, "count": 378}]                            # <- regression
```

A spot check on the live site confirms it's not just the agent-authored example that's missing — `findAll`, `count`, `create`, `deleteByKey`, and `average` all have reference files on disk and all render no Examples section on `https://api.wheels.dev/v4-0-0-snapshot/model-class/{name}/`.

## Test plan

- [ ] Snapshot.yml runs on merge → fast-test job produces `v4.0.0-snapshot.json`
- [ ] Verify `hasExtended: true` count is ~245 (matching the number of `.txt` files in `vendor/wheels/public/docs/reference/`):
  ```bash
  gh run download <run-id> -n api-docs-snapshot -D /tmp/snap
  jq '[.functions[] | {name, hasExt: .extended.hasExtended}] | group_by(.hasExt) | map({key: .[0].hasExt, count: length})' /tmp/snap/v4.0.0-snapshot.json
  ```
- [ ] Confirm `api.wheels.dev/v4-0-0-snapshot/model-class/associationinfo/` renders the Examples section after deploy completes
- [ ] Spot check `api.wheels.dev/v4-0-0-snapshot/model-class/findall/` also has Examples

## Risk

Low — one character change at a single call site. The function still works the same way; we're just ensuring the input path is unambiguous to `ExpandPath()`. If anything were to break, the v4 snapshot would simply remain in its current (broken) state. The `/wheels` mapping is canonical for both CI and user apps.

https://claude.ai/code/session_014puccJJixwdjRgMx7mPLmz

---
_Generated by [Claude Code](https://claude.ai/code/session_014puccJJixwdjRgMx7mPLmz)_