### PR TITLE
ci: add wheels-bot Claude automation suite (triage, research, review, propose-fix)

### DIFF
--- a/.claude/commands/_shared-rails.md
+++ b/.claude/commands/_shared-rails.md
@@ -1,0 +1,84 @@
+# Shared Rails (paste verbatim into every wheels-bot command)
+
+These rails apply to every wheels-bot slash command. The caller workflow assumes
+they are honored. Violating them is a bug — fix the prompt, not the rails.
+
+## Tool restrictions
+
+- **GitHub state**: use `gh` only. No `curl` to api.github.com, no MCP servers.
+- **Git operations**: read-only only — `git status`, `git log`, `git diff`,
+  `git show`, `git grep`. **Never** `git push`, `git config`, `git checkout -B`
+  on shared branches, `git reset --hard`, `git --force`, or any subcommand that
+  rewrites history. The caller workflow handles branch creation and pushes
+  when applicable.
+- **No write-side network tools** unless the caller workflow's `--allowed-tools`
+  explicitly grants them. `WebFetch` / `WebSearch` are allowed only in
+  `bot-research.yml`.
+- **Filesystem writes** are scoped to your designated working tree by the
+  caller workflow's permissions. Never edit `vendor/wheels/**` unless the
+  command's section explicitly says so.
+
+## Wheels-specific reasoning
+
+- **Read `.ai/wheels/` before reasoning about CFML semantics.** It contains
+  the canonical agent reference for cross-engine compatibility, ORM
+  conventions, controller patterns, view helpers, testing, and security.
+  Specifically check `.ai/wheels/cross-engine-compatibility.md` for any
+  Lucee-vs-Adobe-vs-BoxLang concerns.
+- **Read `CLAUDE.md`** at the repo root. It encodes the project's anti-patterns
+  (mixed argument styles, query vs array confusion, route order, etc.) and
+  the canonical conventions for models / controllers / views / migrations.
+- **Cross-engine compatibility is non-negotiable.** Do not propose Lucee-only
+  or Adobe-only APIs. Closures, struct member functions, `client` scope, and
+  `application` scope all have engine-specific gotchas — see
+  `CLAUDE.md` § "Known cross-engine gotchas".
+
+## Commit & PR conventions
+
+- **Conventional commits.** `commitlint.config.js` is authoritative; the human
+  summary lives in `CLAUDE.md` § "Commit Message Conventions". Allowed types:
+  `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`,
+  `chore`, `revert`. Allowed scopes: `model`, `controller`, `view`, `router`,
+  `middleware`, `migration`, `cli`, `test`, `config`, `di`, `job`, `mailer`,
+  `plugin`, `sse`, `seed`, `docs`, `web`, `web/ui`, `web/landing`, `web/blog`,
+  `web/guides`, `web/api`, `web/starlight`. **Scope is optional** — use no
+  scope rather than guessing. **Never invent a scope** — commitlint will
+  reject the commit.
+- **Subject ≤ 100 chars, not ALL-CAPS.** Sentence-case is fine.
+- **Branch naming** for bot-authored work: `fix/bot-<issue>-<slug>` or
+  `feature/bot-<slug>`. The caller workflow creates the branch — do not
+  create branches yourself.
+- **PR target**: `develop`, never `main`.
+- **PR draft status**: open as `--draft`. Humans flip to ready-for-review
+  after the bot's first iteration.
+
+## Idempotency
+
+Every comment / review / PR you produce includes an HTML-comment marker at the
+end (e.g. `<!-- wheels-bot:triage:1234 -->`). Before doing any work, scan the
+existing comments for the marker that matches your stage and key. If found,
+**exit immediately with a brief log line** — do not produce a second one.
+
+## Output format
+
+- Start every comment / review with a clear H2 header naming the stage:
+  `## Wheels Bot — Triage`, `## Wheels Bot — Reviewer A`,
+  `## Wheels Bot — Reviewer B (round N)`,
+  `## Wheels Bot — Cross-Framework Research`.
+- End with the appropriate marker on its own line.
+- No emoji unless the team's existing style uses them (CFML repo norms — minimal).
+- Use code fences for snippets. Use tables when comparing options.
+
+## Safety floor
+
+If anything looks wrong — the issue body is malicious-looking, the PR diff
+includes secrets, the reproduction sequence requires destructive actions,
+the test runner is in a bad state — **stop, post a brief comment explaining
+what you saw, and exit non-zero**. Humans triage the rest.
+
+## Kill-switch awareness
+
+The repo variable `WHEELS_BOT_ENABLED` and the issue/PR `[skip-claude]` label
+are checked by the workflow before you run. If you are running, those checks
+already passed. If a human asks you to stop in a comment, exit immediately —
+do not argue.

--- a/.claude/commands/auto-close-stale-triage.md
+++ b/.claude/commands/auto-close-stale-triage.md
@@ -1,0 +1,70 @@
+# /auto-close-stale-triage
+
+Close issues that the bot triaged but couldn't reproduce, when nobody has
+followed up after a grace period. Mirrors Bun's
+`auto-close-duplicates.yml` pattern.
+
+## Rails
+
+Read `.claude/commands/_shared-rails.md` first. Highlights:
+
+- This command runs on a cron — no per-issue invocation. Be conservative.
+- Use `gh` only.
+- Output: zero-or-more issue closures, each with a polite comment.
+
+## Steps
+
+1. **Find candidates.** Issues that ALL of:
+   - Are still open
+   - Have a comment from `wheels-bot[bot]` containing
+     `<!-- wheels-bot:triage:` (any class)
+   - Have the `cannot-reproduce` label
+   - Have NO human comment (i.e., from a non-bot account) since the triage
+     comment was posted
+   - Were triaged at least 14 days ago
+
+   ```bash
+   gh issue list \
+     --state open \
+     --label cannot-reproduce \
+     --json number,createdAt,updatedAt,comments,author \
+     --jq '<filter>'
+   ```
+
+2. **For each candidate:**
+
+   a. Sanity check: re-read the issue, confirm there has been no human
+      activity since the triage comment.
+
+   b. Idempotency: skip if a comment with marker
+      `<!-- wheels-bot:auto-close:<issue-number> -->` already exists.
+
+   c. Post the closure comment:
+
+      ```
+      ## Wheels Bot — Auto-close
+
+      This issue was triaged on <date> with classification `cannot-reproduce`
+      and has had no follow-up in 14 days. Closing as stale.
+
+      If you have a fresh reproduction or new context, please reopen with
+      the additional information.
+
+      <!-- wheels-bot:auto-close:<issue-number> -->
+      ```
+
+   d. Close the issue: `gh issue close <issue-number> --reason "not planned"`.
+
+3. **Summary.** Log a one-line summary to stdout for each closure (so the
+   workflow run log is auditable).
+
+## Safety
+
+- Never close an issue that has any human comment newer than the triage
+  comment.
+- Never close an issue without the `cannot-reproduce` label, even if it
+  was triaged.
+- Never close an issue authored by `wheels-bot[bot]` (it shouldn't happen,
+  but guard anyway).
+- If anything looks weird (e.g., the triage comment is older than the
+  issue, suggesting tampering), skip and log a warning.

