### PR TITLE
fix(docs): CLI guide relative links resolve correctly

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/configuration.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/configuration.mdx
@@ -247,22 +247,22 @@ Each directory gets its own modules, servers, deps, and secrets.
 <CardGrid>
   <LinkCard
     title="Installation"
-    href="./installation/"
+    href="../installation/"
     description="Install wheels via Homebrew, Chocolatey, or a manual JAR download."
   />
   <LinkCard
     title="Quick Start"
-    href="./quick-start/"
+    href="../quick-start/"
     description="From a fresh shell to a running Wheels app in under five minutes."
   />
   <LinkCard
     title="MCP Integration"
-    href="./mcp-integration/"
+    href="../mcp-integration/"
     description="Expose wheels commands as MCP tools for AI-driven development."
   />
   <LinkCard
     title="Server"
-    href="./core-commands/server/"
+    href="../core-commands/server/"
     description="wheels server — start, stop, and inspect the Lucee server for a project."
   />
 </CardGrid>

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/installation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/installation.mdx
@@ -106,7 +106,7 @@ Java 21.0.8
 
 The three-line format tells you the Wheels Module version, the underlying LuCLI version, and the JVM the wrapper picked up. If any of those lines is missing or reports an unexpected value, jump to troubleshooting below.
 
-Once the version check passes, `wheels info` inside a Wheels project gives you a deeper sanity check against a real app — datasource connection, environment, route count. See [App Inspection](./wheels-commands/app-inspection/) for the full output and how to read it.
+Once the version check passes, `wheels info` inside a Wheels project gives you a deeper sanity check against a real app — datasource connection, environment, route count. See [App Inspection](../wheels-commands/app-inspection/) for the full output and how to read it.
 
 ## Troubleshooting
 
