### PR TITLE
fix: kill bash tool's full process tree on timeout

### DIFF
--- a/tools/docs-validation/lib/tools.mjs
+++ b/tools/docs-validation/lib/tools.mjs
@@ -200,26 +200,57 @@ async function doEdit(path, oldStr, newStr) {
 function doBash(command, timeoutSeconds = 60) {
   return new Promise((resolveP) => {
     const ms = Math.min(Math.max((timeoutSeconds | 0) || 60, 1), 180) * 1000;
-    const child = spawn('bash', ['-lc', command], { cwd: REPO_ROOT });
+    // detached:true puts the child into its own process group so we can kill
+    // the whole tree (bash -> pnpm -> node -> harness -> wheels -> lucli ...)
+    // by signalling the negative pid. Without this, SIGKILL on bash leaves
+    // descendants orphaned to init and they keep stdio open, so close never
+    // fires and the agent loop deadlocks waiting for tool output.
+    const child = spawn('bash', ['-lc', command], { cwd: REPO_ROOT, detached: true });
     let stdout = '';
     let stderr = '';
     let killed = false;
-    const t = setTimeout(() => {
+    let resolved = false;
+    const finish = (result) => {
+      if (resolved) return;
+      resolved = true;
+      clearTimeout(timer);
+      clearTimeout(graceTimer);
+      resolveP(result);
+    };
+    const cap = (s) => (s.length > 32_000 ? s.slice(0, 32_000) + `\n[...truncated ${s.length - 32_000} bytes]` : s);
+    const killTree = (signal) => {
+      try { process.kill(-child.pid, signal); } catch {}
+      try { child.kill(signal); } catch {}
+    };
+    const timer = setTimeout(() => {
       killed = true;
-      child.kill('SIGKILL');
+      killTree('SIGKILL');
     }, ms);
+    // Backstop: if descendants still hold stdio open after SIGKILL, force-resolve
+    // 5s after the timeout fires so the agent loop never hangs forever on a
+    // single tool call.
+    const graceTimer = setTimeout(() => {
+      finish({
+        ok: false,
+        exit_code: null,
+        timed_out: true,
+        stdout: cap(stdout),
+        stderr: cap(stderr) + '\n[doBash: forced resolve after SIGKILL — descendants still holding stdio]',
+      });
+    }, ms + 5000);
     child.stdout.on('data', (d) => (stdout += d.toString()));
     child.stderr.on('data', (d) => (stderr += d.toString()));
     child.on('close', (code) => {
-      clearTimeout(t);
-      const cap = (s) => (s.length > 32_000 ? s.slice(0, 32_000) + `\n[...truncated ${s.length - 32_000} bytes]` : s);
-      resolveP({
+      finish({
         ok: !killed,
         exit_code: code,
         timed_out: killed,
         stdout: cap(stdout),
         stderr: cap(stderr),
       });
+    });
+    child.on('error', (err) => {
+      finish({ ok: false, exit_code: null, timed_out: false, stdout: cap(stdout), stderr: cap(stderr) + `\n[spawn error: ${err.message}]` });
     });
   });
 }


### PR DESCRIPTION
## Summary

The docs-validation agent deadlocked for 3+ hours on its first guide-mode run. Root cause: the `run_bash` tool's per-call timeout couldn't actually kill commands that spawn long-running grandchildren (the `pnpm verify:docs` chain → node → harness → `wheels` → lucli/Lucee).

When the timer fired, `child.kill('SIGKILL')` terminated the **bash** process directly, but its descendants were reparented to init and kept stdio open — `child.on('close')` never fired, the Promise never resolved, the agent's turn loop hung waiting for tool output, and the workflow ate the 240-min job timeout doing nothing.

## Fix

Three changes to `doBash()` in `tools/docs-validation/lib/tools.mjs`:

1. **`detached: true` on spawn.** The bash subprocess becomes a process-group leader, so we can deliver signals to every descendant via `process.kill(-child.pid, signal)`.
2. **5-second grace timer after SIGKILL.** If descendants still hold stdio open and prevent `close` from firing, the Promise resolves anyway with a marker in stderr so the agent can see what happened.
3. **`error` event handler.** Spawn failures now resolve cleanly instead of leaving the Promise pending.

## Smoke test

```js
// Plain long-running command
exec('run_bash', { command: 'sleep 60', timeout_seconds: 3 })
  // elapsed: 3012ms, timed_out: true ✓

// Daemonized grandchildren (the actual harness pattern)
exec('run_bash', { command: 'bash -c "(sleep 60 &) ; (sleep 60 &) ; sleep 60"', timeout_seconds: 3 })
  // elapsed: 3011ms, timed_out: true ✓
  // no orphan `sleep 60` processes after exit
```

## What this unblocks

After merge, redispatch the `start-here` directory:
```bash
gh workflow run docs-validation.yml --ref develop \
  -f mode=guide -f directory=start-here -f dry_run=false
```

If the harness genuinely takes a long time on tutorial chapters (real possibility — the cumulative-step tutorial driver replays prior steps each run), the per-call timeouts will trip and the agent will see "harness timed out" and fall back to alternate annotation strategies. Worst case: the agent reports `needs_human` for tutorial pages, we tune the prompt or harness-invocation pattern in a follow-up.

## Risk

Low. Pure timeout-handling change in tooling. API mode remains unaffected (it's already proven through 8 sections × 378 functions). The new code is more defensive than the old.

https://claude.ai/code/session_014puccJJixwdjRgMx7mPLmz

---
_Generated by [Claude Code](https://claude.ai/code/session_014puccJJixwdjRgMx7mPLmz)_