### PR TITLE
docs: fix injector() reference example to use real DI container API

### DIFF
--- a/vendor/wheels/public/docs/reference/controller/injector.txt
+++ b/vendor/wheels/public/docs/reference/controller/injector.txt
@@ -1,11 +1,18 @@
-// 1. Get the DI container and register a service binding
+// 1. Register a singleton service in `config/services.cfm` (one instance per app lifetime)
 di = injector();
-di.register(name="emailService", component="app.services.EmailService");
+di.map("emailService").to("app.lib.EmailService").asSingleton();
 
-// 2. Register a singleton service with constructor arguments (typical config/services.cfm usage)
+// 2. Bind an interface name to a concrete implementation
 di = injector();
-di.register(name="paymentGateway", component="app.services.StripeGateway", singleton=true, initArguments={apiKey=env("STRIPE_KEY")});
+di.bind("INotifier").to("app.lib.SlackNotifier").asSingleton();
 
-// 3. Retrieve the container to inspect or manipulate registrations at runtime
+// 3. Register a request-scoped service (one instance per HTTP request)
 di = injector();
-writeOutput(di.containsInstance("emailService")); // true or false
+di.map("currentUser").to("app.lib.CurrentUserResolver").asRequestScoped();
+
+// 4. Inspect or resolve at runtime
+di = injector();
+if (di.containsInstance("emailService")) {
+    mailer = di.getInstance("emailService");
+    mailer.send(to="user@example.com", subject="Welcome");
+}


### PR DESCRIPTION
## Summary

The agent-authored `injector()` reference example in PR #2455 used `di.register(name=..., component=...)` which is not a method on `vendor/wheels/Injector.cfc`. The actual public API is the fluent chain:

- `di.map("name").to("component.path").asSingleton()`
- `di.bind("name").to("component.path").asSingleton()` (semantic alias)
- `di.map("name").to("component.path").asRequestScoped()`

Plus introspection via `containsInstance()` and direct resolution via `getInstance()`.

The agent inferred the API from the `injector()` function name + its docblock without reading `Injector.cfc`. The new examples match `vendor/wheels/Injector.cfc` and CLAUDE.md's documented DI patterns.

## Diff

Replaces four made-up `register()` calls with four examples covering:
1. `map().to().asSingleton()` — basic singleton registration
2. `bind().to().asSingleton()` — interface binding
3. `asRequestScoped()` — per-request lifetime
4. `containsInstance()` + `getInstance()` — runtime introspection

## Why this slipped through

The agent's prompt tells it to read the function source, which it did — but `injector()` in `Global.cfc` just returns `application.wheelsdi`. The agent didn't follow the returned type to inspect what methods are available on the container, so it fabricated a plausible-looking API based on the function name.

Worth a future prompt tweak: when a function returns an object (controller, model, injector, etc.), encourage the agent to also read the returned type's source to ground the example in real method names. Out of scope here.

## Risk

None. Single reference file, no framework code touched. The previous (incorrect) example was a runtime no-op anyway since `register()` doesn't exist — anyone copy-pasting it would have hit a clear error.

https://claude.ai/code/session_014puccJJixwdjRgMx7mPLmz

---
_Generated by [Claude Code](https://claude.ai/code/session_014puccJJixwdjRgMx7mPLmz)_