@@ -127,17 +127,17 @@ The wheels formula deliberately isolates runtime state under `~/.wheels/` (via `
 <CardGrid>
   <LinkCard
     title="Quick Start"
-    href="./quick-start/"
+    href="../quick-start/"
     description="From a fresh shell to a running Wheels app in under five minutes."
   />
   <LinkCard
     title="Configuration"
-    href="./configuration/"
+    href="../configuration/"
     description="Profiles, environment, module.json — how LuCLI and the Wheels Module are configured."
   />
   <LinkCard
     title="Creating a Project"
-    href="./wheels-commands/creating-a-project/"
+    href="../wheels-commands/creating-a-project/"
     description="wheels new and wheels create app — scaffolding a fresh Wheels project after install."
   />
 </CardGrid>

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/mcp-integration.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/mcp-integration.mdx
@@ -100,22 +100,22 @@ Migrate to the stdio surface by switching your IDE's MCP server definition to th
 <CardGrid>
   <LinkCard
     title="Quick Start"
-    href="./quick-start/"
+    href="../quick-start/"
     description="From a fresh shell to a running Wheels app in under five minutes."
   />
   <LinkCard
     title="Configuration"
-    href="./configuration/"
+    href="../configuration/"
     description="lucee.json, environment profiles, global flags, and LUCLI_HOME."
   />
   <LinkCard
     title="Installation"
-    href="./installation/"
+    href="../installation/"
     description="Install wheels via Homebrew, Chocolatey, or a manual JAR download."
   />
   <LinkCard
     title="CLI Reference"
-    href="./"
+    href="../"
     description="The wheels binary — two command surfaces in one install."
   />
 </CardGrid>

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/quick-start.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/quick-start.mdx
@@ -10,7 +10,7 @@ import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 You'll ship a running Wheels app with one CRUD resource — a blog post with a title and body — wired through model, controller, views, migration, tests, and routes.
 
-This page assumes `wheels --version` already works. If it doesn't, run through [Installation](./installation/) first.
+This page assumes `wheels --version` already works. If it doesn't, run through [Installation](../installation/) first.
 
 ## 1. Create the app
 
@@ -80,22 +80,22 @@ wheels test --filter=posts
 <CardGrid>
   <LinkCard
     title="Code Generation"
-    href="./wheels-commands/code-generation/"
+    href="../wheels-commands/code-generation/"
     description="The full catalog — models, controllers, views, migrations, scaffolds, API resources, routes, tests, admin, snippets."
   />
   <LinkCard
     title="Database"
-    href="./wheels-commands/database/"
+    href="../wheels-commands/database/"
     description="wheels migrate, wheels seed, and wheels db — schema management and seed data workflows."
   />
   <LinkCard
     title="Testing"
-    href="./wheels-commands/testing/"
+    href="../wheels-commands/testing/"
     description="wheels test options, the browser suite, and CI reporters."
   />
   <LinkCard
     title="Dev Server"
-    href="./wheels-commands/dev-server/"
+    href="../wheels-commands/dev-server/"
     description="wheels start, wheels stop, wheels reload — running your app locally and driving hot reload."
   />
 </CardGrid>
@@ -108,7 +108,7 @@ The scaffold gives you CRUD, not a login flow. See [Authentication Patterns](/v4
 
 ### Configuration
 
-To swap SQLite for a real database, tune the reload password, or wire per-environment settings, see [Configuration](./configuration/) and the [Database](./wheels-commands/database/) guide. The datasource name defaults to the app name (`myblog`) and lives in `config/settings.cfm`.
+To swap SQLite for a real database, tune the reload password, or wire per-environment settings, see [Configuration](../configuration/) and the [Database](../wheels-commands/database/) guide. The datasource name defaults to the app name (`myblog`) and lives in `config/settings.cfm`.
 
 ### Deployment
 

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/wheels-commands/app-inspection.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/wheels-commands/app-inspection.mdx
@@ -274,12 +274,12 @@ Sweep before a release. Widen the marker list with `--annotations=` or tack on a
   />
   <LinkCard
     title="Code Quality"
-    href="./code-quality/"
+    href="../code-quality/"
     description="wheels analyze, wheels validate — deeper diagnostic surfaces."
   />
   <LinkCard
     title="Upgrade"
-    href="./upgrade/"
+    href="../upgrade/"
     description="wheels upgrade — run after info flags an outdated framework version."
   />
 </CardGrid>

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/wheels-commands/code-generation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/wheels-commands/code-generation.mdx
@@ -422,17 +422,17 @@ No views, no HTML controllers — just a JSON endpoint mounted under `/api/produ
   />
   <LinkCard
     title="Creating a Project"
-    href="./creating-a-project/"
+    href="../creating-a-project/"
     description="wheels new and wheels create app — scaffold a fresh Wheels application."
   />
   <LinkCard
     title="Database"
-    href="./database/"
+    href="../database/"
     description="wheels migrate, wheels seed, wheels db — apply migrations and manage schema."
   />
   <LinkCard
     title="Scaffold Cleanup"
-    href="./scaffold-cleanup/"
+    href="../scaffold-cleanup/"
     description="wheels destroy — remove artifacts created by wheels generate."
   />
 </CardGrid>

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/wheels-commands/creating-a-project.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/wheels-commands/creating-a-project.mdx
@@ -172,17 +172,17 @@ The port lands in `lucee.json`, the datasource name lands in `config/app.cfm`. T
   />
   <LinkCard
     title="Code Generation"
-    href="./code-generation/"
+    href="../code-generation/"
     description="wheels generate — models, controllers, scaffolds, migrations, routes, tests."
   />
   <LinkCard
     title="Database"
-    href="./database/"
+    href="../database/"
     description="wheels migrate, wheels seed, wheels db — schema and seed workflows."
   />
   <LinkCard
     title="Dev Server"
-    href="./dev-server/"
+    href="../dev-server/"
     description="wheels start, wheels stop, wheels reload — running your app locally."
   />
 </CardGrid>


### PR DESCRIPTION
## Summary

Resolves #2424. Resolves #2426.

The "Related Commands" / "What's next" CardGrids and inline markdown links across multiple `v4-0-0-snapshot/command-line-tools/` pages all resolved to 404. Affected pages:

- `command-line-tools/installation.mdx`
- `command-line-tools/quick-start.mdx`
- `command-line-tools/configuration.mdx`
- `command-line-tools/mcp-integration.mdx`
- `command-line-tools/wheels-commands/app-inspection.mdx`
- `command-line-tools/wheels-commands/code-generation.mdx`
- `command-line-tools/wheels-commands/creating-a-project.mdx`

## Root cause

Links used `href="./<sibling>/"` and `[Text](./<sibling>/)`. Per RFC 3986, relative refs resolve against the base URL by stripping everything after the last `/`. For a page served at `/v4-0-0-snapshot/command-line-tools/installation/`, the base path is `/v4-0-0-snapshot/command-line-tools/installation/` — and `./quick-start/` resolves to `/v4-0-0-snapshot/command-line-tools/installation/quick-start/`, which 404s.

`command-line-tools/index.mdx` was the one page where `./` worked, because Astro serves it at `/command-line-tools/` (URL ends in the section dir itself), so `./quick-start/` lands at `/command-line-tools/quick-start/`.

## Fix

Switched every non-index page in `command-line-tools/` and its `wheels-commands/` / `core-commands/` sub-folders to `../<sibling>/` for both `LinkCard` `href` props and inline markdown links. Same transform applied uniformly via sed:

```sh
sed -i -E 's|href="\./|href="../|g'
sed -i -E 's|\]\(\./|](../|g'
```

`command-line-tools/index.mdx` was deliberately excluded — its `./` links work and don't need to change.

## Test plan

- [ ] Visit https://guides.wheels.dev/v4-0-0-snapshot/command-line-tools/installation/ and click each "Related Commands" card — all three resolve.
- [ ] Same on `/quick-start/`, `/configuration/`, `/mcp-integration/` — all "What's next" / "Related Commands" cards resolve.
- [ ] Visit `/wheels-commands/app-inspection/`, click "Related Commands" — resolves.
- [ ] Inline markdown links (e.g. "see [Configuration](...)") — resolve.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_