--- a/.claude/commands/propose-fix.md
+++ b/.claude/commands/propose-fix.md
@@ -1,0 +1,186 @@
+# /propose-fix
+
+Propose a fix for a triaged issue, in a TDD-mandatory draft PR.
+
+## Rails
+
+Read `.claude/commands/_shared-rails.md` first. Highlights for this command:
+
+- Use `gh` for GitHub state, full `git` for **your branch only** (the
+  caller workflow has created `fix/bot-<issue>-<slug>` for you and you are
+  checked out on it).
+- Run tests via `bash tools/test-local.sh`. Do not invoke `lucli` directly.
+- Output is **a single draft PR** against `develop`.
+
+## Args
+
+- `<issue-number>` — the triaged issue to fix
+
+## TDD invariant
+
+You MUST write a failing spec BEFORE writing the implementation, and you
+MUST capture the failure output before proceeding to implement. The
+`bot-tdd-gate.yml` CI check will reject the PR if the diff has no spec
+changes or no implementation changes. The prompt-level discipline below
+is enforced by code, so don't skip steps.
+
+## Steps
+
+1. **Idempotency check.** Read existing comments on the issue via
+   `gh issue view <issue-number> --json comments`. If any comment contains
+   `<!-- wheels-bot:fix:<issue-number> -->`, exit silently — a fix has
+   already been proposed.
+
+2. **Read the authoritative context.** Both must be read before doing
+   anything else:
+   - The triage comment (marker `wheels-bot:triage:<issue-number>`) — gives
+     you the layer, repro spec, and confidence assessment.
+   - **If present**, the research comment (marker
+     `wheels-bot:research:<issue-number>`) — gives you the recommended path
+     forward for framework-design issues. **The research's recommended
+     path IS the spec; do not deviate from it without justification.**
+
+   If neither comment exists, exit with a comment explaining no triage
+   was found.
+
+3. **Read the supporting docs.**
+   - `CLAUDE.md` § "Critical Anti-Patterns" + § "Wheels Conventions" + §
+     "Commit Message Conventions"
+   - `.ai/wheels/<layer>/` for the affected layer
+   - `.ai/wheels/cross-engine-compatibility.md` always
+   - `.github/pull_request_template.md` — you will fill this checklist
+
+4. **Auto-downgrade safety net.** Before writing anything, check whether the
+   intended fix touches any of:
+   - `vendor/wheels/security/**`, `app/middleware/**` auth, password / token
+     code
+   - `vendor/wheels/migrator/**` or migration files under
+     `app/migrator/migrations/**`
+   - `cli/lucli/services/deploy/**` or anything under `wheels deploy`
+   - `vendor/wheels/di/**` or DI container internals
+   - Cross-engine concern (you will need different code paths for
+     Lucee/Adobe/BoxLang)
+
+   If yes: **stop**. Do not open a PR. Post a comment on the issue:
+
+   ```
+   ## Wheels Bot — Fix on hold for human review
+
+   The proposed fix touches a sensitive area (`<area>`) and the bot's
+   safety net requires a human in the loop before any code is written.
+
+   <!-- wheels-bot:fix-held:<issue-number> -->
+   ```
+
+   Then exit.
+
+5. **Write the failing spec.** Place under
+   `vendor/wheels/tests/specs/<layer>/` (framework-level fix) or
+   `tests/specs/<layer>/` (app-level fix). Use `wheels.WheelsTest` BDD
+   syntax. The spec should:
+   - Be the smallest thing that demonstrates the bug or exercises the
+     proposed feature
+   - Match the repro from the triage comment
+   - For `framework-design`: directly assert the API surface the research
+     comment recommends
+
+6. **Run the failing spec.**
+
+   ```bash
+   bash tools/test-local.sh <layer>
+   ```
+
+   Capture the failure to `/tmp/bot-failure.json` (use `format=json` on the
+   test endpoint or save the bash output). **Confirm the spec actually
+   fails.** A passing spec at this point means you wrote the wrong test —
+   redo it.
+
+7. **Implement the fix.** Edit the relevant files under `vendor/wheels/**`
+   or `app/**`. Do not touch:
+   - `commitlint.config.js`, `package.json`, `package-lock.json`
+   - `.github/workflows/pr.yml`
+   - Any other developer's in-flight branch
+
+   Honor every CLAUDE.md anti-pattern. Reference `.ai/wheels/<layer>/`
+   patterns for the right shape.
+
+8. **Re-run the spec.**
+
+   ```bash
+   bash tools/test-local.sh <layer>
+   ```
+
+   Confirm the spec now passes. Also confirm no other tests in the layer
+   regressed. If something else broke, fix it before proceeding.
+
+9. **Update supporting docs.**
+   - If user-visible behavior changed: update
+     `web/sites/guides/src/content/docs/v4-0-0-snapshot/<area>/<page>.mdx`
+   - Always update `.ai/wheels/<layer>/` if the patterns table changed
+   - If model/controller/view conventions changed: update `CLAUDE.md`
+   - Add a `CHANGELOG.md` `[Unreleased]` entry (one line, present tense,
+     no PR number — humans add the link on merge)
+
+10. **Stage, commit, and prepare the PR.**
+
+    Conventional commit. Type from `feat`/`fix`/`refactor`/`perf`/`test`/
+    `docs`/`chore`. Scope from the allowlist (or no scope). Subject ≤ 100
+    chars, sentence-case, not ALL-CAPS.
+
+    Examples:
+    - `fix(model): findOne(where=...) honours nested associations`
+    - `feat(model): add findEach batch processor`
+    - `docs: clarify migration seed pattern for cross-DB compatibility`
+
+    The caller workflow handles the actual `git push` — your job is to
+    `git add` the right files and `git commit` cleanly. Do **not** use
+    `--amend` or `--force`.
+
+11. **Open the draft PR.** Use `gh pr create --draft --base develop`. The
+    PR body must:
+    - Open with one paragraph naming what changed and why
+    - Include `Fixes #<issue-number>`
+    - **If a research comment was used**: include
+      `Recommended path from research: <link to research comment>`
+    - Fill the `.github/pull_request_template.md` checklist honestly:
+      - [x] Tests — your failing-then-passing spec
+      - [x/?] Framework Docs — checked if you updated MDX
+      - [x/?] AI Reference Docs — checked if you updated `.ai/wheels/`
+      - [x/?] CLAUDE.md — checked if you updated it
+      - [x] CHANGELOG.md
+      - [x] Test runner passes (cite the local test-local.sh output)
+    - End with the marker `<!-- wheels-bot:fix:<issue-number> -->`
+
+12. **Self-check before opening.** Do NOT proceed unless every box is
+    checked:
+    - [ ] At least one file under `vendor/wheels/tests/specs/**` or
+      `tests/specs/**` is new or modified in the diff
+    - [ ] At least one file outside `tests/`, `vendor/wheels/tests/`,
+      `.ai/`, `CHANGELOG.md`, `docs/` is new or modified (the
+      implementation)
+    - [ ] `bash tools/test-local.sh <layer>` exits 0 on the final run
+    - [ ] Commit message passes a mental commitlint check
+    - [ ] PR is created with `--draft`
+    - [ ] PR body cites research comment URL if research was used
+    - [ ] Marker is present in PR body
+
+    If any check fails: do not open the PR. Comment "no fix proposed"
+    on the issue and exit.
+
+13. **Comment back on the issue** with a link to the PR:
+
+    ```
+    ## Wheels Bot — Fix proposed
+
+    Draft PR: <link>
+
+    Spec: `<path/to/spec.cfc>` — failing → passing
+    Implementation: `<path(s)>`
+
+    A human review is required before merge. Reviewer A and Reviewer B
+    will weigh in shortly.
+
+    <!-- wheels-bot:fix:<issue-number> -->
+    ```
+
+    Then exit.

