### PR TITLE
ci: allow git push in bot-write-docs allowlist

### DIFF
--- a/.github/workflows/bot-write-docs.yml
+++ b/.github/workflows/bot-write-docs.yml
@@ -101,7 +101,7 @@ jobs:
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 30
-            --allowedTools "Bash(gh:*),Bash(git status),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git grep:*),Bash(git add:*),Bash(git commit:*),Read,Edit,Write,Grep,Glob"
+            --allowedTools "Bash(gh:*),Bash(git status),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git grep:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Read,Edit,Write,Grep,Glob"
 
       - name: Push branch
         if: steps.gate.outputs.skip == 'false'


### PR DESCRIPTION
## Summary

One-line fix to unblock end-to-end runs of the docs-request path. The first real-world run on [issue #2536](https://github.com/wheels-dev/wheels/issues/2536) ([run #25619794274](https://github.com/wheels-dev/wheels/actions/runs/25619794274)) successfully wrote and committed the Debug Panel guide, but couldn't open the draft PR — the bot's allowlist had specific git subcommands (`status`, `log`, `diff`, `show`, `grep`, `add`, `commit`) but not `push`. The workflow's "Push branch" step ran *after* the bot finished, pushing the branch too late for the bot's own `gh pr create` to use.

## What changed

```diff
             --allowedTools "Bash(gh:*),Bash(git status),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git grep:*),Bash(git add:*),Bash(git commit:*),Read,Edit,Write,Grep,Glob"
+            --allowedTools "Bash(gh:*),Bash(git status),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git grep:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Read,Edit,Write,Grep,Glob"
```

## Why this is safe

The repository's `wheels-bot push scope` ruleset (`16174270`) restricts WHERE the bot can push to:
- `bot/**`
- `fix/bot-*/**`
- `docs/bot-*/**`

So granting `Bash(git push:*)` to the bot does not expand its blast radius — it just lets the bot execute the push the ruleset will permit anyway. Mirrors `bot-propose-fix.yml`'s `Bash(git:*)` wildcard, which has been working safely since [PR #2533](https://github.com/wheels-dev/wheels/pull/2533).

## What this means for issue #2536

The branch [`docs/bot-2536-debug-panel-features-have-no-dedicated-docs-sectio`](https://github.com/wheels-dev/wheels/tree/docs/bot-2536-debug-panel-features-have-no-dedicated-docs-sectio) is already on origin with the bot's full docs content. Two options after this PR merges:

1. **Manually open a PR from that branch** — fastest way to see the rest of the cascade run tonight (TDD gate skip, Reviewer A, Reviewer B). The PR would be authored by you (not the bot), and would include the bot's commits as-is. The issue's `wheels-bot:write-docs:2536` marker correctly belongs to the bot, so don't add additional bot markers in the new PR.

2. **Delete the branch and re-trigger via a fresh issue** — cleaner test of the full pipeline (with this fix in place, the bot will open its own PR). Requires a new docs-request issue since #2536's existing `wheels-bot:write-docs:2536` marker would block re-triggering on the same issue.

## Test plan

- [ ] Merge to develop.
- [ ] (Optional) Pick option 1 or 2 above to verify the rest of the docs-request cascade.
- [ ] Confirm: the next docs-request run with `docs-confidence:high` triggers write-docs, the bot pushes its own branch, and `gh pr create` succeeds inside the bot run (not deferred to manual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)