### PR TITLE
fix(cli): generated app config points at 4.0 docs, not 3.1.0

### DIFF
--- a/cli/lucli/templates/app/config/environment.cfm
+++ b/cli/lucli/templates/app/config/environment.cfm
@@ -2,7 +2,7 @@
 // Use this file to set the current environment for your application.
 // You can set it to "development", "testing", "maintenance" or "production".
 // Don't forget to issue a reload request (e.g. reload=true) after making changes.
-// See https://wheels.dev/3.1.0/guides/working-with-wheels/switching-environments for more info.
+// See https://guides.wheels.dev/v4-0-0-snapshot/working-with-wheels/switching-environments for more info.
 
 // Below, we have set it to "development" for you since that is convenient when you are building your application.
 // We recommend that you change this to "production" when you're running your application live.

--- a/cli/lucli/templates/app/config/routes.cfm
+++ b/cli/lucli/templates/app/config/routes.cfm
@@ -2,7 +2,7 @@
 
 	// Use this file to add routes to your application and point the root route to a controller action.
 	// Don't forget to issue a reload request (e.g. reload=true) after making changes.
-	// See https://wheels.dev/3.1.0/guides/handling-requests-with-controllers/routing for more info.
+	// See https://guides.wheels.dev/v4-0-0-snapshot/handling-requests-with-controllers/routing for more info.
 
 	mapper()
 		// CLI-Appends-Here

--- a/cli/lucli/templates/app/config/settings.cfm
+++ b/cli/lucli/templates/app/config/settings.cfm
@@ -3,7 +3,7 @@
 		Use this file to configure your application.
 		You can also use the environment specific files (e.g. /config/production/settings.cfm) to override settings set here.
 		Don't forget to issue a reload request (e.g. reload=true) after making changes.
-		See https://wheels.dev/3.1.0/guides/working-with-wheels/configuration-and-defaults for more info.
+		See https://guides.wheels.dev/v4-0-0-snapshot/working-with-wheels/configuration-and-defaults for more info.
 	*/
 
 	/*


### PR DESCRIPTION
## Summary

Resolves #2471.

The reporter ran `wheels new myApp` and concluded from the generated `config/settings.cfm` that the CLI scaffolds a Wheels 3.x application. They asked for a `--snapshot` flag to scaffold a 4.0 app.

Looking at the generator: it always copies the bundled `cli/lucli/templates/app/` and the bundled `vendor/wheels/` (resolved by `resolveFrameworkSourceOrFail`). Both are 4.0. The directory layout (`app/`, `vendor/`, `app/controllers/Controller.cfc` extending `wheels.Controller`, etc.) is the 4.0 layout.

So the app **is** Wheels 4.0. What confused the reporter was three doc-comment URLs in the generated config pointing at `https://wheels.dev/3.1.0/guides/...`:

```cfm
// config/settings.cfm
See https://wheels.dev/3.1.0/guides/working-with-wheels/configuration-and-defaults for more info.

// config/routes.cfm
See https://wheels.dev/3.1.0/guides/handling-requests-with-controllers/routing for more info.

// config/environment.cfm
See https://wheels.dev/3.1.0/guides/working-with-wheels/switching-environments for more info.
```

3.1.0 was the last release on the legacy `wheels.dev/<version>/guides/...` host; 4.0 docs live at `guides.wheels.dev/v4-0-0-snapshot/...`.

## Fix

Rewrite the three URLs to the 4.0-SNAPSHOT guide host. No template structure changes — just the link targets, which is enough to remove the "this is 3.x" misread.

## Out of scope

The reporter also asked for `--snapshot` to opt into bleeding-edge. That's a separate feature ask (the CLI currently always uses the framework bundled with the release). I'm not implementing it here — the CLI already ships with whatever framework version was current at release time, so `--snapshot` would mean "fetch develop branch" or similar, which is a meaningful design choice that needs maintainer input.

## Test plan

- [ ] `wheels new myApp`
- [ ] Open `config/settings.cfm`, `config/routes.cfm`, `config/environment.cfm`
- [ ] All three doc-comment URLs point at `guides.wheels.dev/v4-0-0-snapshot/...`
- [ ] Click through to verify the destinations resolve (post-merge of #2505 — relative-link fixes for the same guide section).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_