--- a/.claude/commands/research-frameworks.md
+++ b/.claude/commands/research-frameworks.md
@@ -1,0 +1,179 @@
+# /research-frameworks
+
+Cross-framework research synthesis for a `framework-design` issue. Compare
+how Rails, Laravel, Django, Phoenix, Spring Boot, and one other relevant
+framework handle the topic, then propose a Wheels-idiomatic adaptation
+with a self-rated confidence.
+
+## Rails
+
+Read `.claude/commands/_shared-rails.md` first. Highlights for this command:
+
+- `WebFetch` and `WebSearch` are allowed. Other write-side network tools
+  are not.
+- `WebFetch` should target official documentation domains:
+  - `rubyonrails.org`, `guides.rubyonrails.org`, `api.rubyonrails.org`
+  - `laravel.com`, `laravel.com/docs`
+  - `docs.djangoproject.com`
+  - `hexdocs.pm/phoenix`
+  - `spring.io/guides`, `docs.spring.io`
+  - The framework's own GitHub repo for source-of-truth
+- Use `WebSearch` to discover URLs first when you don't know the canonical
+  page.
+- Do NOT propose Lucee-only or Adobe-only APIs — see
+  `.ai/wheels/cross-engine-compatibility.md`.
+
+## Args
+
+- `<issue-number>` — the framework-design issue to research
+
+## Steps
+
+1. **Idempotency check.** Read existing comments on the issue. If any
+   contains `<!-- wheels-bot:research:<issue-number> -->`, exit silently.
+
+2. **Re-read the issue.** Pull the title, body, and any human follow-up
+   comments via `gh issue view <issue-number> --json title,body,comments`.
+   Extract the actual question:
+   - What problem is the requester trying to solve?
+   - What API surface are they imagining (if any)?
+   - What constraints have they named?
+   - Have any humans weighed in with preferences?
+
+3. **Parallel framework research.** Use the Agent tool to launch 6 parallel
+   sub-agents (or fewer if fewer frameworks are relevant). Each agent gets:
+
+   - **The exact question** (one paragraph extracted from step 2)
+   - **A specific framework** to research
+   - **An explicit return format**: `{ apiSurface, exampleUsage, ergonomicTradeoffs, edgeCases, idiomaticNaming, sourceUrls }`
+
+   Frameworks to dispatch:
+   - **Rails** (always) — search rubyonrails.org/guides + api.rubyonrails.org
+   - **Laravel** (always) — search laravel.com/docs
+   - **Django** (always) — search docs.djangoproject.com
+   - **Phoenix** (when ORM / web-layer relevant) — hexdocs.pm/phoenix
+   - **Spring Boot** (when validation / DI / middleware relevant) — docs.spring.io
+   - **One other** — pick based on topic. Examples: Symfony for HTTP plumbing,
+     Express/Koa for middleware, FastAPI for type-driven routing, Hanami for
+     Rails-alternatives. Justify the pick in your synthesis.
+
+   Each agent uses `WebFetch` against the canonical docs and returns its
+   structured summary.
+
+4. **Synthesize.** With all framework summaries in hand:
+
+   a. **Build a comparison table**: rows are frameworks, columns are
+      `Naming`, `Surface`, `Trade-offs`, `Edge cases`. Be terse —
+      one phrase per cell.
+
+   b. **Identify the dominant pattern.** Which approach do most frameworks
+      converge on? Where do they meaningfully diverge? Is there a clear
+      "modern consensus" or do the trade-offs split reasonable people?
+
+   c. **Cross-reference Wheels constraints.** Read:
+      - `CLAUDE.md` § "Critical Anti-Patterns"
+      - `CLAUDE.md` § "Wheels Conventions"
+      - `.ai/wheels/cross-engine-compatibility.md`
+      - `.ai/wheels/<closest-layer>/`
+
+      Flag any conflict between the dominant pattern and existing Wheels
+      conventions. Specifically:
+      - Does the proposed API use mixed positional+named arguments? (anti-pattern)
+      - Does it depend on `struct.map()` / `obj["key"]()` / array-by-value? (cross-engine break)
+      - Does it require Lucee-only or Adobe-only APIs?
+      - Does it conflict with existing scope / enum / association naming?
+
+   d. **Draft a Wheels-idiomatic API sketch in CFML.** This is what the
+      `propose-fix` workflow will use as its spec target. Include:
+      - Function signature(s)
+      - Two or three usage examples
+      - Where it lives (`vendor/wheels/<layer>/`, mixin or component)
+      - How it composes with existing scopes / chainable query builder /
+        enum / DI container
+
+5. **Self-rate confidence.** Apply these rules in order:
+
+   - Default = `high` if the dominant pattern is clear AND your CFML sketch
+     respects all Wheels conventions AND no cross-engine concerns surfaced.
+   - **Downgrade to `medium`** if:
+     - The dominant pattern conflicts with a CLAUDE.md "Critical Anti-Pattern"
+       and you had to adapt it
+     - The dominant pattern conflicts with an existing Wheels convention
+       (naming, association style, scope semantics) and you had to adapt it
+     - The "+1 framework" you picked is doing it differently and the
+       trade-off is non-trivial
+   - **Downgrade to `low`** if:
+     - Frameworks materially disagree (e.g., Rails and Django pick opposite
+       sides of an ergonomic trade-off and there's no obvious right answer
+       for Wheels)
+     - The proposal would require new infrastructure (a new mixin, a new
+       lifecycle hook, a new DI scope) — these warrant a human discussion
+     - The issue is broad enough that "what should the API be" is itself
+       a multi-week design conversation
+
+6. **Post the comment.** Format:
+
+   ```
+   ## Wheels Bot — Cross-Framework Research
+
+   ### Question
+   <one-paragraph restatement of what the issue is asking>
+
+   ### How other frameworks handle this
+
+   | Framework | Naming | Surface | Trade-offs | Edge cases |
+   |---|---|---|---|---|
+   | Rails | … | … | … | … |
+   | Laravel | … | … | … | … |
+   | Django | … | … | … | … |
+   | <Phoenix or Spring Boot> | … | … | … | … |
+   | <+1 with justification> | … | … | … | … |
+
+   ### Dominant pattern
+   <one-paragraph synthesis: where do they converge, where do they diverge>
+
+   ### Recommended path for Wheels
+
+   <one-paragraph rationale>
+
+   ```cfml
+   <CFML API sketch — function signatures + usage examples>
+   ```
+
+   Lives in: `vendor/wheels/<layer>/<file>.cfc`.
+   Composes with: <existing primitives, e.g. scopes / chainable builder>.
+
+   ### Cross-engine notes
+   <one paragraph: Lucee/Adobe/BoxLang concerns; "none" if clean>
+
+   ### Open questions
+   <bullets — anything a human should weigh in on>
+
+   ### Confidence: `<low|medium|high>`
+
+   <one sentence: why this confidence level (cite any auto-downgrade rule
+   that fired)>
+
+   ### Sources
+   - <Rails URL>
+   - <Laravel URL>
+   - <Django URL>
+   - <…>
+
+   <!-- wheels-bot:research:<issue-number> -->
+   <CONFIDENCE_MARKER>
+   ```
+
+   Where `<CONFIDENCE_MARKER>` is:
+   - `<!-- wheels-bot:research-confidence:high -->` if confidence is high
+   - omitted otherwise
+
+7. **Self-check before posting.**
+   - Have you cited at least one URL per framework?
+   - Is the comparison table populated (no placeholder dashes)?
+   - Does the CFML sketch compile mentally — no obvious anti-patterns,
+     mixed argument styles, or cross-engine traps?
+   - Is the confidence level consistent with the auto-downgrade rules?
+   - Are all required markers present?
+
+   If any check fails, fix and re-post (do not double-post).

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,128 @@
+# /review-pr
+
+Reviewer A. Review the given pull request as a senior Wheels maintainer would.
+
+## Rails
+
+Read `.claude/commands/_shared-rails.md` first — they apply to every step
+below. Highlights for this command:
+
+- Use `gh` for GitHub state and **read-only** `git` (`git diff`, `git log`,
+  `git show`, `git grep`). No writes, no pushes, no MCP servers.
+- Never edit files. This is a review-only command.
+- Output is a **single PR review** (line comments + summary), not a comment.
+
+## Args
+
+- `<pr-number>` — the PR to review
+
+## Steps
+
+1. **Idempotency check.** Read existing reviews on the PR with
+   `gh pr view <pr-number> --json reviews,headRefOid --jq '.'`. If any review
+   body contains the marker `<!-- wheels-bot:review-a:<pr>:<sha> -->` for the
+   current head SHA, exit silently — there is nothing to do.
+
+2. **Gather context.** Read in this order, then build a mental model:
+   - `gh pr view <pr-number>` — title, body, author, base, head, labels
+   - `gh pr diff <pr-number>` — the full diff
+   - `gh pr view <pr-number> --json files` — file list
+   - `git log --oneline origin/develop..<head-sha>` — commit list (for
+     commit-message review)
+   - `CLAUDE.md` § "Critical Anti-Patterns" + § "Wheels Conventions" + §
+     "Commit Message Conventions"
+   - `.ai/wheels/cross-engine-compatibility.md` — Lucee/Adobe/BoxLang gotchas
+   - For any layer touched, the corresponding `.ai/wheels/<layer>/` doc
+     (e.g. if `app/models/**` is touched, read `.ai/wheels/models/`)
+
+3. **Review the diff.** Score the change against this checklist. For each
+   issue you find, prepare a line comment with file path + line number +
+   actionable suggestion.
+
+   **Correctness**
+   - Does the change do what the PR title / body claims?
+   - Are all code paths covered? Branches, error paths, edge cases?
+   - Are there off-by-ones, null derefs, race conditions?
+
+   **Wheels conventions** (CLAUDE.md anti-patterns)
+   - Mixed positional + named arguments in Wheels functions
+   - Query vs array confusion in views (`<cfloop array=` on a query)
+   - Nested resource routes use callback syntax, not Rails inline blocks
+   - HTML5 form helpers used (`emailField`, not manual `type="email"`)
+   - Migration seed data uses inline SQL (not parameter binding)
+   - Route order: MCP → resources → custom → root → wildcard last
+   - `t.timestamps()` includes deletedAt — no separate datetime columns
+   - Database-agnostic dates (`NOW()`, not `CURRENT_TIMESTAMP`)
+   - Controller filters declared `private`
+   - View variables `cfparam`-ed at top of view file
+
+   **Cross-engine compatibility** (.ai/wheels/cross-engine-compatibility.md)
+   - `struct.map()` member functions on CFC objects (Lucee/Adobe collide)
+   - `application` scope function members (Adobe-broken)
+   - `client` reserved scope inside closures (Lucee throws)
+   - `obj["key"]()` bracket-notation calls (Adobe parser crash)
+   - Array by-value in struct literals (Adobe copies)
+   - `private` mixin functions in `vendor/wheels/model/*.cfc` etc. — must use
+     `public` access with `$` prefix
+   - `Left(str, 0)` on Lucee 7
+
+   **Test coverage**
+   - Are there tests under `tests/specs/` or `vendor/wheels/tests/specs/`?
+   - Are happy path AND error paths covered?
+   - For new features, is there a BDD spec extending `wheels.WheelsTest`?
+     (Never RocketUnit / `wheels.Test` — that is legacy only.)
+
+   **Docs & metadata**
+   - PR template feature-completeness checklist filled honestly
+   - `.ai/wheels/<layer>/` updated if behavior changed
+   - `web/sites/guides/src/content/docs/v4-0-0-snapshot/` page updated for
+     user-facing features
+   - `CHANGELOG.md` `[Unreleased]` entry
+   - `CLAUDE.md` updated if model/controller/view conventions changed
+
+   **Commits**
+   - Each commit conforms to `commitlint.config.js` (type from allowlist,
+     scope from allowlist or empty, subject ≤ 100 chars, not ALL-CAPS)
+   - Commit messages reflect the "why," not the "what"
+
+   **Security**
+   - SQL injection (raw `where=` strings with user input vs query builder)
+   - XSS in views (`#unsafeUserInput#` without `EncodeForHTML`)
+   - CSRF on state-changing actions
+   - Secret leakage (.env, credentials in fixtures)
+
+4. **Write the review.** Use `gh pr review <pr-number> --comment` for the
+   summary plus `gh api` to attach line comments — or use a single
+   `gh pr review` invocation with `--body` containing line-anchored Markdown
+   if line comments are not feasible.
+
+   The review body must:
+   - Open with `## Wheels Bot — Reviewer A`
+   - Have a one-paragraph **TL;DR** that names the PR's purpose and your
+     overall verdict (`approve` / `request changes` / `comment`)
+   - Group findings under `### Correctness`, `### Conventions`,
+     `### Cross-engine`, `### Tests`, `### Docs`, `### Commits`,
+     `### Security` — omit empty sections
+   - For each finding, cite the file + line, quote the offending snippet,
+     and propose a concrete fix
+   - End with the marker `<!-- wheels-bot:review-a:<pr>:<sha> -->` where
+     `<sha>` is the head SHA you saw at step 2
+
+   Submit verdict:
+   - `--request-changes` if any **Correctness**, **Cross-engine**, or
+     **Security** finding fires, OR if commitlint / TDD violations are
+     present
+   - `--comment` if only minor convention / docs nits
+   - `--approve` only when the diff is genuinely clean — bias toward
+     `--comment` if uncertain. Do not approve as a courtesy.
+
+5. **Self-check before submitting.**
+   - Have you cited specific files + lines for every finding? (No vague
+     handwaving.)
+   - Is your TL;DR consistent with your findings? (Don't say "looks good"
+     above a list of correctness issues.)
+   - Did you cite at least one piece of evidence (a quoted line, a
+     `.ai/wheels/` reference) for each non-trivial claim?
+   - Is the marker present?
+
+   If any check fails, redo the review body before submitting.

--- a/.claude/commands/review-the-review.md
+++ b/.claude/commands/review-the-review.md
@@ -1,0 +1,131 @@
+# /review-the-review
+
+Reviewer B. Critique Reviewer A's review of a PR. The goal is to catch
+sycophancy, false positives, and missed issues — NOT to re-review the PR
+from scratch.
+
+## Rails
+
+Read `.claude/commands/_shared-rails.md` first. Highlights for this command:
+
+- Use `gh` for GitHub state and read-only `git`. No writes, no edits.
+- **Output is a PR comment, not a review.** Reviews would re-trigger the
+  caller workflow into an infinite loop.
+- Loop cap: 3 rounds. Check the existing comment count before posting.
+
+## Args
+
+- `<pr-number>` — the PR being reviewed
+- `<review-id>` — the Reviewer A review to critique
+
+## Steps
+
+1. **Idempotency + round counting.** Read the PR comments via
+   `gh pr view <pr-number> --json comments,headRefOid`. Count comments
+   whose body matches `wheels-bot:review-b:<pr-number>:<sha>:` (any round).
+
+   - If the most recent matching comment has the **current head SHA**, exit
+     silently (we already commented on this exact head).
+   - Round number = (count of B comments for any SHA on this PR) + 1.
+   - **If round > 3**: post the terminal comment and exit:
+
+     ```
+     ## Wheels Bot — Reviewer B (no further iterations)
+
+     Round cap (3) reached. Handing back to humans.
+
+     <!-- wheels-bot:review-b:<pr>:<sha>:terminal -->
+     ```
+
+2. **Read Reviewer A's review.** Use
+   `gh api repos/{owner}/{repo}/pulls/<pr-number>/reviews/<review-id>` to get
+   the full body and any line comments. Confirm the author is
+   `wheels-bot[bot]` — if not, exit (this command only critiques the bot's
+   own reviews).
+
+3. **Read the PR diff.** `gh pr diff <pr-number>` and `gh pr view <pr-number>`.
+   You need enough context to verify A's claims.
+
+4. **Critique A's review.** For each section / finding A made, ask:
+
+   **Sycophancy**
+   - Did A say "looks good" / "LGTM" / "approve" without citing evidence?
+   - Did A approve despite touching security, migration, deploy, or DI
+     subsystems (which should always require a human)?
+
+   **False positives**
+   - Read the actual lines A cited. Is A's claim accurate? E.g., A says
+     "this could SQL inject," but the code uses parameter binding — that
+     is a false positive.
+   - A flagged a CFML idiom as wrong, but it is a documented pattern in
+     `.ai/wheels/` or `CLAUDE.md` — false positive.
+   - A insisted on a convention that does not exist in this repo — false
+     positive.
+
+   **Missed issues**
+   - Re-scan the diff for anything obvious A skipped, especially:
+     - Cross-engine compat issues (`.ai/wheels/cross-engine-compatibility.md`)
+     - Tests that exist but don't actually exercise the change
+     - Commits that violate `commitlint.config.js` (scope, type, length)
+     - Missing `.ai/wheels/` updates when behavior changes
+     - Security issues A glossed over
+
+   **Tone & actionability**
+   - Are A's findings actionable? (file + line + suggestion)
+   - Is A's verdict (`approve` / `request-changes` / `comment`) consistent
+     with the findings?
+
+5. **Post the comment.** Format:
+
+   ```
+   ## Wheels Bot — Reviewer B (round <N>)
+
+   <one-paragraph TL;DR of your assessment of A's review>
+
+   ### Sycophancy
+   <bullets, or "none detected">
+
+   ### False positives
+   <bullets — quote A's claim, cite the actual code, explain why A is
+   wrong, or "none detected">
+
+   ### Missed issues
+   <bullets — file + line + the issue A should have flagged, or "none
+   detected">
+
+   ### Verdict alignment
+   <one sentence: is A's approve/request-changes/comment consistent with
+   their findings?>
+
+   <!-- wheels-bot:review-b:<pr>:<sha>:<round> -->
+   ```
+
+   Use `gh pr comment <pr-number> --body "<...>"` — do **not** use
+   `gh pr review`.
+
+6. **Self-check before posting.**
+   - Have you actually read the cited diff lines for each false-positive
+     claim? (Do not handwave.)
+   - Are your missed-issue findings concrete enough that A could act on
+     them in a follow-up review?
+   - Is the round number correct in the marker?
+   - Have you avoided re-reviewing the PR from scratch? (Stay focused on
+     critiquing A.)
+
+   If any check fails, fix and re-post (do not double-post).
+
+## When to be terse
+
+If A's review is genuinely clean — no sycophancy, no false positives, no
+missed issues — say so concisely. A short comment like:
+
+```
+## Wheels Bot — Reviewer B (round 1)
+
+A's review checks out. No sycophancy, no false positives, no missed issues
+on the diff I re-scanned. Verdict alignment looks correct.
+
+<!-- wheels-bot:review-b:<pr>:<sha>:1 -->
+```
+
+…is the right output. Don't pad.

