### PR TITLE
ci: add docs-request path — write-docs stage parallel to propose-fix

### DIFF
--- a/.claude/commands/triage-issue.md
+++ b/.claude/commands/triage-issue.md
@@ -39,8 +39,15 @@ below. Highlights for this command:
      should Wheels do X," "Rails does it like Y, can Wheels do that," anything
      that requires picking among reasonable approaches before code can be
      written. The answer is a design decision, not a defect fix.
-   - **`other`** — docs request, support question ("how do I…"), discussion
-     thread without an actionable ask, broad product feedback.
+   - **`docs-request`** — actionable docs work needed. There's a concrete
+     deliverable (a specific feature, page, or section that should exist
+     or be updated). Distinguished from `other` by: is there a clear
+     "what should the docs contain" deliverable in the issue?
+     "Document the Debug Panel features" → `docs-request`.
+     "The docs are confusing" → `other`.
+   - **`other`** — non-actionable docs feedback, support question
+     ("how do I…"), discussion thread without an actionable ask, broad
+     product feedback.
 
    When the report mixes a bug with a feature request, classify as `bug` if
    the bug is reproducible in isolation; otherwise `framework-design`.
@@ -81,6 +88,53 @@ below. Highlights for this command:
    <!-- wheels-bot:triage:<issue-number> -->
    <!-- wheels-bot:triage-class:framework-design -->
    ```
+
+   Then exit.
+
+   ### If `docs-request`
+
+   Identify the rough docs scope from the issue body — what page(s) or
+   section(s) need creating or updating, and roughly how much work it
+   represents. Then self-rate confidence:
+
+   - **`high`**: the gap is concrete (specific feature/behavior to
+     document), the right page/path is clear from the issue or from
+     existing structure under
+     `web/sites/guides/src/content/docs/v4-0-0-snapshot/`, the work is
+     mostly translation-of-code (not requiring deep design decisions).
+     High-confidence docs-requests trigger the auto-fire write-docs
+     workflow.
+   - **`medium`**: the gap is real but the right page/path is ambiguous,
+     OR a new top-level section is needed (a structural design decision),
+     OR the docs require significant code investigation to write
+     accurately.
+   - **`low`**: the gap is vague, the scope is large (e.g. "rewrite the X
+     chapter"), or it's not clear what concretely needs to exist.
+
+   Post the triage comment:
+
+   ```
+   ## Wheels Bot — Triage
+
+   Classified as **docs-request**.
+
+   ### Docs scope
+
+   <one paragraph: what page(s) need creating/updating and what they should cover>
+
+   ### Confidence: `<low|medium|high>`
+
+   <one sentence: why this confidence level>
+
+   <!-- wheels-bot:triage:<issue-number> -->
+   <!-- wheels-bot:triage-class:docs-request -->
+   <CONFIDENCE_MARKER>
+   ```
+
+   Where `<CONFIDENCE_MARKER>` is:
+   - `<!-- wheels-bot:docs-confidence:high -->` if confidence is high
+     (triggers auto-fire of `bot-write-docs.yml`)
+   - omitted otherwise (medium/low confidence does not auto-trigger)
 
    Then exit.
 
@@ -153,6 +207,9 @@ below. Highlights for this command:
      and does the fix sketch identify a plausible target file?
    - For `bug` path: is the confidence consistent with the auto-downgrade
      rules?
+   - For `docs-request` path: is the docs scope concrete (a named page or
+     section), and is the confidence rating consistent with how clear the
+     deliverable is?
    - Are all required markers present?
 
    If any check fails, fix and re-post (do not post twice).

--- a/.claude/commands/write-docs.md
+++ b/.claude/commands/write-docs.md
@@ -1,0 +1,184 @@
+# /write-docs
+
+Create a new documentation PR from a docs-request triaged issue. Writes
+MDX guide pages, `.ai/wheels/` references, or `CLAUDE.md` updates as
+appropriate, then opens a draft PR against `develop`. This stage is the
+docs-path counterpart to propose-fix — it bypasses the TDD invariant
+since docs-only PRs have nothing to spec.
+
+## Rails
+
+Read `.claude/commands/_shared-rails.md` first. Highlights for this command:
+
+- Use `gh` for GitHub state, full `git` for **your branch only** (the
+  caller workflow has created `docs/bot-<issue>-<slug>` for you and you
+  are checked out on it).
+- **Filesystem writes are scoped to doc paths only**:
+  `web/sites/guides/**`, `.ai/wheels/**`, `CLAUDE.md`, `CHANGELOG.md`.
+  **Do NOT modify any file under `vendor/wheels/**`, `app/**`,
+  `tests/**`, `vendor/wheels/tests/**`, `.github/**`, `cli/**`, or
+  `config/**`** — this is a docs-only stage. The TDD gate skips this
+  branch class precisely because docs PRs don't need specs.
+- Output is **one draft PR** against `develop` plus one comment on the
+  issue.
+
+## Args
+
+- `<issue-number>` — the docs-request issue to write docs for
+
+## Steps
+
+1. **Idempotency check.** Read existing comments on the issue via
+   `gh issue view <issue-number> --json comments`. If any comment
+   contains `<!-- wheels-bot:write-docs:<issue-number> -->` or
+   `<!-- wheels-bot:docs-held:<issue-number> -->`, exit silently — docs
+   have already been written or the safety net already held them.
+
+2. **Read the authoritative context.**
+   - The triage comment (marker `wheels-bot:triage:<issue-number>`) —
+     gives you the docs scope and confidence assessment.
+   - The issue body — original wording on what's needed.
+   - Any human follow-up comments — they may refine the scope.
+
+   If no triage comment exists, exit with a comment explaining no triage
+   was found.
+
+3. **Read the supporting context.**
+   - `CLAUDE.md` § "Commit Message Conventions" — type `docs`, allowed
+     scopes (`docs`, `web/guides`, `web/landing`, `web/blog`, etc.).
+   - `web/sites/guides/src/content/docs/v4-0-0-snapshot/` — browse the
+     existing structure to find the right place for the new content.
+   - One or two existing pages in the same area for style/depth
+     reference. Match existing tone (no emoji unless the surrounding
+     pages use them).
+
+4. **Auto-downgrade safety net.** Before writing anything, check whether
+   the work would:
+   - Touch more than ~5 files (signals over-broad scope)
+   - Require creating a new top-level section (vs. extending existing)
+   - Demand significant code-reading to write accurately (signals the
+     issue is really `framework-design`, not `docs-request`)
+   - Need real screenshots that the bot cannot produce (these become
+     placeholders; see step 6)
+
+   If the scope feels too big to write cleanly, **stop**. Post a comment
+   on the issue:
+
+   ```
+   ## Wheels Bot — Docs work on hold for human review
+
+   The proposed docs scope is larger than this stage handles cleanly
+   (<one-line reason>). A human should plan the structure before the
+   bot writes content.
+
+   <!-- wheels-bot:docs-held:<issue-number> -->
+   ```
+
+   Then exit.
+
+5. **Decide what to write.** Based on the triage scope and the issue body,
+   pick targets:
+
+   - **MDX guide page(s)** under
+     `web/sites/guides/src/content/docs/v4-0-0-snapshot/`. If the issue
+     is about a feature or subsystem, look for the right `<area>/`
+     (e.g. `working-with-wheels/`, `digging-deeper/`,
+     `command-line-tools/`). Add to an existing page where possible;
+     create a new page only when no existing page covers the area.
+   - **`.ai/wheels/<layer>/`** — only if the docs change documents a
+     pattern or convention an AI agent should know about. Most user-
+     facing docs do NOT need a corresponding `.ai/` update.
+   - **`CLAUDE.md`** — only if the change is about a top-level convention
+     or critical anti-pattern. Most docs PRs do NOT touch `CLAUDE.md`.
+
+6. **Write conservatively.**
+   - Read the existing page (if extending) before editing.
+   - Match the existing style: heading depth, code-fence language tags,
+     prose tone.
+   - **For features that benefit from screenshots:** insert a placeholder
+     comment in the MDX where the screenshot belongs:
+
+     ```mdx
+     {/* screenshot: short description of what to capture, e.g.
+         "Debug Panel — Packages tab showing both installed and
+         available-from-registry tables" */}
+     ```
+
+     The bot cannot capture screenshots itself (no headless browser
+     available in the runner). The PR description (step 8) will list
+     these placeholders so a human can capture and replace them.
+   - Add a `CHANGELOG.md` `[Unreleased]` entry. One line, present
+     tense, no PR number.
+
+7. **Stage and commit.**
+
+   Conventional commit. Type `docs`. Scope from the allowlist:
+   - `web/guides` for changes under `web/sites/guides/src/content/docs/`
+   - `docs` for `.ai/wheels/` changes
+   - no scope for `CLAUDE.md` or mixed paths
+   Subject ≤ 100 chars, sentence-case.
+
+   Examples:
+   - `docs(web/guides): add Debug Panel guide outlining each feature`
+   - `docs(web/guides): document scope on findOne nested includes`
+
+   ```bash
+   git add <files>
+   git commit -m "<message>"
+   ```
+
+   The caller workflow handles the actual `git push` — just commit
+   cleanly. Do **not** use `--amend` or `--force`.
+
+8. **Open the draft PR.** Use `gh pr create --draft --base develop`. The
+   PR body must:
+
+   - Open with one paragraph naming what was added/changed and why.
+   - Include `Fixes #<issue-number>`.
+   - **List screenshot placeholders** if any were inserted. Format:
+
+     ```markdown
+     ## Screenshots needed
+
+     This docs PR includes screenshot-placeholder markers that a human
+     reviewer can replace with captured images:
+
+     - `<file>:line` — `<description from the placeholder>`
+     - ...
+
+     The bot cannot run the app or capture images — these are
+     intentional gaps for a human follow-up.
+     ```
+
+   - End with the marker `<!-- wheels-bot:write-docs:<issue-number> -->`.
+
+9. **Self-check before opening.** Do NOT open the PR if any check fails:
+   - [ ] No files changed outside doc paths (`web/sites/guides/`,
+     `.ai/wheels/`, `CLAUDE.md`, `CHANGELOG.md`)
+   - [ ] At least one doc file changed (don't open empty PRs)
+   - [ ] Commit message is conventional and ≤ 100 chars
+   - [ ] PR body includes `Fixes #<issue-number>`
+   - [ ] PR body includes any screenshot-placeholder list
+   - [ ] PR is created with `--draft`
+   - [ ] Marker is present in PR body
+
+   If any check fails: do not open the PR. Comment "no docs proposed"
+   on the issue and exit non-zero.
+
+10. **Comment back on the issue** with a link to the PR:
+
+    ```
+    ## Wheels Bot — Docs proposed
+
+    Draft PR: <link>
+
+    Pages updated: <list>
+    Screenshots needed: <count, or "none">
+
+    A human review is required before merge. Reviewer A and Reviewer B
+    will weigh in shortly.
+
+    <!-- wheels-bot:write-docs:<issue-number> -->
+    ```
+
+    Then exit.

--- a/.github/workflows/bot-tdd-gate.yml
+++ b/.github/workflows/bot-tdd-gate.yml
@@ -23,24 +23,31 @@ jobs:
         run: |
           set -euo pipefail
           is_bot=false
+          is_docs=false
           if [[ "$PR_AUTHOR" == "wheels-bot[bot]" ]]; then
             is_bot=true
-          elif [[ "$PR_HEAD" =~ ^bot/ || "$PR_HEAD" =~ ^fix/bot- ]]; then
+          elif [[ "$PR_HEAD" =~ ^bot/ || "$PR_HEAD" =~ ^fix/bot- || "$PR_HEAD" =~ ^docs/bot- ]]; then
             is_bot=true
           fi
+          if [[ "$PR_HEAD" =~ ^docs/bot- ]]; then
+            is_docs=true
+          fi
           echo "is_bot=$is_bot" >> "$GITHUB_OUTPUT"
+          echo "is_docs=$is_docs" >> "$GITHUB_OUTPUT"
           if [[ "$is_bot" == "false" ]]; then
             echo "Human-authored PR — gate is a no-op."
+          elif [[ "$is_docs" == "true" ]]; then
+            echo "Docs-only bot PR (docs/bot-* branch) — TDD invariant doesn't apply, gate is a no-op."
           fi
 
       - name: Checkout
-        if: steps.classify.outputs.is_bot == 'true'
+        if: steps.classify.outputs.is_bot == 'true' && steps.classify.outputs.is_docs == 'false'
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Verify bot PR contains spec + implementation changes
-        if: steps.classify.outputs.is_bot == 'true'
+        if: steps.classify.outputs.is_bot == 'true' && steps.classify.outputs.is_docs == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/bot-update-docs.yml
+++ b/.github/workflows/bot-update-docs.yml
@@ -28,12 +28,16 @@ jobs:
     # Auto-fire only for the bot's own PRs. The bot-identity check is
     # load-bearing: prevents human PRs from triggering this stage and
     # adding bot-authored doc commits to in-flight branches.
+    # Skips docs/bot-* branches — those are write-docs's own PRs, which
+    # are docs-only by construction. Running update-docs on them would
+    # be redundant work.
     if: |
       vars.WHEELS_BOT_ENABLED == 'true'
       && (
         github.event_name == 'workflow_dispatch'
         || (github.event_name == 'pull_request'
-            && github.event.pull_request.user.login == 'wheels-bot[bot]')
+            && github.event.pull_request.user.login == 'wheels-bot[bot]'
+            && !startsWith(github.event.pull_request.head.ref, 'docs/bot-'))
       )
     env:
       PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr-number }}

