### PR TITLE
fix: resolve develop CI failures (cli # escape + skip-check + allowed_bots)

### DIFF
--- a/.github/actions/wheels-bot-skip-check/action.yml
+++ b/.github/actions/wheels-bot-skip-check/action.yml
@@ -2,11 +2,14 @@ name: Wheels Bot — skip check
 description: |
   Centralised gate for every wheels-bot workflow. Sets `outputs.skip` to "true"
   when any of the following are met:
-    - The repo variable `WHEELS_BOT_ENABLED` is not "true"
     - The issue / PR carries the `[skip-claude]` label
     - The issue / PR title contains `[skip-claude]` or `[wip]` (case-insensitive)
     - A marker matching `marker-pattern` is already present on the target
   Workflows should consume `outputs.skip` and `exit 0` early when it is "true".
+
+  Note: the kill-switch (`vars.WHEELS_BOT_ENABLED`) is enforced at the job
+  level via `if: vars.WHEELS_BOT_ENABLED == 'true'`. Composite actions cannot
+  read the `vars` context, so the kill switch cannot be checked here.
 
 inputs:
   target-type:
@@ -41,7 +44,6 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
-        WHEELS_BOT_ENABLED: ${{ vars.WHEELS_BOT_ENABLED }}
         TARGET_TYPE: ${{ inputs.target-type }}
         TARGET_NUMBER: ${{ inputs.target-number }}
         MARKER_PATTERN: ${{ inputs.marker-pattern }}
@@ -51,47 +53,40 @@ runs:
         skip=false
         reason=""
 
-        if [[ "${WHEELS_BOT_ENABLED:-}" != "true" ]]; then
-          skip=true
-          reason="vars.WHEELS_BOT_ENABLED is not 'true'"
+        if [[ "$TARGET_TYPE" == "issue" ]]; then
+          payload=$(gh issue view "$TARGET_NUMBER" --repo "$GH_REPO" --json title,labels,comments,body)
+        elif [[ "$TARGET_TYPE" == "pr" ]]; then
+          payload=$(gh pr view "$TARGET_NUMBER" --repo "$GH_REPO" --json title,labels,comments,body,reviews)
+        else
+          echo "::error::Invalid target-type: $TARGET_TYPE (must be 'issue' or 'pr')"
+          exit 1
         fi
 
-        if [[ "$skip" == "false" ]]; then
-          if [[ "$TARGET_TYPE" == "issue" ]]; then
-            payload=$(gh issue view "$TARGET_NUMBER" --repo "$GH_REPO" --json title,labels,comments,body)
-          elif [[ "$TARGET_TYPE" == "pr" ]]; then
-            payload=$(gh pr view "$TARGET_NUMBER" --repo "$GH_REPO" --json title,labels,comments,body,reviews)
-          else
-            echo "::error::Invalid target-type: $TARGET_TYPE (must be 'issue' or 'pr')"
-            exit 1
+        title=$(echo "$payload" | jq -r '.title')
+        has_skip_label=$(echo "$payload" | jq -r '[.labels[]?.name] | any(. == "skip-claude")')
+        title_lc=$(echo "$title" | tr '[:upper:]' '[:lower:]')
+
+        if [[ "$has_skip_label" == "true" ]]; then
+          skip=true
+          reason="[skip-claude] label is present"
+        elif [[ "$title_lc" == *"[skip-claude]"* ]]; then
+          skip=true
+          reason="title contains [skip-claude]"
+        elif [[ "$title_lc" == *"[wip]"* ]]; then
+          skip=true
+          reason="title contains [wip]"
+        fi
+
+        if [[ "$skip" == "false" && -n "$MARKER_PATTERN" ]]; then
+          haystack=""
+          haystack+=$(echo "$payload" | jq -r '[.comments[]?.body] | join("\n")')
+          if [[ "$TARGET_TYPE" == "pr" ]]; then
+            haystack+=$'\n'
+            haystack+=$(echo "$payload" | jq -r '[.reviews[]?.body] | join("\n")')
           fi
-
-          title=$(echo "$payload" | jq -r '.title')
-          has_skip_label=$(echo "$payload" | jq -r '[.labels[]?.name] | any(. == "skip-claude")')
-          title_lc=$(echo "$title" | tr '[:upper:]' '[:lower:]')
-
-          if [[ "$has_skip_label" == "true" ]]; then
+          if echo "$haystack" | grep -Eq "$MARKER_PATTERN"; then
             skip=true
-            reason="[skip-claude] label is present"
-          elif [[ "$title_lc" == *"[skip-claude]"* ]]; then
-            skip=true
-            reason="title contains [skip-claude]"
-          elif [[ "$title_lc" == *"[wip]"* ]]; then
-            skip=true
-            reason="title contains [wip]"
-          fi
-
-          if [[ "$skip" == "false" && -n "$MARKER_PATTERN" ]]; then
-            haystack=""
-            haystack+=$(echo "$payload" | jq -r '[.comments[]?.body] | join("\n")')
-            if [[ "$TARGET_TYPE" == "pr" ]]; then
-              haystack+=$'\n'
-              haystack+=$(echo "$payload" | jq -r '[.reviews[]?.body] | join("\n")')
-            fi
-            if echo "$haystack" | grep -Eq "$MARKER_PATTERN"; then
-              skip=true
-              reason="idempotency marker already present (pattern: $MARKER_PATTERN)"
-            fi
+            reason="idempotency marker already present (pattern: $MARKER_PATTERN)"
           fi
         fi
 

--- a/.github/workflows/bot-auto-close.yml
+++ b/.github/workflows/bot-auto-close.yml
@@ -35,6 +35,10 @@ jobs:
       - name: Run Auto-close
         uses: anthropics/claude-code-action@v1
         with:
+          # Daily cron triggers run as github-actions[bot]; manual workflow_dispatch
+          # may run as wheels-bot[bot] or a human. Allow both bot identities so the
+          # cron path doesn't fail-fast on the action's "non-human actor" check.
+          allowed_bots: 'wheels-bot[bot],github-actions[bot]'
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           prompt: |

--- a/.github/workflows/bot-propose-fix.yml
+++ b/.github/workflows/bot-propose-fix.yml
@@ -89,6 +89,10 @@ jobs:
         if: steps.gate.outputs.skip == 'false'
         uses: anthropics/claude-code-action@v1
         with:
+          # When un-gated at Phase 4a/4b, this workflow fires from wheels-bot[bot]
+          # comments containing high-confidence triage or research markers. Allow
+          # that bot identity (and github-actions[bot] for consistency).
+          allowed_bots: 'wheels-bot[bot],github-actions[bot]'
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           prompt: |

--- a/.github/workflows/bot-research.yml
+++ b/.github/workflows/bot-research.yml
@@ -56,6 +56,10 @@ jobs:
         if: steps.gate.outputs.skip == 'false'
         uses: anthropics/claude-code-action@v1
         with:
+          # When un-gated at Phase 4b, this workflow fires from wheels-bot[bot]
+          # comments containing the framework-design class marker. Allow that
+          # bot identity (and github-actions[bot] for consistency).
+          allowed_bots: 'wheels-bot[bot],github-actions[bot]'
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           prompt: |

--- a/.github/workflows/bot-review-a.yml
+++ b/.github/workflows/bot-review-a.yml
@@ -48,6 +48,11 @@ jobs:
         if: steps.gate.outputs.skip == 'false'
         uses: anthropics/claude-code-action@v1
         with:
+          # Allow our App's bot identity and github-actions[bot] to initiate
+          # the action. Currently the job-level if: blocks wheels-bot[bot] PRs,
+          # so this is defensive for future bot-authored PRs (Dependabot,
+          # Renovate) — and for consistency with the other bot workflows.
+          allowed_bots: 'wheels-bot[bot],github-actions[bot]'
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           prompt: |

--- a/.github/workflows/bot-review-b.yml
+++ b/.github/workflows/bot-review-b.yml
@@ -47,6 +47,11 @@ jobs:
         if: steps.gate.outputs.skip == 'false'
         uses: anthropics/claude-code-action@v1
         with:
+          # This workflow is triggered by `wheels-bot[bot]` submitting a review.
+          # The action defaults to blocking bot-initiated runs; explicitly allow
+          # our App's bot identity (and github-actions[bot] for any future cron
+          # triggers). Specific allowlist preferred over '*' — the repo is public.
+          allowed_bots: 'wheels-bot[bot],github-actions[bot]'
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           prompt: |

--- a/.github/workflows/bot-triage.yml
+++ b/.github/workflows/bot-triage.yml
@@ -55,6 +55,10 @@ jobs:
         if: steps.gate.outputs.skip == 'false'
         uses: anthropics/claude-code-action@v1
         with:
+          # Issues are typically opened by humans, but defensive: allow our App
+          # bot and github-actions[bot] in case an upstream automation creates
+          # an issue we want to triage. Specific allowlist (not '*') — public repo.
+          allowed_bots: 'wheels-bot[bot],github-actions[bot]'
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           prompt: |

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -3720,7 +3720,7 @@ component extends="modules.BaseModule" {
 				out("App tests run against the configured app datasource (or", "yellow");
 				out("<datasource>_test when --useTestDB is set). To test against a different", "yellow");
 				out("engine, point your app's datasource env var at it (or use --core).", "yellow");
-				out("See: command-line-tools/wheels-commands/testing#testing-against-different-engines", "yellow");
+				out("See: command-line-tools/wheels-commands/testing##testing-against-different-engines", "yellow");
 				out("", "yellow");
 			}
 		}


