### PR TITLE
docs: clarify which generators use the attribute syntax

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/wheels-commands/code-generation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/wheels-commands/code-generation.mdx
@@ -47,7 +47,9 @@ Running `wheels generate` with no arguments prints the list of supported types a
 
 ## Attribute syntax
 
-Most generators accept a trailing list of `name:type` property pairs after the resource name. The parser also recognises a few `--belongsTo=`, `--hasMany=`, and `--hasOne=` flags for associations. Type names are normalised to Wheels migration column types — unknown types fall back to `string`.
+Property-aware generators — `model`, `scaffold`, `api-resource`, and `property` — accept a trailing list of `name:type` property pairs after the resource name. They also recognise `--belongsTo=`, `--hasMany=`, and `--hasOne=` flags for associations. Type names are normalised to Wheels migration column types — unknown types fall back to `string`.
+
+The other generators (`controller`, `view`, `migration`, `route`, `test`, `helper`, `snippets`, `admin`) take their own positional arguments — see the per-subcommand Synopsis sections below for what each accepts.
 
 | You write | Column type | Notes |
 |---|---|---|


### PR DESCRIPTION
## Summary

Resolves #2466.

The Code Generation guide had an "Attribute syntax" section opening with "Most generators accept a trailing list of name:type pairs" — without naming which ones. The table that followed sat between the dispatcher overview and the per-subcommand sections, so readers reasonably parsed it as global-to-all-generators, then got confused when `generate controller` and `generate test` didn't accept `name:type` args.

## Fix

Make the boundary explicit in the lead paragraph:

- The four property-aware generators (`model`, `scaffold`, `api-resource`, `property`) take `name:type` and `--belongsTo=` / `--hasMany=` / `--hasOne=`.
- The others (`controller`, `view`, `migration`, `route`, `test`, `helper`, `snippets`, `admin`) take their own positional args, already documented per-subcommand.

No structural change to the page — every Synopsis section already accurately listed what its subcommand accepts. This change just removes the ambiguous lede.

## Test plan

- [ ] Render `code-generation.mdx` and confirm the new lead paragraph reads cleanly.
- [ ] Confirm the rest of the page is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_