### PR TITLE
fix(cli): wheels generate admin produces working controller and views

### DIFF
--- a/cli/lucli/services/Admin.cfc
+++ b/cli/lucli/services/Admin.cfc
@@ -219,15 +219,21 @@ component {
 		var t = chr(9);
 		var resourceLine = '.resources("' & arguments.plural & '")';
 
-		// Check if this admin resource already exists
-		if (findNoCase('scope(path="admin"', content) && findNoCase(resourceLine, content)) {
+		// Check if this admin resource already exists. Detect both the new
+		// `.namespace("admin")` form and the legacy `.scope(path="admin")`
+		// form so re-running on existing routes still no-ops.
+		var hasAdminNamespace = reFindNoCase('\.namespace\(\s*"admin"', content)
+			|| reFindNoCase('\.scope\(\s*path\s*=\s*"admin"', content);
+		if (hasAdminNamespace && findNoCase(resourceLine, content)) {
 			return false;
 		}
 
-		// Try to find existing admin scope and append inside it
-		if (reFindNoCase('\.scope\(\s*path\s*=\s*"admin"', content)) {
-			// Find the admin scope opening and insert the resource before its .end()
-			var adminScopePos = reFindNoCase('\.scope\(\s*path\s*=\s*"admin"[^)]*\)', content);
+		// Try to find existing admin namespace/scope and append inside it.
+		if (hasAdminNamespace) {
+			var adminScopePos = reFindNoCase('\.namespace\(\s*"admin"[^)]*\)', content);
+			if (!adminScopePos) {
+				adminScopePos = reFindNoCase('\.scope\(\s*path\s*=\s*"admin"[^)]*\)', content);
+			}
 			if (adminScopePos > 0) {
 				// Find the .end() that closes this scope — simple heuristic: first .end() after scope
 				var afterScope = mid(content, adminScopePos, len(content));
@@ -242,8 +248,13 @@ component {
 		}
 
 		// No existing admin scope — create one before CLI-Appends-Here or last .end()
+		// Use `.namespace("admin")` rather than `.scope(path="admin", package="admin")`
+		// so the named-route prefix is set: routes resolve to `adminUsers`,
+		// `adminUser`, etc. (camelCase concat per `vendor/wheels/mapper/matching.cfc`).
+		// Without a name on the scope, routes collide with any same-named
+		// non-admin resource.
 		var marker = "// CLI-Appends-Here";
-		var adminBlock = t & '.scope(path="admin", package="admin")' & nl;
+		var adminBlock = t & '.namespace("admin")' & nl;
 		adminBlock &= t & t & resourceLine & nl;
 		adminBlock &= t & ".end()" & nl & t;
 

--- a/cli/lucli/templates/admin/_form.txt
+++ b/cli/lucli/templates/admin/_form.txt
@@ -1,9 +1,11 @@
 <cfparam name="{{singular}}" default="">
-#errorMessagesFor(objectName="{{singular}}")#
-<cfset local.formRoute = {{singular}}.isPersisted() ? "admin~{{singular}}" : "admin~{{plural}}">
+<cfset local.formRoute = {{singular}}.isPersisted() ? "admin{{SingularCap}}" : "admin{{PluralCap}}">
 <cfset local.formMethod = {{singular}}.isPersisted() ? "patch" : "post">
 <cfset local.formKey = {{singular}}.isPersisted() ? {{singular}}.key() : "">
+<cfoutput>
+#errorMessagesFor(objectName="{{singular}}")#
 #startFormTag(route=local.formRoute, method=local.formMethod, key=local.formKey)#
 {{formFields}}
 	<div>#submitTag(value="Save {{SingularCap}}")#</div>
 #endFormTag()#
+</cfoutput>

--- a/cli/lucli/templates/admin/controller.txt
+++ b/cli/lucli/templates/admin/controller.txt
@@ -1,4 +1,4 @@
-component extends="Controller" {
+component extends="app.controllers.Controller" {
 
 	function config() {
 		protectsFromForgery();
@@ -17,7 +17,7 @@ component extends="Controller" {
 	function show() {
 		{{singular}} = model("{{SingularCap}}").findByKey(params.key);
 		if (!IsObject({{singular}})) {
-			redirectTo(route="admin~{{plural}}");
+			redirectTo(route="admin{{PluralCap}}");
 		}
 	}
 
@@ -28,7 +28,7 @@ component extends="Controller" {
 	function edit() {
 		{{singular}} = model("{{SingularCap}}").findByKey(params.key);
 		if (!IsObject({{singular}})) {
-			redirectTo(route="admin~{{plural}}");
+			redirectTo(route="admin{{PluralCap}}");
 		}
 	}
 
@@ -36,7 +36,7 @@ component extends="Controller" {
 		{{singular}} = model("{{SingularCap}}").new(params.{{singular}});
 		if ({{singular}}.save()) {
 			flashInsert(success="{{SingularCap}} created.");
-			redirectTo(route="admin~{{singular}}", key={{singular}}.key());
+			redirectTo(route="admin{{SingularCap}}", key={{singular}}.key());
 		} else {
 			flashInsert(error="Could not create {{SingularCap}}.");
 			renderView(action="new");
@@ -46,12 +46,12 @@ component extends="Controller" {
 	function update() {
 		{{singular}} = model("{{SingularCap}}").findByKey(params.key);
 		if (!IsObject({{singular}})) {
-			redirectTo(route="admin~{{plural}}");
+			redirectTo(route="admin{{PluralCap}}");
 			return;
 		}
 		if ({{singular}}.update(params.{{singular}})) {
 			flashInsert(success="{{SingularCap}} updated.");
-			redirectTo(route="admin~{{singular}}", key={{singular}}.key());
+			redirectTo(route="admin{{SingularCap}}", key={{singular}}.key());
 		} else {
 			flashInsert(error="Could not update {{SingularCap}}.");
 			renderView(action="edit");
@@ -64,7 +64,7 @@ component extends="Controller" {
 			{{singular}}.delete();
 			flashInsert(success="{{SingularCap}} deleted.");
 		}
-		redirectTo(route="admin~{{plural}}");
+		redirectTo(route="admin{{PluralCap}}");
 	}
 
 }

--- a/cli/lucli/templates/admin/edit.txt
+++ b/cli/lucli/templates/admin/edit.txt
@@ -1,4 +1,6 @@
 <cfparam name="{{singular}}" default="">
 <h1>Edit {{SingularCap}}</h1>
+<cfoutput>
 #includePartial(partial="form")#
-#linkTo(text="Back to list", route="admin~{{plural}}")#
+#linkTo(text="Back to list", route="admin{{PluralCap}}")#
+</cfoutput>

--- a/cli/lucli/templates/admin/index.txt
+++ b/cli/lucli/templates/admin/index.txt
@@ -1,6 +1,8 @@
 <cfparam name="{{plural}}" default="">
 <h1>{{PluralCap}} Admin</h1>
-<p>#linkTo(text="New {{SingularCap}}", route="admin~new_{{singular}}")#</p>
+<cfoutput>
+<p>#linkTo(text="New {{SingularCap}}", route="newAdmin{{SingularCap}}")#</p>
+</cfoutput>
 <cfif {{plural}}.recordCount>
 <table>
 	<thead>
@@ -14,8 +16,10 @@
 		<tr>
 {{indexCells}}
 			<td>
-				#linkTo(text="Show", route="admin~{{singular}}", key={{plural}}.{{primaryKey}})#
-				#linkTo(text="Edit", route="admin~edit_{{singular}}", key={{plural}}.{{primaryKey}})#
+				<cfoutput>
+				#linkTo(text="Show", route="admin{{SingularCap}}", key={{plural}}.{{primaryKey}})#
+				#linkTo(text="Edit", route="editAdmin{{SingularCap}}", key={{plural}}.{{primaryKey}})#
+				</cfoutput>
 			</td>
 		</tr>
 		</cfloop>
@@ -24,4 +28,4 @@
 <cfelse>
 <p>No {{plural}} found.</p>
 </cfif>
-#paginationNav()#
+<cfoutput>#paginationNav()#</cfoutput>

--- a/cli/lucli/templates/admin/new.txt
+++ b/cli/lucli/templates/admin/new.txt
@@ -1,4 +1,6 @@
 <cfparam name="{{singular}}" default="">
 <h1>New {{SingularCap}}</h1>
+<cfoutput>
 #includePartial(partial="form")#
-#linkTo(text="Back to list", route="admin~{{plural}}")#
+#linkTo(text="Back to list", route="admin{{PluralCap}}")#
+</cfoutput>

--- a/cli/lucli/templates/admin/show.txt
+++ b/cli/lucli/templates/admin/show.txt
@@ -3,7 +3,9 @@
 <dl>
 {{showFields}}
 </dl>
+<cfoutput>
 <p>
-	#linkTo(text="Edit", route="admin~edit_{{singular}}", key={{singular}}.key())#
-	#linkTo(text="Back to list", route="admin~{{plural}}")#
+	#linkTo(text="Edit", route="editAdmin{{SingularCap}}", key={{singular}}.key())#
+	#linkTo(text="Back to list", route="admin{{PluralCap}}")#
 </p>
+</cfoutput>


### PR DESCRIPTION
## Summary

Resolves #2488. Four defects made `wheels generate admin <Model>` produce a non-functional interface; this PR fixes all four.

## 1. Route names used a non-existent `~` separator

Templates emitted `redirectTo(route="admin~users")`, `linkTo(route="admin~edit_user")`, etc. Wheels concatenates scope name and resource name **camelCase** (see `vendor/wheels/mapper/matching.cfc`):

| Before | After |
|---|---|
| `admin~users` | `adminUsers` |
| `admin~user` | `adminUser` |
| `admin~new_user` | `newAdminUser` |
| `admin~edit_user` | `editAdminUser` |

## 2. Scope had no name → route collisions

`Admin.cfc` produced `.scope(path="admin", package="admin")` — no `name` arg, so `$scopeName()` returned empty and the routes registered as just `users`/`user`, colliding with any non-admin `users` resource. Switched to `.namespace("admin")` which sets `name`, `package`, and `path` together. Existing-block detection accepts either form so re-runs on legacy `.scope(path="admin")` blocks still no-op.

## 3. Subfolder controllers can't resolve `extends="Controller"`

For `app/controllers/admin/Users.cfc`, CFML looks for `Controller.cfc` in `app/controllers/admin/` first — doesn't exist. There's no global `Controller` mapping. Result: Lucee throws "cannot find component Controller". Switched to `extends="app.controllers.Controller"` which resolves via the `/app` mapping the starter `Application.cfc` registers (line 16).

## 4. Views missing `<cfoutput>`

Every view template called `#linkTo(...)#`, `#startFormTag(...)#`, `#errorMessagesFor(...)#` etc. with no `<cfoutput>` wrapper — so helpers rendered as literal text. Wrapped each helper-call region across `_form.txt`, `edit.txt`, `new.txt`, `show.txt`, and `index.txt`.

## Test plan

- [ ] `wheels generate admin User`
- [ ] Open the generated `app/controllers/admin/Users.cfc` — confirm `extends="app.controllers.Controller"`
- [ ] `wheels start && wheels reload`, visit `/admin/users` — index page renders the table (not literal `#linkTo(...)#` text)
- [ ] Click "New User", submit — record creates, redirects to `/admin/users/<id>`
- [ ] Click "Edit", change a field, save — redirects to show page
- [ ] Click "Back to list" links — all named routes resolve (no `RouteNotFound`)
- [ ] Confirm `config/routes.cfm` now has `.namespace("admin")` not `.scope(path="admin", package="admin")`

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_