### PR TITLE
ci: bump docs-validation job timeout to 240 minutes for View Helpers run

### DIFF
--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -48,7 +48,7 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 240
 
     steps:
       - name: Checkout dispatching ref


### PR DESCRIPTION
## Summary

Bumps `timeout-minutes` on the `docs-validation` workflow's `validate` job from 90 to 240 so the upcoming **View Helpers** section (88 functions, projected ~140 min at the current ~5 turns × ~30s/turn + ~3 min Linuxbrew/Node setup) can complete in a single dispatch.

The previous 7 sections all finished well under 90 min, so this change only affects the one outlier and is otherwise inert.

## Test plan

After merge, dispatch View Helpers:
```bash
gh workflow run docs-validation.yml --ref develop \
  -f section="View Helpers" -f dry_run=false
```

Expected to finish in 2–3 hours and open one PR with all 88 functions validated.

## Risk

None. Pure timeout extension. GitHub Actions billing is per-minute used, not per-minute allocated, so this doesn't change cost — only allows longer runs.

https://claude.ai/code/session_014puccJJixwdjRgMx7mPLmz

---
_Generated by [Claude Code](https://claude.ai/code/session_014puccJJixwdjRgMx7mPLmz)_