### PR TITLE
docs: clarify reload password CLI/HTTP threat model (#2477)

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -511,7 +511,13 @@ component extends="modules.BaseModule" {
 	// ─────────────────────────────────────────────────
 
 	/**
-	 * hint: Reload the running Wheels application
+	 * hint: Reload the running Wheels application. The reload password
+	 * gates the HTTP `?reload=true` endpoint against remote attackers;
+	 * the CLI reads it from `.env` or `config/settings.cfm` and forwards
+	 * it because it runs locally with filesystem access. This matches
+	 * how Rails, Laravel, Symfony, etc. treat CLI-vs-HTTP — the CLI is
+	 * already trusted at the same level as the project on disk. See
+	 * issue #2477 and `deployment/security-hardening.mdx`.
 	 */
 	public string function reload() {
 		var serverPort = $requireRunningServer();

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/wheels-commands/dev-server.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/wheels-commands/dev-server.mdx
@@ -97,6 +97,14 @@ wheels reload
 
 `wheels reload` detects the running server's port automatically (from `lucee.json`, then `.env`) and hits `http://localhost:<port>/?reload=true&password=<password>` with the reload password it finds in your project config. If no server is running, it prints `No running Wheels server detected. Start one with: wheels start` and exits.
 
+<Aside type="note" title="Why the CLI doesn't re-prompt for the reload password">
+The reload password gates the **HTTP** endpoint `?reload=true` — it's an ACL against remote attackers who could otherwise hit that URL and wipe your app's state. The CLI runs locally, has filesystem access to your project, and reads the configured password directly from `.env` or `config/settings.cfm`. Re-prompting you for a password the tool just read from disk wouldn't add security: an attacker with disk read would already have the password.
+
+This matches how Rails (no reload password concept; `bin/rails restart`/deploy tooling instead), Laravel (`php artisan optimize:clear` and friends never authenticate), Symfony (`bin/console cache:clear`), Django (`manage.py runserver`/`migrate`), and Phoenix (`mix phx.server`) treat the CLI/HTTP boundary. The CLI carries owner-of-the-project trust by definition.
+
+If you need to keep `wheels reload` itself behind a credential check (e.g. a shared dev box where multiple users have shell access), gate it at the OS level with file permissions on `.env`. See [Security Hardening — Reload password](/v4-0-0-snapshot/deployment/security-hardening/#reload-password) for the full threat model.
+</Aside>
+
 #### Example
 
 ```bash title="illustrative — requires running server"

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/security-hardening.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/deployment/security-hardening.mdx
@@ -163,6 +163,28 @@ set(reloadPassword=application.wo.env("WHEELS_RELOAD_PASSWORD"));
 
 Rotate it in every environment. The scaffolded template uses `{{reloadPassword}}` as a placeholder the generator fills in (`cli/lucli/templates/app/config/settings.cfm` line 25); replace with an env-var lookup before you ship. Never commit the literal value.
 
+### What it protects (and what it doesn't)
+
+The reload password defends a single threat: **a remote attacker who can reach your app over HTTP** otherwise being able to call `/?reload=true` and clobber app state, or `/?reload=production` and switch environments at will. With the password set, those URLs return 403 unless the attacker also knows the secret.
+
+What it explicitly does **not** gate:
+
+- **`wheels reload` from the CLI.** The CLI runs locally with filesystem access to `.env` and `config/settings.cfm`, reads the password from one of those, and forwards it to the HTTP endpoint as a trusted local proxy. Re-prompting the operator for a password the tool just read from disk would add no security — anyone with that disk read already has the password. This matches how Rails, Laravel, Symfony, Django, and Phoenix treat their CLI/HTTP boundary: the CLI carries owner-of-the-project trust by definition.
+- **`wheels stop && wheels start`.** A full restart goes through LuCLI and never touches the HTTP reload endpoint. The reload password is irrelevant.
+- **Filesystem-level access.** Anyone who can read `config/settings.cfm` (or whatever env file you've pointed it at) sees the password in plaintext. The defence is `chmod` + filesystem ACLs + secret managers, not the password itself.
+
+### Hardening beyond the password
+
+If your threat model needs to defend against compromised disk read or a hostile co-tenant on a shared dev box, gate the actual disk:
+
+- `.env` permissions: `chmod 600 .env` so only the app's UNIX user can read it.
+- Use a secret manager (1Password Connect, AWS Parameter Store, Doppler) to inject `WHEELS_RELOAD_PASSWORD` at process start; never write it to disk in the first place.
+- For the HTTP endpoint specifically, layer a network ACL: bind the dev server to `127.0.0.1` only, or front it with a reverse proxy that requires VPN-side IPs for the reload path.
+
+The password is the cheapest of these — it's a single defence-in-depth layer against opportunistic remote scans. It's not a substitute for keeping the secret out of attacker-readable storage.
+
+See issue [#2477](https://github.com/wheels-dev/wheels/issues/2477) for the full Rails / Laravel comparison that informed this design.
+
 ## Secret management
 
 Keep every runtime secret out of source control:


### PR DESCRIPTION
## Summary

Documents the design of `reloadPassword` so the question raised in #2477 doesn't recur. No code changes — `wheels reload` behaviour is unchanged.

## Background

#2477 asked why `wheels reload` doesn't re-prompt for the configured reload password. Researched the convention across Rails, Laravel, Symfony, Django, and Phoenix:

- **Rails** has no reload-password concept at all; restart goes through deploy tooling with SSH-key auth.
- **Laravel** `php artisan optimize:clear` / `cache:clear` / `up` / `down` never authenticate. `php artisan down --secret=` goes the *opposite* direction — the CLI mints a token; HTTP visitors must present it.
- **Symfony / Django / Phoenix** — same shape. CLI carries owner-of-the-project trust by definition.

Wheels' current behaviour is correct and matches them all. Issue closed as working-as-designed; this PR makes the design intent visible in three places.

## Changes

### `cli/lucli/Module.cfc::reload()` hint

Expanded the LuCLI hint comment with a short threat-model note and a pointer at the security guide. So `wheels --help` and `wheels reload --help` carry the explanation.

### `command-line-tools/wheels-commands/dev-server.mdx`

`Aside type="note"` on the `wheels reload` reference page explaining why the CLI doesn't re-prompt, with the Rails / Laravel / etc. parity point and a deep-link to the security-hardening section.

### `deployment/security-hardening.mdx`

The existing `## Reload password` section grew two new subsections:

- **"What it protects (and what it doesn't)"** — names the threat model explicitly (remote attackers hitting `?reload=true`), lists what the password does NOT gate (the CLI, full restart, filesystem access).
- **"Hardening beyond the password"** — concrete defence-in-depth recommendations: `chmod 600 .env`, secret managers, network ACLs.

Linked back to #2477 for the rationale trail.

## Test plan

- [ ] Render `dev-server.mdx` — the new Aside appears between the synopsis and the example, with a working link to `security-hardening/#reload-password`.
- [ ] Render `security-hardening.mdx` — two new subsections appear under `## Reload password`.
- [ ] Run `wheels reload --help` (after rebuild) — hint shows the new threat-model note.
- [ ] Confirm no behavioural change: `wheels reload` still works exactly as before; only docs/hints differ.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFsuLinL6VuPYkHnoNekqi)_