--- a/.claude/commands/triage-issue.md
+++ b/.claude/commands/triage-issue.md
@@ -1,0 +1,181 @@
+# /triage-issue
+
+Classify a freshly-opened GitHub issue and, if it's a bug, attempt to reproduce
+it against the local Wheels test stack.
+
+## Rails
+
+Read `.claude/commands/_shared-rails.md` first — they apply to every step
+below. Highlights for this command:
+
+- Use `gh` for GitHub state and read-only `git`. No writes outside your
+  scratch worktree.
+- Test runs go through `bash tools/test-local.sh`. Do not invoke `lucli`
+  directly or hit other test endpoints.
+- Output is **one comment** on the issue with a stage-appropriate marker.
+
+## Args
+
+- `<issue-number>` — the issue to triage
+
+## Steps
+
+1. **Idempotency check.** Read existing comments via
+   `gh issue view <issue-number> --json comments,labels,title,body`. If any
+   comment body contains `<!-- wheels-bot:triage:<issue-number> -->` or
+   `<!-- wheels-bot:triage-class:` (any class), exit silently.
+
+2. **Read the issue.** Capture: title, body, any code blocks, error messages,
+   stack traces, environment info (CFML engine, Wheels version, OS, DB).
+
+3. **Classify.** Pick exactly one of:
+
+   - **`bug`** — the report describes observable wrong behavior, an error,
+     a crash, output that doesn't match documented behavior, or a regression.
+     Bugs usually have: a "what happened" + a "what I expected" + (often)
+     reproduction steps or a code sample.
+   - **`framework-design`** — feature request, API design question, "how
+     should Wheels do X," "Rails does it like Y, can Wheels do that," anything
+     that requires picking among reasonable approaches before code can be
+     written. The answer is a design decision, not a defect fix.
+   - **`other`** — docs request, support question ("how do I…"), discussion
+     thread without an actionable ask, broad product feedback.
+
+   When the report mixes a bug with a feature request, classify as `bug` if
+   the bug is reproducible in isolation; otherwise `framework-design`.
+
+4. **Branch by classification.**
+
+   ### If `other`
+
+   Post a brief acknowledgment comment, no automation downstream. Use this
+   format:
+
+   ```
+   ## Wheels Bot — Triage
+
+   Classified as **other** (general discussion / support / docs request).
+   No further bot action will be taken on this issue.
+
+   <!-- wheels-bot:triage:<issue-number> -->
+   <!-- wheels-bot:triage-class:other -->
+   ```
+
+   Then exit.
+
+   ### If `framework-design`
+
+   Post the classification comment with the trigger marker for the research
+   workflow. **Do not attempt to reproduce.** **Do not propose a design
+   opinion.** That is the research workflow's job.
+
+   ```
+   ## Wheels Bot — Triage
+
+   Classified as **framework-design** (API/feature design question).
+   Cross-framework research will follow shortly — Rails, Laravel, Django,
+   and other modern frameworks will be consulted before any path forward
+   is proposed.
+
+   <!-- wheels-bot:triage:<issue-number> -->
+   <!-- wheels-bot:triage-class:framework-design -->
+   ```
+
+   Then exit.
+
+   ### If `bug`
+
+   Continue to step 5.
+
+5. **Reproduce (bug path only).** This is the heavy step. The caller workflow
+   has already brought up Lucee + SQLite via the `setup-wheels-test-env`
+   composite action and the test endpoint at `http://localhost:60007/` is
+   ready.
+
+   a. **Identify the layer**: model / controller / view / router / middleware /
+      migrator / cli / di / job / mailer / sse / seed / config. Read the
+      corresponding `.ai/wheels/<layer>/` doc to ground your reasoning.
+
+   b. **Write a minimal failing spec** under
+      `vendor/wheels/tests/specs/<layer>/` (or `tests/specs/<layer>/` for
+      app-level repros). Use `wheels.WheelsTest` BDD syntax (never RocketUnit).
+      The spec should be the smallest thing that demonstrates the bug.
+
+   c. **Run it**: `bash tools/test-local.sh <layer>` (e.g. `model`).
+      Capture the failure: which assertion fired, what the diff between
+      expected and actual is.
+
+   d. **Do NOT commit the spec.** Triage is read-only as far as the
+      repository is concerned. Store the spec content + run output in
+      memory for the comment body.
+
+   e. If the spec passes (no reproduction): the bug is either invalid, was
+      already fixed, or you wrote the wrong spec. Note this in the comment
+      and downgrade confidence.
+
+6. **Self-rate confidence (bug path only).**
+
+   - **`high`**: you reproduced the bug; the failure is unambiguous; the
+     suspected layer is clear; a fix is mechanical (one file, no design
+     decisions). High-confidence bugs trigger the auto-fire fix-PR
+     workflow.
+   - **`medium`**: you reproduced the bug but the fix has design
+     trade-offs OR you couldn't write a clean spec but the bug is real
+     and obvious from the report.
+   - **`low`**: you couldn't reproduce; the report is ambiguous; multiple
+     layers could be involved; you suspect environment-specific behavior.
+
+   **Auto-downgrade rules** (force at least one level lower):
+   - The diff would touch `vendor/wheels/security/**`, auth flows, or any
+     `vendor/wheels/middleware/**` → at most `medium`
+   - Cross-engine concern detected (Lucee vs Adobe vs BoxLang behavior
+     differs) → at most `medium`
+   - The spec passes (no reproduction) → at most `low`
+   - Migration files, deploy subsystem, or DI container involved → at most
+     `medium`
+
+7. **Post the triage comment (bug path).** Format:
+
+   ```
+   ## Wheels Bot — Triage
+
+   Classified as **bug**.
+
+   ### Reproduction
+
+   <one paragraph: did you reproduce, what did you see, what spec did you write>
+
+   <fenced code block: the failing spec you wrote>
+
+   <fenced code block: the run output / failure summary>
+
+   ### Suspected layer
+
+   `<layer>` — see `.ai/wheels/<layer>/` for canonical patterns.
+
+   ### Fix sketch
+
+   <one paragraph: what file(s) likely change, what the fix shape looks like>
+
+   ### Confidence: `<low|medium|high>`
+
+   <one sentence: why this confidence level (cite any auto-downgrade rule
+   that fired)>
+
+   <!-- wheels-bot:triage:<issue-number> -->
+   <!-- wheels-bot:triage-class:bug -->
+   <CONFIDENCE_MARKER>
+   ```
+
+   Where `<CONFIDENCE_MARKER>` is:
+   - `<!-- wheels-bot:triage-confidence:high -->` if confidence is high
+   - omitted otherwise (medium/low confidence does not auto-trigger fix-PR)
+
+8. **Self-check before posting.**
+   - Is the classification justified by quoted text from the issue?
+   - For `bug` path: is the spec short and self-contained?
+   - For `bug` path: is the confidence consistent with the auto-downgrade
+     rules?
+   - Are all required markers present?
+
+   If any check fails, fix and re-post (do not post twice).

