### PR TITLE
fix(cli): scaffold edit form posts as PATCH not POST

### DIFF
--- a/cli/src/templates/crud/_form.txt
+++ b/cli/src/templates/crud/_form.txt
@@ -1,7 +1,11 @@
 <cfparam name="|ObjectNameSingular|" default="">
 <cfoutput>
 #errorMessagesFor("|ObjectNameSingular|")#
-#startFormTag(action=IsNumeric(|ObjectNameSingular|.id ?: "") ? "update" : "create", key=|ObjectNameSingular|.id ?: "")#
+<cfif IsNumeric(|ObjectNameSingular|.id ?: "")>
+	#startFormTag(action="update", key=|ObjectNameSingular|.id, method="patch")#
+<cfelse>
+	#startFormTag(action="create")#
+</cfif>
 	|FormFields|
 	<button type="submit">Save</button>
 #endFormTag()#


### PR DESCRIPTION
## Summary

Resolves #2433.

The generated scaffold's `_form.txt` partial calls `startFormTag(action="update")` without specifying a `method`, so the form defaults to POST. The RESTful member route only accepts `GET/PATCH/PUT/DELETE`, so submitting the edit form raises:

```
Wheels.RouteNotFound — The posts/2 path does not allow POST requests,
only GET,PATCH,PUT,DELETE,GET requests.
```

## Fix

Pass `method="patch"` when the bound object has a numeric id (edit case). The framework auto-renders the `_method` hidden override input, so the browser still POSTs but the router dispatches PATCH.

```cfm
<cfif IsNumeric(post.id ?: "")>
    #startFormTag(action="update", key=post.id, method="patch")#
<cfelse>
    #startFormTag(action="create")#
</cfif>
```

## Test plan

- [ ] `wheels generate scaffold Post title:string body:text`
- [ ] Create a post, edit it, submit — should redirect to show, not error
- [ ] Inspect the rendered HTML to confirm `<input type="hidden" name="_method" value="patch">` is present

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_