--- a/.github/workflows/bot-write-docs.yml
+++ b/.github/workflows/bot-write-docs.yml
@@ -1,0 +1,117 @@
+name: Wheels Bot — Write Docs
+
+# Phase 4 (auto-fire): runs from wheels-bot[bot] comments containing
+# `wheels-bot:docs-confidence:high` (the docs-request path's auto-fire
+# marker). workflow_dispatch is preserved for manual reruns.
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      issue-number:
+        description: 'Issue number to write docs for'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wheels-bot-write-docs-${{ github.event.issue.number || inputs.issue-number }}
+  cancel-in-progress: false
+
+jobs:
+  write-docs:
+    name: Write docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Auto-fires from wheels-bot[bot] comments with docs-confidence:high.
+    # The bot-identity check is load-bearing: prevents humans from
+    # triggering write-docs by quoting a marker in a reply.
+    if: |
+      vars.WHEELS_BOT_ENABLED == 'true'
+      && (
+        github.event_name == 'workflow_dispatch'
+        || (github.event_name == 'issue_comment'
+            && github.event.comment.user.login == 'wheels-bot[bot]'
+            && contains(github.event.comment.body, 'wheels-bot:docs-confidence:high'))
+      )
+    env:
+      ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue-number }}
+      WHEELS_CI: "true"
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WHEELS_BOT_APP_ID }}
+          private-key: ${{ secrets.WHEELS_BOT_PRIVATE_KEY }}
+
+      - name: Checkout develop
+        uses: actions/checkout@v6
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Skip check
+        id: gate
+        uses: ./.github/actions/wheels-bot-skip-check
+        with:
+          target-type: issue
+          target-number: ${{ env.ISSUE_NUMBER }}
+          marker-pattern: 'wheels-bot:write-docs:${{ env.ISSUE_NUMBER }}|wheels-bot:docs-held:${{ env.ISSUE_NUMBER }}'
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: Compute branch slug
+        if: steps.gate.outputs.skip == 'false'
+        id: branch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          title=$(gh issue view "$ISSUE_NUMBER" --json title --jq '.title')
+          slug=$(echo "$title" | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+            | cut -c1-50 \
+            | sed -E 's/-+$//')
+          [[ -z "$slug" ]] && slug="issue"
+          name="docs/bot-${ISSUE_NUMBER}-${slug}"
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git + create branch
+        if: steps.gate.outputs.skip == 'false'
+        run: |
+          git config user.name "wheels-bot[bot]"
+          git config user.email "wheels-bot[bot]@users.noreply.github.com"
+          git checkout -b "${{ steps.branch.outputs.name }}"
+
+      - name: Run Write Docs
+        if: steps.gate.outputs.skip == 'false'
+        uses: anthropics/claude-code-action@v1
+        with:
+          # Triggered by wheels-bot[bot] comments containing the
+          # docs-confidence:high marker. Allow the bot identity (and
+          # github-actions[bot] for consistency).
+          allowed_bots: 'wheels-bot[bot],github-actions[bot]'
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          prompt: |
+            /write-docs ${{ env.ISSUE_NUMBER }}
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 30
+            --allowedTools "Bash(gh:*),Bash(git status),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git grep:*),Bash(git add:*),Bash(git commit:*),Read,Edit,Write,Grep,Glob"
+
+      - name: Push branch
+        if: steps.gate.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Only push if the bot actually committed doc changes; otherwise
+          # the run was a no-op (e.g. write-docs hit its safety net).
+          if git diff --quiet origin/develop -- && git diff --cached --quiet; then
+            echo "No changes produced — nothing to push."
+            exit 0
+          fi
+          git push -u origin "${{ steps.branch.outputs.name }}"

