### PR TITLE
fix(cli): wheels validate skips framework parent files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,9 @@
 # Check formatting of staged CFML files only (not the entire project)
-if command -v box &> /dev/null; then
+# Use POSIX-compatible redirect: husky invokes hooks via `sh`, where `&>` is
+# parsed as `&` (background) + `>`, so the original `command -v box &> /dev/null`
+# always succeeded regardless of whether box was installed and the loop below
+# ran `box cfformat check` against a missing binary.
+if command -v box >/dev/null 2>&1; then
   STAGED_CFC=$(git diff --cached --name-only --diff-filter=ACM -- '*.cfc' '*.cfm')
   if [ -n "$STAGED_CFC" ]; then
     FAILED=0

--- a/cli/lucli/services/Analysis.cfc
+++ b/cli/lucli/services/Analysis.cfc
@@ -90,20 +90,29 @@ component {
 	public struct function validate() {
 		var issues = [];
 
-		// Check model associations
+		// Check model associations. Skip the framework's parent Model.cfc —
+		// it intentionally extends "wheels.Model" rather than "Model", since
+		// it IS the parent that user models inherit from.
 		var modelsDir = variables.projectRoot & "/app/models";
 		if (directoryExists(modelsDir)) {
 			var models = directoryList(modelsDir, false, "path", "*.cfc");
 			for (var modelFile in models) {
+				if (listLast(modelFile, "/\") == "Model.cfc") {
+					continue;
+				}
 				issues.addAll(validateModel(modelFile));
 			}
 		}
 
-		// Check controller conventions
+		// Check controller conventions. Skip the framework's parent
+		// Controller.cfc for the same reason as Model.cfc above.
 		var controllersDir = variables.projectRoot & "/app/controllers";
 		if (directoryExists(controllersDir)) {
 			var controllers = directoryList(controllersDir, false, "path", "*.cfc");
 			for (var ctrlFile in controllers) {
+				if (listLast(ctrlFile, "/\") == "Controller.cfc") {
+					continue;
+				}
 				issues.addAll(validateController(ctrlFile));
 			}
 		}

--- a/cli/lucli/tests/specs/services/AnalysisSpec.cfc
+++ b/cli/lucli/tests/specs/services/AnalysisSpec.cfc
@@ -112,6 +112,34 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					expect(issueMessages).toInclude("Model");
 				});
 
+				it("does not flag the framework's parent Model.cfc / Controller.cfc", () => {
+					// The base parent files extend "wheels.Model" / "wheels.Controller"
+					// rather than "Model" / "Controller", since they ARE the parent.
+					// The validator must skip them.
+					var modelDir = tempRoot & "/app/models";
+					var ctrlDir = tempRoot & "/app/controllers";
+					directoryCreate(modelDir, true, true);
+					directoryCreate(ctrlDir, true, true);
+					fileWrite(modelDir & "/Model.cfc", 'component extends="wheels.Model" {}');
+					fileWrite(ctrlDir & "/Controller.cfc", 'component extends="wheels.Controller" {}');
+
+					// Remove any leftover broken files so the assertion is clean.
+					var brokenModel = modelDir & "/Broken.cfc";
+					if (fileExists(brokenModel)) {
+						fileDelete(brokenModel);
+					}
+					var badModel = modelDir & "/BadModel.cfc";
+					if (fileExists(badModel)) {
+						fileDelete(badModel);
+					}
+
+					var results = analysis.validate();
+					for (var issue in results.issues) {
+						expect(issue.message).notToInclude("Model.cfc does not extend Model");
+						expect(issue.message).notToInclude("Controller.cfc does not extend Controller");
+					}
+				});
+
 			});
 
 		});


### PR DESCRIPTION
## Summary

Resolves #2491. Also includes a prerequisite fix for a husky pre-commit hook bug that was blocking any CFC commit in environments without CommandBox installed.

## #2491: validate skips framework parent files

`wheels validate` was flagging the auto-generated parent files with:

```
[ERROR] Model.cfc — Model.cfc does not extend Model
[ERROR] Controller.cfc — Controller.cfc does not extend Controller
```

The check requires `extends="Model"` / `extends="Controller"`, but the parent files intentionally extend the framework's `wheels.Model` / `wheels.Controller` because they **are** the parents user models inherit from. They're emitted by `wheels new`, never hand-authored.

### Fix

Skip files literally named `Model.cfc` / `Controller.cfc` directly under `app/models/` / `app/controllers/`. Regression test added in `AnalysisSpec` confirming the parent files are not flagged.

## Prerequisite: husky pre-commit POSIX bug

The first commit on this branch fixes an unrelated bug that surfaced while staging the validate fix:

```sh
if command -v box &> /dev/null; then ...
```

`&>` is bash-only syntax; husky invokes hooks via `sh`, where the expression parses as `command -v box &` (background) followed by `> /dev/null`. The backgrounded command always returns 0, so the if-block **always** entered — meaning the loop ran `box cfformat check` against a missing binary on every CFC commit in environments without CommandBox, producing a false-positive `cfformat check failed`. Switched to POSIX-compatible `>/dev/null 2>&1`.

This is in scope for this PR because without it, no contributor or CI environment without box can commit a CFC file. Happy to split it out into its own PR if preferred.

## Test plan

- [ ] `wheels validate` on a fresh `wheels new` app — no errors for `Model.cfc` / `Controller.cfc`
- [ ] Add a deliberately broken `app/models/Bad.cfc` (no extends) — still flagged
- [ ] In an environment without box, `git commit` a CFC change — pre-commit no longer reports a false-positive cfformat failure
- [ ] In an environment with box and a malformed CFC — pre-commit still reports a real cfformat failure

## Commits

- `9a7f050` ci: pre-commit hook POSIX-compat for box detection
- `91ac98b` fix(cli): wheels validate skips framework parent files

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_