### PR TITLE
ci: lift bot stage turn caps to ~10x — let timeout-minutes be the ceiling

### DIFF
--- a/.github/workflows/bot-propose-fix.yml
+++ b/.github/workflows/bot-propose-fix.yml
@@ -108,7 +108,7 @@ jobs:
             /propose-fix ${{ env.ISSUE_NUMBER }}
           claude_args: |
             --model claude-opus-4-7
-            --max-turns 100
+            --max-turns 1000
             --allowedTools "Bash(gh:*),Bash(git:*),Bash(bash tools/test-local.sh*),Bash(curl:*),Read,Edit,Write,Grep,Glob"
 
       - name: Push branch

--- a/.github/workflows/bot-research.yml
+++ b/.github/workflows/bot-research.yml
@@ -74,5 +74,5 @@ jobs:
             /research-frameworks ${{ env.ISSUE_NUMBER }}
           claude_args: |
             --model claude-opus-4-7
-            --max-turns 40
+            --max-turns 400
             --allowedTools "Bash(gh:*),Bash(git log:*),Bash(git show:*),Bash(git grep:*),WebFetch,WebSearch,Read,Grep,Glob"

--- a/.github/workflows/bot-review-a.yml
+++ b/.github/workflows/bot-review-a.yml
@@ -66,5 +66,5 @@ jobs:
             /review-pr ${{ github.event.pull_request.number }}
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 25
+            --max-turns 250
             --allowedTools "Bash(gh:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git grep:*),Bash(git status),Read,Grep,Glob"

--- a/.github/workflows/bot-review-b.yml
+++ b/.github/workflows/bot-review-b.yml
@@ -65,5 +65,5 @@ jobs:
             /review-the-review ${{ github.event.pull_request.number }} ${{ github.event.review.id }}
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 30
+            --max-turns 300
             --allowedTools "Bash(gh:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git grep:*),Bash(git status),Read,Grep,Glob"

--- a/.github/workflows/bot-triage.yml
+++ b/.github/workflows/bot-triage.yml
@@ -58,5 +58,5 @@ jobs:
             /triage-issue ${{ github.event.issue.number }}
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 20
+            --max-turns 200
             --allowedTools "Bash(gh:*),Bash(git status),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git grep:*),Read,Grep,Glob"

--- a/.github/workflows/bot-write-docs.yml
+++ b/.github/workflows/bot-write-docs.yml
@@ -100,7 +100,7 @@ jobs:
             /write-docs ${{ env.ISSUE_NUMBER }}
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 30
+            --max-turns 300
             --allowedTools "Bash(gh:*),Bash(git status),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git grep:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Read,Edit,Write,Grep,Glob"
 
       - name: Push branch


### PR DESCRIPTION
## Summary

Lifts `--max-turns` across all six bot stages to ~10× the originally-shipped values. Originally scoped as a 30 → 50 single-stage fix for `bot-write-docs.yml`, then expanded to 2× across the board, then expanded again to ~10× after we recognized:

> Turn caps that compete with `timeout-minutes` just create a redundant cliff. Misjudging where the cliff sits costs a full failed run plus manual cleanup plus a re-dispatch. The timeout is the real ceiling. Let it be.

## The math

With `timeout-minutes` already enforcing a hard ceiling on each job:

| Stage | Model | timeout-minutes | Practical turns possible (rough) | Old `--max-turns` | % of time budget |
|---|---|---|---|---|---|
| triage | Sonnet | 25 | ~300–500 | 20 | 4–6% |
| research | Opus | 30 | ~180–360 | 40 | 11–22% |
| propose-fix | Opus | 60 | ~360–600 | 100 | 17–28% |
| write-docs | Sonnet | 30 | ~360–600 | 30 | 5–8% |
| review-a | Sonnet | 20 | ~240–400 | 25 | 6–10% |
| review-b | Sonnet | 15 | ~180–300 | 30 | 10–17% |

Every old cap was a cliff at 4–28% of the time budget — well below where the timeout would kick in for a runaway. **The cap was the failure mode, not the safety mechanism.**

## What changed

| Stage | Old | New | Multiplier | Effectively unreachable? |
|---|---|---|---|---|
| `bot-triage` | 20 | **200** | 10× | Yes (timeout caps at ~300–500) |
| `bot-research` | 40 | **400** | 10× | Yes (timeout caps at ~180–360) — likely never hit either |
| `bot-propose-fix` | 100 | **1000** | 10× | Yes (timeout caps at ~360–600) |
| `bot-write-docs` | 30 | **300** | 10× | Yes (timeout caps at ~360–600) |
| `bot-review-a` | 25 | **250** | 10× | Yes (timeout caps at ~240–400) |
| `bot-review-b` | 30 | **300** | 10× | Yes (timeout caps at ~180–300) |

After this lands, **the active ceiling for every stage is `timeout-minutes`, not `--max-turns`.** A genuine runaway loop can still consume the full time budget worth of model spend (~\$30–50 worst case for propose-fix), but that's already the reality today — turn caps below the timeout-equivalent are pure premature optimization.

## The data-collection plan

Run for a few weeks with these ceilings effectively non-binding. Collect:

- Actual `num_turns` distribution per stage across a variety of issue shapes (bugs, framework-design, docs-requests; trivial vs complex)
- Cost distribution per stage
- Cap-hit rate (should be near zero)
- Timeout-hit rate (should be near zero unless something is genuinely broken)

After a representative sample, we can either tighten caps based on observed P95/P99 turn counts (predictable optimization) or leave as-is if the data shows everything fits comfortably.

## What this does *not* change

- Workflow `timeout-minutes` — unchanged, still the actual ceiling
- `WHEELS_BOT_ENABLED=false` kill switch — unchanged, still the active-incident safety net
- The `[skip-claude]` per-issue/PR opt-out — unchanged
- Any prompt logic, allowlist, or model selection
- The bot-identity author checks on every auto-fire `if:` block

## Test plan

- [ ] Merge.
- [ ] Re-dispatch `bot-write-docs.yml` on issue [#2536](https://github.com/wheels-dev/wheels/issues/2536) (orphan branch deleted, marker absent).
- [ ] Confirm: write-docs completes naturally (turns far below 300), opens its own PR, posts comment.
- [ ] Watch the rest of the cascade run cleanly with the new headroom.
- [ ] No follow-up bumps expected — if any stage hits one of these new caps, that's a signal worth investigating (likely a prompt bug or a genuinely massive issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)