### PR TITLE
fix(cli): wheels --version emits the documented three-line format

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -123,26 +123,62 @@ component extends="modules.BaseModule" {
 	//  version / help — banner + command listing
 	// ─────────────────────────────────────────────────
 
-	// Produces the same output the brew/choco wrapper emits for `wheels --version`,
-	// so `wheels version` (no leading dashes) reaches the same banner via module
-	// dispatch. See cli/lucli/ARCHITECTURE.md for the two paths.
-	//
-	// Internal callers that want the bare version string use super.version() to
-	// bypass the banner formatting.
+	// Emits the three-line `wheels --version` format the installation guide
+	// documents (Wheels Module + LuCLI runtime + JVM). See
+	// web/sites/guides/.../command-line-tools/installation.mdx for the
+	// canonical output shape; issue #2431 tracked the prior banner output
+	// drifting from the doc.
 	/**
-	 * hint: Show Wheels CLI version and banner
+	 * hint: Show Wheels Module, LuCLI runtime, and JVM versions
 	 */
 	public string function version() {
-		var v = super.version();
 		var nl = chr(10);
-		var banner = "Wheels Version: " & v & nl & nl;
-		banner &= " __        ___               _     " & nl;
-		banner &= " \ \      / / |__   ___  ___| |___ " & nl;
-		banner &= "  \ \ /\ / /| '_ \ / _ \/ _ \ / __|" & nl;
-		banner &= "   \ V  V / | | | |  __/  __/ \__ \" & nl;
-		banner &= "    \_/\_/  |_| |_|\___|\___|_|___/" & nl & nl;
-		banner &= "https://wheels.dev";
-		return banner;
+		var moduleVersion = super.version();
+		var snapshotTag = reFindNoCase("snapshot|dev", moduleVersion) ? " (snapshot)" : "";
+
+		var lines = ["Wheels " & moduleVersion & snapshotTag];
+
+		var lucliVersion = $detectLucliVersion();
+		if (len(lucliVersion)) {
+			arrayAppend(lines, "LuCLI " & lucliVersion);
+		}
+
+		var javaVersion = $detectJavaVersion();
+		if (len(javaVersion)) {
+			arrayAppend(lines, "Java " & javaVersion);
+		}
+
+		return arrayToList(lines, nl);
+	}
+
+	private string function $detectLucliVersion() {
+		try {
+			var sys = createObject("java", "java.lang.System");
+			var v = sys.getProperty("lucli.version");
+			if (!isNull(v) && len(v)) {
+				return v;
+			}
+			v = sys.getenv("LUCLI_VERSION");
+			if (!isNull(v) && len(v)) {
+				return v;
+			}
+		} catch (any e) {
+			// fall through
+		}
+		return "";
+	}
+
+	private string function $detectJavaVersion() {
+		try {
+			var sys = createObject("java", "java.lang.System");
+			var v = sys.getProperty("java.version");
+			if (!isNull(v) && len(v)) {
+				return v;
+			}
+		} catch (any e) {
+			// fall through
+		}
+		return "";
 	}
 
 	// Hand-written replacement for BaseModule's auto-discovered help. Grouped by


### PR DESCRIPTION
## Summary

Resolves #2431.

The installation guide documents the expected `wheels --version` output as:

```
Wheels 4.0.0-SNAPSHOT+1523 (snapshot)
LuCLI 0.3.7
Java 21.0.8
```

The CLI was emitting an ASCII art banner instead — just the Wheels module version with no LuCLI or JVM line. The docs harness assertion (`asserts-output="Wheels"`) still passed because the banner contains the word "Wheels", but humans saw a mismatch between the doc and reality.

## Fix

Replace the banner with the three-line format:

```cfm
public string function version() {
    var moduleVersion = super.version();
    var snapshotTag = reFindNoCase("snapshot|dev", moduleVersion) ? " (snapshot)" : "";
    var lines = ["Wheels " & moduleVersion & snapshotTag];
    if (len($detectLucliVersion())) arrayAppend(lines, "LuCLI " & $detectLucliVersion());
    if (len($detectJavaVersion()))  arrayAppend(lines, "Java "  & $detectJavaVersion());
    return arrayToList(lines, chr(10));
}
```

- **Wheels** version: `super.version()` (already reads `.module-version` with `BuildInfo.cfc` fallback).
- **LuCLI** version: `lucli.version` Java system property, then `LUCLI_VERSION` env var.
- **Java** version: `java.version` system property.

Each detector is wrapped in try/catch and returns empty if the source isn't available — the line is then skipped, so the output degrades to just "Wheels …" rather than crashing on environments where LuCLI/JVM hooks aren't exposed.

## Snapshot tag

The doc shows `(snapshot)` after the version when the build is a snapshot. Append the same suffix when `super.version()` contains `"snapshot"` or `"dev"` (case-insensitive).

## Test plan

- [ ] Run `wheels --version` on a Homebrew-installed CLI — three lines appear.
- [ ] Run `wheels --version` on a manual-tarball install — three lines appear (LuCLI line may degrade if the system property isn't set; verify env-var fallback works).
- [ ] Confirm the docs harness assertion (`asserts-output="Wheels"`) still passes.
- [ ] Confirm the snapshot suffix appears when the version contains `SNAPSHOT` and not on a clean release version.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_