### PR TITLE
ci: fix propose-fix /tmp prompt bug; extend Reviewer A/B to bot PRs

### DIFF
--- a/.claude/commands/propose-fix.md
+++ b/.claude/commands/propose-fix.md
@@ -91,10 +91,15 @@ is enforced by code, so don't skip steps.
    bash tools/test-local.sh <layer>
    ```
 
-   Capture the failure to `/tmp/bot-failure.json` (use `format=json` on the
-   test endpoint or save the bash output). **Confirm the spec actually
-   fails.** A passing spec at this point means you wrote the wrong test —
-   redo it.
+   Read the bash output directly to confirm the failure — note which
+   assertion fired and the diff between expected and actual. **Do NOT
+   write to `/tmp/` or anywhere outside the repository working tree.**
+   The runtime sandboxes file operations to the working directory; `cp`
+   to `/tmp` (or any out-of-tree path) will be blocked and burn turns on
+   retries. If you need to persist test output for the next step, write
+   to a working-tree path like `./.bot-test-output.txt` and clean it up
+   before commit. **Confirm the spec actually fails.** A passing spec at
+   this point means you wrote the wrong test — redo it.
 
 7. **Implement the fix.** Edit the relevant files under `vendor/wheels/**`
    or `app/**`. Do not touch:

--- a/.github/workflows/bot-propose-fix.yml
+++ b/.github/workflows/bot-propose-fix.yml
@@ -98,11 +98,6 @@ jobs:
         if: steps.gate.outputs.skip == 'false'
         uses: anthropics/claude-code-action@v1
         with:
-          # DIAGNOSTIC (temporary): show_full_output exposes per-turn tool
-          # calls including which were denied, so we can see which tools
-          # Opus is reaching for that the allowlist rejects. Remove this
-          # line once the next run's data has informed allowlist tuning.
-          show_full_output: true
           # When un-gated at Phase 4a/4b, this workflow fires from wheels-bot[bot]
           # comments containing high-confidence triage or research markers. Allow
           # that bot identity (and github-actions[bot] for consistency).

--- a/.github/workflows/bot-review-a.yml
+++ b/.github/workflows/bot-review-a.yml
@@ -17,10 +17,17 @@ jobs:
     name: Reviewer A
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Reviews human PRs that are ready-for-review, AND the bot's own PRs
+    # even while draft. Bot PRs get reviewed pre-merge so the human merge
+    # decision is informed by Reviewer A's analysis (and Reviewer B's
+    # critique) rather than blind. Human drafts are skipped because drafts
+    # are work-in-progress and reviews would churn.
     if: |
       vars.WHEELS_BOT_ENABLED == 'true'
-      && github.event.pull_request.draft == false
-      && github.event.pull_request.user.login != 'wheels-bot[bot]'
+      && (
+        github.event.pull_request.user.login == 'wheels-bot[bot]'
+        || github.event.pull_request.draft == false
+      )
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v6
@@ -49,9 +56,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           # Allow our App's bot identity and github-actions[bot] to initiate
-          # the action. Currently the job-level if: blocks wheels-bot[bot] PRs,
-          # so this is defensive for future bot-authored PRs (Dependabot,
-          # Renovate) — and for consistency with the other bot workflows.
+          # the action. Reviewer A now runs on wheels-bot[bot] PRs too (so
+          # the human merge decision has analysis to lean on), so this is
+          # the primary case — not defensive.
           allowed_bots: 'wheels-bot[bot],github-actions[bot]'
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/bot-review-b.yml
+++ b/.github/workflows/bot-review-b.yml
@@ -16,10 +16,17 @@ jobs:
     name: Reviewer B
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Critiques Reviewer A's reviews on human ready-for-review PRs AND on
+    # the bot's own PRs (even draft). The bot-PR draft case lets the human
+    # merge decision benefit from both Reviewer A's findings and Reviewer
+    # B's quality check before the PR is marked ready.
     if: |
       vars.WHEELS_BOT_ENABLED == 'true'
       && github.event.review.user.login == 'wheels-bot[bot]'
-      && github.event.pull_request.draft == false
+      && (
+        github.event.pull_request.user.login == 'wheels-bot[bot]'
+        || github.event.pull_request.draft == false
+      )
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v6

--- a/docs/contributing/wheels-bot.md
+++ b/docs/contributing/wheels-bot.md
@@ -126,8 +126,14 @@ in-flight branches.
 ### 5. Reviewer A (`bot-review-a.yml`)
 
 Fires on `pull_request: opened/synchronize/ready_for_review` against
-`develop`. Skips bot-authored PRs (Reviewer A is for human PRs); the bot's
-own PRs get reviewed by humans.
+`develop`. Reviews:
+
+- Human PRs that are ready-for-review (drafts are skipped — they're
+  work-in-progress and reviewing them would churn).
+- The bot's own PRs **even while draft**, so the human merge decision is
+  informed by Reviewer A's analysis (and Reviewer B's critique) rather
+  than blind. The PR stays draft until a human marks it ready, which
+  remains the explicit "I've read the reviews and want to merge" signal.
 
 Posts a single PR review with line comments grouped under: Correctness,
 Conventions, Cross-engine, Tests, Docs, Commits, Security. Verdict is
@@ -140,10 +146,16 @@ Fires when Reviewer A submits a review (filtered on
 `review.user.login == 'wheels-bot[bot]'`). Reviewer B critiques A's review,
 not the PR — looking for sycophancy ("LGTM" without evidence), false
 positives (claims that don't match the actual code), and missed issues.
+Runs on both human PRs (ready-for-review only) and the bot's own PRs
+(even draft — same rationale as Reviewer A).
 
 Posts as a PR comment (not a review) so it doesn't re-trigger itself.
 Loop is capped at 3 rounds. Round 4 emits a terminal "no further
-iterations" message.
+iterations" message. The natural stopping condition for the bot-PR flow
+is one Reviewer A review per SHA — once the bot's PR stops emitting new
+commits (typically after `bot-update-docs` lands its docs commit), no
+new SHA → no new Reviewer A → no new Reviewer B. The human reads the
+final A+B exchange and decides whether to mark ready and merge.
 
 ## Maintenance: auto-close stale triage (`bot-auto-close.yml`)
 


### PR DESCRIPTION
## Summary

Two related fixes from tonight's pipeline-test session:

1. **Fix the propose-fix `/tmp/` prompt bug.** Tonight's data finally identified what was actually causing the 15-19 "permission denials" per propose-fix run that we kept attributing to tool allowlist mismatch.
2. **Extend Reviewer A/B to cover the bot's own PRs (even draft).** So humans don't merge bot work without analytical context.

## What we learned tonight

`show_full_output: true` exposed the per-turn tool calls on the successful 100-turn run ([#25618096945](https://github.com/wheels-dev/wheels/actions/runs/25618096945)). The histogram:

| Tool | Calls |
|---|---|
| Bash | 62 |
| Read | 17 |
| Edit | 6 |
| Write | 2 |
| Task / WebFetch / WebSearch / Grep / Glob | **0** |

Opus never reached for sub-agents or the web. The "denials" were Claude Code's working-directory sandbox blocking commands like:

```
cp in '/tmp/bot-failure.json' was blocked. For security, Claude Code 
may only copy files to/from the allowed working directories for this 
session: '/home/runner/work/wheels/wheels'.
```

The cause traced directly to [`propose-fix.md`](.claude/commands/propose-fix.md) step 6:

> *"Capture the failure to `/tmp/bot-failure.json` (use `format=json` on the test endpoint or save the bash output)."*

Every run, Opus dutifully tried to follow that instruction, got sandboxed, retried, and burned roughly 20 turns on an instruction the runtime cannot satisfy. Three identical 61-turn failures on issues #2526/#2530 ([#25616307210](https://github.com/wheels-dev/wheels/actions/runs/25616307210), [#25616508963](https://github.com/wheels-dev/wheels/actions/runs/25616508963), [#25617692327](https://github.com/wheels-dev/wheels/actions/runs/25617692327)) all hit this same wall. The 100-turn bump worked because it gave headroom to absorb the wasted retries.

## What's in this PR

### `.claude/commands/propose-fix.md`

Step 6 rewritten:

```diff
 6. **Run the failing spec.**

    bash tools/test-local.sh <layer>

-   Capture the failure to `/tmp/bot-failure.json` (use `format=json` on the
-   test endpoint or save the bash output). **Confirm the spec actually
-   fails.** A passing spec at this point means you wrote the wrong test —
-   redo it.
+   Read the bash output directly to confirm the failure — note which
+   assertion fired and the diff between expected and actual. **Do NOT
+   write to `/tmp/` or anywhere outside the repository working tree.**
+   The runtime sandboxes file operations to the working directory; `cp`
+   to `/tmp` (or any out-of-tree path) will be blocked and burn turns on
+   retries. If you need to persist test output for the next step, write
+   to a working-tree path like `./.bot-test-output.txt` and clean it up
+   before commit. **Confirm the spec actually fails.** A passing spec at
+   this point means you wrote the wrong test — redo it.
```

### `.github/workflows/bot-propose-fix.yml`

Removes the diagnostic `show_full_output: true` line that was added in PR [#2531](https://github.com/wheels-dev/wheels/pull/2531). Job done — its data informed this PR. `max-turns 100` stays.

### `.github/workflows/bot-review-a.yml`

```diff
+    # Reviews human PRs that are ready-for-review, AND the bot's own PRs
+    # even while draft. Bot PRs get reviewed pre-merge so the human merge
+    # decision is informed by Reviewer A's analysis (and Reviewer B's
+    # critique) rather than blind. Human drafts are skipped because drafts
+    # are work-in-progress and reviews would churn.
     if: |
       vars.WHEELS_BOT_ENABLED == 'true'
-      && github.event.pull_request.draft == false
-      && github.event.pull_request.user.login != 'wheels-bot[bot]'
+      && (
+        github.event.pull_request.user.login == 'wheels-bot[bot]'
+        || github.event.pull_request.draft == false
+      )
```

### `.github/workflows/bot-review-b.yml`

Same author-aware condition: critiques Reviewer A's reviews on human ready-for-review PRs and the bot's own PRs (even draft).

### `docs/contributing/wheels-bot.md`

Stage 5 (Reviewer A) and Stage 6 (Reviewer B) descriptions updated to reflect the new bot-PR coverage and document the natural stopping condition.

## Why this is the right design

**For the prompt fix:** structural — the `/tmp/` instruction was always going to fail. Removing it unblocks every future propose-fix run, not just this one.

**For Reviewer A/B coverage of bot PRs:** without it, the human merge decision is blind. The bot is producing a draft PR with implementation + spec + docs commit; the human needs Reviewer A's read on correctness/conventions/cross-engine and Reviewer B's quality check on Reviewer A before deciding to merge. The PR remains `--draft` throughout (the load-bearing safeguard against any auto-merge), so marking ready stays the explicit human signal.

**Stopping condition:** existing mechanics handle it. Reviewer B's 3-round cap is the upper bound. The typical bot-PR flow is: PR opened (SHA-A) → Reviewer A reviews SHA-A → bot-update-docs adds docs commit (SHA-B) → Reviewer A reviews SHA-B → Reviewer B critiques each → no further commits → no further reviews. 1-2 rounds in practice.

## Test plan

- [ ] Merge to develop.
- [ ] **Test the prompt fix** — re-dispatch propose-fix on issue [#2530](https://github.com/wheels-dev/wheels/issues/2530) (or a new issue): `gh workflow run bot-propose-fix.yml --repo wheels-dev/wheels -F issue-number=2530`. Expect: turns well under 100, near-zero permission_denials, no `/tmp/` errors in the log.
- [ ] **Test the Reviewer A coverage** — observe Reviewer A run on PR [#2533](https://github.com/wheels-dev/wheels/pull/2533) once it picks up changes from this PR's merge (or close+reopen #2533 to retrigger).
  - Actually, since #2533 was opened pre-merge, Reviewer A still skipped it. Easiest: dispatch a fresh propose-fix on a new test issue once this PR lands; Reviewer A and B should both run on the resulting bot PR.
- [ ] Verify `bot-tdd-gate.yml` still passes on bot PRs (TDD invariant unchanged).
- [ ] Confirm the bot PR remains `--draft` after the cascade (so the `required_approving_review_count: 1` gate continues to require a human ready+approve).

## Tonight's session totals (for context)

This PR closes out tonight's investigation. Cumulative spend across all bot runs: roughly \$15. The investment surfaced one architectural fix (PR [#2528](https://github.com/wheels-dev/wheels/pull/2528) — propose-fix scope reduction), one Phase 4 lift (PR [#2529](https://github.com/wheels-dev/wheels/pull/2529)), one diagnostic instrumentation (PR [#2531](https://github.com/wheels-dev/wheels/pull/2531)), and now one prompt-bug fix + reviewer-coverage extension (this PR). The pipeline shipped one real-world bot PR ([#2533](https://github.com/wheels-dev/wheels/pull/2533) — the registry-list fix), which is the proof of life.

🤖 Generated with [Claude Code](https://claude.com/claude-code)