### PR TITLE
docs: align destroy references with #2493 type-scoped contract

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/mcp-integration.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/mcp-integration.mdx
@@ -60,7 +60,7 @@ Every public function in the Wheels Module is auto-discovered as an MCP tool, pr
 | Tool | Purpose |
 |---|---|
 | `wheels_generate` | Scaffold a model, controller, view, migration, scaffold, route, test, property, or helper. |
-| `wheels_destroy` | Remove a previously generated component and its associated files. |
+| `wheels_destroy` | Remove a previously generated component. The default `resource` type cascades (model + controller + views + tests + route + drop-table migration); `model`, `controller`, and `view` are scoped to that artefact only. |
 | `wheels_migrate` | Run, roll back, or inspect database migrations. |
 | `wheels_seed` | Run convention-based seeds against the configured environment. |
 | `wheels_db` | Database utility operations (schema, reset, status). |

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/wheels-commands/scaffold-cleanup.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/wheels-commands/scaffold-cleanup.mdx
@@ -63,7 +63,7 @@ wheels destroy Post
 wheels destroy Post --force
 ```
 
-The second command removes `app/models/Post.cfc`, `app/controllers/Posts.cfc`, `app/views/posts/`, `tests/specs/models/PostSpec.cfc`, `tests/specs/controllers/PostsSpec.cfc`, `tests/specs/views/posts/`, and the `.resources("posts")` line from `config/routes.cfm`. It also writes a new `<timestamp>_remove_posts_table.cfc` migration into `app/migrator/migrations/` — you still need to run `wheels migrate latest` to actually drop the table from the database.
+The second command removes `app/models/Post.cfc`, `app/controllers/Posts.cfc`, `app/views/posts/`, `tests/specs/models/PostSpec.cfc`, `tests/specs/controllers/PostsControllerSpec.cfc`, `tests/specs/views/posts/`, and the `.resources("posts")` line from `config/routes.cfm`. It also writes a new `<timestamp>_remove_posts_table.cfc` migration into `app/migrator/migrations/` — you still need to run `wheels migrate latest` to actually drop the table from the database.
 
 ## Safety notes
 
@@ -71,7 +71,8 @@ The second command removes `app/models/Post.cfc`, `app/controllers/Posts.cfc`, `
 - Commit your work before running `destroy`. Deleted files are gone — `destroy` does not move them to a backup directory.
 - Run `destroy` without `--force` first and read the preview. The command always lists what it would delete before doing anything.
 - `destroy model` and `destroy resource` generate a drop-table migration but do **not** execute it. Your database schema is unchanged until you run `wheels migrate latest`. If you want the schema back the way it was, delete the generated migration file before migrating.
-- `destroy` removes whole view directories by default. Pass a `controller/action` path to `destroy view` when you only want a single template deleted.
+- `destroy resource` (the default form, no type) removes the views directory. `destroy controller` does NOT — it deletes only the controller `.cfc` and its spec, so a hand-written partial in `app/views/<name>/` is left in place. Use `destroy view` (or the resource form) when you want the views gone.
+- Pass a `controller/action` path to `destroy view` when you only want a single template deleted instead of the whole directory.
 - Files not found are reported as skipped, not errors — `destroy` succeeds even if the files you asked about were already gone.
 </Aside>
 

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/03-crud-scaffold.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/tutorial/03-crud-scaffold.mdx
@@ -76,9 +76,10 @@ Drop the hand-written controller and views. The model, migration, seed file, and
 
 ```bash title="your shell"
 wheels destroy Posts controller --force
+wheels destroy Posts view --force
 ```
 
-The argument order is `<name> [type]` — `Posts controller`, not `controller Posts`. The `--force` flag skips the interactive confirmation; without it, `destroy` prints `Use --force to confirm deletion.` and exits without touching anything. If you'd rather skip the CLI and remove the files yourself:
+The argument order is `<name> [type]` — `Posts controller`, not `controller Posts`. `destroy controller` removes the controller `.cfc` and its spec; `destroy view` removes the views directory. They're separate commands so you can scope each cleanup independently — e.g. `destroy controller` alone if you want to keep your views intact while rewriting the controller. The `--force` flag skips the interactive confirmation; without it, `destroy` prints `Use --force to confirm deletion.` and exits without touching anything. If you'd rather skip the CLI and remove the files yourself:
 
 ```bash title="your shell"
 rm app/controllers/Posts.cfc


### PR DESCRIPTION
## Summary

Doc follow-up to PR #2513, which narrowed `wheels destroy <Name> controller` to delete only the controller `.cfc` + spec (no longer cascading views). Three doc surfaces still described the old behaviour or carried stale filenames — this PR aligns them.

## Changes

### `start-here/tutorial/03-crud-scaffold.mdx`

Chapter 3 says "Drop the hand-written controller and views. The model, migration, seed file, and the `resources("posts")` route stay." Under the old contract that was a single `wheels destroy Posts controller --force`. Under the new contract that command leaves the views directory alone.

The tutorial's stated intent (drop controller AND views, keep everything else) needs two commands now:

```bash
wheels destroy Posts controller --force
wheels destroy Posts view --force
```

The resource form (`wheels destroy Posts`) would also work but it'd drop the model, migration, and route — which the chapter explicitly wants to keep. Added an explanatory sentence so readers understand why the split exists.

### `command-line-tools/wheels-commands/scaffold-cleanup.mdx`

Two fixes:

1. The "destroy is destructive" caution said `destroy removes whole view directories by default` — true for the resource form and `destroy view`, NOT for `destroy controller`. Rewrote that bullet to call out the boundary explicitly.
2. The "Example" output mentioned `tests/specs/controllers/PostsSpec.cfc` — stale name from before #2502 fixed the destroy filename. Corrected to `PostsControllerSpec.cfc`.

The Types table on line 48 was already accurate (described `controller` as removing only the CFC + spec). The behaviour now matches.

### `command-line-tools/mcp-integration.mdx`

The `wheels_destroy` tool description was a generic one-liner. Made it crisper so AI agents understand the cascade-vs-scoped split before they call the tool.

## Out of scope

- `command-line-tools/index.mdx` line 91 ("undo a generator cleanly") — generic enough to leave alone.
- `command-line-tools/wheels-commands/code-quality.mdx` line 176 — generic related-link description.
- `digging-deeper/caching.mdx` line 229 — refers to the HTTP `destroy` REST verb, not the CLI command. Untouched.
- v3 docs (`v3-0-0/...`) — frozen historical version, do not touch.

## Test plan

- [ ] Render `tutorial/03-crud-scaffold.mdx` — the two-command block appears with the explanatory paragraph.
- [ ] Render `scaffold-cleanup.mdx` — caution bullet calls out the controller-vs-resource boundary; example output references `PostsControllerSpec.cfc`.
- [ ] Render `mcp-integration.mdx` — `wheels_destroy` row reads correctly in the table.
- [ ] Walk through the tutorial chapter 3 as written — `wheels generate scaffold Post` succeeds after the two destroy commands run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_