--- a/.github/actions/setup-wheels-test-env/action.yml
+++ b/.github/actions/setup-wheels-test-env/action.yml
@@ -1,0 +1,161 @@
+name: Set up Wheels test environment
+description: |
+  Brings up the canonical Wheels test stack on the runner: JDK 21, LuCLI,
+  SQLite test databases, Playwright (cached), SQLite JDBC driver, and a
+  running Lucee 7 server with the JDBC driver installed.
+
+  Lifted from `.github/workflows/pr.yml` so the bot workflows
+  (bot-triage.yml, bot-propose-fix.yml) can reuse the same harness without
+  duplicating ~130 lines.
+
+  After this action runs, `tools/test-local.sh` and the test endpoint at
+  `http://localhost:<port>/wheels/core/tests` are ready to use.
+
+inputs:
+  port:
+    description: 'Port to bind Lucee to'
+    required: false
+    default: '60007'
+  lucli-version:
+    description: 'LuCLI release version'
+    required: false
+    default: '0.3.7'
+  install-playwright:
+    description: 'Install Playwright + Chromium (set "false" to skip if no browser tests run)'
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Set up JDK 21
+      uses: actions/setup-java@v5
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+
+    - name: Install LuCLI
+      shell: bash
+      env:
+        LUCLI_VERSION: ${{ inputs.lucli-version }}
+      run: |
+        curl -sL "https://github.com/cybersonic/LuCLI/releases/download/v${LUCLI_VERSION}/lucli-${LUCLI_VERSION}-linux" \
+          -o /usr/local/bin/lucli
+        chmod +x /usr/local/bin/lucli
+        lucli --version
+
+    - name: Create test databases
+      shell: bash
+      run: |
+        sudo apt-get update -y && sudo apt-get install -y --no-install-recommends sqlite3
+        sqlite3 wheelstestdb.db "SELECT 1;"
+        sqlite3 wheelstestdb_tenant_b.db "SELECT 1;"
+
+    - name: Cache Playwright
+      if: inputs.install-playwright == 'true'
+      id: playwright-cache
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.wheels/browser/lib
+          ~/.cache/ms-playwright
+        key: playwright-${{ hashFiles('vendor/wheels/browser-manifest.json') }}
+        restore-keys: |
+          playwright-
+
+    - name: Install Playwright
+      if: inputs.install-playwright == 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        mkdir -p ~/.wheels/browser/lib
+
+        # Download JARs from manifest
+        for row in $(jq -c '.classpath[]' vendor/wheels/browser-manifest.json); do
+          URL=$(echo "$row" | jq -r '.url')
+          FILE=$(echo "$row" | jq -r '.filename')
+          SHA=$(echo "$row" | jq -r '.sha256')
+
+          echo "Downloading ${FILE}..."
+          curl -sL "$URL" -o ~/.wheels/browser/lib/"$FILE"
+
+          ACTUAL=$(sha256sum ~/.wheels/browser/lib/"$FILE" | cut -d' ' -f1)
+          if [ "$ACTUAL" != "$SHA" ]; then
+            echo "::error::SHA-256 mismatch for ${FILE}: expected ${SHA}, got ${ACTUAL}"
+            exit 1
+          fi
+        done
+
+        # Build classpath and install Chromium + system deps
+        CP=$(ls ~/.wheels/browser/lib/*.jar | tr '\n' ':')
+        java -cp "$CP" com.microsoft.playwright.CLI install --with-deps chromium
+
+    - name: Download SQLite JDBC driver
+      shell: bash
+      run: |
+        curl -sL "https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.50.3.0/sqlite-jdbc-3.50.3.0.jar" \
+          -o /tmp/sqlite-jdbc.jar
+
+    - name: Start Lucee server
+      shell: bash
+      env:
+        WHEELS_PORT: ${{ inputs.port }}
+      run: |
+        cp tools/ci/lucee.ci.json lucee.json
+
+        nohup lucli server run --port="${WHEELS_PORT}" > /tmp/lucli-server.log 2>&1 &
+        echo $! > /tmp/lucli-server.pid
+
+        echo "Waiting for Lucee to start..."
+        for i in $(seq 1 120); do
+          if curl -s -o /dev/null --connect-timeout 2 --max-time 3 "http://localhost:${WHEELS_PORT}/" 2>/dev/null; then
+            echo "Lucee is up (attempt ${i})"
+            break
+          fi
+          if ! kill -0 $(cat /tmp/lucli-server.pid) 2>/dev/null; then
+            echo "::error::LuCLI server process died"
+            cat /tmp/lucli-server.log
+            exit 1
+          fi
+          sleep 2
+        done
+
+    - name: Install SQLite JDBC into Lucee + restart
+      shell: bash
+      env:
+        WHEELS_PORT: ${{ inputs.port }}
+      run: |
+        LUCEE_LIB=$(find ~/.lucli/express -path "*/lib/ext" -type d 2>/dev/null | head -1)
+        if [ -z "$LUCEE_LIB" ]; then
+          LUCEE_LIB=$(find ~/.lucli/express -maxdepth 2 -name "lib" -type d 2>/dev/null | head -1)
+        fi
+        if [ -n "$LUCEE_LIB" ]; then
+          cp /tmp/sqlite-jdbc.jar "$LUCEE_LIB/"
+          echo "SQLite JDBC installed to: $LUCEE_LIB"
+        else
+          echo "::error::Could not find Lucee lib directory"
+          find ~/.lucli/express -type d | head -20
+          exit 1
+        fi
+
+        kill $(cat /tmp/lucli-server.pid) 2>/dev/null || true
+        lucli server stop 2>/dev/null || true
+        for i in $(seq 1 15); do
+          if ! curl -s -o /dev/null --connect-timeout 1 "http://localhost:${WHEELS_PORT}/" 2>/dev/null; then
+            break
+          fi
+          sleep 1
+        done
+        fuser -k "${WHEELS_PORT}/tcp" 2>/dev/null || true
+        sleep 2
+
+        nohup lucli server run --port="${WHEELS_PORT}" --force > /tmp/lucli-server.log 2>&1 &
+        echo $! > /tmp/lucli-server.pid
+
+        echo "Waiting for Lucee to restart..."
+        for i in $(seq 1 60); do
+          if curl -s -o /dev/null --connect-timeout 2 --max-time 3 "http://localhost:${WHEELS_PORT}/" 2>/dev/null; then
+            echo "Lucee restarted with SQLite JDBC"
+            break
+          fi
+          sleep 2
+        done

--- a/.github/actions/wheels-bot-skip-check/action.yml
+++ b/.github/actions/wheels-bot-skip-check/action.yml
@@ -1,0 +1,102 @@
+name: Wheels Bot — skip check
+description: |
+  Centralised gate for every wheels-bot workflow. Sets `outputs.skip` to "true"
+  when any of the following are met:
+    - The repo variable `WHEELS_BOT_ENABLED` is not "true"
+    - The issue / PR carries the `[skip-claude]` label
+    - The issue / PR title contains `[skip-claude]` or `[wip]` (case-insensitive)
+    - A marker matching `marker-pattern` is already present on the target
+  Workflows should consume `outputs.skip` and `exit 0` early when it is "true".
+
+inputs:
+  target-type:
+    description: '"issue" or "pr"'
+    required: true
+  target-number:
+    description: 'Issue or PR number'
+    required: true
+  marker-pattern:
+    description: |
+      Optional regex (POSIX ERE) to grep for in the existing comments / reviews.
+      If a match is found, skip is set to true. Pass an empty string to disable
+      the marker check.
+    required: false
+    default: ''
+  github-token:
+    description: 'Token with read access to the issue/PR (App token preferred)'
+    required: true
+
+outputs:
+  skip:
+    description: '"true" if the workflow should exit early, "false" otherwise'
+    value: ${{ steps.gate.outputs.skip }}
+  reason:
+    description: 'Human-readable reason for the skip (empty when skip=false)'
+    value: ${{ steps.gate.outputs.reason }}
+
+runs:
+  using: composite
+  steps:
+    - id: gate
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        WHEELS_BOT_ENABLED: ${{ vars.WHEELS_BOT_ENABLED }}
+        TARGET_TYPE: ${{ inputs.target-type }}
+        TARGET_NUMBER: ${{ inputs.target-number }}
+        MARKER_PATTERN: ${{ inputs.marker-pattern }}
+        GH_REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        skip=false
+        reason=""
+
+        if [[ "${WHEELS_BOT_ENABLED:-}" != "true" ]]; then
+          skip=true
+          reason="vars.WHEELS_BOT_ENABLED is not 'true'"
+        fi
+
+        if [[ "$skip" == "false" ]]; then
+          if [[ "$TARGET_TYPE" == "issue" ]]; then
+            payload=$(gh issue view "$TARGET_NUMBER" --repo "$GH_REPO" --json title,labels,comments,body)
+          elif [[ "$TARGET_TYPE" == "pr" ]]; then
+            payload=$(gh pr view "$TARGET_NUMBER" --repo "$GH_REPO" --json title,labels,comments,body,reviews)
+          else
+            echo "::error::Invalid target-type: $TARGET_TYPE (must be 'issue' or 'pr')"
+            exit 1
+          fi
+
+          title=$(echo "$payload" | jq -r '.title')
+          has_skip_label=$(echo "$payload" | jq -r '[.labels[]?.name] | any(. == "skip-claude")')
+          title_lc=$(echo "$title" | tr '[:upper:]' '[:lower:]')
+
+          if [[ "$has_skip_label" == "true" ]]; then
+            skip=true
+            reason="[skip-claude] label is present"
+          elif [[ "$title_lc" == *"[skip-claude]"* ]]; then
+            skip=true
+            reason="title contains [skip-claude]"
+          elif [[ "$title_lc" == *"[wip]"* ]]; then
+            skip=true
+            reason="title contains [wip]"
+          fi
+
+          if [[ "$skip" == "false" && -n "$MARKER_PATTERN" ]]; then
+            haystack=""
+            haystack+=$(echo "$payload" | jq -r '[.comments[]?.body] | join("\n")')
+            if [[ "$TARGET_TYPE" == "pr" ]]; then
+              haystack+=$'\n'
+              haystack+=$(echo "$payload" | jq -r '[.reviews[]?.body] | join("\n")')
+            fi
+            if echo "$haystack" | grep -Eq "$MARKER_PATTERN"; then
+              skip=true
+              reason="idempotency marker already present (pattern: $MARKER_PATTERN)"
+            fi
+          fi
+        fi
+
+        echo "skip=$skip" >> "$GITHUB_OUTPUT"
+        echo "reason=$reason" >> "$GITHUB_OUTPUT"
+        if [[ "$skip" == "true" ]]; then
+          echo "::notice::wheels-bot skipping: $reason"
+        fi

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,3 +32,6 @@ Closes #
 ## Screenshots / Output
 
 <!-- If applicable -->
+
+<!-- wheels-bot opt-out: add the [skip-claude] label or include [skip-claude] in the title -->
+

--- a/.github/workflows/bot-auto-close.yml
+++ b/.github/workflows/bot-auto-close.yml
@@ -1,0 +1,45 @@
+name: Wheels Bot — Auto-close stale triage
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wheels-bot-auto-close
+  cancel-in-progress: false
+
+jobs:
+  auto-close:
+    name: Auto-close stale triage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: vars.WHEELS_BOT_ENABLED == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: develop
+          fetch-depth: 1
+
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WHEELS_BOT_APP_ID }}
+          private-key: ${{ secrets.WHEELS_BOT_PRIVATE_KEY }}
+
+      - name: Run Auto-close
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          prompt: |
+            /auto-close-stale-triage
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 15
+            --allowedTools "Bash(gh:*),Read,Grep,Glob"

