### PR TITLE
ci: gate bot-propose-fix and bot-research to workflow_dispatch

### DIFF
--- a/.github/workflows/bot-propose-fix.yml
+++ b/.github/workflows/bot-propose-fix.yml
@@ -22,19 +22,12 @@ jobs:
     name: Propose fix
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # Phase 1-3 rollout: workflow_dispatch only. Lift this gate at Phase 4a
+    # (bug-path) by re-adding the triage-confidence:high branch, and at Phase 4b
+    # by re-adding the research-confidence:high branch.
     if: |
       vars.WHEELS_BOT_ENABLED == 'true'
-      && (
-        github.event_name == 'workflow_dispatch'
-        || (
-          github.event.comment.user.login == 'wheels-bot[bot]'
-          && (
-            contains(github.event.comment.body, 'wheels-bot:triage-confidence:high')
-            || contains(github.event.comment.body, 'wheels-bot:research-confidence:high')
-          )
-          && github.event.issue.pull_request == null
-        )
-      )
+      && github.event_name == 'workflow_dispatch'
     env:
       ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue-number }}
       WHEELS_CI: "true"

--- a/.github/workflows/bot-research.yml
+++ b/.github/workflows/bot-research.yml
@@ -22,16 +22,11 @@ jobs:
     name: Cross-framework research
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Phase 1-3 rollout: workflow_dispatch only. Lift this gate at Phase 4b
+    # by re-adding the triage-class:framework-design branch.
     if: |
       vars.WHEELS_BOT_ENABLED == 'true'
-      && (
-        github.event_name == 'workflow_dispatch'
-        || (
-          github.event.comment.user.login == 'wheels-bot[bot]'
-          && contains(github.event.comment.body, 'wheels-bot:triage-class:framework-design')
-          && github.event.issue.pull_request == null
-        )
-      )
+      && github.event_name == 'workflow_dispatch'
     env:
       ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue-number }}
     steps:


### PR DESCRIPTION
## Summary

- Gate `bot-propose-fix.yml` and `bot-research.yml` to `workflow_dispatch` only by replacing the auto-fire branches in each job-level `if:`.
- Phase 1 activates Reviewer A only per [docs/contributing/wheels-bot.md](https://github.com/wheels-dev/wheels/blob/develop/docs/contributing/wheels-bot.md).
- The auto-fire branches will be restored at **Phase 4a** (bug-path propose-fix, after >=5 clean supervised runs) and **Phase 4b** (research + framework-design propose-fix).

## Why this matters

Without this gate, flipping `WHEELS_BOT_ENABLED=true` allows a single new bug report to chain triage → propose-fix → opens a draft PR within ~30 minutes. Phase 1's "Reviewer A only" intent requires propose-fix and research to remain manually-triggered until the upstream phases have produced clean output we trust.

## What still auto-fires after activation

- `bot-review-a.yml` on PRs to develop (Phase 1 target)
- `bot-triage.yml` on new issues (Phase 2 target — fires from kill-switch flip; relying on issue volume to pace ramp)
- `bot-review-b.yml` on bot review submissions (Phase 3 target — won't fire until review-a does)
- `bot-auto-close.yml` daily cron (Phase 5 — passive maintenance)

## Test plan

- [ ] CI passes (including `Bot PR TDD Gate`, which is a no-op for human PRs)
- [ ] After merge + kill-switch flip, manual `gh workflow run bot-propose-fix.yml -f issue-number=<N>` still triggers a run (workflow_dispatch path preserved)
- [ ] Issue comments containing `wheels-bot:triage-confidence:high` no longer auto-trigger propose-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)