### PR TITLE
docs: lock in agent example-style conventions (camelCase, no HTML)

### DIFF
--- a/tools/docs-validation/agent/prompt.md
+++ b/tools/docs-validation/agent/prompt.md
@@ -107,6 +107,29 @@ If you find yourself wanting to re-read a file you've already read,
 
 Use this instead of reading CLAUDE.md.
 
+**Reference example style** (lock these in for every example you write)
+- **camelCase for ALL CFML builtins.** `writeOutput`, `arrayLen`,
+  `structKeyExists`, `listFindNoCase`, `listToArray`, `isStruct`,
+  `arrayToList`, `serializeJSON`, etc. CFML is case-insensitive but
+  the docs render exactly what you write — pick one casing per file
+  and stay consistent.
+- **No HTML output in examples.** Don't write `writeOutput("...<br>")`
+  or other HTML tags. To demonstrate return shapes, use a CFML
+  comment block above or after the call:
+  ```
+  // 1. Get the columns for the User model
+  cols = model("User").columns();
+  // cols -> "id,firstName,lastName,email,createdAt,updatedAt"
+  ```
+  When iteration is the point, just iterate; the example doesn't need
+  to "render" anything. If output really matters for the demo, use
+  `writeOutput(value)` (no HTML) or assign to a variable.
+- **Numbered comment headings** for each example: `// 1. <one-line
+  description>`, `// 2. ...`. One CFML fragment per heading.
+- **Mimic existing files in the same scope** for tone — short,
+  idiomatic, no `<cfcomponent>` wrappers unless the example IS a
+  component definition.
+
 **Naming**
 - Models: singular PascalCase (`User.cfc`); table name plural lowercase (`users`)
 - Controllers: plural PascalCase (`Users.cfc`)


### PR DESCRIPTION
## Summary

Two stylistic inconsistencies surfaced in PR #2450 (the first 5-function batch from the agent):

1. **Mixed casing of CFML builtins** within the same file — e.g. `WriteOutput` alongside `writeOutput`, `ArrayLen` alongside `arrayLen`. CFML is case-insensitive so behavior was correct, but the rendered API docs are visibly inconsistent. Locking in **camelCase** to match the framework's docblock conventions and most of the existing v3 references.

2. **HTML output in examples** — every iteration sample used `writeOutput(value & "<br>")` to render browser-readable output. The existing v3 reference files mostly avoid this pattern. The reference files demonstrate API shape, not rendering. Switching to **CFML comment blocks** for return-shape demos:
   ```
   // 1. Get the columns for the User model
   cols = model("User").columns();
   // cols -> "id,firstName,lastName,email,createdAt,updatedAt"
   ```

Adds a "Reference example style" subsection at the top of the conventions cheat sheet the agent loads (instead of reading CLAUDE.md). Doesn't change the workflow steps — just augments the style reference.

## Test plan

- [ ] Re-dispatch one batch (`limit=5`) on Model Class. Verify generated examples use camelCase exclusively and no `<br>` / `writeOutput("...<br>")` patterns.
- [ ] Eyeball one of the existing PR #2450 examples (e.g. `callbackinfo.txt`) and confirm the new prompt would produce a cleaner version on a re-run.

## Risk

None. Prompt-only change; no framework code, no workflow plumbing. Already-merged examples stay as-is — if you want to reformat them retroactively, it's a separate cleanup pass.

https://claude.ai/code/session_014puccJJixwdjRgMx7mPLmz

---
_Generated by [Claude Code](https://claude.ai/code/session_014puccJJixwdjRgMx7mPLmz)_