### PR TITLE
fix(cli): scaffold tests/runner.cfm in new apps

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,9 @@
 # Check formatting of staged CFML files only (not the entire project)
-if command -v box &> /dev/null; then
+# Use POSIX-compatible redirect: husky invokes hooks via `sh`, where `&>` is
+# parsed as `&` (background) + `>`, so the original `command -v box &> /dev/null`
+# always succeeded regardless of whether box was installed and the loop below
+# ran `box cfformat check` against a missing binary.
+if command -v box >/dev/null 2>&1; then
   STAGED_CFC=$(git diff --cached --name-only --diff-filter=ACM -- '*.cfc' '*.cfm')
   if [ -n "$STAGED_CFC" ]; then
     FAILED=0

--- a/cli/lucli/templates/app/tests/runner.cfm
+++ b/cli/lucli/templates/app/tests/runner.cfm
@@ -1,0 +1,16 @@
+<!---
+	tests/runner.cfm — entry point for /wheels/app/tests in the browser
+	and `wheels test run` from the CLI. By default this defers to the
+	framework's built-in app-test runner, which scans `tests/specs/` via
+	TestBox and emits a structured result the CLI knows how to parse.
+
+	Customise this file when you need pre-test setup the framework
+	runner doesn't cover — e.g. registering a custom reporter,
+	overriding test datasource resolution, applying app-specific
+	bootstrap.
+
+	Keep the include below as the last line (or replicate its body
+	inline) — the framework runner is what produces the JSON / HTML
+	output the rest of the system expects.
+--->
+<cfinclude template="/wheels/tests/app-runner.cfm">


### PR DESCRIPTION
## Summary

Resolves #2422.

Fresh apps generated by `wheels new` had no `tests/runner.cfm`, so hitting `/wheels/app/tests` historically threw:

```
Lucee 7.0.0.395 Error (missinginclude)
Message: Page [/tests/runner.cfm] not found
```

The framework's `Public.cfc::testbox()` already falls back to `/wheels/tests/app-runner.cfm` when the project's runner is missing (added at commit `5485b2e`), so the immediate error is gone for fresh apps on develop. But a scaffolded stub is more discoverable and gives users a file to extend when they need:

- A custom reporter
- App-specific datasource resolution (e.g. swap to `<app>_test` only if `useTestDB=true`)
- Bootstrap that runs before TestBox

## Fix

Add `cli/lucli/templates/app/tests/runner.cfm` containing a thin shim that defers to `/wheels/tests/app-runner.cfm`, with a comment explaining when and how to customise it. The framework runner remains the source of truth for the JSON / HTML output shape — the user's runner is the place to layer pre-test setup on top.

## Includes a prerequisite

The first commit on this branch is the same husky pre-commit POSIX fix that #2499 carries — without it, no CFC commit lands locally on machines without CommandBox. After #2499 merges, this rebases down to a single commit.

## Test plan

- [ ] `wheels new testapp && cd testapp && wheels start`
- [ ] Visit `http://localhost:<port>/wheels/app/tests` — no missinginclude error; TestBox runner page loads
- [ ] Confirm `tests/runner.cfm` exists in the generated project tree
- [ ] Override the runner with a no-op include and confirm the framework still falls back gracefully if the file is deleted

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_