--- a/.github/workflows/bot-propose-fix.yml
+++ b/.github/workflows/bot-propose-fix.yml
@@ -1,0 +1,125 @@
+name: Wheels Bot — Propose Fix
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      issue-number:
+        description: 'Issue number to propose a fix for'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wheels-bot-propose-fix-${{ github.event.issue.number || inputs.issue-number }}
+  cancel-in-progress: false
+
+jobs:
+  propose-fix:
+    name: Propose fix
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: |
+      vars.WHEELS_BOT_ENABLED == 'true'
+      && (
+        github.event_name == 'workflow_dispatch'
+        || (
+          github.event.comment.user.login == 'wheels-bot[bot]'
+          && (
+            contains(github.event.comment.body, 'wheels-bot:triage-confidence:high')
+            || contains(github.event.comment.body, 'wheels-bot:research-confidence:high')
+          )
+          && github.event.issue.pull_request == null
+        )
+      )
+    env:
+      ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue-number }}
+      WHEELS_CI: "true"
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WHEELS_BOT_APP_ID }}
+          private-key: ${{ secrets.WHEELS_BOT_PRIVATE_KEY }}
+
+      - name: Checkout develop
+        uses: actions/checkout@v6
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Skip check
+        id: gate
+        uses: ./.github/actions/wheels-bot-skip-check
+        with:
+          target-type: issue
+          target-number: ${{ env.ISSUE_NUMBER }}
+          marker-pattern: 'wheels-bot:fix:${{ env.ISSUE_NUMBER }}|wheels-bot:fix-held:${{ env.ISSUE_NUMBER }}'
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: Compute branch slug
+        if: steps.gate.outputs.skip == 'false'
+        id: branch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          title=$(gh issue view "$ISSUE_NUMBER" --json title --jq '.title')
+          slug=$(echo "$title" | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+            | cut -c1-50 \
+            | sed -E 's/-+$//')
+          [[ -z "$slug" ]] && slug="issue"
+          name="fix/bot-${ISSUE_NUMBER}-${slug}"
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git + create branch
+        if: steps.gate.outputs.skip == 'false'
+        run: |
+          git config user.name "wheels-bot[bot]"
+          git config user.email "wheels-bot[bot]@users.noreply.github.com"
+          git checkout -b "${{ steps.branch.outputs.name }}"
+
+      - name: Set up Wheels test environment
+        if: steps.gate.outputs.skip == 'false'
+        uses: ./.github/actions/setup-wheels-test-env
+        with:
+          port: '60007'
+          install-playwright: 'false'
+
+      - name: Run Propose Fix
+        if: steps.gate.outputs.skip == 'false'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          prompt: |
+            /propose-fix ${{ env.ISSUE_NUMBER }}
+          claude_args: |
+            --model claude-opus-4-7
+            --max-turns 60
+            --allowedTools "Bash(gh:*),Bash(git:*),Bash(bash tools/test-local.sh*),Bash(curl:*),Read,Edit,Write,Grep,Glob"
+
+      - name: Push branch
+        if: steps.gate.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if git diff --quiet origin/develop -- && git diff --cached --quiet; then
+            echo "No changes produced — nothing to push."
+            exit 0
+          fi
+          git push -u origin "${{ steps.branch.outputs.name }}"
+
+      - name: Stop Lucee server
+        if: always()
+        run: |
+          if [ -f /tmp/lucli-server.pid ]; then
+            kill $(cat /tmp/lucli-server.pid) 2>/dev/null || true
+          fi
+          lucli server stop 2>/dev/null || true

--- a/.github/workflows/bot-research.yml
+++ b/.github/workflows/bot-research.yml
@@ -1,0 +1,71 @@
+name: Wheels Bot — Cross-Framework Research
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      issue-number:
+        description: 'Issue number to research'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wheels-bot-research-${{ github.event.issue.number || inputs.issue-number }}
+  cancel-in-progress: false
+
+jobs:
+  research:
+    name: Cross-framework research
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: |
+      vars.WHEELS_BOT_ENABLED == 'true'
+      && (
+        github.event_name == 'workflow_dispatch'
+        || (
+          github.event.comment.user.login == 'wheels-bot[bot]'
+          && contains(github.event.comment.body, 'wheels-bot:triage-class:framework-design')
+          && github.event.issue.pull_request == null
+        )
+      )
+    env:
+      ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue-number }}
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v6
+        with:
+          ref: develop
+          fetch-depth: 1
+
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WHEELS_BOT_APP_ID }}
+          private-key: ${{ secrets.WHEELS_BOT_PRIVATE_KEY }}
+
+      - name: Skip check
+        id: gate
+        uses: ./.github/actions/wheels-bot-skip-check
+        with:
+          target-type: issue
+          target-number: ${{ env.ISSUE_NUMBER }}
+          marker-pattern: 'wheels-bot:research:${{ env.ISSUE_NUMBER }}'
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: Run Research
+        if: steps.gate.outputs.skip == 'false'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          prompt: |
+            /research-frameworks ${{ env.ISSUE_NUMBER }}
+          claude_args: |
+            --model claude-opus-4-7
+            --max-turns 40
+            --allowedTools "Bash(gh:*),Bash(git log:*),Bash(git show:*),Bash(git grep:*),WebFetch,WebSearch,Read,Grep,Glob"

--- a/.github/workflows/bot-review-a.yml
+++ b/.github/workflows/bot-review-a.yml
@@ -1,0 +1,58 @@
+name: Wheels Bot — Reviewer A
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: [develop]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wheels-bot-review-a-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Reviewer A
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: |
+      vars.WHEELS_BOT_ENABLED == 'true'
+      && github.event.pull_request.draft == false
+      && github.event.pull_request.user.login != 'wheels-bot[bot]'
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WHEELS_BOT_APP_ID }}
+          private-key: ${{ secrets.WHEELS_BOT_PRIVATE_KEY }}
+
+      - name: Skip check
+        id: gate
+        uses: ./.github/actions/wheels-bot-skip-check
+        with:
+          target-type: pr
+          target-number: ${{ github.event.pull_request.number }}
+          marker-pattern: 'wheels-bot:review-a:${{ github.event.pull_request.number }}:${{ github.event.pull_request.head.sha }}'
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: Run Reviewer A
+        if: steps.gate.outputs.skip == 'false'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          prompt: |
+            /review-pr ${{ github.event.pull_request.number }}
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 25
+            --allowedTools "Bash(gh:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git grep:*),Bash(git status),Read,Grep,Glob"

--- a/.github/workflows/bot-review-b.yml
+++ b/.github/workflows/bot-review-b.yml
@@ -1,0 +1,57 @@
+name: Wheels Bot — Reviewer B
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wheels-bot-review-b-${{ github.event.pull_request.number }}-${{ github.event.review.id }}
+  cancel-in-progress: false
+
+jobs:
+  review-the-review:
+    name: Reviewer B
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: |
+      vars.WHEELS_BOT_ENABLED == 'true'
+      && github.event.review.user.login == 'wheels-bot[bot]'
+      && github.event.pull_request.draft == false
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WHEELS_BOT_APP_ID }}
+          private-key: ${{ secrets.WHEELS_BOT_PRIVATE_KEY }}
+
+      - name: Skip check
+        id: gate
+        uses: ./.github/actions/wheels-bot-skip-check
+        with:
+          target-type: pr
+          target-number: ${{ github.event.pull_request.number }}
+          marker-pattern: 'wheels-bot:review-b:${{ github.event.pull_request.number }}:${{ github.event.pull_request.head.sha }}:'
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: Run Reviewer B
+        if: steps.gate.outputs.skip == 'false'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          prompt: |
+            /review-the-review ${{ github.event.pull_request.number }} ${{ github.event.review.id }}
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 20
+            --allowedTools "Bash(gh:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git grep:*),Bash(git status),Read,Grep,Glob"

--- a/.github/workflows/bot-tdd-gate.yml
+++ b/.github/workflows/bot-tdd-gate.yml
@@ -1,0 +1,77 @@
+name: Wheels Bot — TDD Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [develop]
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  tdd-gate:
+    name: Bot PR TDD Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Decide if this PR is bot-authored
+        id: classify
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          is_bot=false
+          if [[ "$PR_AUTHOR" == "wheels-bot[bot]" ]]; then
+            is_bot=true
+          elif [[ "$PR_HEAD" =~ ^bot/ || "$PR_HEAD" =~ ^fix/bot- ]]; then
+            is_bot=true
+          fi
+          echo "is_bot=$is_bot" >> "$GITHUB_OUTPUT"
+          if [[ "$is_bot" == "false" ]]; then
+            echo "Human-authored PR — gate is a no-op."
+          fi
+
+      - name: Checkout
+        if: steps.classify.outputs.is_bot == 'true'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify bot PR contains spec + implementation changes
+        if: steps.classify.outputs.is_bot == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          changed=$(gh pr diff "$PR_NUMBER" --name-only)
+          echo "Files changed in this PR:"
+          echo "$changed"
+          echo "---"
+
+          spec_changes=$(echo "$changed" | grep -E '^(tests/specs/|vendor/wheels/tests/specs/)' || true)
+          if [[ -z "$spec_changes" ]]; then
+            echo "::error::Bot PRs must include a failing-then-passing spec under tests/specs/ or vendor/wheels/tests/specs/"
+            echo ""
+            echo "This PR was authored by the bot (or on a bot branch) but contains no spec changes."
+            echo "Either add a spec, or close this PR and reopen with one."
+            exit 1
+          fi
+
+          impl_changes=$(echo "$changed" | grep -vE '^(tests/|vendor/wheels/tests/|\.ai/|CHANGELOG\.md|docs/|web/|\.github/)' || true)
+          if [[ -z "$impl_changes" ]]; then
+            echo "::error::Bot PR has tests but no implementation"
+            echo ""
+            echo "Spec changes were found but no implementation files. A bot fix should change at least one file outside tests/, .ai/, docs/, and CHANGELOG.md."
+            exit 1
+          fi
+
+          echo "TDD gate passed: spec changes + implementation changes both present."
+          echo ""
+          echo "Spec files:"
+          echo "$spec_changes" | sed 's/^/  /'
+          echo ""
+          echo "Implementation files:"
+          echo "$impl_changes" | sed 's/^/  /'

--- a/.github/workflows/bot-triage.yml
+++ b/.github/workflows/bot-triage.yml
@@ -1,0 +1,73 @@
+name: Wheels Bot — Triage
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wheels-bot-triage-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    name: Triage issue
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    if: |
+      vars.WHEELS_BOT_ENABLED == 'true'
+      && github.event.issue.user.login != 'wheels-bot[bot]'
+    env:
+      WHEELS_CI: "true"
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v6
+        with:
+          ref: develop
+          fetch-depth: 1
+
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WHEELS_BOT_APP_ID }}
+          private-key: ${{ secrets.WHEELS_BOT_PRIVATE_KEY }}
+
+      - name: Skip check
+        id: gate
+        uses: ./.github/actions/wheels-bot-skip-check
+        with:
+          target-type: issue
+          target-number: ${{ github.event.issue.number }}
+          marker-pattern: 'wheels-bot:triage:${{ github.event.issue.number }}|wheels-bot:triage-class:'
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Wheels test environment
+        if: steps.gate.outputs.skip == 'false'
+        uses: ./.github/actions/setup-wheels-test-env
+        with:
+          port: '60007'
+          install-playwright: 'false'
+
+      - name: Run Triage
+        if: steps.gate.outputs.skip == 'false'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          prompt: |
+            /triage-issue ${{ github.event.issue.number }}
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 20
+            --allowedTools "Bash(gh:*),Bash(git status),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git grep:*),Bash(bash tools/test-local.sh*),Bash(curl:*),Read,Grep,Glob,Edit,Write"
+
+      - name: Stop Lucee server
+        if: always()
+        run: |
+          if [ -f /tmp/lucli-server.pid ]; then
+            kill $(cat /tmp/lucli-server.pid) 2>/dev/null || true
+          fi
+          lucli server stop 2>/dev/null || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1085,3 +1085,29 @@ Tools are auto-discovered from `cli/lucli/Module.cfc` public functions, prefixed
 Workflow orchestration (multi-step planning, feature development) is not a framework concern — use your preferred Claude Code plugin (Superpowers, feature-dev, etc.). The framework ships deterministic Wheels operations via MCP; the model orchestrates.
 
 **Deprecated:** The in-dev-server HTTP endpoint at `/wheels/mcp` (routed from `vendor/wheels/public/views/mcp.cfm`). Emits a deprecation notice and warning log on first request. Scheduled for removal in a future release — migrate to the stdio surface. See `docs/command-line-tools/commands/mcp/mcp-configuration-guide.md`.
