### PR TITLE
ci: bump Reviewer B max-turns 20 → 30

### DIFF
--- a/.github/workflows/bot-review-b.yml
+++ b/.github/workflows/bot-review-b.yml
@@ -58,5 +58,5 @@ jobs:
             /review-the-review ${{ github.event.pull_request.number }} ${{ github.event.review.id }}
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 20
+            --max-turns 30
             --allowedTools "Bash(gh:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git grep:*),Bash(git status),Read,Grep,Glob"


### PR DESCRIPTION
## Summary

One-line bump of Reviewer B's `--max-turns` from 20 → 30.

## Why

On PR [#2523](https://github.com/wheels-dev/wheels/pull/2523) (the Astro 5→6 framework upgrade), Reviewer B failed with:

> error: Claude Code returned an error result: Reached maximum number of turns (20)

Reviewer A finished cleanly in the same run. The primary review isn't compromised — but the meta-review's max-turns failure shows up as red in the actions tab and prevents the critique from landing.

## Why 30 (not 25, not 50)

- **Why not 25?** Reviewer A is at 25 turns. Reviewer B's task is *strictly more* than Reviewer A's (it has to read Reviewer A's review, then read the PR, then cross-reference). It should have headroom over Reviewer A.
- **Why not 50?** That's a 2.5× bump and is wasteful for normal-sized PRs. 30 is one standard deviation up from 20, gives ~50% more headroom, and keeps cost growth proportional to the actual issue.
- **Why not just bump on demand?** The cost of a budget hit is one missed meta-review *plus* a red check that demands manual judgment. The cost of an extra turn is fractional cents on Sonnet 4.6. Easy win-vs-cost trade.

## Test plan

- [ ] CI passes (no-op for human PR — `Bot PR TDD Gate` passes)
- [ ] Reviewer B passes on this PR (small diff, will fit comfortably in 30 turns)
- [ ] Future large-PR Reviewer B runs (e.g., dependency bump PRs) don't hit max-turns at 30

## Future signal

If we see another `max turns` failure at 30 on a normal-sized PR, the underlying prompt/tool budget needs a structural fix, not another bump. Tracking this to inform that decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)