### PR TITLE
fix(cli): wheels migrate up/down/info actually run

### DIFF
--- a/vendor/wheels/public/views/cli.cfm
+++ b/vendor/wheels/public/views/cli.cfm
@@ -45,6 +45,42 @@ try {
 			case "migrateToLatest":
 				data.message = migrator.migrateToLatest();
 				break;
+			case "migrateUp":
+				// Walk the migration list (sorted ascending by version) and
+				// migrate to the first pending version after the current one.
+				// `migrateTo` handles the actual transaction + status update.
+				local.targetVersion = "";
+				for (local.m in data.migrations) {
+					if (local.m.status != "migrated" && local.m.version > data.currentVersion) {
+						local.targetVersion = local.m.version;
+						break;
+					}
+				}
+				if (Len(local.targetVersion)) {
+					data.message = migrator.migrateTo(local.targetVersion);
+				} else {
+					data.message = "No pending migrations. Database is at version #data.currentVersion#.";
+				}
+				break;
+			case "migrateDown":
+				// Walk the list in reverse to find the migration immediately
+				// below the current version, then migrate down to it. If the
+				// current version is the first applied migration, target "0"
+				// (rolls back the only migration).
+				local.targetVersion = "0";
+				for (local.i = ArrayLen(data.migrations); local.i >= 1; local.i--) {
+					local.m = data.migrations[local.i];
+					if (local.m.version < data.currentVersion && local.m.status == "migrated") {
+						local.targetVersion = local.m.version;
+						break;
+					}
+				}
+				if (data.currentVersion == "0") {
+					data.message = "Database is at version 0; nothing to roll back.";
+				} else {
+					data.message = migrator.migrateTo(local.targetVersion);
+				}
+				break;
 			case "renameSystemTables":
 				// F15 Phase 2: opt-in rename of legacy c_o_r_e_* system tables.
 				// Returns the full result struct (success/renamed/skipped/errors/sql)
@@ -121,7 +157,35 @@ try {
 				data.message = migrator.redoMigration(local.redoVersion);
 				break;
 			case "info":
-				data.message = "Returning what I know..";
+				// Build a human-readable status block from the data already
+				// populated above (currentVersion, migrations, datasource).
+				// Without this, the CLI's `wheels migrate info` printed an
+				// empty success message (issue #2474).
+				local.lines = [];
+				ArrayAppend(local.lines, "Datasource: " & data.datasource);
+				ArrayAppend(local.lines, "Database type: " & data.databaseType);
+				ArrayAppend(local.lines, "Current version: " & (Len(data.currentVersion) ? data.currentVersion : "0"));
+				ArrayAppend(local.lines, "Total migrations: " & ArrayLen(data.migrations));
+				if (ArrayLen(data.migrations)) {
+					local.applied = 0;
+					local.pending = 0;
+					for (local.m in data.migrations) {
+						if (local.m.status == "migrated") {
+							local.applied++;
+						} else {
+							local.pending++;
+						}
+					}
+					ArrayAppend(local.lines, "  applied: " & local.applied);
+					ArrayAppend(local.lines, "  pending: " & local.pending);
+					ArrayAppend(local.lines, "");
+					ArrayAppend(local.lines, "Migrations (newest last):");
+					for (local.m in data.migrations) {
+						local.marker = local.m.status == "migrated" ? "[x]" : "[ ]";
+						ArrayAppend(local.lines, "  " & local.marker & " " & local.m.version & " " & local.m.name);
+					}
+				}
+				data.message = ArrayToList(local.lines, Chr(10));
 				break;
 			
 			// Database commands


### PR DESCRIPTION
## Summary

Resolves #2474.

`wheels migrate up`, `wheels migrate down`, and `wheels migrate info` all printed `Migration <action> completed.` in green while doing nothing. Only `wheels migrate latest` actually worked.

## Root cause

The framework's `/wheels/cli` endpoint at `vendor/wheels/public/views/cli.cfm` had:
- **No `migrateUp` case.** The CLI sent `command=migrateUp`; the switch fell through to default; `data.success` stayed `true` and the response was returned with no work done.
- **No `migrateDown` case.** Same.
- **An `info` case** that set `data.message = "Returning what I know.."` and nothing else — the available `data.migrations` and `data.currentVersion` were already populated by lines 11/13 but never surfaced.

## Fix

In `cli.cfm`:

- **`migrateUp`** — walk migrations ascending, find the first pending version > `currentVersion`, call `migrator.migrateTo(version)`. Emits "No pending migrations" if everything's applied.
- **`migrateDown`** — walk migrations descending, find the last `migrated` version below `currentVersion`, call `migrator.migrateTo(priorVersion)` (or `"0"` to roll back the sole applied migration). Emits "Database is at version 0" if there's nothing to roll back.
- **`info`** — build a structured status block: datasource, db type, current version, applied/pending counts, then a checkbox list of every migration (`[x]` applied, `[ ]` pending).

The CLI side (`Module.cfc::runMigration`) didn't need changes — it already prints `result.message`, which now contains the real output.

## Test plan

- [ ] Run `wheels migrate latest` to apply, then `wheels migrate down` — verify it rolls back the latest one and the version is now the prior one.
- [ ] `wheels migrate up` — verify it re-applies the rolled-back migration.
- [ ] `wheels migrate info` — verify it lists every migration with applied/pending state and current version.
- [ ] `wheels migrate down` on a fresh DB (`currentVersion == 0`) — verify it prints "nothing to roll back" rather than erroring.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_