### PR TITLE
ci: expose --force input on docs-validation dispatch

### DIFF
--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -31,6 +31,11 @@ on:
         required: false
         type: boolean
         default: false
+      force:
+        description: 'Re-run already-done functions (overwrites their state.json entries)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -96,7 +101,15 @@ jobs:
       - name: List targets (dry-run)
         if: ${{ inputs.dry_run }}
         working-directory: tools/docs-validation
-        run: node orchestrate.mjs --section "${{ inputs.section }}" --dry-run
+        run: |
+          ARGS=(--section "${{ inputs.section }}" --dry-run)
+          if [[ -n "${{ inputs.limit }}" ]]; then
+            ARGS+=(--limit "${{ inputs.limit }}")
+          fi
+          if [[ "${{ inputs.force }}" == "true" ]]; then
+            ARGS+=(--force)
+          fi
+          node orchestrate.mjs "${ARGS[@]}"
 
       - name: Run agent
         if: ${{ !inputs.dry_run }}
@@ -110,6 +123,9 @@ jobs:
           ARGS=(--section "${{ inputs.section }}")
           if [[ -n "${{ inputs.limit }}" ]]; then
             ARGS+=(--limit "${{ inputs.limit }}")
+          fi
+          if [[ "${{ inputs.force }}" == "true" ]]; then
+            ARGS+=(--force)
           fi
           node orchestrate.mjs "${ARGS[@]}"
 


### PR DESCRIPTION
## Summary

`orchestrate.mjs` already accepts `--force` to override the `shouldAttempt()` filter (which treats `done` as terminal). The workflow didn't expose it, so re-running an already-done function to pick up new prompt rules required hand-editing `state.json`.

This PR adds a `force` boolean input (default `false`) and wires it through to both the dry-run and live agent steps.

## Use case driving this

PR #2451 added new style conventions (camelCase CFML builtins; no HTML in examples). The 6 functions already validated in PRs #2448 + #2450 don't follow those conventions. After this lands, you can re-author them with one dispatch:

```bash
gh workflow run docs-validation.yml --ref develop \
  -f section="Model Class" -f limit=6 -f force=true -f dry_run=false
```

## Test plan

- [ ] Dispatch with `force=true` and `dry_run=true` first to confirm the queue includes already-done functions
- [ ] Then live dispatch with `force=true -f limit=6` to re-author `associationInfo`, `associationNames`, `average`, `callbackInfo`, `classInfo`, `columnDataForProperty`
- [ ] Verify the new examples use camelCase exclusively and contain no `<br>` HTML output

## Risk

None — orchestrator-side flag is unchanged; just a new opt-in input on the workflow.

https://claude.ai/code/session_014puccJJixwdjRgMx7mPLmz

---
_Generated by [Claude Code](https://claude.ai/code/session_014puccJJixwdjRgMx7mPLmz)_