### PR TITLE
feat: add guide-mode to docs-validation agent system

### DIFF
--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -3,10 +3,19 @@ name: Docs validation (agent)
 on:
   workflow_dispatch:
     inputs:
-      section:
-        description: 'API section to validate'
+      mode:
+        description: 'Validation mode'
         required: true
         type: choice
+        default: 'api'
+        options:
+          - 'api'
+          - 'guide'
+      section:
+        description: '[api mode] API section to validate (ignored in guide mode)'
+        required: false
+        type: choice
+        default: 'Model Class'
         options:
           - 'Configuration'
           - 'Controller'
@@ -16,8 +25,23 @@ on:
           - 'Model Configuration'
           - 'Model Object'
           - 'View Helpers'
+      directory:
+        description: '[guide mode] Top-level guides directory to validate (ignored in api mode)'
+        required: false
+        type: choice
+        default: 'upgrading'
+        options:
+          - 'basics'
+          - 'command-line-tools'
+          - 'contributing'
+          - 'core-concepts'
+          - 'deployment'
+          - 'digging-deeper'
+          - 'start-here'
+          - 'testing'
+          - 'upgrading'
       limit:
-        description: 'Max functions to validate this run (blank = all pending)'
+        description: 'Max items to validate this run (blank = all pending)'
         required: false
         type: string
         default: ''
@@ -32,7 +56,7 @@ on:
         type: boolean
         default: false
       force:
-        description: 'Re-run already-done functions (overwrites their state.json entries)'
+        description: 'Re-run already-done items (overwrites their state.json entries)'
         required: false
         type: boolean
         default: false
@@ -42,7 +66,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: docs-validation-${{ inputs.section }}
+  group: docs-validation-${{ inputs.mode }}-${{ inputs.section || inputs.directory }}
   cancel-in-progress: false
 
 jobs:
@@ -52,10 +76,6 @@ jobs:
 
     steps:
       - name: Checkout dispatching ref
-        # We check out the ref this workflow was dispatched against (typically
-        # `develop` once merged, but a feature branch during initial testing).
-        # The agent's edits land in a per-run branch derived from this ref;
-        # the resulting PR always targets `develop`.
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -68,6 +88,17 @@ jobs:
       - name: Install tools/docs-validation deps
         working-directory: tools/docs-validation
         run: npm ci --no-audit --no-fund
+
+      - name: Set up pnpm
+        if: ${{ inputs.mode == 'guide' }}
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.23.0
+
+      - name: Install web pnpm deps (for verify-docs harness in guide mode)
+        if: ${{ inputs.mode == 'guide' }}
+        working-directory: web
+        run: pnpm install --frozen-lockfile
 
       - name: Set up Linuxbrew
         uses: Homebrew/actions/setup-homebrew@master
@@ -86,11 +117,22 @@ jobs:
       - name: Warm up wheels module
         run: wheels --version >/dev/null
 
-      - name: Compute branch name
+      - name: Compute branch name + commit message
         id: branch
         run: |
-          slug=$(echo "${{ inputs.section }}" | tr '[:upper:] ' '[:lower:]-')
-          echo "name=docs-validation/${slug}-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+          if [[ "${{ inputs.mode }}" == "guide" ]]; then
+            slug=$(echo "${{ inputs.directory }}" | tr '[:upper:] ' '[:lower:]-')
+            echo "name=docs-validation/guide-${slug}-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+            echo "title=docs(guides): validate ${{ inputs.directory }} directory" >> "$GITHUB_OUTPUT"
+            echo "msg=docs(guides): validate ${{ inputs.directory }} directory (run ${{ github.run_id }})" >> "$GITHUB_OUTPUT"
+            echo "label=${{ inputs.directory }} directory" >> "$GITHUB_OUTPUT"
+          else
+            slug=$(echo "${{ inputs.section }}" | tr '[:upper:] ' '[:lower:]-')
+            echo "name=docs-validation/${slug}-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+            echo "title=docs(api): validate ${{ inputs.section }} section" >> "$GITHUB_OUTPUT"
+            echo "msg=docs(api): validate ${{ inputs.section }} section (run ${{ github.run_id }})" >> "$GITHUB_OUTPUT"
+            echo "label=${{ inputs.section }} section" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Configure git
         run: |
@@ -102,7 +144,12 @@ jobs:
         if: ${{ inputs.dry_run }}
         working-directory: tools/docs-validation
         run: |
-          ARGS=(--section "${{ inputs.section }}" --dry-run)
+          ARGS=(--mode "${{ inputs.mode }}" --dry-run)
+          if [[ "${{ inputs.mode }}" == "guide" ]]; then
+            ARGS+=(--directory "${{ inputs.directory }}")
+          else
+            ARGS+=(--section "${{ inputs.section }}")
+          fi
           if [[ -n "${{ inputs.limit }}" ]]; then
             ARGS+=(--limit "${{ inputs.limit }}")
           fi
@@ -119,8 +166,14 @@ jobs:
           WHEELS_DOCS_MODEL: ${{ inputs.model }}
           WHEELS_DOCS_MAX_TURNS: '24'
           LUCLI_HOME: ${{ runner.temp }}/.wheels
+          WHEELS_FRAMEWORK_PATH: ${{ github.workspace }}/vendor/wheels
         run: |
-          ARGS=(--section "${{ inputs.section }}")
+          ARGS=(--mode "${{ inputs.mode }}")
+          if [[ "${{ inputs.mode }}" == "guide" ]]; then
+            ARGS+=(--directory "${{ inputs.directory }}")
+          else
+            ARGS+=(--section "${{ inputs.section }}")
+          fi
           if [[ -n "${{ inputs.limit }}" ]]; then
             ARGS+=(--limit "${{ inputs.limit }}")
           fi
