### PR TITLE
fix(view): packagelist UI shows canonical 'add' verb, not 'install'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,9 +382,9 @@ Use the `wheels packages` CLI. Resolves names against the `wheels-dev/wheels-pac
 wheels packages list                          # browse the registry
 wheels packages search <query>                # name/description/tag match
 wheels packages show <name>                   # detail page
-wheels packages install <name>                # latest compat version
-wheels packages install <name>@<version>      # pin
-wheels packages install <name> --force        # overwrite an existing vendor/<name>
+wheels packages add <name>                    # latest compat version (canonical verb)
+wheels packages add <name>@<version>          # pin
+wheels packages add <name> --force            # overwrite an existing vendor/<name>
 wheels packages update <name> --yes           # explicit update
 wheels packages update --all --yes            # update every installed package
 wheels packages remove <name>                 # delete vendor/<name>

--- a/vendor/wheels/public/views/packagelist.cfm
+++ b/vendor/wheels/public/views/packagelist.cfm
@@ -161,8 +161,11 @@ for (local.key in packageMeta) {
 								<span class="ui label"><i class="check icon"></i> Installed</span>
 							<cfelse>
 								<!--- rp.name is registry-schema-constrained to ^[a-z0-9][a-z0-9-]*$, so both id and JS string are already safe.
-								      JSStringFormat() is applied in the onclick defensively in case that invariant ever loosens. --->
-								<code id="install-#HTMLEditFormat(local.rpKey)#">wheels packages install #HTMLEditFormat(local.rp.name)#</code>
+								      JSStringFormat() is applied in the onclick defensively in case that invariant ever loosens.
+								      `add` (not `install`) is the canonical verb — LuCLI's built-in extension
+								      installer intercepts the literal subcommand `install`, so `wheels packages
+								      install <name>` never reaches Module.cfc. See PR #2374 / cli/lucli/services/packages/PackagesMainCli.cfc. --->
+								<code id="install-#HTMLEditFormat(local.rpKey)#">wheels packages add #HTMLEditFormat(local.rp.name)#</code>
 								<button type="button"
 									class="ui tiny button"
 									aria-label="Copy install command for #HTMLEditFormat(local.rp.name)#"


### PR DESCRIPTION
## Summary

Resolves #2467.

The Packages dev UI rendered each install hint as:

```
wheels packages install <name>
```

LuCLI's built-in extension installer intercepts the literal subcommand `install` across all modules — `wheels packages install <name>` never reaches `Module.cfc`. PR #2374 renamed the verb to `add` for this reason, but the dev UI never got updated. Users copying the displayed command saw:

- CommandBox: `Command "wheels packages install wheels-hotwire" cannot be resolved.`
- LuCLI: silent no-op (`No git or extension dependencies to install`)

## Fix

Render the canonical `add` verb instead. Same change in `CLAUDE.md`'s package-install snippet so the framework's own contributor reference matches the UI.

## Test plan

- [ ] Visit `/wheels/packages/`, click into the registry tab, copy an install command. Verify it reads `wheels packages add <name>`.
- [ ] Run the copied command in LuCLI — completes the install (vendor folder appears).
- [ ] Confirm the `Copy` button still copies the correct text.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_