+
+## Wheels Bot
+
+`wheels-bot[bot]` is a custom GitHub App that runs Claude-powered automation on issues and PRs in `wheels-dev/wheels`. Five stages, all opt-out via the `[skip-claude]` label or repo variable `WHEELS_BOT_ENABLED=false`. Slash-command prompts live in `.claude/commands/`; workflows in `.github/workflows/bot-*.yml`. Full docs: [`docs/contributing/wheels-bot.md`](docs/contributing/wheels-bot.md).
+
+| Stage | Trigger | Model | Output |
+|---|---|---|---|
+| Triage | issue opened/reopened | Sonnet | Comment classifying as `bug` / `framework-design` / `other` (+ confidence on `bug` path). |
+| Research | bot triage emits `framework-design` marker | Opus | Comment comparing Rails / Laravel / Django / Phoenix / Spring Boot / +1 and recommending a Wheels-idiomatic path (+ confidence). |
+| Propose Fix | bot triage emits `triage-confidence:high` OR research emits `research-confidence:high` (or `workflow_dispatch`) | Opus | TDD-mandatory draft PR on branch `fix/bot-<issue>-<slug>`. Spec-then-implementation, both required by `bot-tdd-gate.yml`. |
+| Reviewer A | PR opened / synchronized / ready_for_review | Sonnet | Single PR review with line comments, verdict, and `wheels-bot:review-a:<pr>:<sha>` marker. |
+| Reviewer B | Reviewer A submits a review | Sonnet | PR comment critiquing A for sycophancy, false positives, and missed issues. Loop cap = 3 rounds. |
+
+**Marker conventions** (HTML comments, used for idempotency):
+- `<!-- wheels-bot:triage:<issue> -->` + `<!-- wheels-bot:triage-class:<bug|framework-design|other> -->` (+ optional `<!-- wheels-bot:triage-confidence:high -->`)
+- `<!-- wheels-bot:research:<issue> -->` (+ optional `<!-- wheels-bot:research-confidence:high -->`)
+- `<!-- wheels-bot:fix:<issue> -->` / `<!-- wheels-bot:fix-held:<issue> -->`
+- `<!-- wheels-bot:review-a:<pr>:<sha> -->`
+- `<!-- wheels-bot:review-b:<pr>:<sha>:<round> -->`
+- `<!-- wheels-bot:auto-close:<issue> -->`
+
+**Allow-listed scopes per stage**: every bot-authored commit must conform to the `commitlint.config.js` allowlist (see § Commit Message Conventions). The bot's prompt (`.claude/commands/_shared-rails.md`) re-states the allowlist verbatim.
+
+**Kill switch**: flip the repo variable `WHEELS_BOT_ENABLED` to `false` to halt every bot workflow without code changes. Add the `[skip-claude]` label (or `[skip-claude]` in the title) to halt activity on a single issue/PR.
+
+**Auto-fire safety net**: the bot is permitted to chain stages (triage → research → propose-fix), but each handoff requires `*-confidence:high` and the propose-fix prompt auto-downgrades on sensitive areas (security, migrations, deploy, DI). All bot PRs land as `--draft` and require a human approving review on `develop`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,6 +224,24 @@ Wheels 3.0 includes these core dependencies (automatically managed):
 
 ---
 
