### PR TITLE
fix(cli): wheels info parses datasource and excludes base Model.cfc

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,9 @@
 # Check formatting of staged CFML files only (not the entire project)
-if command -v box &> /dev/null; then
+# Use POSIX-compatible redirect: husky invokes hooks via `sh`, where `&>` is
+# parsed as `&` (background) + `>`, so the original `command -v box &> /dev/null`
+# always succeeded regardless of whether box was installed and the loop below
+# ran `box cfformat check` against a missing binary.
+if command -v box >/dev/null 2>&1; then
   STAGED_CFC=$(git diff --cached --name-only --diff-filter=ACM -- '*.cfc' '*.cfm')
   if [ -n "$STAGED_CFC" ]; then
     FAILED=0

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -895,12 +895,15 @@ component extends="modules.BaseModule" {
 			// CFML engine
 			out("Engine:   Lucee (LuCLI module)");
 
-			// Datasource
+			// Datasource. Strip CFML/cfscript comments first so commented-out
+			// `set(...)` calls don't get parsed as live config, and use a
+			// word-boundary on the property name so `coreTestDataSourceName`
+			// is not picked up as if it were `dataSourceName`.
 			var settingsFile = variables.projectRoot & "/config/settings.cfm";
 			if (fileExists(settingsFile)) {
 				try {
-					var sContent = fileRead(settingsFile);
-					var dsMatch = reFindNoCase('dataSourceName\s*[=,]\s*"([^"]+)"', sContent, 1, true);
+					var sContent = stripCfmlComments(fileRead(settingsFile));
+					var dsMatch = reFindNoCase('\bdataSourceName\s*=\s*"([^"]+)"', sContent, 1, true);
 					if (arrayLen(dsMatch.match) > 1) {
 						out("Database: #dsMatch.match[2]#");
 					}
@@ -934,10 +937,18 @@ component extends="modules.BaseModule" {
 				}
 			}
 
-			// Count models
+			// Count models. Exclude the framework's parent `Model.cfc` — it
+			// extends `wheels.Model` and is not an application/domain model.
 			var modelsDir = variables.projectRoot & "/app/models";
 			if (directoryExists(modelsDir)) {
-				var modelCount = arrayLen(directoryList(modelsDir, false, "name", "*.cfc"));
+				var modelFiles = directoryList(modelsDir, false, "name", "*.cfc");
+				var modelCount = 0;
+				for (var modelFile in modelFiles) {
+					if (modelFile == "Model.cfc") {
+						continue;
+					}
+					modelCount++;
+				}
 				if (modelCount > 0) {
 					out("Models:   #modelCount# model(s)");
 				}
@@ -5536,6 +5547,24 @@ component extends="modules.BaseModule" {
 		for (var i = 1; i <= arguments.length; i++) {
 			result &= mid(chars, randRange(1, len(chars)), 1);
 		}
+		return result;
+	}
+
+	/**
+	 * Remove CFML and cfscript comments so static parsers don't pick up
+	 * commented-out config calls. Strips:
+	 *   - cfscript line comments  // ...
+	 *   - cfscript/JS block comments  /* ... *​/
+	 *   - CFML tag-style block comments  <!--- ... --->
+	 */
+	private string function stripCfmlComments(required string source) {
+		var result = arguments.source;
+		// Tag-style CFML comments. Non-greedy across lines.
+		result = reReplace(result, "<!---[\s\S]*?--->", "", "all");
+		// /* ... */ block comments. Non-greedy across lines.
+		result = reReplace(result, "/\*[\s\S]*?\*/", "", "all");
+		// // line comments to end of line.
+		result = reReplace(result, "//[^\r\n]*", "", "all");
 		return result;
 	}
 

--- a/cli/lucli/services/Analysis.cfc
+++ b/cli/lucli/services/Analysis.cfc
@@ -90,20 +90,29 @@ component {
 	public struct function validate() {
 		var issues = [];
 
-		// Check model associations
+		// Check model associations. Skip the framework's parent Model.cfc —
+		// it intentionally extends "wheels.Model" rather than "Model", since
+		// it IS the parent that user models inherit from.
 		var modelsDir = variables.projectRoot & "/app/models";
 		if (directoryExists(modelsDir)) {
 			var models = directoryList(modelsDir, false, "path", "*.cfc");
 			for (var modelFile in models) {
+				if (listLast(modelFile, "/\") == "Model.cfc") {
+					continue;
+				}
 				issues.addAll(validateModel(modelFile));
 			}
 		}
 
-		// Check controller conventions
+		// Check controller conventions. Skip the framework's parent
+		// Controller.cfc for the same reason as Model.cfc above.
 		var controllersDir = variables.projectRoot & "/app/controllers";
 		if (directoryExists(controllersDir)) {
 			var controllers = directoryList(controllersDir, false, "path", "*.cfc");
 			for (var ctrlFile in controllers) {
+				if (listLast(ctrlFile, "/\") == "Controller.cfc") {
+					continue;
+				}
 				issues.addAll(validateController(ctrlFile));
 			}
 		}

--- a/cli/lucli/tests/specs/services/AnalysisSpec.cfc
+++ b/cli/lucli/tests/specs/services/AnalysisSpec.cfc
@@ -112,6 +112,34 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					expect(issueMessages).toInclude("Model");
 				});
 
+				it("does not flag the framework's parent Model.cfc / Controller.cfc", () => {
+					// The base parent files extend "wheels.Model" / "wheels.Controller"
+					// rather than "Model" / "Controller", since they ARE the parent.
+					// The validator must skip them.
+					var modelDir = tempRoot & "/app/models";
+					var ctrlDir = tempRoot & "/app/controllers";
+					directoryCreate(modelDir, true, true);
+					directoryCreate(ctrlDir, true, true);
+					fileWrite(modelDir & "/Model.cfc", 'component extends="wheels.Model" {}');
+					fileWrite(ctrlDir & "/Controller.cfc", 'component extends="wheels.Controller" {}');
+
+					// Remove any leftover broken files so the assertion is clean.
+					var brokenModel = modelDir & "/Broken.cfc";
+					if (fileExists(brokenModel)) {
+						fileDelete(brokenModel);
+					}
+					var badModel = modelDir & "/BadModel.cfc";
+					if (fileExists(badModel)) {
+						fileDelete(badModel);
+					}
+
+					var results = analysis.validate();
+					for (var issue in results.issues) {
+						expect(issue.message).notToInclude("Model.cfc does not extend Model");
+						expect(issue.message).notToInclude("Controller.cfc does not extend Controller");
+					}
+				});
+
 			});
 
 		});


### PR DESCRIPTION
## Summary

Resolves #2490. **This branch is stacked on #2499** — when that merges, this rebases down to a single commit on top of `develop`.

`wheels info` was producing inaccurate metadata in three independent ways:

### 1. Commented `set(...)` parsed as live config

```cfm
// set(coreTestDataSourceName="testappdb_test");
set(dataSourceName="testappdb");
```

→ `Database: testappdb_test`. The regex matched anywhere in the file regardless of comment context. Fix: strip CFML/cfscript comments (`//`, `/* */`, `<!--- --->`) via a new `stripCfmlComments` helper before scanning.

### 2. `coreTestDataSourceName` shadowed `dataSourceName`

The regex `dataSourceName\s*[=,]\s*"([^"]+)"` matched `dataSourceName` as a substring of `coreTestDataSourceName`, and the test datasource appeared first in the file so it won. Fix: `\bdataSourceName\s*=\s*"([^"]+)"` — word-boundary prevents substring match. Dropped the unused `[=,]` alternative since `set()` only uses `=`.

### 3. Base `Model.cfc` counted as an application model

`directoryList(... '*.cfc')` swept up the framework's parent `Model.cfc`, inflating the model count by 1 in every project. Fix: skip files literally named `Model.cfc` when tallying.

## Stack

This branch is stacked on `claude/issue-2491` (PR #2499) which carries:
- A husky pre-commit hook POSIX-compat fix (otherwise no CFC commit lands locally).
- The `wheels validate` parent-file fix.

The diff against `develop` shows all three commits; the diff against #2499 shows only this PR's contribution. After #2499 merges I'll rebase to drop the duplicates.

## Test plan

- [ ] Settings with `// set(coreTestDataSourceName=...)` commented and `set(dataSourceName=...)` active → `Database: testappdb`
- [ ] Settings with both uncommented → `Database: testappdb` (primary, not test)
- [ ] Settings with neither → no `Database:` line
- [ ] Project with `Model.cfc` + `Post.cfc` + `User.cfc` → `Models:   2 model(s)`

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_