### PR TITLE
ci: scope triage to classification, defer reproduction to propose-fix

### DIFF
--- a/.claude/commands/propose-fix.md
+++ b/.claude/commands/propose-fix.md
@@ -34,7 +34,7 @@ is enforced by code, so don't skip steps.
 2. **Read the authoritative context.** Both must be read before doing
    anything else:
    - The triage comment (marker `wheels-bot:triage:<issue-number>`) — gives
-     you the layer, repro spec, and confidence assessment.
+     you the layer, fix sketch, and confidence assessment.
    - **If present**, the research comment (marker
      `wheels-bot:research:<issue-number>`) — gives you the recommended path
      forward for framework-design issues. **The research's recommended
@@ -80,7 +80,8 @@ is enforced by code, so don't skip steps.
    syntax. The spec should:
    - Be the smallest thing that demonstrates the bug or exercises the
      proposed feature
-   - Match the repro from the triage comment
+   - Reproduce the bug as described in the issue body, aligned with the
+     fix sketch from the triage comment
    - For `framework-design`: directly assert the API surface the research
      comment recommends
 

--- a/.claude/commands/triage-issue.md
+++ b/.claude/commands/triage-issue.md
@@ -1,7 +1,8 @@
 # /triage-issue
 
-Classify a freshly-opened GitHub issue and, if it's a bug, attempt to reproduce
-it against the local Wheels test stack.
+Classify a freshly-opened GitHub issue, identify the affected layer if it's
+a bug, and post a routing comment for downstream stages. Reproduction and
+spec authoring happen in propose-fix, not here.
 
 ## Rails
 
@@ -10,8 +11,8 @@ below. Highlights for this command:
 
 - Use `gh` for GitHub state and read-only `git`. No writes outside your
   scratch worktree.
-- Test runs go through `bash tools/test-local.sh`. Do not invoke `lucli`
-  directly or hit other test endpoints.
+- **Do not write specs or run tests** — triage classifies and routes only.
+  Reproduction and spec authoring happen in propose-fix.
 - Output is **one comment** on the issue with a stage-appropriate marker.
 
 ## Args
@@ -87,50 +88,33 @@ below. Highlights for this command:
 
    Continue to step 5.
 
-5. **Reproduce (bug path only).** This is the heavy step. The caller workflow
-   has already brought up Lucee + SQLite via the `setup-wheels-test-env`
-   composite action and the test endpoint at `http://localhost:60007/` is
-   ready.
+5. **Identify the layer (bug path only).** Pick one of: model / controller /
+   view / router / middleware / migrator / cli / di / job / mailer / sse /
+   seed / config. Read the corresponding `.ai/wheels/<layer>/` doc to ground
+   your reasoning. **Do not write specs and do not run tests** — that work
+   belongs in propose-fix. Triage's job here is to tell propose-fix which
+   doc to read and roughly where the fix lives.
 
