### PR TITLE
docs: add CFML Engines page covering Adobe CF and BoxLang setup

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/cfml-engines.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/cfml-engines.mdx
@@ -1,0 +1,111 @@
+---
+title: CFML Engines
+description: Run Wheels on Lucee, Adobe ColdFusion, or BoxLang. The wheels CLI ships with Lucee; the framework runs on all three.
+type: explanation
+sidebar:
+  order: 6
+---
+
+import { Aside, Tabs, TabItem, Steps, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+Wheels is the framework. **The framework runs on three CFML engines:** Lucee, Adobe ColdFusion, and BoxLang. The `wheels` CLI is a separate thing — it's a developer convenience that bundles a Lucee runtime so newcomers can `brew install wheels` and have a working dev server in one step. If you need Adobe CF or BoxLang for development or production, you don't use the `wheels` CLI's bundled runtime; you use a CommandBox-managed server (or a manual install) and the framework handles the rest.
+
+## TL;DR
+
+| Engine | Use the `wheels` CLI? | Run via CommandBox? | Production-supported? |
+|---|---|---|---|
+| Lucee 6 / 7 | Yes — bundled, recommended | Yes | Yes |
+| Adobe ColdFusion 2023 / 2025 | No — install manually | Yes — recommended | Yes |
+| BoxLang | No | Yes | Yes |
+
+The framework's CI matrix (`.github/workflows/compat-matrix.yml`) runs every release against Lucee 6, Lucee 7, Adobe CF 2023, Adobe CF 2025, and BoxLang on each release. Engine support is hard-gated.
+
+## Why the `wheels` CLI is Lucee-only
+
+The `wheels` CLI is a thin wrapper around [LuCLI](https://github.com/cybersonic/LuCLI) — a single-binary CFML launcher that boots Lucee Express on demand. LuCLI doesn't ship Adobe CF or BoxLang runtimes (it's not authorised to redistribute Adobe CF, and the BoxLang launcher is a separate project), so `wheels start` always boots Lucee.
+
+If you're starting fresh and don't have engine preferences yet, **stay on Lucee** — it's the path of least resistance and the default the rest of the docs assume.
+
+## Running Wheels on Adobe ColdFusion
+
+Two routes, depending on what you already have installed.
+
+### Route 1 — CommandBox (recommended)
+
+[CommandBox](https://www.ortussolutions.com/products/commandbox) is a CFML server manager from Ortus Solutions. It can boot Adobe CF, Lucee, or BoxLang on demand, downloading the engine on first use. This is the standard path for Adobe CF development on Wheels.
+
+<Steps>
+
+1. **Install CommandBox.** macOS: `brew install commandbox`. Windows: `choco install commandbox`. Linux: see the [CommandBox docs](https://commandbox.ortusbooks.com/setup/installation).
+
+2. **Generate a Wheels app** with the `wheels` CLI as usual — the bundled Lucee will be used to scaffold the project, but you can switch engines in the next step:
+
+   ```bash
+   wheels new myApp
+   cd myApp
+   ```
+
+3. **Boot CommandBox with Adobe CF** in the project directory:
+
+   ```bash
+   box server start cfengine=adobe@2025 port=8080
+   ```
+
+   First run downloads the Adobe CF engine (~500 MB). CommandBox writes a `server.json` you can commit if you want the team to pin the engine version.
+
+4. **Run migrations** the way you would on Lucee:
+
+   ```bash
+   wheels migrate latest
+   ```
+
+   The `wheels` CLI hits the running server's `/wheels/cli` endpoint, which works the same on every engine.
+
+</Steps>
+
+### Route 2 — Manual Adobe ColdFusion install
+
+If you already have Adobe CF installed (e.g. the dev edition from [coldfusion.adobe.com](https://www.adobe.com/products/coldfusion-family.html)), point its web root at your Wheels app's `public/` directory and configure the datasource through the CF Administrator. The framework requires no engine-specific setup beyond having a registered datasource.
+
+<Aside type="note">
+The `wheels start`, `wheels stop`, `wheels reload`, and `wheels test` commands all assume the Lucee Express bundled with the CLI. On Adobe CF you'll use `box server start/stop/restart` instead, and reload via `?reload=true&password=<your-password>` directly. Generators (`wheels generate ...`) are pure file-system operations and work the same regardless of engine.
+</Aside>
+
+## Running Wheels on BoxLang
+
+[BoxLang](https://boxlang.io/) is Ortus's modern CFML alternative. CommandBox supports BoxLang as a server engine just like it does Adobe CF.
+
+```bash
+wheels new myApp
+cd myApp
+box server start cfengine=boxlang@latest port=8080
+```
+
+Wheels' BoxLang compatibility is verified per release in the same CI matrix as Lucee and Adobe CF. Cross-engine gotchas worth knowing about live in [`.ai/wheels/cross-engine-compatibility.md`](https://github.com/wheels-dev/wheels/blob/develop/.ai/wheels/cross-engine-compatibility.md) — most are about minor differences in struct/array semantics under closures.
+
+## Pick an engine
+
+- **You're new to Wheels and want the easiest path:** Lucee, with the bundled `wheels` CLI. Skip the rest of this page.
+- **Your team standardised on Adobe CF:** CommandBox + Adobe CF. Skip the bundled CLI's `start`/`stop` commands; use `box server` instead.
+- **You want a modern, performant CFML runtime and don't have legacy Adobe scripts to support:** BoxLang via CommandBox.
+- **You're shipping to a production server you don't control:** the framework runs on whatever engine that server uses; the `wheels` CLI doesn't ship to production.
+
+## Related
+
+<CardGrid>
+  <LinkCard
+    title="Installing Wheels"
+    href="../installing/"
+    description="Get the wheels CLI on your machine. Lucee-bundled."
+  />
+  <LinkCard
+    title="Your First 15 Minutes"
+    href="../first-15-minutes/"
+    description="Lucee path — fastest way to a running app."
+  />
+  <LinkCard
+    title="CLI Installation"
+    href="/v4-0-0-snapshot/command-line-tools/installation/"
+    description="Detailed install reference for macOS, Windows, Linux."
+  />
+</CardGrid>

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/index.mdx
@@ -16,4 +16,5 @@ The entry path for new Wheels developers. Follow it top to bottom.
   <LinkCard title="Installing Wheels" href="/v4-0-0-snapshot/start-here/installing/" />
   <LinkCard title="Your First 15 Minutes" href="/v4-0-0-snapshot/start-here/first-15-minutes/" />
   <LinkCard title="Tutorial: Build a Blog" href="/v4-0-0-snapshot/start-here/tutorial/" />
+  <LinkCard title="CFML Engines" href="/v4-0-0-snapshot/start-here/cfml-engines/" />
 </CardGrid>

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
@@ -16,6 +16,10 @@ Install the `wheels` CLI. Five minutes.
 - How to verify the install worked
 - How to upgrade later
 
+<Aside type="tip" title="Adobe ColdFusion or BoxLang user?">
+The `wheels` CLI bundles a Lucee runtime — that's the easiest path for development and what the rest of these docs assume. The framework itself runs on Adobe ColdFusion 2023/2025 and BoxLang too; you'll use CommandBox to manage the engine instead of the bundled CLI. See [CFML Engines](/v4-0-0-snapshot/start-here/cfml-engines/) for the setup.
+</Aside>
+
 <Aside type="note">
   **Prerequisite:** Java 21 or newer. `wheels` bundles a CFML runtime (Lucee) that targets JDK 21. Install it from [Adoptium](https://adoptium.net/) if you don't already have it, or on macOS:
 


### PR DESCRIPTION
## Summary

Resolves #2494.

The Start Here section pointed every new developer at LuCLI without explaining that LuCLI is a Lucee-only convenience. The framework runs on Adobe ColdFusion 2023/2025 and BoxLang as well — and the CI matrix gates every release on all three engines — but Adobe CF / BoxLang users had no documented path from "I want to use Wheels" to "I have a running dev server."

## What this adds

- New page `start-here/cfml-engines.mdx`:
  - TL;DR matrix (which engine works with which CLI)
  - Explanation of why the `wheels` CLI is Lucee-only (LuCLI doesn't redistribute Adobe CF; BoxLang's launcher is separate)
  - Two routes for Adobe CF — **CommandBox (recommended)** with `box server start cfengine=adobe@2025`, and a **manual Adobe CF install**
  - BoxLang setup via CommandBox
  - A "Pick an engine" decision section
- Wired into `start-here/index.mdx`'s CardGrid (`sidebar.order: 6`, after the tutorial)
- Top-of-page tip on `installing.mdx` so Adobe / BoxLang users aren't silently steered into the Lucee-only flow

## Test plan

- [ ] Visit `/v4-0-0-snapshot/start-here/cfml-engines/` — page renders with the TL;DR matrix, all sections, and the "Related" CardGrid links resolve.
- [ ] Visit `/v4-0-0-snapshot/start-here/` — new "CFML Engines" card appears after the Tutorial card.
- [ ] Visit `/v4-0-0-snapshot/start-here/installing/` — top tip appears before the Java prerequisite Aside, with a working link to the new page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_