### PR TITLE
docs: update wheels-bot.md to reflect shipped activation state

### DIFF
--- a/docs/contributing/wheels-bot.md
+++ b/docs/contributing/wheels-bot.md
@@ -202,3 +202,4 @@ The bot's structure is modelled on Bun's public Claude workflows
 - A dedicated bot user (Bun: `robobun`; ours: `wheels-bot[bot]`).
 - Scheduled cleanup (Bun: `auto-close-duplicates.yml`; ours:
   `bot-auto-close.yml`).
+

--- a/docs/contributing/wheels-bot.md
+++ b/docs/contributing/wheels-bot.md
@@ -203,3 +203,4 @@ The bot's structure is modelled on Bun's public Claude workflows
 - Scheduled cleanup (Bun: `auto-close-duplicates.yml`; ours:
   `bot-auto-close.yml`).
 
+

--- a/docs/contributing/wheels-bot.md
+++ b/docs/contributing/wheels-bot.md
@@ -204,3 +204,4 @@ The bot's structure is modelled on Bun's public Claude workflows
   `bot-auto-close.yml`).
 
 
+

--- a/docs/contributing/wheels-bot.md
+++ b/docs/contributing/wheels-bot.md
@@ -153,7 +153,13 @@ they make every workflow safely retryable.
    - `Validate Commit Messages` (existing)
    - `Lucee 7 + SQLite (LuCLI)` (existing)
    - `Bot PR TDD Gate` (new — only fails on bot PRs without a spec)
-   And require 1 approving review from `wheels-dev/maintainers` on every PR.
+
+   **Approval requirement is org-size-dependent.** Multi-maintainer
+   teams should require ≥1 approving review from `wheels-dev/maintainers`.
+   Solo-maintainer setups may set `required_approving_review_count: 0`,
+   relying on the bot's `--draft` PR posture and the maintainer's manual
+   review-then-merge workflow as the human-eye gate. The `Bot PR TDD Gate`
+   required check still enforces test discipline regardless of approval count.
 
 ### Day-to-day
 
@@ -161,8 +167,10 @@ they make every workflow safely retryable.
   starting cut. Promote subsequent phases (triage, Reviewer B, propose-fix)
   one at a time.
 - **Promote propose-fix from manual to auto-fire** only after at least 5
-  supervised runs are clean. Until then, leave the auto-fire trigger off
-  by editing `bot-propose-fix.yml` to gate on `workflow_dispatch` only.
+  supervised runs are clean. The shipped default is `workflow_dispatch` only
+  (gated in `bot-propose-fix.yml`'s `if:`); to lift the gate, restore the
+  `triage-confidence:high` branch (Phase 4a) and the `research-confidence:high`
+  branch (Phase 4b). Same pattern applies to `bot-research.yml`.
 - **Review bot-authored PRs the same as human-authored PRs.** Don't
   rubber-stamp.
 - **Watch costs.** API spend per fix-PR is non-trivial (Opus + many turns +


### PR DESCRIPTION
## Summary

Two parts of the operator handbook drifted between the Phase 1 design and what shipped today during activation. This PR catches them up.

### 1. Approval requirement (step 7)

**Before** said: "require 1 approving review from `wheels-dev/maintainers` on every PR."

**After** acknowledges that solo-maintainer setups need `required_approving_review_count: 0` because GitHub blocks self-approval. The Bot PR TDD Gate continues to enforce test discipline regardless of count, and the bot's `--draft` PR posture provides the human-review gate via "mark ready & merge" rather than a formal approval.

### 2. Propose-fix gating (Day-to-day section)

**Before** treated workflow_dispatch-only as a future manual edit ("Until then, leave the auto-fire trigger off by editing `bot-propose-fix.yml`").

**After** notes that PR [#2519](https://github.com/wheels-dev/wheels/pull/2519) already shipped the gate as the default `if:` state. Lifting at Phase 4a/4b means *restoring* specific branches, not gating them in the first place.

## Test plan

- [ ] CI passes (`Bot PR TDD Gate` is no-op for human PRs)
- [ ] Reviewer A produces a review (this is also serving as a smoke test of bot operation on a real PR)

## Note: also serves as smoke test vehicle

I'm using this PR to exercise two safety paths I hadn't deliberately tested yet:

- **`[skip-claude]` label** — I'll add the label, push a trivial follow-up commit, and confirm Reviewer A skips with reason "[skip-claude] label is present"
- **Kill switch flip** — I'll set `WHEELS_BOT_ENABLED=false`, push, confirm Reviewer A's job-level `if:` evaluates false; then flip back on

These will be visible in the run history of this PR. The smoke tests are *separate* from the merge — the docs change here is the actual content; the testing is just incidental on the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)