-   a. **Identify the layer**: model / controller / view / router / middleware /
-      migrator / cli / di / job / mailer / sse / seed / config. Read the
-      corresponding `.ai/wheels/<layer>/` doc to ground your reasoning.
+6. **Self-rate confidence (bug path only).** Rate based on the clarity of the
+   issue and the obviousness of the fix shape — not on test reproduction
+   (you didn't run any).
 
-   b. **Write a minimal failing spec** under
-      `vendor/wheels/tests/specs/<layer>/` (or `tests/specs/<layer>/` for
-      app-level repros). Use `wheels.WheelsTest` BDD syntax (never RocketUnit).
-      The spec should be the smallest thing that demonstrates the bug.
-
-   c. **Run it**: `bash tools/test-local.sh <layer>` (e.g. `model`).
-      Capture the failure: which assertion fired, what the diff between
-      expected and actual is.
-
-   d. **Do NOT commit the spec.** Triage is read-only as far as the
-      repository is concerned. Store the spec content + run output in
-      memory for the comment body.
-
-   e. If the spec passes (no reproduction): the bug is either invalid, was
-      already fixed, or you wrote the wrong spec. Note this in the comment
-      and downgrade confidence.
-
-6. **Self-rate confidence (bug path only).**
-
-   - **`high`**: you reproduced the bug; the failure is unambiguous; the
-     suspected layer is clear; a fix is mechanical (one file, no design
-     decisions). High-confidence bugs trigger the auto-fire fix-PR
-     workflow.
-   - **`medium`**: you reproduced the bug but the fix has design
-     trade-offs OR you couldn't write a clean spec but the bug is real
-     and obvious from the report.
-   - **`low`**: you couldn't reproduce; the report is ambiguous; multiple
-     layers could be involved; you suspect environment-specific behavior.
+   - **`high`**: the report has a clear "what happened / what I expected"
+     description; the suspected layer is unambiguous; the fix sketch is
+     mechanical (one file, no design decisions). High-confidence bugs
+     trigger the auto-fire fix-PR workflow.
+   - **`medium`**: the report is clear but the fix has design trade-offs,
+     OR cross-engine concerns may exist, OR more than one layer is
+     plausibly involved.
+   - **`low`**: the report is ambiguous; reproduction steps are vague;
+     environment-specific symptoms are suspected; the fix shape isn't
+     obvious from the issue body alone.
 
    **Auto-downgrade rules** (force at least one level lower):
-   - The diff would touch `vendor/wheels/security/**`, auth flows, or any
+   - The fix would touch `vendor/wheels/security/**`, auth flows, or any
      `vendor/wheels/middleware/**` → at most `medium`
    - Cross-engine concern detected (Lucee vs Adobe vs BoxLang behavior
      differs) → at most `medium`
-   - The spec passes (no reproduction) → at most `low`
    - Migration files, deploy subsystem, or DI container involved → at most
      `medium`
 
@@ -140,14 +124,6 @@ below. Highlights for this command:
    ## Wheels Bot — Triage
 
    Classified as **bug**.
-
-   ### Reproduction
-
-   <one paragraph: did you reproduce, what did you see, what spec did you write>
-
-   <fenced code block: the failing spec you wrote>
-
-   <fenced code block: the run output / failure summary>
 
    ### Suspected layer
 
@@ -173,7 +149,8 @@ below. Highlights for this command:
 
 8. **Self-check before posting.**
    - Is the classification justified by quoted text from the issue?
-   - For `bug` path: is the spec short and self-contained?
+   - For `bug` path: is the suspected layer one of the documented layers,
+     and does the fix sketch identify a plausible target file?
    - For `bug` path: is the confidence consistent with the auto-downgrade
      rules?
    - Are all required markers present?

--- a/.github/workflows/bot-triage.yml
+++ b/.github/workflows/bot-triage.yml
@@ -44,13 +44,6 @@ jobs:
           marker-pattern: 'wheels-bot:triage:${{ github.event.issue.number }}|wheels-bot:triage-class:'
           github-token: ${{ steps.app-token.outputs.token }}
 
-      - name: Set up Wheels test environment
-        if: steps.gate.outputs.skip == 'false'
-        uses: ./.github/actions/setup-wheels-test-env
-        with:
-          port: '60007'
-          install-playwright: 'false'
-
       - name: Run Triage
         if: steps.gate.outputs.skip == 'false'
         uses: anthropics/claude-code-action@v1
@@ -66,12 +59,4 @@ jobs:
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 20
-            --allowedTools "Bash(gh:*),Bash(git status),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git grep:*),Bash(bash tools/test-local.sh*),Bash(curl:*),Read,Grep,Glob,Edit,Write"
-
-      - name: Stop Lucee server
-        if: always()
-        run: |
-          if [ -f /tmp/lucli-server.pid ]; then
-            kill $(cat /tmp/lucli-server.pid) 2>/dev/null || true
-          fi
-          lucli server stop 2>/dev/null || true
+            --allowedTools "Bash(gh:*),Bash(git status),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git grep:*),Read,Grep,Glob"

--- a/docs/contributing/wheels-bot.md
+++ b/docs/contributing/wheels-bot.md
@@ -28,9 +28,10 @@ contribution rules, see [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 Fires on `issues: opened` and `issues: reopened`. Reads the issue body and
 posts a comment classifying it as one of:
 
-- **`bug`** — observable wrong behavior. The bot tries to reproduce against
-  the local Wheels test stack (Lucee 7 + SQLite). Includes a confidence
-  assessment.
+- **`bug`** — observable wrong behavior. The bot identifies the affected
+  layer (model / controller / view / etc.) and emits a fix sketch with a
+  confidence rating. Reproduction and spec authoring happen in the
+  propose-fix stage, not here.
 - **`framework-design`** — feature request or API design question. The bot
   hands off to the research stage; it does not opine yet.
 - **`other`** — docs, support, or general discussion. No further automation.


### PR DESCRIPTION
## Summary

The bot's triage stage was failing on its first real-world test ([run 25613993155](https://github.com/wheels-dev/wheels/actions/runs/25613993155) on issue [#2526](https://github.com/wheels-dev/wheels/issues/2526)) — Sonnet hit `error_max_turns` at 21 turns and never posted a triage verdict. Cost: \$0.495 for zero output.

**Root cause:** the triage prompt asked Sonnet to do propose-fix's job. Step 5 of [`.claude/commands/triage-issue.md`](.claude/commands/triage-issue.md) instructed it to:

1. Identify the layer
2. **Write a minimal failing spec** under `vendor/wheels/tests/specs/<layer>/`
3. **Run `bash tools/test-local.sh <layer>`**
4. Capture the failure output

That's the same TDD-shaped work propose-fix does in 60 turns under the [`bot-tdd-gate.yml`](.github/workflows/bot-tdd-gate.yml) enforcement, with Opus. Triage was running it in 20 turns with Sonnet, hit the ceiling on every clear-bug-class issue, and burned the workflow's `setup-wheels-test-env` Lucee bootstrap on every issue regardless of outcome.

## What changed

- **[`.claude/commands/triage-issue.md`](.claude/commands/triage-issue.md)** — step 5 reduced from "Reproduce" (write spec + run test + capture failure) to "Identify the layer" (read `.ai/wheels/<layer>/`, no file writes). Step 6 confidence rules rewritten around issue clarity rather than test reproduction. Step 7 comment template drops the `### Reproduction` section and code-fence blocks for the spec + run output. Step 8 self-check follows.
- **[`.github/workflows/bot-triage.yml`](.github/workflows/bot-triage.yml)** — drops the `Set up Wheels test environment` step (no Lucee server boot), drops the `Stop Lucee server` cleanup, trims `--allowedTools` to remove `Bash(bash tools/test-local.sh*)`, `Bash(curl:*)`, `Edit`, and `Write`. `--max-turns 20` and `claude-sonnet-4-6` retained — the budget is plenty when the prompt isn't asking for spec-writing.
- **[`.claude/commands/propose-fix.md`](.claude/commands/propose-fix.md)** — companion edit. Step 2 changes "the layer, repro spec, and confidence assessment" → "the layer, fix sketch, and confidence assessment". Step 5 adjusts the spec authoring bullet to align with the fix sketch instead of expecting a prior repro.
- **[`docs/contributing/wheels-bot.md`](docs/contributing/wheels-bot.md)** — keeps the doc in sync with the new triage scope.

## What did not change

- Reviewer A and Reviewer B prompts/workflows — untouched.
- Propose-fix's TDD-gate enforcement — still requires spec + implementation in every bot PR; the test that *would have* been written by triage is now written by propose-fix as part of the gated work.
- The classification taxonomy (`bug` / `framework-design` / `other`) and the auto-fire markers (`triage-confidence:high`, `research-confidence:high`).

## Why a single change instead of also bumping max-turns or upgrading the model

Address the root cause once, observe, then layer further changes if needed. If triage still hits 20 turns post-merge (e.g., Sonnet over-investigates `.ai/wheels/<layer>/` while identifying the layer), we have a clean follow-up — bump turns, or further restrict tools. Bundling the bump now would mask which lever actually fixed the failure.

Notably: bumping the model to Opus would *increase* methodical investigation time, not reduce it (Opus is already used for propose-fix at 60 turns precisely because the work is heavier). Treating the symptom would have left the prompt-vs-budget mismatch in place.

## Test plan

- [ ] Merge to `develop`.
- [ ] Close and reopen issue [#2526](https://github.com/wheels-dev/wheels/issues/2526) to retrigger `bot-triage.yml`.
- [ ] Confirm: workflow run completes successfully, single triage comment posted with `<!-- wheels-bot:triage-class:bug -->` and (likely) `<!-- wheels-bot:triage-confidence:high -->` markers, no Lucee server step in the run log, `num_turns` well under 20.
- [ ] If `triage-confidence:high` marker fires, observe whether `bot-propose-fix.yml` auto-dispatches per the [#2519](https://github.com/wheels-dev/wheels/pull/2519) gating (separable concern; tracked outside this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)