+## Wheels Bot
+
+Issues and PRs on this repo are processed by an automated Claude-powered bot
+(`wheels-bot[bot]`). Five stages: triage, cross-framework research,
+propose-fix, Reviewer A, Reviewer B. See
+[`docs/contributing/wheels-bot.md`](docs/contributing/wheels-bot.md) for the
+full reference, or [`CLAUDE.md`](CLAUDE.md#wheels-bot) for a quick summary.
+
+**To opt a single issue or PR out of bot activity**: add the `[skip-claude]`
+label, or include `[skip-claude]` in the title. The bot will halt all
+processing for that issue/PR immediately. Any human comment to the bot
+asking it to stop is also honored.
+
+**To interpret bot output**: every bot comment / review opens with a clear
+H2 header (`## Wheels Bot — Triage`, `## Wheels Bot — Reviewer A`, etc.) and
+ends with an HTML-comment marker. Bot-authored draft PRs are clearly
+labelled and require a human approving review on `develop` before merge.
+
 ## Getting Help
 
 Need assistance? Here are your options:

--- a/docs/contributing/wheels-bot.md
+++ b/docs/contributing/wheels-bot.md
@@ -1,0 +1,196 @@
+# Wheels Bot
+
+`wheels-bot[bot]` is a custom GitHub App that automates issue triage,
+cross-framework design research, fix-PR generation, and PR review on
+`wheels-dev/wheels`. It runs as five stages, each backed by a slash-command
+prompt in `.claude/commands/` and a workflow in `.github/workflows/bot-*.yml`.
+
+This page is for humans interacting with the bot. For the design rationale,
+see the plan at `/root/.claude/plans/i-just-watched-a-polymorphic-plum.md` (or
+its archived copy in the repo when published). For the framework's general
+contribution rules, see [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
+
+## TL;DR
+
+- The bot reads issues and PRs and posts comments / reviews / draft PRs.
+- It always opens PRs as `--draft` and never merges them. Humans merge.
+- It never pushes to `develop`, `main`, or `release/*`. Only to its own
+  `bot/**` and `fix/bot-*/**` branches.
+- Add the `[skip-claude]` label (or include `[skip-claude]` in the title)
+  to halt bot activity on a single issue/PR.
+- Flip the repo variable `WHEELS_BOT_ENABLED` to `false` to halt the bot
+  entirely without code changes.
+
+## The five stages
+
+### 1. Triage (`bot-triage.yml`)
+
+Fires on `issues: opened` and `issues: reopened`. Reads the issue body and
+posts a comment classifying it as one of:
+
+- **`bug`** — observable wrong behavior. The bot tries to reproduce against
+  the local Wheels test stack (Lucee 7 + SQLite). Includes a confidence
+  assessment.
+- **`framework-design`** — feature request or API design question. The bot
+  hands off to the research stage; it does not opine yet.
+- **`other`** — docs, support, or general discussion. No further automation.
+
+For high-confidence `bug` triages the bot emits an additional marker
+(`<!-- wheels-bot:triage-confidence:high -->`) which is the trigger for
+the propose-fix stage.
+
+### 2. Cross-framework research (`bot-research.yml`)
+
+Fires when triage classifies as `framework-design`. The bot:
+
+1. Re-reads the issue and any human follow-up comments.
+2. Launches parallel sub-agents to look up how each of Rails, Laravel,
+   Django, Phoenix, Spring Boot, and one other relevant framework handles
+   the topic. Agents fetch official docs (rubyonrails.org, laravel.com,
+   docs.djangoproject.com, hexdocs.pm, spring.io).
+3. Synthesizes a comparison table, identifies the dominant pattern,
+   cross-references existing Wheels conventions and `.ai/wheels/`, and
+   proposes a Wheels-idiomatic API sketch in CFML.
+4. Self-rates confidence (high / medium / low) with explicit auto-downgrade
+   rules: any conflict with a CLAUDE.md anti-pattern caps at `medium`;
+   material framework disagreement caps at `low`.
+
+For high-confidence research the bot emits
+`<!-- wheels-bot:research-confidence:high -->`, which is the trigger for
+the propose-fix stage on the framework-design path.
+
+### 3. Propose Fix (`bot-propose-fix.yml`)
+
+Fires on the high-confidence triage marker (bug path) or the high-confidence
+research marker (framework-design path). Also runnable manually via
+`workflow_dispatch`.
+
+The bot:
+
+1. Reads the triage comment and (if present) the research comment.
+2. Auto-downgrades and stops if the proposed fix touches sensitive areas
+   (security, migrations, deploy, DI). Posts `wheels-bot:fix-held:<issue>`
+   instead of opening a PR.
+3. Writes a failing WheelsTest spec.
+4. Confirms the spec fails by running `bash tools/test-local.sh <layer>`.
+5. Implements the fix in `vendor/wheels/**` or `app/**`.
+6. Re-runs and confirms the spec passes.
+7. Updates `.ai/wheels/<layer>/`, `CHANGELOG.md`, and the relevant guide page.
+8. Opens a draft PR on `fix/bot-<issue>-<slug>` against `develop`,
+   referencing the research comment when applicable.
+
+The PR must pass `bot-tdd-gate.yml` before any other check — that gate
+hard-rejects bot PRs that don't include both a spec change and an
+implementation change. The gate is a no-op for human-authored PRs.
+
+### 4. Reviewer A (`bot-review-a.yml`)
+
+Fires on `pull_request: opened/synchronize/ready_for_review` against
+`develop`. Skips bot-authored PRs (Reviewer A is for human PRs); the bot's
+own PRs get reviewed by humans.
+
+Posts a single PR review with line comments grouped under: Correctness,
+Conventions, Cross-engine, Tests, Docs, Commits, Security. Verdict is
+`approve` / `request-changes` / `comment`. Verdict and findings must be
+consistent — Reviewer B will catch sycophancy if they aren't.
+
+### 5. Reviewer B (`bot-review-b.yml`)
+
+Fires when Reviewer A submits a review (filtered on
+`review.user.login == 'wheels-bot[bot]'`). Reviewer B critiques A's review,
+not the PR — looking for sycophancy ("LGTM" without evidence), false
+positives (claims that don't match the actual code), and missed issues.
+
+Posts as a PR comment (not a review) so it doesn't re-trigger itself.
+Loop is capped at 3 rounds. Round 4 emits a terminal "no further
+iterations" message.
+
+## Maintenance: auto-close stale triage (`bot-auto-close.yml`)
+
+Runs on cron at 06:00 UTC daily. Closes issues that:
+
+- Have a bot triage comment
+- Have the `cannot-reproduce` label
+- Have no human comment newer than the triage comment
+- Are at least 14 days old
+
+Mirrors Bun's `auto-close-duplicates.yml` pattern.
+
+## Markers
+
+Every bot comment, review, or PR ends with an HTML-comment marker. Markers
+are how the bot detects whether it's already processed a given target —
+they make every workflow safely retryable.
+
+| Marker | Meaning |
+|---|---|
+| `wheels-bot:triage:<issue>` | Triage stage processed this issue. |
+| `wheels-bot:triage-class:<bug\|framework-design\|other>` | Triage classification. |
+| `wheels-bot:triage-confidence:high` | Triggers propose-fix on the bug path. |
+| `wheels-bot:research:<issue>` | Research stage processed this issue. |
+| `wheels-bot:research-confidence:high` | Triggers propose-fix on the framework-design path. |
+| `wheels-bot:fix:<issue>` | Fix PR has been opened for this issue. |
+| `wheels-bot:fix-held:<issue>` | Fix would have been proposed but the safety net held it for a human. |
+| `wheels-bot:review-a:<pr>:<sha>` | Reviewer A reviewed this PR at this SHA. |
+| `wheels-bot:review-b:<pr>:<sha>:<round>` | Reviewer B critiqued round N. |
+| `wheels-bot:auto-close:<issue>` | Auto-close cron closed this issue. |
+
+## Operating the bot
+
+### One-time setup (admins)
+
+1. Create the GitHub App at `github.com/settings/apps/new` under the
+   `wheels-dev` org. Permissions: Contents R/W, Issues R/W, Pull Requests
+   R/W, Metadata R. No webhooks.
+2. Install the App on `wheels-dev/wheels`.
+3. Create a repo ruleset that allows the App's identity to push only to
+   refs matching `bot/**` and `fix/bot-*/**`. Block force-push everywhere.
+4. Add repo secrets: `WHEELS_BOT_APP_ID`, `WHEELS_BOT_PRIVATE_KEY`. Confirm
+   `ANTHROPIC_API_KEY` is already present (used by `docs-validation.yml`).
+5. Create the repo variable `WHEELS_BOT_ENABLED` and set it to `true`.
+6. Create the labels `skip-claude` and `cannot-reproduce` in the GitHub UI.
+7. Update branch protection on `develop` to require these checks:
+   - `Validate Commit Messages` (existing)
+   - `Lucee 7 + SQLite (LuCLI)` (existing)
+   - `Bot PR TDD Gate` (new — only fails on bot PRs without a spec)
+   And require 1 approving review from `wheels-dev/maintainers` on every PR.
+
+### Day-to-day
+
+- **Watch the bot's first runs.** Phase 1 (Reviewer A only) is the safe
+  starting cut. Promote subsequent phases (triage, Reviewer B, propose-fix)
+  one at a time.
+- **Promote propose-fix from manual to auto-fire** only after at least 5
+  supervised runs are clean. Until then, leave the auto-fire trigger off
+  by editing `bot-propose-fix.yml` to gate on `workflow_dispatch` only.
+- **Review bot-authored PRs the same as human-authored PRs.** Don't
+  rubber-stamp.
+- **Watch costs.** API spend per fix-PR is non-trivial (Opus + many turns +
+  test runner minutes). Phase 5 includes a budget-alerter cron — wire it in
+  before going wider.
+
+### Stopping the bot
+
+- `[skip-claude]` label or title token → halts on a single issue/PR.
+- Repo variable `WHEELS_BOT_ENABLED=false` → halts the entire bot suite.
+- Suspending the App in GitHub Settings → halts everything and revokes
+  push permissions.
+
+The first option is the right tool for almost every "stop on this one"
+case. Reach for the second only during an outage or runaway-cost incident.
+
+## Reference patterns
+
+The bot's structure is modelled on Bun's public Claude workflows
+(`oven-sh/bun/.github/workflows/claude-*.yml` and
+`oven-sh/bun/.claude/commands/*.md`):
+
+- Slash commands as Markdown files with numbered steps and explicit rails.
+- HTML-comment idempotency markers (Bun: `<!-- dedupe-bot:marker -->`,
+  ours: `<!-- wheels-bot:<stage>:<key> -->`).
+- Parallel sub-agent fan-out for multi-source research (Bun's `dedupe.md`
+  fan-outs across 5 search strategies; our `research-frameworks.md`
+  fan-outs across 6 frameworks).
+- A dedicated bot user (Bun: `robobun`; ours: `wheels-bot[bot]`).
+- Scheduled cleanup (Bun: `auto-close-duplicates.yml`; ours:
+  `bot-auto-close.yml`).


### PR DESCRIPTION
## Summary

Adds a five-stage Claude-powered GitHub bot for `wheels-dev/wheels`, modeled on Bun's public Claude workflows (`oven-sh/bun/.github/workflows/claude-*.yml` + `.claude/commands/`). The bot is **dormant by default** — no workflow runs until a repo admin sets `vars.WHEELS_BOT_ENABLED='true'`.

The five stages:

| Stage | Trigger | Model | Output |
|---|---|---|---|
| Triage | issue opened | Sonnet | Comment classifying as `bug` / `framework-design` / `other` (+ confidence on bug path) |
| Cross-framework research | bot triage marker `framework-design` | Opus | Comparison of Rails / Laravel / Django / Phoenix / Spring Boot / +1 with a Wheels-idiomatic API sketch (+ confidence) |
| Propose Fix | high-confidence triage OR research marker (or `workflow_dispatch`) | Opus | TDD-mandatory draft PR; gated by `bot-tdd-gate.yml` |
| Reviewer A | PR opened/synchronize | Sonnet | Single PR review with line comments + verdict |
| Reviewer B | Reviewer A submits a review | Sonnet | PR comment critiquing A for sycophancy / false positives / missed issues. Loop cap = 3. |

Plus a daily cron (`bot-auto-close.yml`) that closes stale `cannot-reproduce` triages after 14 days.

## Files

**New (17):**
- `.claude/commands/_shared-rails.md` — common safety rails included in every prompt
- `.claude/commands/{triage-issue,research-frameworks,propose-fix,review-pr,review-the-review,auto-close-stale-triage}.md`
- `.github/workflows/bot-{triage,research,propose-fix,tdd-gate,review-a,review-b,auto-close}.yml`
- `.github/actions/wheels-bot-skip-check/action.yml` — central kill-switch + marker check
- `.github/actions/setup-wheels-test-env/action.yml` — composite action lifted from `pr.yml:30-164` (LuCLI + Lucee + SQLite + Playwright)
- `docs/contributing/wheels-bot.md` — operator handbook

**Modified (3):**
- `CLAUDE.md` — new §"Wheels Bot" subsection
- `CONTRIBUTING.md` — `[skip-claude]` opt-out + bot-output legibility
- `.github/pull_request_template.md` — opt-out hint at the bottom

## Safety controls

- `vars.WHEELS_BOT_ENABLED` — repo variable, must be `'true'` for any workflow to run. Default unset = dormant.
- `[skip-claude]` label or title token — per-issue/PR opt-out, checked by every workflow.
- HTML-comment markers (`wheels-bot:<stage>:<key>`) prevent duplicate runs across retries.
- Bot identity is a custom GitHub App (`wheels-bot[bot]`) — push permissions scoped to `bot/**` and `fix/bot-*/**` via repo ruleset (set up by admins as part of activation).
- `bot-tdd-gate.yml` hard-rejects bot PRs that don't include both a spec change and an implementation change. Human PRs bypass automatically.
- Propose-fix prompt auto-downgrades on sensitive areas (security, migrations, deploy, DI) and posts `wheels-bot:fix-held:<issue>` instead of opening a PR.
- Research prompt auto-downgrades when the dominant framework pattern conflicts with a CLAUDE.md anti-pattern (capped at `medium`) or when frameworks disagree (capped at `low`) — only `high`-confidence research auto-fires the fix-PR stage.
- Reviewer B is capped at 3 rounds; round 4 emits a terminal "no further iterations" comment.

## Activation steps (post-merge, admins only)

1. Create the GitHub App `wheels-bot[bot]` at github.com/settings/apps/new under `wheels-dev`. Permissions: Contents R/W, Issues R/W, Pull Requests R/W, Metadata R. No webhooks. Install on this repo only.
2. Add secrets: `WHEELS_BOT_APP_ID`, `WHEELS_BOT_PRIVATE_KEY`. Confirm `ANTHROPIC_API_KEY` is already present.
3. Create labels `skip-claude`, `cannot-reproduce` in the repo.
4. Add a repo ruleset allowing the App identity to push only to `bot/**` and `fix/bot-*/**`.
5. Update `develop` branch protection: add `Bot PR TDD Gate` to required checks, require 1 approving review from `wheels-dev/maintainers`.
6. Set `vars.WHEELS_BOT_ENABLED='true'` to activate.

Phased rollout — see `docs/contributing/wheels-bot.md` § "Operating the bot". Phase 1 (Reviewer A only) is the smallest first cut; promote subsequent stages one at a time.

## Test plan

- [ ] **Phase 1 (Reviewer A)** — open a trivial test PR against `develop`, confirm `bot-review-a.yml` runs and posts a review with the `wheels-bot:review-a` marker. Push a second commit, confirm cancel-in-progress supersedes the first run.
- [ ] **Phase 2 (Triage)** — open a test issue with a CFML repro, confirm `bot-triage.yml` brings up Lucee + SQLite via the composite action and lands a triage comment with confidence + marker. Re-open the issue, confirm the marker check skips a duplicate run.
- [ ] **Phase 3 (Reviewer B)** — wait for a Reviewer A review, confirm `bot-review-b.yml` fires only on bot-authored reviews. Have A re-review, confirm round counter increments. Confirm cap at round 3.
- [ ] **Phase 4a (Fix-PR — bug path)** — `workflow_dispatch` first; verify spec + implementation both committed, `bot-tdd-gate.yml` passes, commitlint + fast-test pass, PR is `--draft`. Then enable auto-fire on `triage-confidence:high`.
- [ ] **Phase 4b (Research + framework-design fix path)** — `workflow_dispatch` against historical issues; verify research lands an accurate comparison table + Wheels-idiomatic API sketch with explicit confidence. After ≥ 5 supervised runs, extend `bot-propose-fix.yml`'s trigger to fire on `research-confidence:high`.
- [ ] **Phase 5 (Auto-close)** — manual cron run, confirm 14-day stale `cannot-reproduce` triages close politely.
- [ ] **Kill-switch test** — set `WHEELS_BOT_ENABLED=false`, open a PR, confirm `bot-review-a.yml` exits 0 immediately.

## Notes

- All YAML validated locally with `yaml.safe_load`.
- Existing `docs-validation.yml` orchestrator is **intentionally not reused** — it is a stateful batch runner; these bots are one-shot per event.
- `pr.yml`'s required-checks contract is undisturbed — the test-env composite action references its prelude by extraction, not modification.

https://claude.ai/code/session_01F5Ev5XsFMzLncPCZ43hjVP

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5Ev5XsFMzLncPCZ43hjVP)_