### PR TITLE
ci: lift Phase 4 gates — wire propose-fix/research/update-docs auto-fire

### DIFF
--- a/.github/workflows/bot-propose-fix.yml
+++ b/.github/workflows/bot-propose-fix.yml
@@ -22,12 +22,21 @@ jobs:
     name: Propose fix
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # Phase 1-3 rollout: workflow_dispatch only. Lift this gate at Phase 4a
-    # (bug-path) by re-adding the triage-confidence:high branch, and at Phase 4b
-    # by re-adding the research-confidence:high branch.
+    # Phase 4 (auto-fire): runs from wheels-bot[bot] comments containing
+    # `wheels-bot:triage-confidence:high` (bug path) or
+    # `wheels-bot:research-confidence:high` (framework-design path).
+    # workflow_dispatch is preserved for manual reruns.
+    # The bot-identity check is load-bearing: prevents humans from
+    # triggering propose-fix by quoting a marker in a comment reply.
     if: |
       vars.WHEELS_BOT_ENABLED == 'true'
-      && github.event_name == 'workflow_dispatch'
+      && (
+        github.event_name == 'workflow_dispatch'
+        || (github.event_name == 'issue_comment'
+            && github.event.comment.user.login == 'wheels-bot[bot]'
+            && (contains(github.event.comment.body, 'wheels-bot:triage-confidence:high')
+                || contains(github.event.comment.body, 'wheels-bot:research-confidence:high')))
+      )
     env:
       ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue-number }}
       WHEELS_CI: "true"

--- a/.github/workflows/bot-research.yml
+++ b/.github/workflows/bot-research.yml
@@ -22,11 +22,19 @@ jobs:
     name: Cross-framework research
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Phase 1-3 rollout: workflow_dispatch only. Lift this gate at Phase 4b
-    # by re-adding the triage-class:framework-design branch.
+    # Phase 4 (auto-fire): runs from wheels-bot[bot] comments containing
+    # `wheels-bot:triage-class:framework-design`. workflow_dispatch is
+    # preserved for manual reruns.
+    # The bot-identity check is load-bearing: prevents humans from
+    # triggering research by quoting a marker in a comment reply.
     if: |
       vars.WHEELS_BOT_ENABLED == 'true'
-      && github.event_name == 'workflow_dispatch'
+      && (
+        github.event_name == 'workflow_dispatch'
+        || (github.event_name == 'issue_comment'
+            && github.event.comment.user.login == 'wheels-bot[bot]'
+            && contains(github.event.comment.body, 'wheels-bot:triage-class:framework-design'))
+      )
     env:
       ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue-number }}
     steps:

--- a/.github/workflows/bot-update-docs.yml
+++ b/.github/workflows/bot-update-docs.yml
@@ -1,10 +1,8 @@
 name: Wheels Bot — Update Docs
 
-# Phase 1 rollout: workflow_dispatch only. After several supervised runs
-# produce clean output, a future PR can re-add an auto-fire branch — e.g.
-# trigger on `pull_request: opened` for `wheels-bot[bot]` head refs, or
-# on `issue_comment: created` matching a `wheels-bot:fix:<pr>` marker
-# emitted by propose-fix.
+# Phase 4 (auto-fire): runs on pull_request opened from wheels-bot[bot]
+# head refs (after propose-fix opens its draft PR). workflow_dispatch is
+# preserved for manual reruns.
 on:
   workflow_dispatch:
     inputs:
@@ -12,12 +10,14 @@ on:
         description: 'PR number to add doc updates to'
         required: true
         type: string
+  pull_request:
+    types: [opened]
 
 permissions:
   contents: read
 
 concurrency:
-  group: wheels-bot-update-docs-${{ inputs.pr-number }}
+  group: wheels-bot-update-docs-${{ github.event.pull_request.number || inputs.pr-number }}
   cancel-in-progress: false
 
 jobs:
@@ -25,9 +25,18 @@ jobs:
     name: Update docs
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: vars.WHEELS_BOT_ENABLED == 'true'
+    # Auto-fire only for the bot's own PRs. The bot-identity check is
+    # load-bearing: prevents human PRs from triggering this stage and
+    # adding bot-authored doc commits to in-flight branches.
+    if: |
+      vars.WHEELS_BOT_ENABLED == 'true'
+      && (
+        github.event_name == 'workflow_dispatch'
+        || (github.event_name == 'pull_request'
+            && github.event.pull_request.user.login == 'wheels-bot[bot]')
+      )
     env:
