### PR TITLE
ci: add bot-update-docs stage to unblock propose-fix budget

### DIFF
--- a/.claude/commands/propose-fix.md
+++ b/.claude/commands/propose-fix.md
@@ -114,13 +114,12 @@ is enforced by code, so don't skip steps.
    Confirm the spec now passes. Also confirm no other tests in the layer
    regressed. If something else broke, fix it before proceeding.
 
-9. **Update supporting docs.**
-   - If user-visible behavior changed: update
-     `web/sites/guides/src/content/docs/v4-0-0-snapshot/<area>/<page>.mdx`
-   - Always update `.ai/wheels/<layer>/` if the patterns table changed
-   - If model/controller/view conventions changed: update `CLAUDE.md`
-   - Add a `CHANGELOG.md` `[Unreleased]` entry (one line, present tense,
-     no PR number — humans add the link on merge)
+9. **Add a CHANGELOG entry.** Append one line to `CHANGELOG.md` under
+   `[Unreleased]` (present tense, no PR number — humans add the link on
+   merge). **Do not touch MDX guides, `.ai/wheels/`, or `CLAUDE.md`** —
+   those are handled separately by the `bot-update-docs.yml` workflow,
+   which runs after this PR opens. The bot's scope here is failing-spec →
+   implementation → passing-spec → CHANGELOG → PR.
 
 10. **Stage, commit, and prepare the PR.**
 
@@ -145,9 +144,12 @@ is enforced by code, so don't skip steps.
       `Recommended path from research: <link to research comment>`
     - Fill the `.github/pull_request_template.md` checklist honestly:
       - [x] Tests — your failing-then-passing spec
-      - [x/?] Framework Docs — checked if you updated MDX
-      - [x/?] AI Reference Docs — checked if you updated `.ai/wheels/`
-      - [x/?] CLAUDE.md — checked if you updated it
+      - [ ] Framework Docs — leave unchecked (`bot-update-docs.yml`
+        will add MDX updates as a follow-up commit if needed)
+      - [ ] AI Reference Docs — leave unchecked (handled by
+        `bot-update-docs.yml`)
+      - [ ] CLAUDE.md — leave unchecked (handled by
+        `bot-update-docs.yml`)
       - [x] CHANGELOG.md
       - [x] Test runner passes (cite the local test-local.sh output)
     - End with the marker `<!-- wheels-bot:fix:<issue-number> -->`
@@ -179,7 +181,8 @@ is enforced by code, so don't skip steps.
     Implementation: `<path(s)>`
 
     A human review is required before merge. Reviewer A and Reviewer B
