### PR TITLE
fix(view): package View Tests link uses params, not raw &-concat

### DIFF
--- a/vendor/wheels/public/views/packageentry.cfm
+++ b/vendor/wheels/public/views/packageentry.cfm
@@ -106,7 +106,7 @@ local.manifest = local.meta.manifest;
 
 		<!--- Show test link if package has tests --->
 		<cfif DirectoryExists(expandPath("/vendor/#LCase(local.pkgName)#/tests"))>
-			<a class="ui button" href="#urlFor(route='testbox')#&directory=vendor.#LCase(local.pkgName)#.tests">
+			<a class="ui button" href="#urlFor(route='testbox', params='directory=vendor.#LCase(local.pkgName)#.tests')#">
 				Run Package Tests
 			</a>
 		</cfif>


### PR DESCRIPTION
## Summary

Resolves #2428.

The "Run Package Tests" button on `/wheels/packages/<pkg>` returned `Could not find a route that matched this request.` when URL rewriting is on. The view rendered:

```cfm
href="#urlFor(route='testbox')#&directory=vendor.<pkg>.tests"
```

`urlFor(route='testbox')` returns the rewritten path `/core/tests` (no query string). Concatenating `&directory=...` produces `/core/tests&directory=vendor.<pkg>.tests`, which the router treats as a mismatched path against the `/core/tests` pattern.

## Fix

Use the `params` arg of `urlFor`, which knows when to use `?` vs `&` and encodes correctly:

```cfm
urlFor(route='testbox', params='directory=vendor.<pkg>.tests')
→ /core/tests?directory=vendor.<pkg>.tests
```

## Test plan

- [ ] Visit `/wheels/packages/wheels-i18n` (or any installed package) — click "Run Package Tests" — request resolves and the test runner output renders.
- [ ] Confirm the URL bar shows `/core/tests?directory=vendor.wheels-i18n.tests`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_