### PR TITLE
fix(cli): destroy controller leaves views in place; cascade only via resource form

### DIFF
--- a/cli/lucli/services/Destroy.cfc
+++ b/cli/lucli/services/Destroy.cfc
@@ -100,31 +100,36 @@ component {
 	}
 
 	/**
-	 * Destroy a controller, its views, and its test.
+	 * Destroy a controller and its test.
 	 *
-	 * Uses the input name verbatim (just capitalised for the filename), to
-	 * mirror how `wheels generate controller <Name>` writes the file. The
-	 * previous implementation pluralised + lowercased + recapitalised, so
-	 * `wheels destroy WidgetTest controller` looked for `Widgettests.cfc`
-	 * — which was never created. See issue #2330 and the related
-	 * name-mangling side-finding.
+	 * Type-scoped destroy: removes only the controller .cfc and its
+	 * spec. Views are intentionally left in place — to clean up the
+	 * controller AND its views together, run `wheels destroy <Name>`
+	 * (no type), which calls `destroyResource` and cascades model +
+	 * controller + views + tests + route + drop-table migration.
+	 *
+	 * Earlier behaviour (#2330) cascaded views from this command too,
+	 * but #2493 surfaced the Rails-style over-delete risk: a
+	 * hand-written partial inside `app/views/<name>/` would be wiped
+	 * by `destroy controller` even though the user never asked for
+	 * views to be touched. The split form (resource-level destroy =
+	 * cascade, type-level destroy = scoped) matches the Laravel
+	 * artisan-destroy convention.
+	 *
+	 * Uses the input name verbatim (just capitalised for the filename),
+	 * to mirror how `wheels generate controller <Name>` writes the
+	 * file. The previous implementation pluralised + lowercased +
+	 * recapitalised, so `wheels destroy WidgetTest controller` looked
+	 * for `Widgettests.cfc` — which was never created. See issue
+	 * #2330 and the related name-mangling side-finding.
 	 */
 	public struct function destroyController(required string name) {
 		var result = {success: true, deleted: [], warnings: []};
 		var clean = variables.helpers.stripSpecialChars(trim(arguments.name));
 		var controllerCap = variables.helpers.capitalize(clean);
-		var viewsDir = lCase(controllerCap);
 
 		deleteFileIfExists(
 			variables.projectRoot & "/app/controllers/" & controllerCap & ".cfc",
-			result
-		);
-		// Views directory is generated alongside the controller; destroy
-		// removes it too. Issue #2330: previously views were left behind,
-		// making `wheels generate scaffold` over the same name fail with
-		// orphaned partial state.
-		deleteDirIfExists(
-			variables.projectRoot & "/app/views/" & viewsDir,
 			result
 		);
 		deleteFileIfExists(
@@ -195,11 +200,13 @@ component {
 			case "controller":
 				// Controller destroy uses the input verbatim (matching how
 				// `generate controller` writes the file), not the pluralised
-				// name. Views directory comes along too.
+				// name. Views are intentionally NOT included here — the
+				// type-scoped form deletes only the named type. For a full
+				// resource teardown including views, run
+				// `wheels destroy <Name>` (no type). See issue #2493.
 				var clean = variables.helpers.stripSpecialChars(trim(arguments.name));
 				var controllerCap = variables.helpers.capitalize(clean);
 				arrayAppend(preview, "app/controllers/" & controllerCap & ".cfc");
-				arrayAppend(preview, "app/views/" & lCase(controllerCap) & "/");
 				arrayAppend(preview, "tests/specs/controllers/" & controllerCap & "ControllerSpec.cfc");
 				break;
 			case "view":

--- a/cli/lucli/tests/specs/services/DestroySpec.cfc
+++ b/cli/lucli/tests/specs/services/DestroySpec.cfc
@@ -50,7 +50,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 
 			describe("destroyController()", () => {
 
-				it("deletes controller, views directory, and test files (##2330)", () => {
+				it("deletes controller and test files but NOT views (##2493)", () => {
 					var controllerPath = tempRoot & "/app/controllers/Deletemes.cfc";
 					var viewsDir = tempRoot & "/app/views/deletemes";
 					// Generator writes <name>ControllerSpec.cfc (CodeGen.cfc
@@ -64,13 +64,31 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					fileWrite(controllerPath, 'component extends="Controller" {}');
 					fileWrite(testPath, 'component {}');
 
-					// Input matches the controller filename verbatim — destroy
-					// no longer pluralises (which used to produce wrong target
-					// filenames for non-conventional names; see #2330).
+					// Type-scoped destroy is intentionally narrow: only the
+					// named type goes. Views stay. Use `destroy <Name>` (no
+					// type) for the resource-level cascade.
 					var result = destroy.destroyController("Deletemes");
 					expect(fileExists(controllerPath)).toBeFalse();
-					expect(directoryExists(viewsDir)).toBeFalse();
 					expect(fileExists(testPath)).toBeFalse();
+					expect(directoryExists(viewsDir)).toBeTrue();
+					expect(fileExists(viewsDir & "/index.cfm")).toBeTrue();
+				});
+
+				it("preserves hand-written partials in the views dir (##2493)", () => {
+					// Rails-style over-delete regression: an unrelated file
+					// inside app/views/<name>/ that the user authored by hand
+					// must NOT be touched by `destroy controller`.
+					var controllerPath = tempRoot & "/app/controllers/Posts.cfc";
+					var viewsDir = tempRoot & "/app/views/posts";
+					var handwrittenPartial = viewsDir & "/_custom_widget.cfm";
+					directoryCreate(getDirectoryFromPath(controllerPath), true, true);
+					directoryCreate(viewsDir, true, true);
+					fileWrite(controllerPath, 'component extends="Controller" {}');
+					fileWrite(handwrittenPartial, "<cfoutput>handcrafted</cfoutput>");
+
+					destroy.destroyController("Posts");
+					expect(fileExists(controllerPath)).toBeFalse();
+					expect(fileExists(handwrittenPartial)).toBeTrue();
 				});
 
 				it("preserves PascalCase for non-conventional names (##2330 side-finding)", () => {
@@ -78,14 +96,11 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					// recapitalised, mangling `WidgetTest` into `Widgettests`
 					// which never matched the actually-generated file.
 					var controllerPath = tempRoot & "/app/controllers/WidgetTest.cfc";
-					var viewsDir = tempRoot & "/app/views/widgettest";
 					directoryCreate(getDirectoryFromPath(controllerPath), true, true);
-					directoryCreate(viewsDir, true, true);
 					fileWrite(controllerPath, 'component extends="Controller" {}');
 
 					var result = destroy.destroyController("WidgetTest");
 					expect(fileExists(controllerPath)).toBeFalse();
-					expect(directoryExists(viewsDir)).toBeFalse();
 				});
 
 				it("does not generate a migration", () => {
@@ -182,14 +197,17 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					expect(arrayToList(preview)).toInclude("drop table");
 				});
 
-				it("returns expected items for controller type (##2330)", () => {
-					// 3 items: controller .cfc, views/ directory, controller spec.
-					// Issue #2330 added the views directory to controller destroy.
+				it("returns controller and spec only — views excluded (##2493)", () => {
+					// Type-scoped controller destroy is narrow: only the
+					// controller .cfc and its spec. Views are explicitly NOT
+					// previewed because they're not deleted. The resource
+					// form (previewDestroy("Products", "resource")) covers
+					// the cascade case.
 					var preview = destroy.previewDestroy("Products", "controller");
-					expect(arrayLen(preview)).toBe(3);
+					expect(arrayLen(preview)).toBe(2);
 					expect(arrayToList(preview)).toInclude("Products.cfc");
-					expect(arrayToList(preview)).toInclude("app/views/products/");
 					expect(arrayToList(preview)).toInclude("ProductsControllerSpec.cfc");
+					expect(arrayToList(preview)).notToInclude("app/views/products/");
 				});
 
 			});


### PR DESCRIPTION
## Summary

Resolves #2493. Reverses the views-deletion behaviour added by #2330. The cascade is preserved — it just lives on the resource-level form now.

## Background

Two prior issues disagreed about what `wheels destroy <Name> controller --force` should do:

- **#2330** added view-directory deletion: "controllers and views are a unit; destroying one but leaving the other means re-running scaffold trips on orphan views."
- **#2493** flagged the same behaviour as a bug: "I asked to destroy the controller; my hand-written partial in the views dir got wiped."

Researched [Rails](https://github.com/rails/rails/blob/main/railties/lib/rails/commands/destroy/destroy_command.rb) and [Laravel's artisan-destroy package](https://github.com/msazzuhair/laravel-artisan-destroy):

- Rails: `rails destroy controller <Name>` walks the generator recipe in reverse and deletes everything it would have generated, views included. Has [the same over-delete sharp edge](https://github.com/rails/rails/issues/13708), accepts the trade-off.
- Laravel (community package): each type-level destroy is narrow. `destroy:controller` deletes the controller. `destroy:view` is separate. `destroy:model -a` is the explicit cascade flag. No accidental cross-deletion.

Wheels has something Rails doesn't — a real **resource-level destroy** (`wheels destroy <Name>` with no type, calls `destroyResource()`, cascades model + controller + views + tests + route + drop-table migration). So the type-scoped form can stay narrow without losing the cascade case. That's the contract this PR codifies.

## The new contract

| Command | What it removes |
|---|---|
| `wheels destroy Posts` | Model, controller, views dir, model + controller specs, view-tests dir, route, drop-table migration |
| `wheels destroy Posts controller` | Controller `.cfc` + controller spec |
| `wheels destroy Posts model` | Model `.cfc` + model spec + drop-table migration |
| `wheels destroy Posts view` | Views directory + view-tests directory |

Predictable: the type argument scopes the destroy. No accidental over-delete. No capability lost — `destroy <Name>` (resource form) covers cascade.

## Changes

- `destroyController()` (`cli/lucli/services/Destroy.cfc`) no longer deletes the views directory.
- `previewDestroy("controller")` no longer lists the views directory (2 items instead of 3).
- `DestroySpec`:
  - Original `deletes controller, views directory, and test files (#2330)` test flipped — now asserts views are **preserved**.
  - New regression test `preserves hand-written partials in the views dir (#2493)` writes an unrelated `_custom_widget.cfm` and asserts it survives.
  - PascalCase-name test no longer creates a fixture views dir (no longer relevant).

## Out-of-scope follow-up

Chapter 3 of the tutorial uses `wheels destroy Posts controller` to drop a hand-written controller before scaffolding. Under the new contract that step leaves views behind. The right replacement is `wheels destroy Posts` (resource form) for the full reset, or `wheels generate scaffold Post --force`. Worth a tutorial-side PR if @bpamiri or another maintainer wants to wire it up — flagging here, not changing in this PR to keep the diff focused.

## Test plan

- [ ] `wheels generate scaffold Post title:string body:text` — scaffold the resource.
- [ ] Add a hand-written `app/views/posts/_custom.cfm`.
- [ ] `wheels destroy Posts controller --force` — controller gone, views dir intact, `_custom.cfm` intact.
- [ ] `wheels destroy Posts --force` (no type) — full cascade including views dir.
- [ ] `wheels destroy Posts controller --force` then `wheels generate scaffold Post --force` — scaffold completes, overwriting the orphan views.
- [ ] Run `cli/lucli/tests/specs/services/DestroySpec.cfc` — all assertions pass on Lucee + Adobe + BoxLang.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_