### PR DESCRIPTION
## Summary

Three sequentially-discovered fixes that together restore develop CI to green. Each new fix was uncovered by the previous one passing.

### 1. `cli/lucli/Module.cfc:3723` — unescaped `#` in CFML string literal

PR [#2517](https://github.com/wheels-dev/wheels/pull/2517) added a help banner whose URL fragment contains `testing#testing-against-different-engines`. Lucee's parser interprets unescaped `#` in CFScript string literals as expression delimiters and crashes the file's compilation with `Invalid Syntax Closing [#] not found`.

Crashed `Module.cfc`, which broke `wheels new` and the **Wheels Snapshots → Smoke Test Installed Distribution** pipeline on every push since #2517.

**Fix**: one character — `testing#` → `testing##`. CFML rule: `##` in a string literal outputs a literal `#`.

### 2. `.github/actions/wheels-bot-skip-check/action.yml` — `vars` context not accessible in composite actions

The skip-check composite action's internal `env:` block declared `WHEELS_BOT_ENABLED: ${{ vars.WHEELS_BOT_ENABLED }}`. Composite actions don't have access to the `vars` context — only workflow files do. Every invocation failed with `Unrecognized named-value: 'vars'`, causing **Reviewer A** to fail-fast in 13 seconds on every PR after the kill switch was activated.

The kill switch is already enforced at the job level via `if: vars.WHEELS_BOT_ENABLED == 'true'` in every wheels-bot workflow, so the action's internal check was redundant as well as broken.

**Fix**: remove the unreachable check. The action now focuses on label/title/marker checks; the kill switch lives at the job level.

### 3. All wheels-bot workflows — `claude-code-action` blocks bot-initiated runs by default

After fix #2, Reviewer A passed and triggered Reviewer B. Reviewer B failed in 17s with:

> Action failed with error: Workflow initiated by non-human actor: wheels-bot (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

The `anthropics/claude-code-action` defaults to blocking workflow runs initiated by any GitHub Bot identity. Same shape would hit `bot-research`, `bot-propose-fix`, and `bot-auto-close` (cron actor is `github-actions[bot]`) as the rollout progresses through Phases 2-5.

**Fix**: add `allowed_bots: 'wheels-bot[bot],github-actions[bot]'` to all 6 wheels-bot workflows (review-a, review-b, research, propose-fix, triage, auto-close). Specific allowlist preferred over `'*'` because the repo is public — `'*'` would let any external GitHub App invoke the action with prompts they could influence.

## Why one PR for three fixes

Each new fix was a *consequence* of the prior one passing. Without #1, the smoke test failure masked everything else. Without #2, Reviewer A never ran successfully so the bot-initiator block in #3 was never surfaced. Splitting into three PRs would mean each ran into the unfixed downstream issues in CI; bundling resolves them as a unit.

## Test plan

- [ ] CI passes (smoke test, full Lucee suite, Reviewer A, Reviewer B all green)
- [ ] Reviewer B successfully runs on this PR (after Reviewer A's review triggers it)
- [ ] After merge, `wheels test --db=mysql` (without `--core`) prints the help banner with a literal `#` in the URL
- [ ] Future bot-triggered workflows (research, propose-fix in Phase 4; auto-close cron in Phase 5) don't hit the bot-actor block

🤖 Generated with [Claude Code](https://claude.com/claude-code)