### PR TITLE
fix(cli): scaffold controller fetches records via findByKey

### DIFF
--- a/cli/lucli/templates/app/app/snippets/CRUDContent.txt
+++ b/cli/lucli/templates/app/app/snippets/CRUDContent.txt
@@ -11,7 +11,7 @@
 	* View |ObjectNameSingularC|
 	**/
 	function show() {
-		|ObjectNameSingular|=params.|ObjectNameSingular|;
+		|ObjectNameSingular|=model("|ObjectNameSingularC|").findByKey(params.key);
 	}
 
 	/**
@@ -37,14 +37,14 @@
 	* Edit |ObjectNameSingularC|
 	**/
 	function edit() {
-		|ObjectNameSingular|=params.|ObjectNameSingular|;
+		|ObjectNameSingular|=model("|ObjectNameSingularC|").findByKey(params.key);
 	}
 
 	/**
 	* Update |ObjectNameSingularC|
 	**/
 	function update() {
-		|ObjectNameSingular|=params.|ObjectNameSingular|;
+		|ObjectNameSingular|=model("|ObjectNameSingularC|").findByKey(params.key);
 		if(|ObjectNameSingular|.update(params.|ObjectNameSingular|)){
 			redirectTo(route="|ObjectNameSingular|", key=|ObjectNameSingular|.id);
 		} else {
@@ -56,7 +56,7 @@
 	* Delete |ObjectNameSingularC|
 	**/
 	function delete() {
-		|ObjectNameSingular|=params.|ObjectNameSingular|;
+		|ObjectNameSingular|=model("|ObjectNameSingularC|").findByKey(params.key);
 		|ObjectNameSingular|.delete();
 		redirectTo(route="|ObjectNamePlural|");
 	}

--- a/cli/src/templates/CRUDContent.txt
+++ b/cli/src/templates/CRUDContent.txt
@@ -11,7 +11,7 @@
 	* View |ObjectNameSingularC|
 	**/
 	function show() {
-		|ObjectNameSingular|=params.|ObjectNameSingular|;
+		|ObjectNameSingular|=model("|ObjectNameSingularC|").findByKey(params.key);
 	}
 
 	/**
@@ -37,14 +37,14 @@
 	* Edit |ObjectNameSingularC|
 	**/
 	function edit() {
-		|ObjectNameSingular|=params.|ObjectNameSingular|;
+		|ObjectNameSingular|=model("|ObjectNameSingularC|").findByKey(params.key);
 	}
 
 	/**
 	* Update |ObjectNameSingularC|
 	**/
 	function update() {
-		|ObjectNameSingular|=params.|ObjectNameSingular|;
+		|ObjectNameSingular|=model("|ObjectNameSingularC|").findByKey(params.key);
 		if(|ObjectNameSingular|.update(params.|ObjectNameSingular|)){
 			redirectTo(route="|ObjectNameSingular|", key=|ObjectNameSingular|.id);
 		} else {
@@ -56,7 +56,7 @@
 	* Delete |ObjectNameSingularC|
 	**/
 	function delete() {
-		|ObjectNameSingular|=params.|ObjectNameSingular|;
+		|ObjectNameSingular|=model("|ObjectNameSingularC|").findByKey(params.key);
 		|ObjectNameSingular|.delete();
 		redirectTo(route="|ObjectNamePlural|");
 	}


### PR DESCRIPTION
## Summary

Resolves #2432.

The generated CRUD controller used `params.<singular>` directly in `show`/`edit`/`update`/`delete`:

```cfm
function show() { post = params.post; }
function update() {
    post = params.post;
    if (post.update(params.post)) { ... }
}
```

When [route model binding](../../blob/develop/CLAUDE.md#route-model-binding) is disabled (the default), `params.post` is the form-data struct, not a model instance. Calling `.update()` on a struct errors at runtime; `.delete()` errors; `post.id` returns the wrong value.

## Fix

Switch read paths to `model("<Singular>").findByKey(params.key)`:

```cfm
function show()   { post = model("Post").findByKey(params.key); }
function edit()   { post = model("Post").findByKey(params.key); }
function update() {
    post = model("Post").findByKey(params.key);
    if (post.update(params.post)) { ... }
}
function delete() {
    post = model("Post").findByKey(params.key);
    post.delete();
    redirectTo(route="posts");
}
```

This works regardless of whether route model binding is on; when it is, `params.post` is already the resolved instance but `findByKey(params.key)` returns the equivalent.

## Two copies fixed

The same template lives in two byte-identical locations:
- `cli/src/templates/CRUDContent.txt` (canonical, used by the LuCLI fallback)
- `cli/lucli/templates/app/app/snippets/CRUDContent.txt` (copied into every new app's `app/snippets/`, which overrides the canonical via `Templates.cfc::findTemplate`)

Without fixing the snippet copy, every newly-scaffolded app continues to ship the broken template even after the canonical is fixed. Both updated and verified `diff`-identical.

## Test plan

- [ ] `wheels generate scaffold Post title:string body:text`
- [ ] Create, view, edit, update, delete a post end-to-end — no struct-method errors
- [ ] Re-scaffold in a fresh `wheels new` app and confirm the snippet copy emits the corrected template

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_