--- a/docs/contributing/wheels-bot.md
+++ b/docs/contributing/wheels-bot.md
@@ -2,7 +2,7 @@
 
 `wheels-bot[bot]` is a custom GitHub App that automates issue triage,
 cross-framework design research, fix-PR generation, and PR review on
-`wheels-dev/wheels`. It runs as six stages, each backed by a slash-command
+`wheels-dev/wheels`. It runs as seven stages, each backed by a slash-command
 prompt in `.claude/commands/` and a workflow in `.github/workflows/bot-*.yml`.
 
 This page is for humans interacting with the bot. For the design rationale,
@@ -21,7 +21,7 @@ contribution rules, see [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 - Flip the repo variable `WHEELS_BOT_ENABLED` to `false` to halt the bot
   entirely without code changes.
 
-## The six stages
+## The seven stages
 
 ### 1. Triage (`bot-triage.yml`)
 
@@ -34,11 +34,18 @@ posts a comment classifying it as one of:
   propose-fix stage, not here.
 - **`framework-design`** — feature request or API design question. The bot
   hands off to the research stage; it does not opine yet.
-- **`other`** — docs, support, or general discussion. No further automation.
+- **`docs-request`** — actionable docs work needed (a specific page or
+  section that should exist or be updated). The bot identifies the docs
+  scope and emits a confidence rating. High-confidence docs-requests
+  hand off to the write-docs stage.
+- **`other`** — non-actionable docs feedback, support, or general
+  discussion. No further automation.
 
 For high-confidence `bug` triages the bot emits an additional marker
 (`<!-- wheels-bot:triage-confidence:high -->`) which is the trigger for
-the propose-fix stage.
+the propose-fix stage. For high-confidence `docs-request` triages the
+bot emits `<!-- wheels-bot:docs-confidence:high -->`, which is the
+trigger for the write-docs stage.
 
 ### 2. Cross-framework research (`bot-research.yml`)
 
@@ -84,9 +91,39 @@ The bot:
 
 The PR must pass `bot-tdd-gate.yml` before any other check — that gate
 hard-rejects bot PRs that don't include both a spec change and an
-implementation change. The gate is a no-op for human-authored PRs.
+implementation change. The gate is a no-op for human-authored PRs and
+for docs-only bot PRs (`docs/bot-*` branches from the write-docs stage).
 
-### 4. Update Docs (`bot-update-docs.yml`)
+### 4. Write Docs (`bot-write-docs.yml`)
+
+The docs-path counterpart to propose-fix. Fires from triage's
+`wheels-bot:docs-confidence:high` marker on issues classified as
+`docs-request`. Sonnet, 30-turn budget — doc work is pattern-recognition,
+not reasoning-heavy. Also runnable manually via `workflow_dispatch`.
+
+The bot:
+
+1. Reads the triage comment and the issue body for the docs scope.
+2. Auto-downgrades and stops if the work signals a larger structural
+   docs-architecture decision than this stage handles cleanly. Posts
+   `wheels-bot:docs-held:<issue>` instead of opening a PR.
+3. Writes MDX guide pages, `.ai/wheels/` references, or `CLAUDE.md`
+   updates as appropriate. Filesystem writes are scoped to doc paths
+   only — the workflow's allowlist forbids touching `vendor/`, `app/`,
+   `tests/`, `.github/`, `cli/`, or `config/`.
+4. For features that benefit from screenshots, inserts placeholder
+   comments in the MDX (the bot has no headless browser available; the
+   PR description lists the placeholders so a human can capture and
+   replace them).
+5. Adds a `CHANGELOG.md` entry.
+6. Opens a draft PR on `docs/bot-<issue>-<slug>` against `develop`.
+
+The `docs/bot-*` branch prefix is what causes the `bot-tdd-gate.yml`
+check to skip — docs-only PRs have no spec/impl invariant. Reviewer A
+and Reviewer B still cover the PR, so the human merge decision has the
+same analytical context as for fix PRs.
+
+### 5. Update Docs (`bot-update-docs.yml`)
 
 Adds doc commits to a freshly-opened bot PR. Runs as a separate stage so
 propose-fix's budget can stay focused on TDD work (failing spec →
@@ -123,7 +160,7 @@ bot-identity check on the `if:` block is load-bearing — it prevents human
 PRs from triggering this stage and adding bot-authored doc commits to
 in-flight branches.
 
-### 5. Reviewer A (`bot-review-a.yml`)
+### 6. Reviewer A (`bot-review-a.yml`)
 
 Fires on `pull_request: opened/synchronize/ready_for_review` against
 `develop`. Reviews:
@@ -140,7 +177,7 @@ Conventions, Cross-engine, Tests, Docs, Commits, Security. Verdict is
 `approve` / `request-changes` / `comment`. Verdict and findings must be
 consistent — Reviewer B will catch sycophancy if they aren't.
 
-### 6. Reviewer B (`bot-review-b.yml`)
+### 7. Reviewer B (`bot-review-b.yml`)
 
 Fires when Reviewer A submits a review (filtered on
 `review.user.login == 'wheels-bot[bot]'`). Reviewer B critiques A's review,
@@ -177,12 +214,15 @@ they make every workflow safely retryable.
 | Marker | Meaning |
 |---|---|
 | `wheels-bot:triage:<issue>` | Triage stage processed this issue. |
-| `wheels-bot:triage-class:<bug\|framework-design\|other>` | Triage classification. |
+| `wheels-bot:triage-class:<bug\|framework-design\|docs-request\|other>` | Triage classification. |
 | `wheels-bot:triage-confidence:high` | Triggers propose-fix on the bug path. |
+| `wheels-bot:docs-confidence:high` | Triggers write-docs on the docs-request path. |
 | `wheels-bot:research:<issue>` | Research stage processed this issue. |
 | `wheels-bot:research-confidence:high` | Triggers propose-fix on the framework-design path. |
 | `wheels-bot:fix:<issue>` | Fix PR has been opened for this issue. |
 | `wheels-bot:fix-held:<issue>` | Fix would have been proposed but the safety net held it for a human. |
+| `wheels-bot:write-docs:<issue>` | Write Docs stage opened a docs PR for this issue. |
+| `wheels-bot:docs-held:<issue>` | Docs would have been written but the safety net held it for a human. |
 | `wheels-bot:update-docs:<pr>` | Update Docs stage processed this PR (with or without doc edits). |
 | `wheels-bot:review-a:<pr>:<sha>` | Reviewer A reviewed this PR at this SHA. |
 | `wheels-bot:review-b:<pr>:<sha>:<round>` | Reviewer B critiqued round N. |
@@ -226,11 +266,13 @@ they make every workflow safely retryable.
 - **Auto-fire (Phase 4) is on.** propose-fix runs from
   `wheels-bot:triage-confidence:high` and
   `wheels-bot:research-confidence:high` markers; research runs from
-  `wheels-bot:triage-class:framework-design`; bot-update-docs runs on
-  `pull_request: opened` for `wheels-bot[bot]` PRs. To halt auto-fire
-  without code changes, flip `WHEELS_BOT_ENABLED=false`. To halt
-  permanently, revert the `if:` blocks in the three workflows back to
-  `workflow_dispatch`-only and keep the kill-switch flipped.
+  `wheels-bot:triage-class:framework-design`; write-docs runs from
+  `wheels-bot:docs-confidence:high`; bot-update-docs runs on
+  `pull_request: opened` for `wheels-bot[bot]` PRs (excluding
+  `docs/bot-*` branches, which are write-docs's own output). To halt
+  auto-fire without code changes, flip `WHEELS_BOT_ENABLED=false`. To
+  halt permanently, revert the `if:` blocks in the four workflows back
+  to `workflow_dispatch`-only and keep the kill-switch flipped.
 - **Review bot-authored PRs the same as human-authored PRs.** Don't
   rubber-stamp.
 - **Watch costs.** API spend per fix-PR is non-trivial (Opus + many turns +


### PR DESCRIPTION
## Summary

Adds a fourth classification path to the wheels-bot pipeline. Previously, docs-only issues fell through to `other` (no automation) or, when reframed as `framework-design`, would hit propose-fix's TDD-shaped prompt that doesn't fit doc-only work. This PR adds a parallel **docs-request → write-docs** path that mirrors propose-fix's shape but is doc-paths-only.

## The new path

```
triage → docs-request + docs-confidence:high
     → bot-write-docs.yml
     → docs/bot-<issue>-<slug> branch
     → draft PR (TDD gate skips, since the branch prefix says docs)
     → Reviewer A/B run as normal so the human merge has context
```

## What changed

### New files

| File | Purpose |
|---|---|
| [`.claude/commands/write-docs.md`](.claude/commands/write-docs.md) | The prompt. Doc-paths-only (no `vendor/`, `app/`, `tests/`). Uses MDX screenshot-placeholder comments for features that benefit from images (the bot has no headless browser). |
| [`.github/workflows/bot-write-docs.yml`](.github/workflows/bot-write-docs.yml) | The workflow. Sonnet, 30-turn budget, narrow allowlist. Same `wheels-bot[bot]` author check pattern as the other Phase 4 auto-fire stages. |

### Modified files

| File | Change |
|---|---|
| [`.claude/commands/triage-issue.md`](.claude/commands/triage-issue.md) | New `docs-request` classification with explicit boundary against `other` ("clear deliverable in the issue?"). New branch in step 4 with confidence rating + comment template emitting `docs-confidence:high`. |
| [`.github/workflows/bot-tdd-gate.yml`](.github/workflows/bot-tdd-gate.yml) | Gains `is_docs` output that detects `docs/bot-*` head refs; verify step guards on `is_bot && !is_docs`. Docs-only PRs by definition have no spec/impl pair. |
| [`.github/workflows/bot-update-docs.yml`](.github/workflows/bot-update-docs.yml) | Skips `docs/bot-*` head refs to avoid the redundant case where update-docs runs on a PR whose entire purpose was docs. |
| [`docs/contributing/wheels-bot.md`](docs/contributing/wheels-bot.md) | Six stages → seven; new "### 4. Write Docs" section; Update Docs / Reviewer A / Reviewer B renumbered 5/6/7; markers table updated. |

## Design decisions worth flagging

| # | Decision | Rationale |
|---|---|---|
| 1 | Separate workflow vs. dual-mode `bot-update-docs.yml` | bot-update-docs adds commits to an *existing* PR; bot-write-docs creates a *new* PR. Different env shape (PR number vs issue number), different concurrency key, different branch creation. Two narrow workflows keep each one clear. |
| 2 | TDD gate skips by branch prefix, not by author or label | Branch prefix is the cleanest signal — it's set once at branch creation and read on every gate run. Plus it lets humans replicate the docs-only pattern by naming branches `docs/bot-*` (though no human would, which is fine). |
| 3 | Sonnet not Opus, 30 turns | Doc work is translation-of-code, pattern-recognition. Sonnet handles it well at much lower cost than Opus. Mirrors `bot-update-docs.yml`'s choice. |
| 4 | Screenshots are placeholder comments, not skipped | Honest about the bot's limits. The PR description lists each placeholder so the human reviewer knows exactly what images need capturing. |
| 5 | Auto-fire on `docs-confidence:high` | Phase 4 consistency — all confidence-marker auto-fires use the same shape. Kill switch + bot-author check are the safety nets. |
| 6 | Reviewer A/B still run on docs PRs | PR [#2534](https://github.com/wheels-dev/wheels/pull/2534)'s broadened condition (`bot PR even draft` → review) already covers this. No new work needed. |

## Coordinated repo-level change

The `wheels-bot push scope` ruleset (`16174270`) needed `docs/bot-*/**` added to the allowed push patterns alongside `bot/**` and `fix/bot-*/**`. **Done out-of-band via the GitHub UI before this PR landed.**

## Test plan

After merge, file an issue that should classify as `docs-request` (e.g., the Debug Panel docs gap discussed earlier) and observe:

- [ ] Triage classifies as `docs-request` (not `other` or `framework-design`).
- [ ] Triage emits `wheels-bot:docs-confidence:high` on a clear, well-scoped docs gap.
- [ ] `bot-write-docs.yml` auto-fires from the marker (event = `issue_comment`, author = `wheels-bot[bot]`).
- [ ] Bot creates `docs/bot-<issue>-<slug>` branch and opens a draft PR.
- [ ] PR diff is doc-paths-only (no `vendor/`, `app/`, `tests/`).
- [ ] PR body lists screenshot placeholders if any were inserted.
- [ ] `bot-tdd-gate.yml` runs and exits cleanly with "Docs-only bot PR — gate is a no-op" message (no spec required).
- [ ] `bot-update-docs.yml` does NOT fire on the docs PR (head ref starts with `docs/bot-`).
- [ ] Reviewer A runs on the draft PR.
- [ ] Reviewer B fires after Reviewer A submits.
- [ ] PR remains `--draft` until a human marks ready and approves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)