### PR TITLE
docs: tell agent to read returned-type source for object-returning helpers

### DIFF
--- a/tools/docs-validation/agent/prompt.md
+++ b/tools/docs-validation/agent/prompt.md
@@ -38,6 +38,30 @@ Aim for this turn budget:
 1. **(1 turn)** Read the function source at the candidate path. The user
    message gives you the line; jump there. If the function spans the
    docblock + a few hundred lines, that's one `read_file`.
+
+   **If the function returns an object** (e.g. `injector()` returns the
+   DI container, `controller(name)` returns a controller object,
+   `model(name)` returns a model class, `findByKey()` returns a model
+   instance), **also `read_file` the returned type's source** to
+   discover the real method names you'll call in your example. Don't
+   guess method names from the function name. Common return types and
+   where they live:
+   - `injector()` → `vendor/wheels/Injector.cfc`
+   - `controller(name)` → `vendor/wheels/Controller.cfc` (composed from
+     `vendor/wheels/controller/*.cfc` mixins)
+   - `model(name)` → `vendor/wheels/Model.cfc` (composed from
+     `vendor/wheels/model/*.cfc` mixins)
+   - `findByKey()` / `findOne()` → returns a model object — the
+     instance methods come from the same `vendor/wheels/model/*.cfc`
+     mixins
+   - `service(name)` → returns a user-defined service class (no
+     framework methods to verify; look at how other reference examples
+     use it)
+
+   Skip this extra read for functions that return primitives or
+   structs (most string/util functions, `count()`, `findAll()` returning
+   a query, etc.) — the function source is enough.
+
 2. **(0–1 turns)** If you've never seen a Wheels reference example, read
    ONE for format reference (e.g. `reference/model/findall.txt`). Don't
    read more than one.


### PR DESCRIPTION
## Summary

Follow-up to PR #2457. Adds a prompt sub-step that tells the agent: when the function being documented returns an object (not a primitive or struct), also read the returned type's source to ground the example in real method names.

## Why

The agent's first `injector()` reference example (PR #2455) used a fabricated `di.register(...)` API. Root cause: the agent read `Global.cfc` (where `injector()` just returns `application.wheelsdi`) but didn't follow through to `vendor/wheels/Injector.cfc` to discover what methods are actually on the container. It guessed plausible names from the function signature.

Same failure mode would apply to:
- `controller(name)` → fabricated controller methods
- `model(name)` → fabricated model class methods
- `findByKey()` / `findOne()` → fabricated model instance methods

The new prompt section enumerates the common object-returning helpers (`injector`, `controller`, `model`, finders, `service`) and where the real methods live. For primitive/struct-returning functions, the extra read is skipped.

## Test plan

The next dispatch on a section that includes object-returning functions (View Helpers has `linkTo`, `formTag` etc.; Controller has many) will exercise this. If the agent now reads `vendor/wheels/view/links.cfc` etc. when documenting them, the prompt is working.

## Risk

None — prompt-only change. Agent will use 1 more turn per object-returning function on average. Cost impact: negligible (~$0.05 extra per affected function).

https://claude.ai/code/session_014puccJJixwdjRgMx7mPLmz

---
_Generated by [Claude Code](https://claude.ai/code/session_014puccJJixwdjRgMx7mPLmz)_