### PR TITLE
fix(cli): wheels destroy looks for ControllerSpec, not Spec

### DIFF
--- a/cli/lucli/services/Destroy.cfc
+++ b/cli/lucli/services/Destroy.cfc
@@ -48,9 +48,11 @@ component {
 			result
 		);
 
-		// Controller test
+		// Controller test. The generator writes <Plural>ControllerSpec.cfc
+		// (see CodeGen.cfc::generateTest where the controller suffix is
+		// "ControllerSpec"), so destroy must look for the matching name.
 		deleteFileIfExists(
-			variables.projectRoot & "/tests/specs/controllers/" & names.pluralCap & "Spec.cfc",
+			variables.projectRoot & "/tests/specs/controllers/" & names.pluralCap & "ControllerSpec.cfc",
 			result
 		);
 
@@ -126,7 +128,7 @@ component {
 			result
 		);
 		deleteFileIfExists(
-			variables.projectRoot & "/tests/specs/controllers/" & controllerCap & "Spec.cfc",
+			variables.projectRoot & "/tests/specs/controllers/" & controllerCap & "ControllerSpec.cfc",
 			result
 		);
 
@@ -180,7 +182,7 @@ component {
 				arrayAppend(preview, "app/controllers/" & names.pluralCap & ".cfc");
 				arrayAppend(preview, "app/views/" & names.plural & "/");
 				arrayAppend(preview, "tests/specs/models/" & names.singularCap & "Spec.cfc");
-				arrayAppend(preview, "tests/specs/controllers/" & names.pluralCap & "Spec.cfc");
+				arrayAppend(preview, "tests/specs/controllers/" & names.pluralCap & "ControllerSpec.cfc");
 				arrayAppend(preview, "tests/specs/views/" & names.plural & "/");
 				arrayAppend(preview, 'Route: .resources("' & names.plural & '") from config/routes.cfm');
 				arrayAppend(preview, "Migration: drop table " & names.plural);
@@ -198,7 +200,7 @@ component {
 				var controllerCap = variables.helpers.capitalize(clean);
 				arrayAppend(preview, "app/controllers/" & controllerCap & ".cfc");
 				arrayAppend(preview, "app/views/" & lCase(controllerCap) & "/");
-				arrayAppend(preview, "tests/specs/controllers/" & controllerCap & "Spec.cfc");
+				arrayAppend(preview, "tests/specs/controllers/" & controllerCap & "ControllerSpec.cfc");
 				break;
 			case "view":
 				if (find("/", arguments.name)) {

--- a/cli/lucli/tests/specs/services/DestroySpec.cfc
+++ b/cli/lucli/tests/specs/services/DestroySpec.cfc
@@ -53,7 +53,10 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 				it("deletes controller, views directory, and test files (##2330)", () => {
 					var controllerPath = tempRoot & "/app/controllers/Deletemes.cfc";
 					var viewsDir = tempRoot & "/app/views/deletemes";
-					var testPath = tempRoot & "/tests/specs/controllers/DeletemesSpec.cfc";
+					// Generator writes <name>ControllerSpec.cfc (CodeGen.cfc
+					// suffix = "ControllerSpec"); destroy must use the same
+					// name. See issue ##2492.
+					var testPath = tempRoot & "/tests/specs/controllers/DeletemesControllerSpec.cfc";
 					directoryCreate(getDirectoryFromPath(controllerPath), true, true);
 					directoryCreate(viewsDir, true, true);
 					fileWrite(viewsDir & "/index.cfm", "<p>i</p>");
@@ -100,7 +103,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					var controllerPath = tempRoot & "/app/controllers/Widgets.cfc";
 					var viewsDir = tempRoot & "/app/views/widgets";
 					var modelTestPath = tempRoot & "/tests/specs/models/WidgetSpec.cfc";
-					var controllerTestPath = tempRoot & "/tests/specs/controllers/WidgetsSpec.cfc";
+					var controllerTestPath = tempRoot & "/tests/specs/controllers/WidgetsControllerSpec.cfc";
 					var viewTestsDir = tempRoot & "/tests/specs/views/widgets";
 
 					directoryCreate(getDirectoryFromPath(modelPath), true, true);
@@ -186,7 +189,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					expect(arrayLen(preview)).toBe(3);
 					expect(arrayToList(preview)).toInclude("Products.cfc");
 					expect(arrayToList(preview)).toInclude("app/views/products/");
-					expect(arrayToList(preview)).toInclude("ProductsSpec.cfc");
+					expect(arrayToList(preview)).toInclude("ProductsControllerSpec.cfc");
 				});
 
 			});


### PR DESCRIPTION
## Summary

Resolves #2492.

`wheels destroy <Name>` was logging:

```
skip    Not found: /tests/specs/controllers/PostsSpec.cfc
```

even though the file existed — because the generator writes `<Plural>ControllerSpec.cfc` (CodeGen uses `suffix = "ControllerSpec"` for the controller test), but destroy was looking for `<Plural>Spec.cfc`. The orphaned spec was left on disk every time.

## Fix

Update destroy paths to use `ControllerSpec.cfc` across all four call sites:
- `destroyResource()` cleanup
- `destroyController()` cleanup
- `previewDestroy("resource")` preview list
- `previewDestroy("controller")` preview list

Model spec naming (`<Singular>Spec.cfc`) is unchanged — generator suffix for models is `"Spec"`.

## Tests

The existing `DestroySpec` was creating the wrong filename in fixtures (`PostsSpec.cfc` etc.) and asserting destroy could find it — verifying the broken behaviour against itself. Updated three test sites to mirror the real generator output.

## Related — out of scope

#2493 reports that `wheels destroy <Name> controller --force` also deletes the views directory and argues it shouldn't. That directly conflicts with #2330's resolution (which intentionally added the views deletion so re-running scaffold doesn't trip over orphans). Leaving for maintainer judgement; this PR only fixes the unambiguous spec-filename bug.

## Test plan

- [ ] `wheels generate scaffold Post title:string body:text`
- [ ] Confirm `tests/specs/controllers/PostsControllerSpec.cfc` exists
- [ ] `wheels destroy Posts --force`
- [ ] Confirm the spec is deleted (no `skip Not found`)
- [ ] Same for `wheels destroy Posts controller --force`

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_