@@ -147,8 +200,7 @@ jobs:
             exit 0
           fi
           git add -A
-          MSG="docs(api): validate ${{ inputs.section }} section (run ${{ github.run_id }})"
-          git commit -m "$MSG"
+          git commit -m "${{ steps.branch.outputs.msg }}"
           git push -u origin "${{ steps.branch.outputs.name }}"
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
@@ -160,15 +212,16 @@ jobs:
           BODY=$(cat <<'EOF'
           ## Summary
 
-          Agent-driven docs validation for the **${{ inputs.section }}** section.
+          Agent-driven docs validation for the **${{ steps.branch.outputs.label }}**.
 
-          - Snapshot: `docs/api/v4.0.0.json`
-          - Edits scoped to: `vendor/wheels/**/*.cfc` (docblocks + narrow body fixes) and `vendor/wheels/public/docs/reference/{scope}/{name}.txt`
-          - Per-function status tracked in `tools/docs-validation/state.json`
+          - Mode: `${{ inputs.mode }}`
+          - Edit scope (api mode): `vendor/wheels/**/*.cfc` (docblocks + narrow body fixes) and `vendor/wheels/public/docs/reference/{scope}/{name}.txt`
+          - Edit scope (guide mode): `web/sites/guides/src/content/docs/v4-0-0-snapshot/**/*.mdx?` and `vendor/wheels/**/*.cfc` (docblock prose only)
+          - Per-item status tracked in `tools/docs-validation/state.json`
 
           ## Review checklist
 
-          - [ ] Each `state.json` entry with `status: done` has a sensible reference example file added or updated
+          - [ ] Each `state.json` entry with `status: done` has the corresponding reference file (api) or annotated guide page (guide)
           - [ ] No CFC function signature changes (agent is forbidden from changing them — verify anyway)
           - [ ] Any docblock/body edits hold up against the test suite
           - [ ] `state.json` items with `status: needs_human` describe the open question in `notes`
@@ -177,7 +230,7 @@ jobs:
           gh pr create \
             --base develop \
             --head "${{ steps.branch.outputs.name }}" \
-            --title "docs(api): validate ${{ inputs.section }} section" \
+            --title "${{ steps.branch.outputs.title }}" \
             --body "$BODY" \
             --draft
 

--- a/tools/docs-validation/README.md
+++ b/tools/docs-validation/README.md
@@ -1,45 +1,59 @@
 # tools/docs-validation
 
-Per-function and per-guide-page documentation validation, run by Claude
-agents. The agent reads `docs/api/v4.0.0.json` (the framework's live
-self-introspection), walks the listed functions, and for each one:
+Agent-driven docs validation. Two modes:
 
-1. Reads the CFC source for the function in `vendor/wheels/`.
-2. Reads any existing example body in
-   `vendor/wheels/public/docs/reference/<scope>/<name>.txt`.
-3. Validates samples by compiling them with `wheels cfml` (existing
-   `verify-docs` harness primitive) or by running them through a fresh
-   fixture app (also reused from `verify-docs`).
-4. Reconciles the docblock prose in the CFC against actual behavior.
-   When the body is genuinely buggy and the documented contract is
-   right, fixes the body — bounded by the test suite staying green.
-5. Commits the edits.
+- **`--mode=api`** (the original) — walks `docs/api/v4.0.0.json` and
+  validates each public function: reads CFC source, refreshes/authors
+  reference example at `vendor/wheels/public/docs/reference/<scope>/<name>.txt`,
+  fixes docblock drift in the CFC.
+- **`--mode=guide`** — walks `web/sites/guides/src/content/docs/v4-0-0-snapshot/`
+  and validates each page: enumerates code blocks, adds `{test:*}`
+  annotations to anything tag-able, marks illustrative blocks with
+  `title="..."`, fixes prose drift, validates via the existing
+  `verify-docs` harness.
 
-## Edit scope (enforced)
+## Edit scope (enforced at the tool layer)
 
 - `vendor/wheels/**/*.cfc` — docblock hint + `@param` hints + (rarely)
   function bodies when behavior contradicts the contract
-- `vendor/wheels/public/docs/reference/<scope>/<name>.txt` — examples
-- Nothing else. Anything else trips the "needs human" flag.
+- `vendor/wheels/public/docs/reference/<scope>/<name>.txt` — API
+  examples (api mode)
+- `web/sites/guides/src/content/docs/v4-0-0-snapshot/**/*.mdx?` —
+  guide page edits (guide mode)
+- Nothing else. Anything else trips the `needs_human` flag.
 
 ## Running locally
 
     cd tools/docs-validation
-    pnpm install
-    ANTHROPIC_API_KEY=sk-... node orchestrate.mjs --section "Model Class" --dry-run
+    npm install
+
+    # API mode
+    node orchestrate.mjs --list-sections
+    node orchestrate.mjs --section "Model Class" --dry-run
     ANTHROPIC_API_KEY=sk-... node orchestrate.mjs --function findEach
-    node orchestrate.mjs --section "Model Class" --status     # show progress
+
+    # Guide mode
+    node orchestrate.mjs --mode=guide --list-directories
+    node orchestrate.mjs --mode=guide --directory upgrading --dry-run
+    ANTHROPIC_API_KEY=sk-... node orchestrate.mjs --mode=guide --path "upgrading/3x-to-4x.mdx"
+
+    # Shared
+    node orchestrate.mjs --status
 
 ## Running in CI
 
-`.github/workflows/docs-validation.yml` exposes `workflow_dispatch`
-with a `section` input. Triggering it picks one of the 9 sections,
-runs the orchestrator over every function in that section, opens a
-draft PR against `develop` with the edits.
+`.github/workflows/docs-validation.yml` exposes `workflow_dispatch` with
+a `mode` input (`api` / `guide`). Pick the appropriate `section` (api
+mode) or `directory` (guide mode), and the orchestrator opens a draft
+PR back into `develop`.
 
 ## State
 
-`state.json` (committed) tracks per-function status:
+`state.json` (committed) tracks per-item status:
 `pending` → `in_progress` → `done` | `failed` | `needs_human`.
-Re-runs are idempotent — only `pending` and `failed` items are
-re-attempted.
+
+Item keys: `function:<name>` for api mode, `guide:<rel-path>` for
+guide mode (e.g. `guide:upgrading/3x-to-4x.mdx`).
+
+Re-runs are idempotent — `done` items are skipped unless `--force` is
+passed; `pending` and `failed` items are re-attempted.

--- a/tools/docs-validation/agent/prompt-guide.md
+++ b/tools/docs-validation/agent/prompt-guide.md
@@ -1,0 +1,76 @@
+# Wheels Guides Validator
+
+You are validating ONE guide page in `web/sites/guides/src/content/docs/v4-0-0-snapshot/`. Your job is to add `{test:*}` annotations to code blocks that should compile/execute, fix prose drift against current framework behavior, and mark genuinely-illustrative blocks as such.
+
+**Target turn count: 6–10 per page. Hard cap: 24.**
+
+## Sources of truth
+
+1. **The page itself** (`web/sites/guides/src/content/docs/v4-0-0-snapshot/<rel>.mdx`) — what the agent reads + edits.
+2. **The verify-docs harness** (`web/sites/guides/scripts/verify-docs/VALIDATION.md`) — defines the `{test:compile}`, `{test:cli ...}`, `{test:tutorial ...}` annotations and what each driver does.
+3. **The framework** (`vendor/wheels/**/*.cfc`, `docs/api/v4.0.0.json`) — for cross-checking that the code in the page actually matches current API.
+
+## The three test drivers (read VALIDATION.md if unsure)
+
+- **`{test:compile}`** — block body is handed to `wheels cfml '<body>'`. Pass if exit 0. Use for standalone CFML expressions: function definitions, struct/array literals, snippets that reference no Wheels framework calls (or only ones that don't need a running app — `model()`/`findAll()` etc. WILL FAIL because `wheels cfml` is bare CFML).
+- **`{test:cli cmd="..."}`** — runs the CLI command in a fixture app. Use for `wheels generate ...`, `wheels migrate ...`, etc. Optional asserts: `asserts-stdout="text"`, `asserts-stderr="text"`, `asserts-output="text"` (forgiving), `asserts-exit=N` (default 0), `step=N` (cumulative ordering).
+- **`{test:tutorial step=N file="path" [mode="write|append"] [asserts-http="..."] [asserts-db-rows="..."]}`** — writes the body to a file in a long-lived `blog-tutorial` fixture app. Use for tutorial chapters that build up an app over many steps. `step=N` orders within and across files.
+
+## Workflow per page
+
+You're invoked once per page. The user message gives you:
+- The page's `relPath` (relative to `v4-0-0-snapshot/`)
+- The page's `frontmatter` (yaml fields like `title`, `description`, `type`, `sidebar.order`)
+- A list of code blocks with: `lang`, current `meta` string, `startLine`, `bodyLength`, `tested` boolean, and `testKind` if already tagged
+
+1. **(0–1 turn)** If the block list shows lots of untested CFML/CLI blocks, scan the page once with `read_file`. If the block list is small (< 4 blocks) and all already tagged, you may not need to read the full page.
+
+2. **(0–1 turn) Determine page type:**
+   - **Tutorial chapter**: `relPath` matches `start-here/blog-tutorial-*`, OR frontmatter has `type: tutorial`, OR the page describes a step-by-step build of a fixture app. Use `{test:tutorial step=N file="..."}` for code-that-goes-into-the-fixture, `{test:cli step=N cmd="..."}` for shell commands run between file edits.
+   - **Prose + snippets** (most pages): individual snippets demonstrate API usage. Use `{test:compile}` for CFML, `{test:cli}` for CLI commands. Snippets that demonstrate behavior requiring a full app context (model finders, controller actions running, view rendering) are **illustrative-only** — leave untagged but add `title="..."` so the existing harness skips them cleanly.
+
+3. **(2–4 turns) Annotate each untagged block.** For each block in the user message marked `tested: false, illustrative: false`:
+   - Decide its category (compile / cli / tutorial / illustrative)
+   - Edit the page with `edit_file` to add the annotation right after the language identifier in the fence: ```` ```cfm {test:compile}```` etc.
+   - Use `replace_all: false`; provide enough surrounding context (e.g. include the line above and the language identifier) to make the match unique.
+
+4. **(0–2 turns) Reconcile prose drift.** If the page describes behavior that contradicts current framework (deprecated function names, removed args, anti-patterns from CLAUDE.md), fix the prose. Same authority as the API loop: docblock-only fixes in `vendor/wheels/**/*.cfc` are allowed; signature/body changes are not.
+
+5. **(1 turn) Validate.** Run the harness against just this page:
+   ```
+   cd web/sites/guides && pnpm verify:docs src/content/docs/v4-0-0-snapshot/<rel-path>
+   ```
+   If pass, proceed to step 6. If fail:
+   - For compile failures: revise the annotation choice (compile → cli, or compile → illustrative if it's not actually executable).
+   - For cli failures: check the `cmd` and `asserts-*` strings; revise.
+   - For tutorial failures: check step ordering and file paths; revise.
+   - Hard limit: 3 retry rounds, then `report_outcome status="needs_human"` with the failure tail in `notes`.
+
+6. **(1 turn)** `report_outcome`. **Do this immediately after validation passes. Do not re-read files.**
+
+## Tutorial step numbering
+
+When annotating a tutorial chapter:
+- Steps within a single file should ascend monotonically (1, 2, 3, ...). Lower numbers run first.
+- The harness orders globally by `(frontmatter.sidebar.order, step, file-line-position)`. Within your single-page run, `sidebar.order` is fixed; just keep your `step=N` values internally consistent — the harness handles cross-file ordering.
+- If a previous tutorial chapter already used steps 1–10, start your page's steps at 11 to avoid collisions. Check by grepping the directory: `grep -rh 'step=' <directory> | grep -oP 'step=\d+' | sort -nu`.
+
+## Annotation format reminders
+
+- Inline meta after the language: ```` ```cfm {test:compile} title="optional"```` (title is consumed by Starlight for code-block titles; ignored by harness).
+- For `{test:cli}`, the `cmd` is tokenized on whitespace — no pipes, redirects, `&&`, or quoted args with spaces. Restructure the example or mark illustrative.
+- For `{test:tutorial}`, the `file` path is relative to the fixture app root; paths escaping the root are rejected.
+
+## Hard rules
+
+- **Never edit anything outside `web/sites/guides/src/content/docs/v4-0-0-snapshot/**/*.mdx?` and `vendor/wheels/**/*.cfc`** (the latter for narrow docblock fixes only). Tool layer enforces this.
+- **Never change a function signature in framework code.** Docblock prose only.
+- **Don't break what already works.** If a block already has a `{test:*}` annotation that passes the harness, don't change it unless the surrounding code has materially changed.
+- **One `report_outcome` call.** Terminal action.
+- **Don't re-read files.** Trust your context.
+
+## When the page is mostly-untested
+
+You may legitimately decide a guide page has many illustrative blocks (concept explanation, anti-pattern callouts, before/after diff comparisons). The bar isn't "tag everything" — it's "tag everything that should run, mark illustrative the rest". A page with 20 blocks where 5 are tested + 15 illustrative is a successful outcome if the choice is principled.
+
+In `report_outcome`, summarize: how many blocks tested, how many illustrative, how many CFC docblock fixes (if any), and any prose drift you fixed.

--- a/tools/docs-validation/lib/agent.mjs
+++ b/tools/docs-validation/lib/agent.mjs
@@ -4,17 +4,19 @@ import { resolve } from 'node:path';
 import { TOOLS, makeExecutor } from './tools.mjs';
 import { locateFunction } from './source-map.mjs';
 import { readReferenceAnyScope } from './reference-store.mjs';
+import { loadGuidePage, summarizeBlocks } from './guides.mjs';
 
-const PROMPT_PATH = resolve(new URL('../agent/prompt.md', import.meta.url).pathname);
+const PROMPT_PATH_API = resolve(new URL('../agent/prompt.md', import.meta.url).pathname);
+const PROMPT_PATH_GUIDE = resolve(new URL('../agent/prompt-guide.md', import.meta.url).pathname);
 
 const DEFAULT_MODEL = process.env.WHEELS_DOCS_MODEL ?? 'claude-sonnet-4-6';
 const MAX_TURNS = Number(process.env.WHEELS_DOCS_MAX_TURNS ?? 16);
 const MAX_TOKENS = Number(process.env.WHEELS_DOCS_MAX_TOKENS ?? 8192);
 
-let SYSTEM_PROMPT;
-async function getSystemPrompt() {
-  SYSTEM_PROMPT ??= await readFile(PROMPT_PATH, 'utf8');
-  return SYSTEM_PROMPT;
+const PROMPT_CACHE = {};
+async function getPrompt(path) {
+  PROMPT_CACHE[path] ??= await readFile(path, 'utf8');
+  return PROMPT_CACHE[path];
 }
 
 async function userPayload(fn) {
@@ -76,14 +78,69 @@ async function userPayload(fn) {
   return lines.join('\n');
 }
 
+async function guidePayload(relPath) {
+  const page = await loadGuidePage(relPath);
+  const summary = summarizeBlocks(page.blocks);
+  const lines = [
+    `# Guide page: ${relPath}`,
+    '',
+    `**Repo path:** \`${page.repoRelPath}\``,
+    '',
+    '## Frontmatter',
+    '',
+  ];
+  if (page.frontmatter) {
+    for (const [k, v] of Object.entries(page.frontmatter)) lines.push(`- **${k}:** ${v}`);
+  } else {
+    lines.push('_(no frontmatter found)_');
+  }
+  lines.push('');
+  lines.push('## Code blocks');
+  lines.push('');
+  lines.push(`Total: ${summary.total}, tested: ${summary.tested}, illustrative: ${summary.illustrative}, untested: ${summary.untested}`);
+  if (Object.keys(summary.byKind).length > 0) {
+    lines.push(`By kind: ${Object.entries(summary.byKind).map(([k, n]) => `${k}=${n}`).join(', ')}`);
+  }
+  lines.push('');
+  lines.push('| # | Lang | Line | Tested | Kind | Illustrative | Body bytes | Meta |');
+  lines.push('| - | --- | --- | --- | --- | --- | --- | --- |');
+  page.blocks.forEach((b, i) => {
+    lines.push(
+      `| ${i + 1} | ${b.lang || '_'} | ${b.startLine} | ${b.tested ? 'yes' : 'no'} | ${b.testKind || '_'} | ${b.illustrative ? 'yes' : 'no'} | ${b.bodyLength} | ${(b.meta || '').replace(/\|/g, '\\|') || '_'} |`,
+    );
+  });
+  lines.push('');
+  lines.push('## Your task');
+  lines.push('');
+  lines.push(
+    `Follow the workflow in the system prompt for THIS page only. \`read_file\` the page at \`${page.repoRelPath}\` if you need the full content. Annotate untested blocks, validate via the verify-docs harness, and call \`report_outcome\` exactly once.`,
+  );
+  return lines.join('\n');
+}
+
+export async function runAgentForGuidePage(relPath, { logger = console.log } = {}) {
+  const client = new Anthropic();
+  const system = await getPrompt(PROMPT_PATH_GUIDE);
+  const outcome = { value: null };
+  const runState = { filesChanged: new Set(), referencesWritten: new Set() };
+  const exec = makeExecutor({ outcome, runState });
+
+  const messages = [{ role: 'user', content: await guidePayload(relPath) }];
+  return runAgentLoop({ client, system, outcome, runState, exec, messages, logger });
+}
+
 export async function runAgentForFunction(fn, { logger = console.log } = {}) {
   const client = new Anthropic();
-  const system = await getSystemPrompt();
+  const system = await getPrompt(PROMPT_PATH_API);
   const outcome = { value: null };
   const runState = { filesChanged: new Set(), referencesWritten: new Set() };
   const exec = makeExecutor({ outcome, runState });
 
   const messages = [{ role: 'user', content: await userPayload(fn) }];
+  return runAgentLoop({ client, system, outcome, runState, exec, messages, logger });
+}
+
+async function runAgentLoop({ client, system, outcome, runState, exec, messages, logger }) {
   let turn = 0;
   let usage = { input_tokens: 0, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 };
 

--- a/tools/docs-validation/lib/guides.mjs
+++ b/tools/docs-validation/lib/guides.mjs
@@ -1,0 +1,101 @@
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+const REPO_ROOT = resolve(new URL('../../..', import.meta.url).pathname);
+const GUIDES_ROOT = `${REPO_ROOT}/web/sites/guides/src/content/docs/v4-0-0-snapshot`;
+
+const MDX_RE = /\.(mdx?|md)$/i;
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n/;
+const CODE_BLOCK_RE = /```([a-zA-Z0-9_+-]*)([^\n]*)\n([\s\S]*?)```/g;
+const TEST_META_RE = /\{test:([^}]+)\}/;
+
+export function relativeToGuidesRoot(absPath) {
+  return relative(GUIDES_ROOT, absPath);
+}
+
+export async function listDirectories() {
+  const entries = await readdir(GUIDES_ROOT, { withFileTypes: true });
+  return entries.filter((e) => e.isDirectory()).map((e) => e.name).sort();
+}
+
+export async function listPagesInDirectory(dirName) {
+  const dir = join(GUIDES_ROOT, dirName);
+  if (!existsSync(dir)) return [];
+  const out = [];
+  await collectPages(dir, out);
+  return out.sort();
+}
+
+async function collectPages(dir, out) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) await collectPages(full, out);
+    else if (entry.isFile() && MDX_RE.test(entry.name)) {
+      out.push(relative(GUIDES_ROOT, full));
+    }
+  }
+}
+
+export async function loadGuidePage(relPath) {
+  const abs = join(GUIDES_ROOT, relPath);
+  if (!existsSync(abs)) throw new Error(`page not found: ${relPath}`);
+  const content = await readFile(abs, 'utf8');
+  return {
+    relPath,
+    absPath: abs,
+    repoRelPath: relative(REPO_ROOT, abs),
+    content,
+    frontmatter: parseFrontmatter(content),
+    blocks: extractCodeBlocks(content),
+  };
+}
+
+function parseFrontmatter(content) {
+  const m = FRONTMATTER_RE.exec(content);
+  if (!m) return null;
+  const raw = m[1];
+  const out = {};
+  for (const line of raw.split('\n')) {
+    const km = /^([A-Za-z][\w-]*):\s*(.*)$/.exec(line);
+    if (km) out[km[1]] = km[2].trim();
+  }
+  return out;
+}
+
+function extractCodeBlocks(content) {
+  const blocks = [];
+  let match;
+  const re = new RegExp(CODE_BLOCK_RE);
+  while ((match = re.exec(content)) !== null) {
+    const lang = match[1] || '';
+    const meta = (match[2] || '').trim();
+    const body = match[3];
+    const startLine = content.slice(0, match.index).split('\n').length;
+    const testTagMatch = TEST_META_RE.exec(meta);
+    blocks.push({
+      lang,
+      meta,
+      body,
+      startLine,
+      bodyLength: body.length,
+      tested: testTagMatch !== null,
+      testKind: testTagMatch ? testTagMatch[1].split(/\s/)[0] : null,
+      illustrative: /title=/.test(meta) && !testTagMatch,
+    });
+  }
+  return blocks;
+}
+
+export function summarizeBlocks(blocks) {
+  return {
+    total: blocks.length,
+    tested: blocks.filter((b) => b.tested).length,
+    illustrative: blocks.filter((b) => b.illustrative).length,
+    untested: blocks.filter((b) => !b.tested && !b.illustrative).length,
+    byKind: blocks.reduce((acc, b) => {
+      if (b.testKind) acc[b.testKind] = (acc[b.testKind] || 0) + 1;
+      return acc;
+    }, {}),
+  };
+}

--- a/tools/docs-validation/lib/tools.mjs
+++ b/tools/docs-validation/lib/tools.mjs
@@ -14,13 +14,19 @@ const READ_ROOTS = [
   'tests',
   'config',
   'CLAUDE.md',
+  'web/sites/guides/src/content',
+  'web/sites/guides/scripts/verify-docs',
 ];
 
 const WRITE_GLOBS = [
   /^vendor\/wheels\/public\/docs\/reference\/(controller|model|mapper|migration|migrator|deprecated|tabledefinition)\/[a-z][a-z0-9]*\.txt$/,
+  /^web\/sites\/guides\/src\/content\/docs\/v4-0-0-snapshot\/.+\.mdx?$/,
 ];
 
-const EDIT_GLOBS = [/^vendor\/wheels\/.+\.cfc$/];
+const EDIT_GLOBS = [
+  /^vendor\/wheels\/.+\.cfc$/,
+  /^web\/sites\/guides\/src\/content\/docs\/v4-0-0-snapshot\/.+\.mdx?$/,
+];
 
 function withinRoot(absPath) {
   const norm = normalize(absPath);

--- a/tools/docs-validation/orchestrate.mjs
+++ b/tools/docs-validation/orchestrate.mjs
@@ -2,24 +2,37 @@
 import { parseArgs } from 'node:util';
 import { loadSnapshot, listSections, functionsInSection, findFunction } from './lib/snapshot.mjs';
 import { loadState, saveState, setItem, getItem, shouldAttempt, summary } from './lib/state.mjs';
+import { listDirectories, listPagesInDirectory } from './lib/guides.mjs';
 
 const USAGE = `Usage:
+  # API mode (default)
   node orchestrate.mjs --list-sections
   node orchestrate.mjs --section "Model Class" [--list | --dry-run | --force | --limit=N]
   node orchestrate.mjs --function findEach   [--dry-run | --force]
+
+  # Guide mode
+  node orchestrate.mjs --mode=guide --list-directories
+  node orchestrate.mjs --mode=guide --directory upgrading [--list | --dry-run | --force | --limit=N]
+  node orchestrate.mjs --mode=guide --path "upgrading/3x-to-4x.mdx" [--dry-run | --force]
+
+  # Shared
   node orchestrate.mjs --status
 
 Env:
   ANTHROPIC_API_KEY=sk-...        required for live runs (not --dry-run / --list)
   WHEELS_DOCS_MODEL=claude-...    override agent model (default: claude-sonnet-4-6)
-  WHEELS_DOCS_MAX_TURNS=N         per-function turn cap (default: 16)
+  WHEELS_DOCS_MAX_TURNS=N         per-item turn cap (default: 16)
 `;
 
 const { values } = parseArgs({
   options: {
+    mode: { type: 'string', default: 'api' },
     section: { type: 'string' },
     function: { type: 'string' },
+    directory: { type: 'string' },
+    path: { type: 'string' },
     'list-sections': { type: 'boolean' },
+    'list-directories': { type: 'boolean' },
     list: { type: 'boolean' },
     status: { type: 'boolean' },
     'dry-run': { type: 'boolean' },
@@ -34,16 +47,7 @@ if (values.help) {
   process.exit(0);
 }
 
-const snap = await loadSnapshot();
 const state = await loadState();
-
-if (values['list-sections']) {
-  for (const s of listSections(snap)) {
-    const fns = functionsInSection(snap, s);
-    console.log(`${s.padEnd(28)} ${String(fns.length).padStart(4)} functions`);
-  }
-  process.exit(0);
-}
 
 if (values.status) {
   const counts = summary(state);
@@ -53,79 +57,185 @@ if (values.status) {
   process.exit(0);
 }
 
-let targets = [];
-if (values.function) {
-  const fn = findFunction(snap, values.function);
-  if (!fn) {
-    console.error(`function not found in snapshot: ${values.function}`);
-    process.exit(1);
-  }
-  targets = Array.isArray(fn) ? fn : [fn];
-} else if (values.section) {
-  if (!listSections(snap).includes(values.section)) {
-    console.error(`section not found: ${values.section}`);
-    console.error(`available: ${listSections(snap).join(', ')}`);
-    process.exit(1);
-  }
-  targets = functionsInSection(snap, values.section);
-} else {
-  console.error(USAGE);
+const mode = values.mode;
+if (mode !== 'api' && mode !== 'guide') {
+  console.error(`Invalid --mode: ${mode}. Expected 'api' or 'guide'.`);
   process.exit(2);
 }
 
-if (values.list) {
-  for (const fn of targets) {
-    const item = getItem(state, 'function', fn.name);
-    const status = item?.status ?? 'pending';
-    console.log(`  ${status.padEnd(12)} ${fn.name.padEnd(36)} (${(fn.availableIn ?? []).join(',')})`);
+if (mode === 'api') await runApiMode();
+else await runGuideMode();
+
+async function runApiMode() {
+  const snap = await loadSnapshot();
+
+  if (values['list-sections']) {
+    for (const s of listSections(snap)) {
+      const fns = functionsInSection(snap, s);
+      console.log(`${s.padEnd(28)} ${String(fns.length).padStart(4)} functions`);
+    }
+    process.exit(0);
   }
-  process.exit(0);
-}
 
-const limit = values.limit ? Number(values.limit) : Infinity;
-const queue = targets.filter((fn) => values.force || shouldAttempt(state, 'function', fn.name)).slice(0, limit);
+  let targets = [];
+  if (values.function) {
+    const fn = findFunction(snap, values.function);
+    if (!fn) {
+      console.error(`function not found in snapshot: ${values.function}`);
+      process.exit(1);
+    }
+    targets = Array.isArray(fn) ? fn : [fn];
+  } else if (values.section) {
+    if (!listSections(snap).includes(values.section)) {
+      console.error(`section not found: ${values.section}`);
+      console.error(`available: ${listSections(snap).join(', ')}`);
+      process.exit(1);
+    }
+    targets = functionsInSection(snap, values.section);
+  } else {
+    console.error(USAGE);
+    process.exit(2);
+  }
 
-console.log(`Processing ${queue.length} function(s) (skipped ${targets.length - queue.length} already-done).`);
+  if (values.list) {
+    for (const fn of targets) {
+      const item = getItem(state, 'function', fn.name);
+      const status = item?.status ?? 'pending';
+      console.log(`  ${status.padEnd(12)} ${fn.name.padEnd(36)} (${(fn.availableIn ?? []).join(',')})`);
+    }
+    process.exit(0);
+  }
 
-if (values['dry-run']) {
+  const limit = values.limit ? Number(values.limit) : Infinity;
+  const queue = targets.filter((fn) => values.force || shouldAttempt(state, 'function', fn.name)).slice(0, limit);
+
+  console.log(`Processing ${queue.length} function(s) (skipped ${targets.length - queue.length} already-done).`);
+
+  if (values['dry-run']) {
+    for (const fn of queue) {
+      console.log(`  [dry-run] would validate: ${fn.name} (${(fn.availableIn ?? []).join(',')})`);
+    }
+    process.exit(0);
+  }
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error('ANTHROPIC_API_KEY is not set. Refusing to start agent runs.');
+    process.exit(3);
+  }
+
+  const { runAgentForFunction } = await import('./lib/agent.mjs');
+  const totalUsage = { input_tokens: 0, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 };
+
   for (const fn of queue) {
-    console.log(`  [dry-run] would validate: ${fn.name} (${(fn.availableIn ?? []).join(',')})`);
-  }
-  process.exit(0);
-}
-
-if (!process.env.ANTHROPIC_API_KEY) {
-  console.error('ANTHROPIC_API_KEY is not set. Refusing to start agent runs.');
-  process.exit(3);
-}
-
-const { runAgentForFunction } = await import('./lib/agent.mjs');
-
-let totalUsage = { input_tokens: 0, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 };
-
-for (const fn of queue) {
-  console.log(`\n=== ${fn.name} (${fn.tags?.section} / ${fn.tags?.category}) ===`);
-  setItem(state, 'function', fn.name, { status: 'in_progress', attempts: (getItem(state, 'function', fn.name)?.attempts ?? 0) + 1 });
-  await saveState(state);
-  try {
-    const { outcome, usage, turns } = await runAgentForFunction(fn);
-    for (const k of Object.keys(totalUsage)) totalUsage[k] += usage[k] ?? 0;
+    console.log(`\n=== ${fn.name} (${fn.tags?.section} / ${fn.tags?.category}) ===`);
     setItem(state, 'function', fn.name, {
-      status: outcome.status,
-      summary: outcome.summary,
-      files_changed: outcome.files_changed,
-      notes: outcome.notes,
-      turns,
-      usage,
+      status: 'in_progress',
+      attempts: (getItem(state, 'function', fn.name)?.attempts ?? 0) + 1,
     });
     await saveState(state);
-    console.log(`  -> ${outcome.status} in ${turns} turn(s): ${outcome.summary}`);
-  } catch (err) {
-    console.error(`  -> error: ${err.message ?? err}`);
-    setItem(state, 'function', fn.name, { status: 'failed', summary: `agent error: ${err.message ?? err}` });
-    await saveState(state);
+    try {
+      const { outcome, usage, turns } = await runAgentForFunction(fn);
+      for (const k of Object.keys(totalUsage)) totalUsage[k] += usage[k] ?? 0;
+      setItem(state, 'function', fn.name, {
+        status: outcome.status,
+        summary: outcome.summary,
+        files_changed: outcome.files_changed,
+        notes: outcome.notes,
+        turns,
+        usage,
+      });
+      await saveState(state);
+      console.log(`  -> ${outcome.status} in ${turns} turn(s): ${outcome.summary}`);
+    } catch (err) {
+      console.error(`  -> error: ${err.message ?? err}`);
+      setItem(state, 'function', fn.name, { status: 'failed', summary: `agent error: ${err.message ?? err}` });
+      await saveState(state);
+    }
   }
+
+  console.log('\nUsage totals:');
+  for (const [k, v] of Object.entries(totalUsage)) console.log(`  ${k.padEnd(32)} ${v}`);
 }
 
-console.log('\nUsage totals:');
-for (const [k, v] of Object.entries(totalUsage)) console.log(`  ${k.padEnd(32)} ${v}`);
+async function runGuideMode() {
+  if (values['list-directories']) {
+    for (const d of await listDirectories()) {
+      const pages = await listPagesInDirectory(d);
+      console.log(`${d.padEnd(28)} ${String(pages.length).padStart(4)} pages`);
+    }
+    process.exit(0);
+  }
+
+  let targets = [];
+  if (values.path) {
+    targets = [values.path];
+  } else if (values.directory) {
+    targets = await listPagesInDirectory(values.directory);
+    if (targets.length === 0) {
+      const known = await listDirectories();
+      console.error(`directory not found or empty: ${values.directory}`);
+      console.error(`available: ${known.join(', ')}`);
+      process.exit(1);
+    }
+  } else {
+    console.error(USAGE);
+    process.exit(2);
+  }
+
+  if (values.list) {
+    for (const p of targets) {
+      const item = getItem(state, 'guide', p);
+      const status = item?.status ?? 'pending';
+      console.log(`  ${status.padEnd(12)} ${p}`);
+    }
+    process.exit(0);
+  }
+
+  const limit = values.limit ? Number(values.limit) : Infinity;
+  const queue = targets.filter((p) => values.force || shouldAttempt(state, 'guide', p)).slice(0, limit);
+
+  console.log(`Processing ${queue.length} page(s) (skipped ${targets.length - queue.length} already-done).`);
+
+  if (values['dry-run']) {
+    for (const p of queue) console.log(`  [dry-run] would validate guide page: ${p}`);
+    process.exit(0);
+  }
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error('ANTHROPIC_API_KEY is not set. Refusing to start agent runs.');
+    process.exit(3);
+  }
+
+  const { runAgentForGuidePage } = await import('./lib/agent.mjs');
+  const totalUsage = { input_tokens: 0, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 };
+
+  for (const p of queue) {
+    console.log(`\n=== ${p} ===`);
+    setItem(state, 'guide', p, {
+      status: 'in_progress',
+      attempts: (getItem(state, 'guide', p)?.attempts ?? 0) + 1,
+    });
+    await saveState(state);
+    try {
+      const { outcome, usage, turns } = await runAgentForGuidePage(p);
+      for (const k of Object.keys(totalUsage)) totalUsage[k] += usage[k] ?? 0;
+      setItem(state, 'guide', p, {
+        status: outcome.status,
+        summary: outcome.summary,
+        files_changed: outcome.files_changed,
+        notes: outcome.notes,
+        turns,
+        usage,
+      });
+      await saveState(state);
+      console.log(`  -> ${outcome.status} in ${turns} turn(s): ${outcome.summary}`);
+    } catch (err) {
+      console.error(`  -> error: ${err.message ?? err}`);
+      setItem(state, 'guide', p, { status: 'failed', summary: `agent error: ${err.message ?? err}` });
+      await saveState(state);
+    }
+  }
+
+  console.log('\nUsage totals:');
+  for (const [k, v] of Object.entries(totalUsage)) console.log(`  ${k.padEnd(32)} ${v}`);
+}


### PR DESCRIPTION
## Summary

Extends the docs validation system from API-only to also handle the 181-page v4 guides corpus, per the plan in [`docs/superpowers/plans/2026-05-07-api-docs-validation-retro.md`](https://github.com/wheels-dev/wheels/blob/develop/docs/superpowers/plans/2026-05-07-api-docs-validation-retro.md).

Reuses the existing orchestrator, state model, sandboxed tool layer, prompt caching, and per-section dispatch from the API loop. Changes are additive — API mode behavior is unchanged.

## What's new

### Guide mode (`--mode=guide`)

The agent walks `web/sites/guides/src/content/docs/v4-0-0-snapshot/<directory>/`, takes one `.mdx` page at a time, and:

1. Enumerates fenced code blocks
2. For each untagged block, decides if it should be `{test:compile}`, `{test:cli ...}`, `{test:tutorial step=N file="..."}`, or illustrative-only (no test annotation, just `title="..."`)
3. Adds the annotations via `edit_file`
4. Fixes prose drift (and may make narrow CFC docblock fixes if it discovers framework drift while validating)
5. Runs `pnpm --filter @wheels/guides verify:docs <path>` against just that page to validate
6. Reports outcome

### Files changed

- **New** `tools/docs-validation/lib/guides.mjs` — page enumeration, frontmatter parsing, code-block extraction with `{test:*}` detection
- **New** `tools/docs-validation/agent/prompt-guide.md` — per-page agent workflow (page-type detection, the three test drivers, tutorial step numbering, harness validation, hard rules)
- `tools/docs-validation/lib/tools.mjs` — `WRITE_GLOBS` + `EDIT_GLOBS` extended to allow guide MDX paths; `READ_ROOTS` adds `web/sites/guides/src/content` and `web/sites/guides/scripts/verify-docs`
- `tools/docs-validation/lib/agent.mjs` — adds `runAgentForGuidePage()` next to `runAgentForFunction()`; refactored shared loop into `runAgentLoop()`
- `tools/docs-validation/orchestrate.mjs` — accepts `--mode=guide` with `--directory <name>` or `--path <rel>`, plus `--list-directories`
- `.github/workflows/docs-validation.yml` — `mode` + `directory` inputs added; guide mode installs pnpm + web deps so `verify-docs` is callable; branch name / commit msg / PR title vary by mode

## State key change

API: `function:<name>` (unchanged)
Guide: `guide:<rel-path>` (new), e.g. `guide:upgrading/3x-to-4x.mdx`

## Smoke test (no API key needed)

```bash
$ node tools/docs-validation/orchestrate.mjs --mode=guide --list-directories
basics                         12 pages
command-line-tools             99 pages
contributing                    4 pages
core-concepts                   9 pages
deployment                     13 pages
digging-deeper                 15 pages
start-here                     14 pages
testing                        10 pages
upgrading                       3 pages

$ node tools/docs-validation/orchestrate.mjs --mode=guide --directory upgrading --dry-run
Processing 3 page(s) (skipped 0 already-done).
  [dry-run] would validate guide page: upgrading/2x-to-3x.mdx
  [dry-run] would validate guide page: upgrading/3x-to-4x.mdx
  [dry-run] would validate guide page: upgrading/index.mdx
```

## Recommended first dispatch

`upgrading` is the smallest directory (3 pages, 2 of which are already partially annotated). Lowest blast radius for prompt tuning.

```bash
# Dry run (no tokens spent)
gh workflow run docs-validation.yml --ref develop \
  -f mode=guide -f directory=upgrading -f dry_run=true

# Live run
gh workflow run docs-validation.yml --ref develop \
  -f mode=guide -f directory=upgrading -f dry_run=false
```

## Risk

Low. API mode behavior unchanged. New code paths gated by `--mode=guide`. Tool-layer allowlist additions are restrictive (only `web/sites/guides/src/content/docs/v4-0-0-snapshot/**/*.mdx?` writable, no escape).

## Test plan

- [ ] Smoke-test `--list-directories` and `--dry-run` (verified locally above)
- [ ] After merge, dispatch dry-run on `upgrading` to confirm CI wiring
- [ ] Then live dispatch on `upgrading` (3 pages, ~$0.50)
- [ ] Review the resulting PR for prompt tuning needs before scaling to larger directories
- [ ] Iteratively work through 8 directories: `upgrading` → `start-here` → `basics` → `core-concepts` → `database` (none — actually `digging-deeper`) → `digging-deeper` → `testing` → `deployment` → `command-line-tools` (largest, save for last). Skip `contributing` until last; it's mostly meta.

https://claude.ai/code/session_014puccJJixwdjRgMx7mPLmz

---
_Generated by [Claude Code](https://claude.ai/code/session_014puccJJixwdjRgMx7mPLmz)_