### PR TITLE
fix(cli): api-resource template uses correct placeholder syntax

### DIFF
--- a/cli/lucli/templates/app/app/snippets/ApiControllerContent.txt
+++ b/cli/lucli/templates/app/app/snippets/ApiControllerContent.txt
@@ -2,60 +2,60 @@
 
     function config() {
         provides("json");
-				filters(through="setJsonResponse");
+        filters(through="setJsonResponse");
     }
 
     /**
-     * GET /#objectNamePlural#
-     * Returns a list of all #objectNamePlural#
+     * GET /|ObjectNamePlural|
+     * Returns a list of all |ObjectNamePlural|
      */
     function index() {
-        local.#objectNamePlural# = model("|ObjectNameSingular|").findAll();
-        renderWith(data={ #objectNamePlural#=local.#objectNamePlural# });
+        local.|ObjectNamePlural| = model("|ObjectNameSingular|").findAll();
+        renderWith(data={ |ObjectNamePlural|=local.|ObjectNamePlural| });
     }
 
     /**
-     * GET /#objectNamePlural#/:key
-     * Returns a specific #objectNameSingular# by ID
+     * GET /|ObjectNamePlural|/:key
+     * Returns a specific |ObjectNameSingular| by ID
      */
     function show() {
-        local.#objectNameSingular# = model("|ObjectNameSingular|").findByKey(params.key);
+        local.|ObjectNameSingular| = model("|ObjectNameSingular|").findByKey(params.key);
 
-        if (IsObject(local.#objectNameSingular#)) {
-            renderWith(data={ #objectNameSingular#=local.#objectNameSingular# });
+        if (IsObject(local.|ObjectNameSingular|)) {
+            renderWith(data={ |ObjectNameSingular|=local.|ObjectNameSingular| });
         } else {
             renderWith(data={ error="Record not found" }, status=404);
         }
     }
 
     /**
-     * POST /#objectNamePlural#
-     * Creates a new #objectNameSingular#
+     * POST /|ObjectNamePlural|
+     * Creates a new |ObjectNameSingular|
      */
     function create() {
-        local.#objectNameSingular# = model("|ObjectNameSingular|").new(params.#objectNameSingular#);
+        local.|ObjectNameSingular| = model("|ObjectNameSingular|").new(params.|ObjectNameSingular|);
 
-        if (local.#objectNameSingular#.save()) {
-            renderWith(data={ #objectNameSingular#=local.#objectNameSingular# }, status=201);
+        if (local.|ObjectNameSingular|.save()) {
+            renderWith(data={ |ObjectNameSingular|=local.|ObjectNameSingular| }, status=201);
         } else {
-            renderWith(data={ error="Validation failed", errors=local.#objectNameSingular#.allErrors() }, status=422);
+            renderWith(data={ error="Validation failed", errors=local.|ObjectNameSingular|.allErrors() }, status=422);
         }
     }
 
     /**
-     * PUT /#objectNamePlural#/:key
-     * Updates an existing #objectNameSingular#
+     * PUT /|ObjectNamePlural|/:key
+     * Updates an existing |ObjectNameSingular|
      */
     function update() {
-        local.#objectNameSingular# = model("|ObjectNameSingular|").findByKey(params.key);
+        local.|ObjectNameSingular| = model("|ObjectNameSingular|").findByKey(params.key);
 
-        if (IsObject(local.#objectNameSingular#)) {
-            local.#objectNameSingular#.update(params.#objectNameSingular#);
+        if (IsObject(local.|ObjectNameSingular|)) {
+            local.|ObjectNameSingular|.update(params.|ObjectNameSingular|);
 
-            if (local.#objectNameSingular#.hasErrors()) {
-                renderWith(data={ error="Validation failed", errors=local.#objectNameSingular#.allErrors() }, status=422);
+            if (local.|ObjectNameSingular|.hasErrors()) {
+                renderWith(data={ error="Validation failed", errors=local.|ObjectNameSingular|.allErrors() }, status=422);
             } else {
-                renderWith(data={ #objectNameSingular#=local.#objectNameSingular# });
+                renderWith(data={ |ObjectNameSingular|=local.|ObjectNameSingular| });
             }
         } else {
             renderWith(data={ error="Record not found" }, status=404);
@@ -63,25 +63,25 @@
     }
 
     /**
-     * DELETE /#objectNamePlural#/:key
-     * Deletes a #objectNameSingular#
+     * DELETE /|ObjectNamePlural|/:key
+     * Deletes a |ObjectNameSingular|
      */
     function delete() {
-        local.#objectNameSingular# = model("|ObjectNameSingular|").findByKey(params.key);
+        local.|ObjectNameSingular| = model("|ObjectNameSingular|").findByKey(params.key);
 
-        if (IsObject(local.#objectNameSingular#)) {
-            local.#objectNameSingular#.delete();
+        if (IsObject(local.|ObjectNameSingular|)) {
+            local.|ObjectNameSingular|.delete();
             renderWith(data={}, status=204);
         } else {
             renderWith(data={ error="Record not found" }, status=404);
         }
     }
 
-		/**
-		* Set Response to JSON
-		*/
-		private function setJsonResponse() {
-			params.format = "json";
-		}
+    /**
+     * Set Response to JSON
+     */
+    private function setJsonResponse() {
+        params.format = "json";
+    }
 
 }


### PR DESCRIPTION
## Summary

Resolves #2468.

`wheels generate api-resource Product ...` was emitting controllers with literal placeholder text instead of substituted values:

```cfm
/**
 * GET /#objectNamePlural#
 * Returns a list of all #objectNamePlural#
 */
function index() {
    local.#objectNamePlural# = model("product").findAll();
    renderWith(data={ #objectNamePlural#=local.#objectNamePlural# });
}
```

## Root cause

There are **two** copies of the API controller template:
- `cli/src/templates/ApiControllerContent.txt` — canonical, uses `|ObjectNamePlural|` / `|ObjectNameSingular|` markers (correct).
- `cli/lucli/templates/app/app/snippets/ApiControllerContent.txt` — copied into every new app's `app/snippets/` and overrides the canonical via `Templates.cfc::findTemplate`. **This copy used `#objectNamePlural#` / `#objectNameSingular#` markers that the substitution pass doesn't recognise.**

`Templates.cfc::generateFromTemplate` only replaces pipe-delimited tokens (`|ObjectNameSingular|` etc.) — the hash-delimited variants drift through to the generated file as raw text.

## Fix

Replace the buggy snippet copy with the canonical template byte-for-byte. Verified `diff` reports zero differences post-fix.

## Test plan

- [ ] In a fresh `wheels new` app, run `wheels generate api-resource Product name price:decimal sku:string`
- [ ] Open the generated `app/controllers/api/Products.cfc` — no `#objectName...#` literals; all placeholders substituted
- [ ] Hit one of the routes (e.g. `GET /api/products`) — controller compiles and responds with JSON

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_