### PR TITLE
ci: bump propose-fix max-turns 60 → 100 + temporary show_full_output (diagnostic)

### DIFF
--- a/.github/workflows/bot-propose-fix.yml
+++ b/.github/workflows/bot-propose-fix.yml
@@ -98,6 +98,11 @@ jobs:
         if: steps.gate.outputs.skip == 'false'
         uses: anthropics/claude-code-action@v1
         with:
+          # DIAGNOSTIC (temporary): show_full_output exposes per-turn tool
+          # calls including which were denied, so we can see which tools
+          # Opus is reaching for that the allowlist rejects. Remove this
+          # line once the next run's data has informed allowlist tuning.
+          show_full_output: true
           # When un-gated at Phase 4a/4b, this workflow fires from wheels-bot[bot]
           # comments containing high-confidence triage or research markers. Allow
           # that bot identity (and github-actions[bot] for consistency).

--- a/.github/workflows/bot-propose-fix.yml
+++ b/.github/workflows/bot-propose-fix.yml
@@ -108,7 +108,7 @@ jobs:
             /propose-fix ${{ env.ISSUE_NUMBER }}
           claude_args: |
             --model claude-opus-4-7
-            --max-turns 60
+            --max-turns 100
             --allowedTools "Bash(gh:*),Bash(git:*),Bash(bash tools/test-local.sh*),Bash(curl:*),Read,Edit,Write,Grep,Glob"
 
       - name: Push branch


### PR DESCRIPTION
## Summary

**Two diagnostic levers in one PR:**

1. **`max-turns: 60 → 100`** (permanent — sized for actual work) — the cliff three identical runs hit was 61 turns.
2. **`show_full_output: true`** (temporary — remove after next run yields data) — so we can finally see *which* tools Opus is reaching for that the allowlist rejects.

Three identical `error_max_turns` failures at 61 turns on issue [#2530](https://github.com/wheels-dev/wheels/issues/2530) and earlier on [#2526](https://github.com/wheels-dev/wheels/issues/2526):

| Run | Turns | Cost | Denials |
|---|---|---|---|
| [#25616307210](https://github.com/wheels-dev/wheels/actions/runs/25616307210) | 61 | \$3.66 | 15 |
| [#25616508963](https://github.com/wheels-dev/wheels/actions/runs/25616508963) | 61 | \$3.36 | 19 |
| [#25617692327](https://github.com/wheels-dev/wheels/actions/runs/25617692327) | 61 | \$3.63 | 18 |

PR [#2528](https://github.com/wheels-dev/wheels/pull/2528) cut step 9 (doc updates) from 4 locations to 1 CHANGELOG entry. The third run, post-#2528 merge, hit the same wall in the same number of turns at the same cost — disproving the "doc updates were the budget sink" hypothesis. The persistent 15-19 permission denials per run mean Opus is wasting roughly **30% of every run on rejected tool attempts**, and we don't currently have visibility into *which* tools.

## Why both levers in one PR

Bumping the budget without expanding visibility means the next 100-turn run will produce *more* unobservable denials and we'll learn nothing actionable. Adding `show_full_output: true` without bumping the budget means the run still fails at 61 turns and we don't see how the chain *would* play out with headroom. Both knobs are needed for one informative experiment.

The action's existing log line tells us the visibility flag is the right approach:
> *"Running Claude Code via SDK (full output hidden for security)..."*
> *"Rerun in debug mode or enable `show_full_output: true` in your workflow file for full output."*

## Outcome decision tree (after this lands and one run completes)

The follow-up PR depends on what we observe:

| Observed | Diagnosis | Follow-up |
|---|---|---|
| Succeeds, 60–80 turns, denials < 5 | 60-turn cap was just too tight; no real waste | Drop ceiling to 80, remove `show_full_output`, done |
| Succeeds, 80–95 turns, denials 15–20 | Denials are 30% waste; need allowlist or prompt tightening | Identify top 3 denied tool patterns; expand allowlist (e.g. add `Task`, `WebFetch`) or add explicit "do not use these" to the prompt; remove `show_full_output` |
| Succeeds, 95–100 turns | Same as above, but barely fits at 100 — risky long-term | Same fix as above + keep ceiling at 100 |
| Fails at 100 with similar denial rate | Architecture mismatch — prompt fundamentally too big for one stage | Surgical refactor: split propose-fix into "context-gathering" + "implementation" stages, separate budgets |

## Security note on `show_full_output`

The action redacts `anthropic_api_key` and `github_token` at a separate layer regardless of this flag, so credentials don't leak into logs. What `show_full_output` exposes:

- Tool names called (e.g. `Task`, `WebFetch`, `Read`)
- Arguments to those calls (file paths, search terms, etc.)
- Tool results (file contents Opus read, command outputs)

For a public repo, every public Actions log is world-readable. We're trading a one-time exposure of "what Opus tried to do on this specific issue" for the ability to fix the budget mismatch. The flag comes back out in a follow-up PR.

## Cost expectation

A successful 100-turn Opus run with full output enabled is roughly \$5–8 (full output adds some token weight to the trace logs). A failure at 100 would be similar.

## Test plan

- [ ] Merge this PR.
- [ ] Manually re-dispatch propose-fix on issue #2530: `gh workflow run bot-propose-fix.yml --repo wheels-dev/wheels -F issue-number=2530`.
- [ ] Capture from the run log: turns used, cost, denied-tool list, denied-tool counts.
- [ ] If a draft PR opens: verify the rest of the cascade (bot-update-docs, TDD gate, Reviewer A, Reviewer B).
- [ ] Open follow-up PR removing `show_full_output: true` and either expanding the allowlist or tightening the prompt based on what we learned.

## Mirror precedent

Budget-bump style mirrors [#2524](https://github.com/wheels-dev/wheels/pull/2524) ("ci: bump Reviewer B max-turns 20 → 30"). The visibility flag is the diagnostic equivalent of `set -x` in a flaky shell script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)