-    will weigh in shortly.
+    will weigh in shortly. Doc updates (MDX guides, `.ai/wheels/`,
+    `CLAUDE.md`) are handled separately by `bot-update-docs.yml`.
 
     <!-- wheels-bot:fix:<issue-number> -->
     ```

--- a/.claude/commands/update-docs.md
+++ b/.claude/commands/update-docs.md
@@ -1,0 +1,131 @@
+# /update-docs
+
+Read a PR's implementation diff and add follow-up doc commits (MDX user
+guides, `.ai/wheels/<layer>/`, `CLAUDE.md`) to the PR branch. The bot's
+implementation is already in the PR; your job is documentation only.
+
+## Rails
+
+Read `.claude/commands/_shared-rails.md` first. Highlights for this command:
+
+- Use `gh` for GitHub state. Use `git add` and `git commit` to land doc
+  commits on the PR branch (the caller workflow handles the actual push).
+- **Filesystem writes are scoped to doc paths only**:
+  `web/sites/guides/**`, `.ai/wheels/**`, `CLAUDE.md`, `CHANGELOG.md`.
+  **Do NOT modify any file under `vendor/wheels/**`, `app/**`, `tests/**`,
+  `vendor/wheels/tests/**`, `.github/**`, `cli/**`, or `config/**`** —
+  the implementation is already in the PR; touching it would create a
+  merge conflict and trigger Reviewer A re-runs.
+- Output is at most one doc-update commit + one comment on the PR.
+
+## Args
+
+- `<pr-number>` — the PR to add doc commits to
+
+## Steps
+
+1. **Idempotency check.** Read existing PR comments via
+   `gh pr view <pr-number> --repo wheels-dev/wheels --json comments`. If
+   any comment contains `<!-- wheels-bot:update-docs:<pr-number> -->`,
+   exit silently — docs have already been processed for this PR.
+
+2. **Read the PR context.**
+   - Title and body via `gh pr view <pr-number> --json title,body`. The
+     body should contain `Fixes #<issue-number>`; capture that issue
+     number.
+   - The implementation diff via
+     `gh pr diff <pr-number> --repo wheels-dev/wheels`. Use this to
+     understand what changed and roughly which layer was affected.
+   - The triage comment on the linked issue (marker
+     `wheels-bot:triage:<issue-number>`) — gives you the canonical layer
+     name (model / controller / view / etc.).
+
+3. **Decide doc scope.** Walk through these in order; each is independent:
+
+   - **MDX user guide?** If user-visible behavior changed (UI, framework
+     feature surface, CLI command, public API, error message text), find
+     the relevant page under
+     `web/sites/guides/src/content/docs/v4-0-0-snapshot/<area>/`. If no
+     obvious page exists, **skip** — note in step 6 that a new doc page
+     may be warranted as a follow-up. Do not create new pages.
+   - **`.ai/wheels/<layer>/`?** Update only if a documented pattern, a
+     conventions table, or a canonical example actually changed in the
+     PR diff. Do not edit prose unrelated to the change.
+   - **`CLAUDE.md`?** Update only if model/controller/view conventions
+     changed (the "Critical Anti-Patterns" or "Wheels Conventions"
+     sections in `CLAUDE.md`), or if a new top-level subsystem surfaced.
+
+   **If none of the above apply** (purely internal refactor, test-only
+   change, or doc-only PR already shipping the docs), skip to step 6
+   with no edits — that is a valid outcome and should be reported as
+   such.
+
+4. **Make conservative edits.** For each location identified in step 3:
+
+   - Read the existing file before editing.
+   - Limit edits to a few sentences or one short table change. Do **not**
+     rewrite whole pages.
+   - Match the existing style (tone, heading depth, code-fence language).
+   - Do **not** introduce emoji unless the surrounding doc already uses
+     them.
+
+5. **Stage and commit (only if there are doc changes).**
+
+   Conventional commit. Type `docs`. Scope from the allowlist if the file
+   path matches: `docs` for `.ai/wheels/` updates, `web/guides` for MDX
+   under `web/sites/guides/`, no scope for `CLAUDE.md`. Subject ≤ 100
+   chars, sentence-case.
+
+   Examples:
+   - `docs(web/guides): note registry-package list in debug-panel guide`
+   - `docs: update view layer patterns table for debug-panel registry`
+   - `docs: clarify findOne nested-association behavior in CLAUDE.md`
+
+   ```bash
+   git add <files>
+   git commit -m "<message>"
+   ```
+
+   The caller workflow handles `git push` — just commit cleanly. Do
+   **not** use `--amend` or `--force`.
+
+6. **Comment on the PR.** Use one of these two formats — whichever
+   matches what you actually did.
+
+   ### If you made doc edits:
+
+   ```
+   ## Wheels Bot — Docs updated
+
+   Added a doc commit to this PR:
+
+   - `<file>` — `<one-line summary>`
+   - ...
+
+   <!-- wheels-bot:update-docs:<pr-number> -->
+   ```
+
+   ### If no doc edits were needed:
+
+   ```
+   ## Wheels Bot — No doc updates
+
+   Reviewed this PR's diff and found no docs that need updating
+   (<one short sentence on why — e.g. "purely internal refactor",
+   "test-only change", "behavior is not user-visible">).
+
+   <!-- wheels-bot:update-docs:<pr-number> -->
+   ```
+
+7. **Self-check before posting.**
+   - [ ] No files changed outside doc paths (`web/sites/guides/`,
+     `.ai/wheels/`, `CLAUDE.md`, `CHANGELOG.md`)
+   - [ ] If a commit was made, message is conventional and ≤ 100 chars
+   - [ ] PR comment with `wheels-bot:update-docs:<pr-number>` marker is
+     posted
+   - [ ] No file under `vendor/wheels/`, `app/`, `tests/`, `.github/`,
+     `cli/`, or `config/` was touched
+   - [ ] No new MDX page was created (additions to existing pages only)
+
+   If any check fails: do not post the comment. Investigate the diff and
+   exit non-zero so a human can clean up.

--- a/.github/workflows/bot-update-docs.yml
+++ b/.github/workflows/bot-update-docs.yml
@@ -1,0 +1,105 @@
+name: Wheels Bot — Update Docs
+
+# Phase 1 rollout: workflow_dispatch only. After several supervised runs
+# produce clean output, a future PR can re-add an auto-fire branch — e.g.
+# trigger on `pull_request: opened` for `wheels-bot[bot]` head refs, or
+# on `issue_comment: created` matching a `wheels-bot:fix:<pr>` marker
+# emitted by propose-fix.
+on:
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'PR number to add doc updates to'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wheels-bot-update-docs-${{ inputs.pr-number }}
+  cancel-in-progress: false
+
+jobs:
+  update-docs:
+    name: Update docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: vars.WHEELS_BOT_ENABLED == 'true'
+    env:
+      PR_NUMBER: ${{ inputs.pr-number }}
+      WHEELS_CI: "true"
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WHEELS_BOT_APP_ID }}
+          private-key: ${{ secrets.WHEELS_BOT_PRIVATE_KEY }}
+
+      - name: Resolve PR head ref
+        id: pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Validate input is numeric to short-circuit any injection vectors
+          # before passing it to gh.
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr-number must be numeric, got: $PR_NUMBER"
+            exit 1
+          fi
+          ref=$(gh pr view "$PR_NUMBER" --repo wheels-dev/wheels --json headRefName -q '.headRefName')
+          if [ -z "$ref" ]; then
+            echo "::error::Could not resolve PR head ref for #$PR_NUMBER"
+            exit 1
+          fi
+          echo "head=$ref" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.head }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Skip check
+        id: gate
+        uses: ./.github/actions/wheels-bot-skip-check
+        with:
+          target-type: pr
+          target-number: ${{ env.PR_NUMBER }}
+          marker-pattern: 'wheels-bot:update-docs:${{ env.PR_NUMBER }}'
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure git
+        if: steps.gate.outputs.skip == 'false'
+        run: |
+          git config user.name "wheels-bot[bot]"
+          git config user.email "wheels-bot[bot]@users.noreply.github.com"
+
+      - name: Run Update Docs
+        if: steps.gate.outputs.skip == 'false'
+        uses: anthropics/claude-code-action@v1
+        with:
+          allowed_bots: 'wheels-bot[bot],github-actions[bot]'
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          prompt: |
+            /update-docs ${{ env.PR_NUMBER }}
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 30
+            --allowedTools "Bash(gh:*),Bash(git status),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git grep:*),Bash(git add:*),Bash(git commit:*),Read,Edit,Write,Grep,Glob"
+
+      - name: Push doc commits
+        if: steps.gate.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Only push if new commits exist beyond what's already on the
+          # remote branch tip.
+          if [ -z "$(git log @{u}..HEAD --oneline 2>/dev/null)" ]; then
+            echo "No new commits — nothing to push."
+            exit 0
+          fi
+          git push origin HEAD

--- a/docs/contributing/wheels-bot.md
+++ b/docs/contributing/wheels-bot.md
@@ -2,7 +2,7 @@
 
 `wheels-bot[bot]` is a custom GitHub App that automates issue triage,
 cross-framework design research, fix-PR generation, and PR review on
-`wheels-dev/wheels`. It runs as five stages, each backed by a slash-command
+`wheels-dev/wheels`. It runs as six stages, each backed by a slash-command
 prompt in `.claude/commands/` and a workflow in `.github/workflows/bot-*.yml`.
 
 This page is for humans interacting with the bot. For the design rationale,
@@ -21,7 +21,7 @@ contribution rules, see [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 - Flip the repo variable `WHEELS_BOT_ENABLED` to `false` to halt the bot
   entirely without code changes.
 
-## The five stages
+## The six stages
 
 ### 1. Triage (`bot-triage.yml`)
 
@@ -76,7 +76,9 @@ The bot:
 4. Confirms the spec fails by running `bash tools/test-local.sh <layer>`.
 5. Implements the fix in `vendor/wheels/**` or `app/**`.
 6. Re-runs and confirms the spec passes.
-7. Updates `.ai/wheels/<layer>/`, `CHANGELOG.md`, and the relevant guide page.
+7. Updates `CHANGELOG.md`. Other doc updates (`.ai/wheels/`, MDX guides,
+   `CLAUDE.md`) happen in the next stage, not here — propose-fix's budget
+   stays focused on TDD work.
 8. Opens a draft PR on `fix/bot-<issue>-<slug>` against `develop`,
    referencing the research comment when applicable.
 
@@ -84,7 +86,43 @@ The PR must pass `bot-tdd-gate.yml` before any other check — that gate
 hard-rejects bot PRs that don't include both a spec change and an
 implementation change. The gate is a no-op for human-authored PRs.
 
-### 4. Reviewer A (`bot-review-a.yml`)
+### 4. Update Docs (`bot-update-docs.yml`)
+
+Adds doc commits to a freshly-opened bot PR. Runs as a separate stage so
+propose-fix's budget can stay focused on TDD work (failing spec →
+implementation → passing spec → CHANGELOG → PR), with documentation
+following as a sibling stage rather than competing for the same turn
+budget. Sonnet, 30-turn budget — doc edits are pattern-recognition work,
+not reasoning-heavy.
+
+Currently `workflow_dispatch` only — invoke with the PR number once
+propose-fix has opened the PR:
+
+```bash
+gh workflow run bot-update-docs.yml --repo wheels-dev/wheels -F pr-number=<N>
+```
+
+The bot:
+
+1. Reads the PR's diff and the linked issue's triage comment to identify
+   the affected layer.
+2. Decides whether docs need updating: MDX guide page (only if user-visible
+   behavior changed), `.ai/wheels/<layer>/` (only if a documented pattern
+   actually changed), `CLAUDE.md` (only if conventions changed). Skips
+   cleanly with a "no doc updates" comment when the diff is purely
+   internal.
+3. Makes conservative edits — limited to the touched paths only, no new
+   page creation, no broad rewrites.
+4. Lands a single `docs:` commit on the PR branch and posts an update
+   comment with the marker `wheels-bot:update-docs:<pr>`.
+
+The narrow allowlist (no test runs, no Lucee bootstrap, no
+`vendor/wheels/` or `app/` writes) keeps this stage fast and cheap. A
+future PR can re-add an auto-fire trigger so this stage runs immediately
+after propose-fix opens the PR; for now the manual gate matches the
+phased-rollout philosophy from PR #2519.
+
+### 5. Reviewer A (`bot-review-a.yml`)
 
 Fires on `pull_request: opened/synchronize/ready_for_review` against
 `develop`. Skips bot-authored PRs (Reviewer A is for human PRs); the bot's
@@ -95,7 +133,7 @@ Conventions, Cross-engine, Tests, Docs, Commits, Security. Verdict is
 `approve` / `request-changes` / `comment`. Verdict and findings must be
 consistent — Reviewer B will catch sycophancy if they aren't.
 
-### 5. Reviewer B (`bot-review-b.yml`)
+### 6. Reviewer B (`bot-review-b.yml`)
 
 Fires when Reviewer A submits a review (filtered on
 `review.user.login == 'wheels-bot[bot]'`). Reviewer B critiques A's review,
@@ -132,6 +170,7 @@ they make every workflow safely retryable.
 | `wheels-bot:research-confidence:high` | Triggers propose-fix on the framework-design path. |
 | `wheels-bot:fix:<issue>` | Fix PR has been opened for this issue. |
 | `wheels-bot:fix-held:<issue>` | Fix would have been proposed but the safety net held it for a human. |
+| `wheels-bot:update-docs:<pr>` | Update Docs stage processed this PR (with or without doc edits). |
 | `wheels-bot:review-a:<pr>:<sha>` | Reviewer A reviewed this PR at this SHA. |
 | `wheels-bot:review-b:<pr>:<sha>:<round>` | Reviewer B critiqued round N. |
 | `wheels-bot:auto-close:<issue>` | Auto-close cron closed this issue. |


### PR DESCRIPTION
## Summary

Two propose-fix runs tonight on issue [#2526](https://github.com/wheels-dev/wheels/issues/2526) ([#25616307210](https://github.com/wheels-dev/wheels/actions/runs/25616307210), [#25616508963](https://github.com/wheels-dev/wheels/actions/runs/25616508963)) both hit `error_max_turns` at 61 turns. Total burn: \~\$7.00 in Opus budget, no PR produced, no draft branch landed.

This is the same shape of failure that PR [#2527](https://github.com/wheels-dev/wheels/pull/2527) fixed for triage, just at the next stage up. The triage prompt was asking Sonnet to do propose-fix's job in 20 turns; tonight propose-fix is asking Opus to do propose-fix's job *plus* a four-target documentation update in 60 turns. Telemetry: `permission_denials_count: 15` and `19` on the two runs respectively, suggesting Opus is cascading through tool denials while looking for ways to investigate doc paths it can't easily locate (e.g., MDX guide pages for a debug-panel UI tweak don't exist).

The empirical evidence is also worth noting: I claimed in this thread that propose-fix had previously succeeded on #2412. That was wrong — [run #25613644484](https://github.com/wheels-dev/wheels/actions/runs/25613644484) was a 5-turn early-exit because no triage comment existed on #2412. **Tonight's failures are the first end-to-end propose-fix attempts in the bot's history.** The 60-turn budget was set on theory, not validated against real runs.

## What changed

### Scope reduction in propose-fix

[`.claude/commands/propose-fix.md`](.claude/commands/propose-fix.md):

- **Step 9** — was \"Update supporting docs\" (4 doc locations: MDX guide, `.ai/wheels/`, `CLAUDE.md`, `CHANGELOG.md`). Now \"Add a CHANGELOG entry\" only. The other three locations move to the new `bot-update-docs.yml` stage.
- **Step 11 PR-template checklist** — leaves Framework Docs / AI Reference Docs / CLAUDE.md unchecked. The new docs stage will fill them on its follow-up commit if needed.
- **Step 13 issue-comment template** — mentions that doc updates are handled by `bot-update-docs.yml` so humans see the picture.

### New stage: `bot-update-docs.yml`

[`.github/workflows/bot-update-docs.yml`](.github/workflows/bot-update-docs.yml) — new workflow file, modeled on the existing bot-* workflows:

- **Trigger:** `workflow_dispatch` only (Phase 1 conservative). Inline comment documents the future auto-fire path (`pull_request: opened` from `wheels-bot[bot]` head refs, or `issue_comment: created` matching the propose-fix marker).
- **Model:** `claude-sonnet-4-6` (not Opus — doc edits are pattern-recognition work).
- **Budget:** 30 turns.
- **Allowlist:** `Bash(gh:*),Bash(git status/log/diff/show/grep/add/commit),Read,Edit,Write,Grep,Glob`. No test-runner, no curl, no broad `git:*`.
- **Input validation:** `pr-number` is regex-checked as numeric before being passed to `gh`.
- **Push step:** only pushes if new commits exist on the branch.

[`.claude/commands/update-docs.md`](.claude/commands/update-docs.md) — new slash-command prompt:

- Idempotency check on `wheels-bot:update-docs:<pr>` marker.
- Reads PR diff + linked issue's triage comment to identify the layer.
- Decides scope per-location: MDX (only if user-visible behavior changed), `.ai/wheels/<layer>/` (only if patterns table actually changed), `CLAUDE.md` (only if conventions changed). \"No doc updates needed\" is a valid outcome and gets reported.
- Conservative edits — limit to a few sentences or one short table change.
- **Hard guardrail:** writes are scoped to doc paths only; cannot touch `vendor/wheels/`, `app/`, `tests/`, `.github/`, `cli/`, `config/`. Self-check enforces this.
- Single `docs:` commit, single PR comment with marker.

### Doc updates

[`docs/contributing/wheels-bot.md`](docs/contributing/wheels-bot.md):

- \"five stages\" → \"six stages\" everywhere.
- Propose-fix step 7 description trimmed (no longer claims to update `.ai/wheels/`).
- New \"### 4. Update Docs\" section explaining the stage.
- Reviewer A renumbered 4 → 5; Reviewer B renumbered 5 → 6.
- Markers table gains `wheels-bot:update-docs:<pr>`.

## Why this approach instead of bumping turns / model

The systematic-debugging principle: address the root cause, then observe. Bumping propose-fix from 60 to 80 turns or upgrading to a hypothetical larger model would let the bloated prompt squeak through, but the *structural* problem — propose-fix doing two jobs (TDD work + multi-location doc work) on one budget — would remain. The next harder issue would re-hit the cliff.

Splitting into stages also gives us:

1. **Independent budget tuning** per stage. If doc updates need more or less time, we tune `bot-update-docs.yml` without touching propose-fix.
2. **Cheaper failure recovery** — if doc updates fail or produce something off, we don't lose the propose-fix PR; we just retry the docs stage.
3. **Tighter security blast radius per stage** — propose-fix's allowlist no longer needs `Bash(curl:*)` or wide `Bash(git:*)`; the doc stage has its own narrower allowlist.

## Test plan

- [ ] Merge to `develop`.
- [ ] Re-dispatch propose-fix on #2526: `gh workflow run bot-propose-fix.yml --repo wheels-dev/wheels -F issue-number=2526`.
- [ ] Confirm: propose-fix completes successfully (turns well under 60), opens a draft PR `fix/bot-2526-*` with a CHANGELOG entry, no MDX/`.ai/`/`CLAUDE.md` touched, marker `wheels-bot:fix:2526` posted on issue.
- [ ] Then dispatch the new docs stage: `gh workflow run bot-update-docs.yml --repo wheels-dev/wheels -F pr-number=<N>`.
- [ ] Confirm: docs stage completes successfully (turns well under 30), either lands a `docs:` commit or posts the \"No doc updates\" comment, marker `wheels-bot:update-docs:<N>` posted on the PR.
- [ ] Verify the bot-tdd-gate.yml check still passes on the bot's PR (TDD invariant unchanged — propose-fix still produces spec + impl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)