-      PR_NUMBER: ${{ inputs.pr-number }}
+      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr-number }}
       WHEELS_CI: "true"
     steps:
       - name: Generate App token

--- a/docs/contributing/wheels-bot.md
+++ b/docs/contributing/wheels-bot.md
@@ -95,8 +95,9 @@ following as a sibling stage rather than competing for the same turn
 budget. Sonnet, 30-turn budget — doc edits are pattern-recognition work,
 not reasoning-heavy.
 
-Currently `workflow_dispatch` only — invoke with the PR number once
-propose-fix has opened the PR:
+Auto-fires on `pull_request: opened` for PRs from the `wheels-bot[bot]`
+identity (the draft PRs that propose-fix produces). Manual dispatch is
+preserved as a fallback:
 
 ```bash
 gh workflow run bot-update-docs.yml --repo wheels-dev/wheels -F pr-number=<N>
@@ -117,10 +118,10 @@ The bot:
    comment with the marker `wheels-bot:update-docs:<pr>`.
 
 The narrow allowlist (no test runs, no Lucee bootstrap, no
-`vendor/wheels/` or `app/` writes) keeps this stage fast and cheap. A
-future PR can re-add an auto-fire trigger so this stage runs immediately
-after propose-fix opens the PR; for now the manual gate matches the
-phased-rollout philosophy from PR #2519.
+`vendor/wheels/` or `app/` writes) keeps this stage fast and cheap. The
+bot-identity check on the `if:` block is load-bearing — it prevents human
+PRs from triggering this stage and adding bot-authored doc commits to
+in-flight branches.
 
 ### 5. Reviewer A (`bot-review-a.yml`)
 
@@ -194,23 +195,30 @@ they make every workflow safely retryable.
    - `Lucee 7 + SQLite (LuCLI)` (existing)
    - `Bot PR TDD Gate` (new — only fails on bot PRs without a spec)
 
-   **Approval requirement is org-size-dependent.** Multi-maintainer
-   teams should require ≥1 approving review from `wheels-dev/maintainers`.
-   Solo-maintainer setups may set `required_approving_review_count: 0`,
-   relying on the bot's `--draft` PR posture and the maintainer's manual
-   review-then-merge workflow as the human-eye gate. The `Bot PR TDD Gate`
-   required check still enforces test discipline regardless of approval count.
+   **Approval requirement: `required_approving_review_count: 1`.** The
+   bot opens PRs as `--draft`, but with auto-fire enabled (Phase 4) the
+   approval gate is the load-bearing safety net that prevents a runaway
+   chain from merging itself. Multi-maintainer teams may require reviews
+   from a specific team (e.g. `wheels-dev/maintainers`); solo-maintainer
+   setups can leave it at 1 with the maintainer as the reviewer. The
+   `Bot PR TDD Gate` required check still enforces test discipline on
+   every bot PR regardless of approval count.
 
 ### Day-to-day
 
-- **Watch the bot's first runs.** Phase 1 (Reviewer A only) is the safe
-  starting cut. Promote subsequent phases (triage, Reviewer B, propose-fix)
-  one at a time.
-- **Promote propose-fix from manual to auto-fire** only after at least 5
-  supervised runs are clean. The shipped default is `workflow_dispatch` only
-  (gated in `bot-propose-fix.yml`'s `if:`); to lift the gate, restore the
-  `triage-confidence:high` branch (Phase 4a) and the `research-confidence:high`
-  branch (Phase 4b). Same pattern applies to `bot-research.yml`.
+- **Watch every bot run.** Even with auto-fire enabled, every bot PR is
+  `--draft` and requires an approving review (`required_approving_review_count: 1`
+  in develop's ruleset) before merge. Spot-check triage classifications
+  and Reviewer A verdicts; flip `WHEELS_BOT_ENABLED=false` if anything
+  looks off.
+- **Auto-fire (Phase 4) is on.** propose-fix runs from
+  `wheels-bot:triage-confidence:high` and
+  `wheels-bot:research-confidence:high` markers; research runs from
+  `wheels-bot:triage-class:framework-design`; bot-update-docs runs on
+  `pull_request: opened` for `wheels-bot[bot]` PRs. To halt auto-fire
+  without code changes, flip `WHEELS_BOT_ENABLED=false`. To halt
+  permanently, revert the `if:` blocks in the three workflows back to
+  `workflow_dispatch`-only and keep the kill-switch flipped.
 - **Review bot-authored PRs the same as human-authored PRs.** Don't
   rubber-stamp.
 - **Watch costs.** API spend per fix-PR is non-trivial (Opus + many turns +


### PR DESCRIPTION
## Summary

Flips the wheels-bot pipeline from Phase 1-3 (`workflow_dispatch`-only on the heavy stages) to Phase 4 (auto-fire on the bot's own marker emissions). After this lands, a fresh issue triggers the full chain end-to-end without any human intervention beyond the final approving review.

## Sequencing

This PR pairs with an out-of-band ruleset change applied first: `required_approving_review_count: 1` on develop's "develop integration policy" ruleset. Both are needed:

| Layer | What it prevents | Set how |
|---|---|---|
| Workflow `if:` blocks | Wrong actor or wrong marker triggering a stage | This PR |
| Ruleset approval count | Runaway chain merging itself without human eyes | Out-of-band ruleset PATCH (already applied) |

## What changed

### `.github/workflows/bot-propose-fix.yml`

```diff
-    # Phase 1-3 rollout: workflow_dispatch only. Lift this gate at Phase 4a
-    # (bug-path) by re-adding the triage-confidence:high branch, and at Phase 4b
-    # by re-adding the research-confidence:high branch.
-    if: |
-      vars.WHEELS_BOT_ENABLED == 'true'
-      && github.event_name == 'workflow_dispatch'
+    # Phase 4 (auto-fire): runs from wheels-bot[bot] comments containing
+    # `wheels-bot:triage-confidence:high` (bug path) or
+    # `wheels-bot:research-confidence:high` (framework-design path).
+    # workflow_dispatch is preserved for manual reruns.
+    if: |
+      vars.WHEELS_BOT_ENABLED == 'true'
+      && (
+        github.event_name == 'workflow_dispatch'
+        || (github.event_name == 'issue_comment'
+            && github.event.comment.user.login == 'wheels-bot[bot]'
+            && (contains(github.event.comment.body, 'wheels-bot:triage-confidence:high')
+                || contains(github.event.comment.body, 'wheels-bot:research-confidence:high')))
+      )
```

### `.github/workflows/bot-research.yml`

Same shape, lifting auto-fire on `wheels-bot:triage-class:framework-design`.

### `.github/workflows/bot-update-docs.yml`

Adds a `pull_request: opened` trigger and lifts the `if:` to fire on bot-authored PRs. `inputs.pr-number || github.event.pull_request.number` covers both event sources for the env, concurrency group, and the skip-check action.

### `docs/contributing/wheels-bot.md`

- Stage 4 (Update Docs) section: "Currently `workflow_dispatch` only" → "Auto-fires on `pull_request: opened` from `wheels-bot[bot]` head refs."
- One-time setup approval-count language: now documents `required_approving_review_count: 1` as the load-bearing safety net under auto-fire.
- Day-to-day rollout bullets: rewritten to reflect Phase 4 reality and the kill-switch path back to gated mode.

## Why the bot-identity checks matter

Each lifted `if:` block adds an explicit author check (`comment.user.login == 'wheels-bot[bot]'` or `pull_request.user.login == 'wheels-bot[bot]'`). Without that:

- A human could quote a triage marker in a comment reply and trigger propose-fix to spend ~$3-5 of Opus budget chasing a phantom issue.
- A human PR could trigger bot-update-docs and have bot-authored doc commits land on their branch unexpectedly.

The author check rejects those cases at the workflow level before any LLM cost is incurred.

## Kill switch

`vars.WHEELS_BOT_ENABLED == 'false'` halts every stage (the kill switch is already wired through every job's `if:`). Reverting this PR puts the gates back to `workflow_dispatch`-only without losing any work.

## Test plan

After merge:

- [ ] Verify the three workflow files' `if:` blocks parse — visit each in the Actions UI to confirm they're listed.
- [ ] Trigger a fresh chain by either:
  - opening a new test issue (cleanest — no idempotency markers in the way), OR
  - removing the `wheels-bot:triage:2526` marker from the existing triage comment on #2526 and closing/reopening to retrigger triage.
- [ ] Watch the cascade:
  1. `bot-triage.yml` runs on issue open → posts `triage-confidence:high` comment.
  2. `bot-propose-fix.yml` auto-fires on the new comment → opens a draft PR.
  3. `bot-update-docs.yml` auto-fires on PR open → adds doc commits or posts "no doc updates".
  4. `bot-tdd-gate.yml` and `bot-reviewer-a.yml` run on the PR.
  5. `bot-reviewer-b.yml` fires after Reviewer A submits.
- [ ] Confirm the PR is `--draft` and cannot merge until a human approves (`required_approving_review_count: 1` enforces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)