### PR TITLE
ci: add convergence loop with address-review + senior-advisor stages

### DIFF
--- a/.claude/commands/address-review.md
+++ b/.claude/commands/address-review.md
@@ -1,0 +1,159 @@
+# /address-review
+
+Implementer for the convergence loop. After Reviewer A and Reviewer B
+have aligned on a "changes needed" verdict for a PR, read the consensus
+and apply the changes. Push commits to the PR's existing branch — new
+commits trigger a fresh Reviewer A on the new SHA, restarting the
+convergence loop until reviewers converge on `approve`.
+
+This is a *coding* stage like propose-fix — Opus, broad allowlist with
+the test runner. Mirrors propose-fix's safety patterns.
+
+## Rails
+
+Read `.claude/commands/_shared-rails.md` first. Highlights:
+
+- Use `gh` for GitHub state, full `git` for **the PR's existing branch
+  only** (the workflow has checked you out on it).
+- Run tests via `bash tools/test-local.sh` for `fix/bot-*` PRs after
+  changes.
+- For `docs/bot-*` PRs, restrict edits to doc paths only —
+  `web/sites/guides/`, `.ai/wheels/`, `CLAUDE.md`, `CHANGELOG.md`.
+- Output is **commits to the PR branch** plus **one comment on the
+  PR** summarizing what you addressed.
+
+## Args
+
+- `<pr-number>` — the PR with converged-changes markers to address
+
+## Steps
+
+1. **Idempotency + outer-loop cap.** Read PR comments via
+   `gh pr view <pr-number> --json comments,headRefOid,headRefName`.
+   - If any comment contains
+     `wheels-bot:address-review:<pr>:<sha>:` for the current head
+     SHA, exit silently — already addressed at this SHA.
+   - Count comments matching `wheels-bot:address-review:<pr>:` for
+     ANY SHA on this PR. If count ≥ 5, post:
+
+     ```
+     ## Wheels Bot — Address Review (max iterations reached)
+
+     Five address-review rounds have run on this PR without the
+     reviewers converging on `approve`. Handing back to humans —
+     either the PR's scope is larger than the bot can resolve, or
+     the reviewers are deadlocked on a design call.
+
+     <!-- wheels-bot:address-review:<pr>:<sha>:terminal -->
+     ```
+
+     and exit.
+   - Otherwise: round number = (count of address-review comments) + 1.
+
+2. **Read the consensus.**
+   - Reviewer A's initial review (`wheels-bot:review-a:<pr>:<sha>:`)
+   - All Reviewer A response reviews (`wheels-bot:review-a-response:`)
+   - All Reviewer B comments
+     (`wheels-bot:review-b:<pr>:<sha>:<round>`) — chronological order
+   - The latest B comment carrying
+     `wheels-bot:converged-changes:<pr>:<sha>` is the trigger; its
+     body summarizes the alignment.
+
+   The **consensus changes** = the union of:
+   - A's findings B did **not** mark as false positives
+   - B's missed-issues findings A did **not** successfully refute in
+     a response
+   - Findings both A and B explicitly agreed on in any round
+
+   Skip (do not act on):
+   - A's findings B successfully refuted as false positives
+   - Findings A and B disagreed on across rounds (the
+     converged-changes verdict means there's enough alignment on the
+     above to act; isolated disputes are left for the next loop)
+
+3. **Auto-downgrade safety net.** Before writing anything, if any
+   consensus finding would touch:
+   - `vendor/wheels/security/**`, auth flows, password / token code
+   - `vendor/wheels/middleware/**` auth-related middleware
+   - Migration files under
+     `vendor/wheels/migrator/**` or `app/migrator/migrations/**`
+   - `cli/lucli/services/deploy/**` or anything under `wheels deploy`
+   - `vendor/wheels/di/**` or DI container internals
+
+   **Stop**. Post:
+
+   ```
+   ## Wheels Bot — Address Review held for human review
+
+   The consensus findings touch a sensitive area (`<area>`) and the
+   bot's safety net requires a human in the loop before any code
+   change. The PR's reviewer-feedback exchange is preserved above
+   for context.
+
+   <!-- wheels-bot:address-held:<pr>:<sha> -->
+   ```
+
+   and exit.
+
+4. **Branch-aware scope check.** Read the PR's head ref via
+   `gh pr view <pr-number> --json headRefName -q '.headRefName'`:
+   - `fix/bot-*` → may modify code, tests, CHANGELOG
+   - `docs/bot-*` → doc paths only. If a consensus finding requires
+     touching code, post `address-held` and exit (the PR's scope is
+     wrong for that finding).
+
+5. **Apply the consensus changes.** For each consensus finding:
+   - Read the cited file
+   - Make the smallest change that addresses the finding
+   - For `fix/bot-*` PRs: after the changes, re-run any affected spec
+     via `bash tools/test-local.sh <layer>` to confirm nothing
+     regressed. Capture the output.
+
+6. **Stage and commit.** Single conventional commit on the existing
+   branch. Don't open a new branch — push back to the same branch
+   the PR is on.
+
+   - Type: `fix` (for `fix/bot-*` PRs) or `docs` (for `docs/bot-*` PRs)
+   - Subject (≤ 100 chars):
+     `address Reviewer A/B consensus findings (round <N>)`
+   - Body: bullet list of what was addressed, with file references.
+
+   ```bash
+   git add <files>
+   git commit -m "<message>"
+   ```
+
+   The workflow's "Push branch" step pushes after this prompt
+   completes.
+
+7. **Post the address-review comment** on the PR:
+
+   ```
+   ## Wheels Bot — Address Review (round <N>)
+
+   Applied consensus findings from Reviewer A and Reviewer B's
+   convergence (round <round-of-convergence-loop>):
+
+   <bulleted list — what was addressed, file:line references>
+
+   <if any findings were intentionally skipped because they weren't in
+   the consensus, list them with "skipped: <reason>">
+
+   The new commit will trigger a fresh Reviewer A run on the updated
+   SHA. Convergence loop continues until reviewers align on `approve`
+   or the outer-loop cap (5 rounds) is reached.
+
+   <!-- wheels-bot:address-review:<pr>:<sha-before>:<N> -->
+   ```
+
+8. **Self-check before posting.**
+   - [ ] Branch-aware scope check passed — no files modified outside
+     allowed paths
+   - [ ] For `fix/bot-*`: tests re-run, output cited in the comment
+   - [ ] Commit message is conventional, subject ≤ 100 chars
+   - [ ] PR comment includes the marker with the correct
+     `<sha-before>` (the head SHA at the start of this run, not after
+     your commit)
+   - [ ] Outer-loop count is correctly reflected in the round number
+
+   If any check fails, do not post; investigate and exit non-zero.

--- a/.claude/commands/advise-on-deadlock.md
+++ b/.claude/commands/advise-on-deadlock.md
@@ -1,0 +1,161 @@
+# /advise-on-deadlock
+
+Senior advisor for the wheels-bot review chain. Fires only when
+Reviewer A and Reviewer B fail to converge on a recommendation after
+the inner loop's 10-round cap (B emits a `:terminal` marker). Read
+the full exchange, identify the specific disputed points, and issue a
+tie-breaking verdict using deeper reasoning than the analytical
+reviewers brought.
+
+This is the only stage in the pipeline that runs **Opus on a
+non-coding task**. The reasoning depth is justified because the
+advisor's verdict overrides the analytical reviewers' deadlock and
+drops back into the existing convergence flow — the advisor either
+ends the loop (`converged-approve`) or triggers `bot-address-review.yml`
+(`converged-changes`).
+
+## Rails
+
+Read `.claude/commands/_shared-rails.md` first. Highlights:
+
+- Use `gh` for GitHub state and **read-only** `git`. No file writes,
+  no edits, no commits.
+- Output is **one PR comment** with the verdict + a convergence
+  marker. No PR reviews, no code modifications.
+- One-shot stage — fires once per terminal marker per SHA and exits.
+  No iteration.
+
+## Args
+
+- `<pr-number>` — the PR with deadlocked A↔B exchange
+
+## Steps
+
+1. **Idempotency check.** Read PR comments via
+   `gh pr view <pr-number> --json comments,headRefOid`. If any
+   comment contains `wheels-bot:advisor:<pr>:<sha>` for the current
+   head SHA, exit silently — already advised at this SHA.
+
+2. **Confirm the deadlock.** Look for a comment containing
+   `wheels-bot:review-b:<pr>:<sha>:terminal` for the current head
+   SHA. That's the trigger marker. If no terminal marker is present
+   for the current SHA, exit silently (this command shouldn't have
+   fired).
+
+3. **Read the full exchange.**
+   - The PR diff via `gh pr diff <pr-number>`.
+   - The PR title/body via `gh pr view <pr-number>` for original
+     context (and the `Fixes #<issue>` link, if any — the original
+     issue's framing matters).
+   - All `wheels-bot[bot]` PR reviews on the current SHA: A's initial
+     review and any response reviews
+     (`wheels-bot:review-a-response:`).
+   - All `wheels-bot[bot]` PR comments on the current SHA matching
+     `wheels-bot:review-b:<pr>:<sha>:` — the full B critique chain in
+     chronological order.
+
+4. **Identify the deadlock.** Make a precise list of the SPECIFIC
+   points where A and B disagreed and never resolved across rounds:
+   - Findings A flagged but B persistently called false positives
+     (and A defended).
+   - Issues B raised but A persistently refuted (and B re-raised).
+   - Verdict disagreements (A says `approve`, B says
+     `request-changes`, or vice versa).
+
+   For each disputed point, capture: A's position, B's position, and
+   why neither yielded.
+
+5. **Read the disputed code.** For each disputed point, `Read` the
+   actual file at the cited line. Don't rely solely on quoted
+   snippets in the exchange — the source of truth is the code on the
+   PR's branch (you're checked out on its head SHA).
+
+6. **Consult canonical references.** Before each ruling:
+   - `.ai/wheels/<layer>/` for the layer in dispute (model, view,
+     controller, etc.).
+   - `CLAUDE.md` § "Critical Anti-Patterns" + § "Wheels Conventions"
+     + § "Commit Message Conventions" — these are authoritative.
+   - `.ai/wheels/cross-engine-compatibility.md` if the dispute
+     touches Lucee/Adobe/BoxLang behavior.
+   - Existing precedent: `Grep`/`Glob` for similar code elsewhere in
+     the repo to see how this convention is handled when it's not
+     contested.
+
+7. **Rule on each disputed point.** For each, decide:
+   - **A was right** (cite the evidence)
+   - **B was right** (cite the evidence)
+   - **Both partially right** (synthesize the actually-correct
+     position)
+   - **Neither was right** (the dispute itself was misframed; here's
+     the real concern)
+
+   Cite a concrete reference for each ruling — file:line, doc path,
+   or both.
+
+8. **Synthesize the verdict.** Roll up the per-point rulings into one
+   final recommendation:
+
+   - **`approve`** — disputed points were minor, or A and B were
+     debating preferences rather than correctness. PR is fine to
+     merge as-is. Use this when the per-point rulings are dominated
+     by "both partially right" or "neither was right" outcomes.
+   - **`changes`** — at least one disputed point clearly required a
+     change (you ruled on a real correctness issue, anti-pattern, or
+     security concern). Specify which findings address-review should
+     act on (the ones you ruled in favor of the side requesting the
+     change) and which to drop.
+
+9. **Post the advisor comment** on the PR. Use
+   `gh pr comment <pr-number> --body "<...>"`:
+
+   ```
+   ## Wheels Bot — Senior Advisor (deadlock resolution)
+
+   Reviewer A and Reviewer B reached the 10-round inner-loop cap
+   without converging. After re-reading the full exchange and the
+   disputed code, here are the rulings on each contested point:
+
+   ### Disputed points
+
+   1. **<short title>** — A claimed `<A's position>`; B claimed
+      `<B's position>`. **Ruling:** `<A right | B right | both
+      partially | neither>`. **Evidence:** `<file:line | doc path |
+      both>`. `<one-sentence reasoning>`.
+   2. ...
+
+   ### Verdict: `<approve | changes>`
+
+   <one paragraph: synthesizing the rulings into the recommendation>
+
+   <if verdict is `changes`, list the specific findings address-review
+   should act on:>
+
+   ### Findings for address-review to apply
+   - **<finding>** at `<file:line>` — `<concrete action>`
+   - ...
+
+   <if verdict is `approve`, note that the disputed findings should be
+   dropped and the PR is fine to merge as-is.>
+
+   <!-- wheels-bot:advisor:<pr>:<sha> -->
+   <CONVERGENCE_MARKER>
+   ```
+
+   Where `<CONVERGENCE_MARKER>` is:
+   - `<!-- wheels-bot:converged-approve:<pr>:<sha> -->` if verdict is
+     `approve`
+   - `<!-- wheels-bot:converged-changes:<pr>:<sha> -->` if verdict is
+     `changes` (triggers `bot-address-review.yml`)
+
+10. **Self-check before posting.**
+    - [ ] Each ruling cites a concrete file:line, doc path, or both —
+      no vague handwaves.
+    - [ ] Read the actual disputed code (not just exchange quotes).
+    - [ ] Consulted `CLAUDE.md` and `.ai/wheels/` where applicable.
+    - [ ] Verdict is one of `approve` or `changes` — not "kinda
+      mostly", not equivocal.
+    - [ ] Convergence marker is consistent with the verdict.
+    - [ ] Advisor marker present.
+
+    If any check fails, fix before posting. The advisor's verdict is
+    authoritative within the convergence loop — get it right.

--- a/.claude/commands/respond-to-critique.md
+++ b/.claude/commands/respond-to-critique.md
@@ -1,0 +1,110 @@
+# /respond-to-critique
+
+Reviewer A — response mode. Engage with Reviewer B's critique on a PR
+that you previously reviewed. The goal of this exchange is to converge
+on an aligned recommendation between A and B; this prompt is the A
+side of that loop.
+
+## Rails
+
+Read `.claude/commands/_shared-rails.md` first. Highlights:
+
+- Use `gh` for GitHub state and read-only `git`. **No file writes.**
+- Output is a **single PR review** (state `COMMENT`) with your response,
+  not a comment-comment. Reviews keep the loop wired correctly:
+  `bot-review-b.yml` fires on `pull_request_review: submitted`, so your
+  response triggers B's next round automatically.
+- Loop cap is enforced by Reviewer B (10 rounds max per SHA). Don't
+  worry about it here.
+
+## Args
+
+- `<pr-number>` — the PR you're discussing with B
+
+## Steps
+
+1. **Idempotency check.** Read PR comments + reviews via
+   `gh pr view <pr-number> --json reviews,comments,headRefOid -q '.'`.
+   - Find the most recent `wheels-bot[bot]` PR comment whose body
+     contains `wheels-bot:review-b:<pr>:<sha>:<N>` for the current
+     head SHA. That's B's latest round number.
+   - Find your most recent review on this SHA (initial or prior
+     response). If its body contains
+     `wheels-bot:review-a-response:<pr>:<sha>:<N>` and N matches B's
+     latest round, exit silently — you've already responded to that
+     critique.
+   - Your response round number = B's latest round number.
+
+2. **Read the exchange.**
+   - The PR diff via `gh pr diff <pr-number>`.
+   - Your most recent review on this SHA (initial or prior response).
+   - All `wheels-bot:review-b:<pr>:<sha>:` comments on this SHA, in
+     chronological order. The most recent one is what you're
+     responding to.
+
+3. **Engage with B's latest critique.** For each finding B raised:
+
+   - **B's missed-issues findings** — re-scan the diff at the cited
+     lines. Either:
+     - **Concede**: B was correct, add the finding to your updated
+       position.
+     - **Reject**: explain why B is wrong with concrete evidence (the
+       line B cited isn't actually problematic; the convention B
+       claims doesn't exist; etc.).
+   - **B's false-positive claims about your review** — re-read your
+     own finding and B's rebuttal. Either:
+     - **Concede**: B caught you flagging a non-issue, retract that
+       part of your position.
+     - **Reject**: defend your finding with additional evidence (cite
+       `.ai/wheels/<layer>/`, `CLAUDE.md`, the actual code semantics).
+   - **B's verdict-alignment concerns** — if B flagged your verdict
+     (approve/request-changes/comment) as inconsistent with findings,
+     decide: are you updating your verdict, or defending the original
+     with reasoning?
+
+4. **Submit your response review.** Use
+   `gh pr review <pr-number> --comment --body "<...>"`. State must be
+   `COMMENT` (not approve, not request-changes — those are reserved
+   for the initial review's verdict; responses use COMMENT so the
+   verdict tracking stays consistent across rounds).
+
+   Format:
+
+   ```
+   ## Wheels Bot — Reviewer A response (round <N>)
+
+   <one-paragraph TL;DR: which points did you concede, which did you
+   defend, and what is your updated position on the verdict>
+
+   ### Conceded points
+
+   <bullets — points where B was right and you've updated your
+   position, or "none">
+
+   ### Defended points
+
+   <bullets — points where you maintain your original position, with
+   evidence (file/line citations, `.ai/wheels/` references), or
+   "none">
+
+   ### Updated verdict
+
+   <one sentence: your current recommendation
+   (approve/request-changes/comment), and why this differs from your
+   initial review if it does>
+
+   <!-- wheels-bot:review-a-response:<pr>:<sha>:<N> -->
+   ```
+
+5. **Self-check before submitting.**
+   - [ ] Have you ACTUALLY read the lines B cited in their
+     false-positive claims? (Don't concede or reject without
+     checking.)
+   - [ ] Are your defended points backed by concrete citations
+     (file/line/`.ai/wheels/`)?
+   - [ ] Is your "Updated verdict" line actionable for B's next round?
+     (Either "still request-changes for X, Y" or "now I agree it's
+     approve.")
+   - [ ] Round number in the marker matches B's latest round?
+
+   If any check fails, fix before submitting. Do not double-submit.

--- a/.claude/commands/review-the-review.md
+++ b/.claude/commands/review-the-review.md
@@ -11,7 +11,23 @@ Read `.claude/commands/_shared-rails.md` first. Highlights for this command:
 - Use `gh` for GitHub state and read-only `git`. No writes, no edits.
 - **Output is a PR comment, not a review.** Reviews would re-trigger the
   caller workflow into an infinite loop.
-- Loop cap: 3 rounds. Check the existing comment count before posting.
+- Loop cap: 10 rounds per SHA. Check the existing comment count before
+  posting. Convergence happens when you and A agree on a recommendation;
+  non-converged rounds keep the loop going via Reviewer A's response.
+
+## Convergence — what this stage decides
+
+After your critique, you choose one of three outcomes:
+
+1. **Aligned, no changes needed** → emit `converged-approve` marker.
+   The PR is review-clean for this SHA. The human can mark ready and
+   merge.
+2. **Aligned, changes needed** → emit `converged-changes` marker. This
+   triggers `bot-address-review.yml` to apply the consensus. New
+   commits → fresh Reviewer A on the new SHA → loop restarts.
+3. **Not aligned** → emit only the round marker (no convergence
+   marker). This triggers Reviewer A to respond to your critique in
+   the next round, continuing the back-and-forth until alignment.
 
 ## Args
 
@@ -24,15 +40,21 @@ Read `.claude/commands/_shared-rails.md` first. Highlights for this command:
    `gh pr view <pr-number> --json comments,headRefOid`. Count comments
    whose body matches `wheels-bot:review-b:<pr-number>:<sha>:` (any round).
 
-   - If the most recent matching comment has the **current head SHA**, exit
-     silently (we already commented on this exact head).
-   - Round number = (count of B comments for any SHA on this PR) + 1.
-   - **If round > 3**: post the terminal comment and exit:
+   - If the most recent matching comment has the **current head SHA**
+     **AND** the comment count on the current SHA already equals the
+     review-id you're processing (a precise dedup), exit silently.
+   - Round number for the current SHA =
+     (count of B comments on this exact SHA) + 1.
+   - **If round > 10**: post the terminal comment and exit. The cap
+     exists so the loop terminates when A and B can't align — humans
+     take over from there.
 
      ```
-     ## Wheels Bot — Reviewer B (no further iterations)
+     ## Wheels Bot — Reviewer B (round cap reached)
 
-     Round cap (3) reached. Handing back to humans.
+     Round cap (10) reached on this SHA. A and B did not converge —
+     the senior advisor (`bot-advisor.yml`, Opus) will engage to
+     break the deadlock and issue a tie-breaking verdict.
 
      <!-- wheels-bot:review-b:<pr>:<sha>:terminal -->
      ```
@@ -75,12 +97,39 @@ Read `.claude/commands/_shared-rails.md` first. Highlights for this command:
    - Is A's verdict (`approve` / `request-changes` / `comment`) consistent
      with the findings?
 
-5. **Post the comment.** Format:
+5. **Convergence decision.** After completing the critique, decide
+   whether you and A are now aligned on a recommendation. Aligned means
+   ALL of:
+
+   - You have no remaining unaddressed missed-issues findings (either
+     A flagged them in their initial review, or A conceded them in a
+     prior response, or B itself raised them and now considers them
+     addressed in A's most recent response).
+   - You have no remaining false-positive disputes (every claim A made
+     has either been verified by you or successfully retracted by A in
+     a response).
+   - A's current verdict (approve / request-changes / comment) is one
+     you would also recommend after seeing the diff yourself.
+
+   Three possible outcomes:
+
+   - **Aligned + verdict is `approve`** → set the convergence marker
+     to `wheels-bot:converged-approve:<pr>:<sha>`. The PR is
+     review-clean for this SHA.
+   - **Aligned + verdict is `request-changes`** (or `comment` with
+     concrete actionable findings) → set the convergence marker to
+     `wheels-bot:converged-changes:<pr>:<sha>`. This triggers
+     `bot-address-review.yml`.
+   - **Not aligned** → no convergence marker (only the round marker).
+     This triggers A's response on the next round.
+
+6. **Post the comment.** Format:
 
    ```
    ## Wheels Bot — Reviewer B (round <N>)
 
-   <one-paragraph TL;DR of your assessment of A's review>
+   <one-paragraph TL;DR of your assessment of A's review/response and
+   your convergence decision>
 
    ### Sycophancy
    <bullets, or "none detected">
@@ -94,23 +143,44 @@ Read `.claude/commands/_shared-rails.md` first. Highlights for this command:
    detected">
 
    ### Verdict alignment
-   <one sentence: is A's approve/request-changes/comment consistent with
-   their findings?>
+   <one sentence: is A's approve/request-changes/comment consistent
+   with their findings?>
+
+   ### Convergence
+   <one paragraph: are you and A now aligned? what's the joint
+   recommendation? if not aligned, what specifically does A need to
+   address in their next response?>
 
    <!-- wheels-bot:review-b:<pr>:<sha>:<round> -->
+   <CONVERGENCE_MARKER>
    ```
+
+   Where `<CONVERGENCE_MARKER>` is:
+   - `<!-- wheels-bot:converged-approve:<pr>:<sha> -->` for aligned-no-
+     changes
+   - `<!-- wheels-bot:converged-changes:<pr>:<sha> -->` for aligned-
+     changes-needed (triggers `bot-address-review.yml`)
+   - omitted entirely if not aligned (triggers A's response in the
+     next round)
 
    Use `gh pr comment <pr-number> --body "<...>"` — do **not** use
    `gh pr review`.
 
-6. **Self-check before posting.**
+7. **Self-check before posting.**
    - Have you actually read the cited diff lines for each false-positive
      claim? (Do not handwave.)
    - Are your missed-issue findings concrete enough that A could act on
-     them in a follow-up review?
+     them in a response?
    - Is the round number correct in the marker?
-   - Have you avoided re-reviewing the PR from scratch? (Stay focused on
-     critiquing A.)
+   - Have you avoided re-reviewing the PR from scratch? (Stay focused
+     on critiquing A.)
+   - Is your convergence decision consistent with the body of your
+     critique? (Don't say "aligned, approve" while listing missed
+     issues; don't say "not aligned" while marking everything
+     resolved.)
+   - If you emitted `converged-changes`, are the changes concrete and
+     actionable? (Address-review will read your prior comments to
+     synthesize the consensus — make sure it has enough detail.)
 
    If any check fails, fix and re-post (do not double-post).
 

--- a/.github/workflows/bot-address-review.yml
+++ b/.github/workflows/bot-address-review.yml
@@ -1,0 +1,140 @@
+name: Wheels Bot — Address Review
+
+# Fires when Reviewer B posts a converged-changes verdict, signaling that
+# A and B have aligned on "this PR needs changes." The bot reads the
+# consensus, applies the changes to the PR's existing branch, and pushes.
+# The new commit triggers a fresh Reviewer A run on the new SHA — the
+# convergence loop restarts on the updated PR state. Bounded by an
+# outer-loop cap (5 implementation rounds per PR; enforced in the prompt).
+#
+# This is a *coding* stage — Opus model, broad allowlist with the test
+# runner, mirrors propose-fix's setup. Different from review-a/review-b
+# which are analytical and stay on Sonnet.
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'PR number whose converged-changes verdict to address'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wheels-bot-address-review-${{ github.event.issue.number || inputs.pr-number }}
+  cancel-in-progress: false
+
+jobs:
+  address-review:
+    name: Address review
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Auto-fires on B's converged-changes marker. The bot-identity check
+    # is load-bearing: prevents humans from quoting the marker in a reply
+    # to trigger this stage.
+    if: |
+      vars.WHEELS_BOT_ENABLED == 'true'
+      && (
+        github.event_name == 'workflow_dispatch'
+        || (github.event_name == 'issue_comment'
+            && github.event.comment.user.login == 'wheels-bot[bot]'
+            && contains(github.event.comment.body, 'wheels-bot:converged-changes:'))
+      )
+    env:
+      PR_NUMBER: ${{ github.event.issue.number || inputs.pr-number }}
+      WHEELS_CI: "true"
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WHEELS_BOT_APP_ID }}
+          private-key: ${{ secrets.WHEELS_BOT_PRIVATE_KEY }}
+
+      - name: Resolve PR head ref
+        id: pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr-number must be numeric, got: $PR_NUMBER"
+            exit 1
+          fi
+          ref=$(gh pr view "$PR_NUMBER" --repo wheels-dev/wheels --json headRefName -q '.headRefName')
+          if [ -z "$ref" ]; then
+            echo "::error::Could not resolve PR head ref for #$PR_NUMBER"
+            exit 1
+          fi
+          echo "head=$ref" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.head }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Skip check
+        id: gate
+        uses: ./.github/actions/wheels-bot-skip-check
+        with:
+          target-type: pr
+          target-number: ${{ env.PR_NUMBER }}
+          # Skip if address-held already engaged for this PR. The prompt
+          # does deeper round counting (outer-loop cap of 5).
+          marker-pattern: 'wheels-bot:address-held:${{ env.PR_NUMBER }}'
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure git
+        if: steps.gate.outputs.skip == 'false'
+        run: |
+          git config user.name "wheels-bot[bot]"
+          git config user.email "wheels-bot[bot]@users.noreply.github.com"
+
+      - name: Set up Wheels test environment
+        if: steps.gate.outputs.skip == 'false'
+        uses: ./.github/actions/setup-wheels-test-env
+        with:
+          port: '60007'
+          install-playwright: 'false'
+
+      - name: Run Address Review
+        if: steps.gate.outputs.skip == 'false'
+        uses: anthropics/claude-code-action@v1
+        with:
+          # Triggered by wheels-bot[bot]'s Reviewer B comment with a
+          # converged-changes marker. Allow that identity.
+          allowed_bots: 'wheels-bot[bot],github-actions[bot]'
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          prompt: |
+            /address-review ${{ env.PR_NUMBER }}
+          claude_args: |
+            --model claude-opus-4-7
+            --max-turns 1000
+            --allowedTools "Bash(gh:*),Bash(git:*),Bash(bash tools/test-local.sh*),Bash(curl:*),Read,Edit,Write,Grep,Glob"
+
+      - name: Push branch
+        if: steps.gate.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Only push if the bot actually committed changes; otherwise
+          # the run was a no-op (e.g., address-held safety net engaged).
+          if [ -z "$(git log @{u}..HEAD --oneline 2>/dev/null)" ]; then
+            echo "No new commits — nothing to push."
+            exit 0
+          fi
+          git push origin HEAD
+
+      - name: Stop Lucee server
+        if: always()
+        run: |
+          if [ -f /tmp/lucli-server.pid ]; then
+            kill $(cat /tmp/lucli-server.pid) 2>/dev/null || true
+          fi
+          lucli server stop 2>/dev/null || true

--- a/.github/workflows/bot-advisor.yml
+++ b/.github/workflows/bot-advisor.yml
@@ -1,0 +1,106 @@
+name: Wheels Bot — Senior Advisor
+
+# Fires when Reviewer A and Reviewer B fail to converge after the
+# inner-loop cap (B emits a `:terminal` marker). The advisor reads the
+# full exchange + the disputed code + canonical references, then issues
+# a tie-breaking verdict using Opus's deeper reasoning. Output is a
+# comment + convergence marker that drops back into the existing flow:
+# converged-approve ends the loop; converged-changes triggers
+# bot-address-review.yml.
+#
+# This is the only stage in the pipeline that runs Opus on a non-coding
+# task. The cost is justified because the advisor's verdict overrides
+# a deadlock — it must be right.
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'PR number with deadlocked A↔B exchange to advise on'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wheels-bot-advisor-${{ github.event.issue.number || inputs.pr-number }}
+  cancel-in-progress: false
+
+jobs:
+  advisor:
+    name: Senior advisor
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Auto-fires only on B's terminal marker (cap reached). The
+    # bot-identity check is load-bearing.
+    if: |
+      vars.WHEELS_BOT_ENABLED == 'true'
+      && (
+        github.event_name == 'workflow_dispatch'
+        || (github.event_name == 'issue_comment'
+            && github.event.comment.user.login == 'wheels-bot[bot]'
+            && contains(github.event.comment.body, 'wheels-bot:review-b:')
+            && contains(github.event.comment.body, ':terminal'))
+      )
+    env:
+      PR_NUMBER: ${{ github.event.issue.number || inputs.pr-number }}
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WHEELS_BOT_APP_ID }}
+          private-key: ${{ secrets.WHEELS_BOT_PRIVATE_KEY }}
+
+      - name: Resolve PR head ref + SHA
+        id: pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr-number must be numeric, got: $PR_NUMBER"
+            exit 1
+          fi
+          info=$(gh pr view "$PR_NUMBER" --repo wheels-dev/wheels --json headRefName,headRefOid)
+          ref=$(echo "$info" | python3 -c "import json,sys; print(json.load(sys.stdin)['headRefName'])")
+          sha=$(echo "$info" | python3 -c "import json,sys; print(json.load(sys.stdin)['headRefOid'])")
+          echo "head=$ref" >> "$GITHUB_OUTPUT"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.sha }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Skip check
+        id: gate
+        uses: ./.github/actions/wheels-bot-skip-check
+        with:
+          target-type: pr
+          target-number: ${{ env.PR_NUMBER }}
+          # Fires once per SHA. If the advisor already advised at this
+          # SHA, the marker is already present and the workflow exits.
+          marker-pattern: 'wheels-bot:advisor:${{ env.PR_NUMBER }}:${{ steps.pr.outputs.sha }}'
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: Run Senior Advisor
+        if: steps.gate.outputs.skip == 'false'
+        uses: anthropics/claude-code-action@v1
+        with:
+          # Triggered by wheels-bot[bot]'s Reviewer B comment carrying
+          # a terminal marker. Allow that bot identity (and
+          # github-actions[bot] for consistency).
+          allowed_bots: 'wheels-bot[bot],github-actions[bot]'
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          prompt: |
+            /advise-on-deadlock ${{ env.PR_NUMBER }}
+          claude_args: |
+            --model claude-opus-4-7
+            --max-turns 500
+            --allowedTools "Bash(gh:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git grep:*),Bash(git status),Read,Grep,Glob"

--- a/.github/workflows/bot-review-a.yml
+++ b/.github/workflows/bot-review-a.yml
@@ -1,40 +1,52 @@
 name: Wheels Bot — Reviewer A
 
+# Two trigger paths into this workflow:
+# 1. pull_request — the standard path (PR opens, syncs, or marks ready).
+#    Reviewer A submits its initial review of the diff via /review-pr.
+# 2. issue_comment — the convergence-loop path. When Reviewer B posts a
+#    not-yet-aligned critique (matches `wheels-bot:review-b:` but NOT
+#    `wheels-bot:converged-` and NOT `:terminal`), A responds via
+#    /respond-to-critique. The response is itself a review (state=COMMENT),
+#    which triggers Reviewer B's next round — loop continues until B
+#    emits a converged-* marker or the round cap fires.
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
     branches: [develop]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
 
 concurrency:
-  group: wheels-bot-review-a-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
-  cancel-in-progress: true
+  group: wheels-bot-review-a-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
 
 jobs:
   review:
     name: Reviewer A
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Reviews human PRs that are ready-for-review, AND the bot's own PRs
-    # even while draft. Bot PRs get reviewed pre-merge so the human merge
-    # decision is informed by Reviewer A's analysis (and Reviewer B's
-    # critique) rather than blind. Human drafts are skipped because drafts
-    # are work-in-progress and reviews would churn.
+    # Initial review: bot PRs (even draft) OR human ready-for-review PRs.
+    # Response: bot's own comment from Reviewer B that is NOT a converged
+    # marker AND NOT terminal — i.e., B is signalling "more discussion
+    # needed."
+    # The bot-identity check on the comment path is load-bearing: prevents
+    # humans from quoting a marker in a reply to trigger the response.
     if: |
       vars.WHEELS_BOT_ENABLED == 'true'
       && (
-        github.event.pull_request.user.login == 'wheels-bot[bot]'
-        || github.event.pull_request.draft == false
+        (github.event_name == 'pull_request'
+          && (github.event.pull_request.user.login == 'wheels-bot[bot]'
+              || github.event.pull_request.draft == false))
+        || (github.event_name == 'issue_comment'
+            && github.event.comment.user.login == 'wheels-bot[bot]'
+            && contains(github.event.comment.body, 'wheels-bot:review-b:')
+            && !contains(github.event.comment.body, 'wheels-bot:converged-')
+            && !contains(github.event.comment.body, ':terminal'))
       )
     steps:
-      - name: Checkout PR head
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
       - name: Generate App token
         id: app-token
         uses: actions/create-github-app-token@v2
@@ -42,28 +54,69 @@ jobs:
           app-id: ${{ secrets.WHEELS_BOT_APP_ID }}
           private-key: ${{ secrets.WHEELS_BOT_PRIVATE_KEY }}
 
-      - name: Skip check
+      - name: Resolve PR info
+        id: pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_FROM_PR_EVENT: ${{ github.event.pull_request.number }}
+          PR_FROM_COMMENT_EVENT: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            pr_num="$PR_FROM_PR_EVENT"
+            sha="${{ github.event.pull_request.head.sha }}"
+            mode="initial"
+          else
+            pr_num="$PR_FROM_COMMENT_EVENT"
+            # Validate numeric.
+            if ! [[ "$pr_num" =~ ^[0-9]+$ ]]; then
+              echo "::error::Invalid PR number from issue context: $pr_num"
+              exit 1
+            fi
+            sha=$(gh pr view "$pr_num" --repo wheels-dev/wheels --json headRefOid -q '.headRefOid')
+            mode="response"
+          fi
+          echo "pr_num=$pr_num" >> "$GITHUB_OUTPUT"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Skip check (initial review only — response mode handles its own idempotency)
+        if: github.event_name == 'pull_request'
         id: gate
         uses: ./.github/actions/wheels-bot-skip-check
         with:
           target-type: pr
-          target-number: ${{ github.event.pull_request.number }}
-          marker-pattern: 'wheels-bot:review-a:${{ github.event.pull_request.number }}:${{ github.event.pull_request.head.sha }}'
+          target-number: ${{ steps.pr.outputs.pr_num }}
+          marker-pattern: 'wheels-bot:review-a:${{ steps.pr.outputs.pr_num }}:${{ steps.pr.outputs.sha }}:'
           github-token: ${{ steps.app-token.outputs.token }}
 
+      - name: Determine prompt
+        id: cmd
+        run: |
+          if [ "${{ steps.pr.outputs.mode }}" = "initial" ]; then
+            echo "cmd=/review-pr ${{ steps.pr.outputs.pr_num }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "cmd=/respond-to-critique ${{ steps.pr.outputs.pr_num }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run Reviewer A
-        if: steps.gate.outputs.skip == 'false'
+        if: github.event_name == 'issue_comment' || steps.gate.outputs.skip == 'false'
         uses: anthropics/claude-code-action@v1
         with:
-          # Allow our App's bot identity and github-actions[bot] to initiate
-          # the action. Reviewer A now runs on wheels-bot[bot] PRs too (so
-          # the human merge decision has analysis to lean on), so this is
-          # the primary case — not defensive.
+          # Allows the App's bot identity (and github-actions[bot] for
+          # consistency). Reviewer A runs on bot's own PRs and responds
+          # to its own Reviewer B comments — both legitimately bot-driven.
           allowed_bots: 'wheels-bot[bot],github-actions[bot]'
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           prompt: |
-            /review-pr ${{ github.event.pull_request.number }}
+            ${{ steps.cmd.outputs.cmd }}
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 250

--- a/docs/contributing/wheels-bot.md
+++ b/docs/contributing/wheels-bot.md
@@ -2,7 +2,7 @@
 
 `wheels-bot[bot]` is a custom GitHub App that automates issue triage,
 cross-framework design research, fix-PR generation, and PR review on
-`wheels-dev/wheels`. It runs as seven stages, each backed by a slash-command
+`wheels-dev/wheels`. It runs as nine stages, each backed by a slash-command
 prompt in `.claude/commands/` and a workflow in `.github/workflows/bot-*.yml`.
 
 This page is for humans interacting with the bot. For the design rationale,
@@ -21,7 +21,7 @@ contribution rules, see [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 - Flip the repo variable `WHEELS_BOT_ENABLED` to `false` to halt the bot
   entirely without code changes.
 
-## The seven stages
+## The nine stages
 
 ### 1. Triage (`bot-triage.yml`)
 
@@ -162,37 +162,137 @@ in-flight branches.
 
 ### 6. Reviewer A (`bot-review-a.yml`)
 
-Fires on `pull_request: opened/synchronize/ready_for_review` against
-`develop`. Reviews:
+Fires on two trigger paths:
 
-- Human PRs that are ready-for-review (drafts are skipped — they're
-  work-in-progress and reviewing them would churn).
-- The bot's own PRs **even while draft**, so the human merge decision is
-  informed by Reviewer A's analysis (and Reviewer B's critique) rather
-  than blind. The PR stays draft until a human marks it ready, which
-  remains the explicit "I've read the reviews and want to merge" signal.
+1. **`pull_request: opened/synchronize/ready_for_review`** — initial
+   review (`/review-pr`). Reviews:
+   - Human PRs that are ready-for-review (drafts are skipped — they're
+     work-in-progress and reviewing them would churn).
+   - The bot's own PRs **even while draft**, so the human merge
+     decision is informed by Reviewer A's analysis (and Reviewer B's
+     critique) rather than blind.
+2. **`issue_comment: created`** matching `wheels-bot:review-b:` (and
+   NOT `:terminal`, NOT `wheels-bot:converged-`) — response mode
+   (`/respond-to-critique`). Triggered by Reviewer B posting a
+   not-yet-aligned critique. A reads B's critique, engages with each
+   finding (concede or defend with evidence), and submits a response
+   review (state `COMMENT`). The response triggers Reviewer B's next
+   round, continuing the back-and-forth until alignment.
 
-Posts a single PR review with line comments grouped under: Correctness,
-Conventions, Cross-engine, Tests, Docs, Commits, Security. Verdict is
-`approve` / `request-changes` / `comment`. Verdict and findings must be
-consistent — Reviewer B will catch sycophancy if they aren't.
+Initial review posts a `gh pr review` with verdict
+`approve` / `request-changes` / `comment` and findings grouped under
+Correctness, Conventions, Cross-engine, Tests, Docs, Commits, Security.
+Response review posts as `COMMENT` state with engagement on each of B's
+findings.
 
 ### 7. Reviewer B (`bot-review-b.yml`)
 
 Fires when Reviewer A submits a review (filtered on
-`review.user.login == 'wheels-bot[bot]'`). Reviewer B critiques A's review,
-not the PR — looking for sycophancy ("LGTM" without evidence), false
-positives (claims that don't match the actual code), and missed issues.
-Runs on both human PRs (ready-for-review only) and the bot's own PRs
-(even draft — same rationale as Reviewer A).
+`review.user.login == 'wheels-bot[bot]'`). Reviewer B critiques A's
+review, not the PR — looking for sycophancy ("LGTM" without evidence),
+false positives (claims that don't match the actual code), and missed
+issues. Runs on both human PRs (ready-for-review only) and the bot's
+own PRs (even draft — same rationale as Reviewer A).
+
+**Reviewer B is also the convergence arbiter.** Each round, after
+critiquing A's review or response, B decides whether they and A are
+now aligned on a recommendation. B emits one of three signals:
+
+- `converged-approve` — aligned, no changes needed. PR is review-clean
+  for this SHA. Loop terminates; the human can mark ready for merge.
+- `converged-changes` — aligned on the need for changes. **Triggers
+  `bot-address-review.yml`** (Stage 8) to apply the consensus.
+- (no convergence marker) — not aligned. Triggers Reviewer A to respond
+  to this critique in the next round, continuing the back-and-forth.
 
 Posts as a PR comment (not a review) so it doesn't re-trigger itself.
-Loop is capped at 3 rounds. Round 4 emits a terminal "no further
-iterations" message. The natural stopping condition for the bot-PR flow
-is one Reviewer A review per SHA — once the bot's PR stops emitting new
-commits (typically after `bot-update-docs` lands its docs commit), no
-new SHA → no new Reviewer A → no new Reviewer B. The human reads the
-final A+B exchange and decides whether to mark ready and merge.
+Loop is capped at **10 rounds per SHA**. Round 11 emits a terminal
+message that triggers Stage 9 (Senior Advisor) — A and B couldn't
+align, so an Opus advisor breaks the deadlock and issues a
+tie-breaking verdict that drops back into the convergence flow.
+
+### 8. Address Review (`bot-address-review.yml`)
+
+Fires when Reviewer B emits a `wheels-bot:converged-changes:<pr>:<sha>`
+marker. Reads the consensus from the A↔B exchange, applies the agreed
+changes to the PR's existing branch, and pushes the new commits. The
+new SHA triggers a fresh Reviewer A run, restarting the convergence
+loop on the updated PR state.
+
+This is a *coding* stage — Opus model, 60-minute timeout, broad
+allowlist with the test runner (mirrors propose-fix's setup). Different
+from the analytical Sonnet stages above.
+
+The bot:
+
+1. Reads A's review/responses and B's critique chain to identify the
+   consensus changes (intersection of A's findings B verified + B's
+   missed-issues findings A didn't refute).
+2. Auto-downgrades and stops if the consensus touches sensitive areas
+   (security, migrations, deploy, DI). Posts
+   `wheels-bot:address-held:<pr>:<sha>` instead of making changes.
+3. Branch-aware scope: `fix/bot-*` PRs allow code/test edits; `docs/bot-*`
+   PRs are doc-paths-only (refuses to touch code if a finding requires
+   it — escalates to held).
+4. Applies the consensus changes and re-runs affected specs for
+   `fix/bot-*` PRs.
+5. Commits + pushes back to the PR's existing branch.
+6. Posts a comment summarizing what was addressed and what was skipped.
+
+**Outer-loop cap: 5 implementation rounds per PR.** After 5 rounds, the
+prompt refuses to fire and posts a "max iterations reached, human
+attention required" comment. Combined with Reviewer B's 10-round inner
+cap, the maximum bot effort per PR is bounded at 5 implementations × 10
+A↔B rounds = 50 review rounds before a human takes over.
+
+Reviewer A and Reviewer B continue to cover the PR after each
+implementation cycle — the address-review's commit triggers `pull_request:
+synchronize` → Reviewer A on the new SHA → loop continues.
+
+### 9. Senior Advisor (`bot-advisor.yml`)
+
+The deadlock-breaker. Fires when Reviewer A and Reviewer B fail to
+converge after the inner-loop cap (B emits a `:terminal` marker at
+round 11). The advisor reads the full A↔B exchange, the disputed
+code, and the canonical references (`CLAUDE.md`, `.ai/wheels/`),
+then issues a tie-breaking verdict.
+
+**This is the only stage that runs Opus on a non-coding task.** The
+reasoning depth is justified because the advisor's verdict overrides
+the analytical reviewers' deadlock — it must be right. Address-
+review uses Opus because it modifies code; advisor uses Opus because
+it adjudicates code-related disputes Sonnet couldn't resolve.
+
+The advisor:
+
+1. Confirms the deadlock by finding B's terminal marker for the
+   current SHA.
+2. Reads A's reviews/responses + B's critiques chronologically.
+3. Identifies the SPECIFIC points of disagreement (findings A flagged
+   but B persistently rejected; issues B raised but A persistently
+   refuted; verdict mismatches).
+4. **Reads the actual disputed code at each cited line** — doesn't
+   rely solely on the exchange's quoted snippets.
+5. Consults canonical references for each ruling.
+6. Rules on each disputed point with concrete evidence (file:line,
+   doc path).
+7. Synthesizes one verdict: `approve` (disputes wash out) or
+   `changes` (at least one disputed finding required action).
+8. Posts a comment with the rulings + verdict + a convergence marker
+   that drops back into the existing flow:
+   - `converged-approve` → loop ends, PR is review-clean for this SHA
+   - `converged-changes` → triggers `bot-address-review.yml` (Stage 8)
+     to apply the advisor's specified findings
+
+The advisor fires once per SHA (idempotent on
+`wheels-bot:advisor:<pr>:<sha>`). It does NOT iterate or re-debate
+the rulings — its verdict is authoritative within the convergence
+loop. If the resulting address-review introduces a new SHA, the
+fresh A↔B loop on that SHA starts over from round 1.
+
+**Cost:** Opus + 30-min timeout + read-only allowlist. Worst case
+per advisor run: ~$3-5. Triggered only on deadlocks, so most PRs
+never invoke it.
 
 ## Maintenance: auto-close stale triage (`bot-auto-close.yml`)
 
@@ -224,8 +324,14 @@ they make every workflow safely retryable.
 | `wheels-bot:write-docs:<issue>` | Write Docs stage opened a docs PR for this issue. |
 | `wheels-bot:docs-held:<issue>` | Docs would have been written but the safety net held it for a human. |
 | `wheels-bot:update-docs:<pr>` | Update Docs stage processed this PR (with or without doc edits). |
-| `wheels-bot:review-a:<pr>:<sha>` | Reviewer A reviewed this PR at this SHA. |
+| `wheels-bot:review-a:<pr>:<sha>` | Reviewer A submitted its initial review at this SHA. |
+| `wheels-bot:review-a-response:<pr>:<sha>:<round>` | Reviewer A responded to B's critique at round N (convergence loop). |
 | `wheels-bot:review-b:<pr>:<sha>:<round>` | Reviewer B critiqued round N. |
+| `wheels-bot:converged-approve:<pr>:<sha>` | A and B aligned on `approve` — PR is review-clean. |
+| `wheels-bot:converged-changes:<pr>:<sha>` | A and B aligned on changes needed — triggers `bot-address-review.yml`. |
+| `wheels-bot:address-review:<pr>:<sha>:<round>` | Address-review applied consensus at SHA, round N (outer loop). |
+| `wheels-bot:address-held:<pr>:<sha>` | Address-review would have made changes but the safety net held it for a human. |
+| `wheels-bot:advisor:<pr>:<sha>` | Senior Advisor (Opus) issued a tie-breaking verdict on a deadlocked A↔B exchange at this SHA. |
 | `wheels-bot:auto-close:<issue>` | Auto-close cron closed this issue. |
 
 ## Operating the bot
@@ -269,10 +375,14 @@ they make every workflow safely retryable.
   `wheels-bot:triage-class:framework-design`; write-docs runs from
   `wheels-bot:docs-confidence:high`; bot-update-docs runs on
   `pull_request: opened` for `wheels-bot[bot]` PRs (excluding
-  `docs/bot-*` branches, which are write-docs's own output). To halt
-  auto-fire without code changes, flip `WHEELS_BOT_ENABLED=false`. To
-  halt permanently, revert the `if:` blocks in the four workflows back
-  to `workflow_dispatch`-only and keep the kill-switch flipped.
+  `docs/bot-*` branches); **address-review runs on
+  `wheels-bot:converged-changes:` markers from Reviewer B**;
+  **Reviewer A's response mode runs on non-converged
+  `wheels-bot:review-b:` markers**; **Senior Advisor runs on B's
+  `:terminal` markers (deadlock resolution)**. To halt auto-fire
+  without code changes, flip `WHEELS_BOT_ENABLED=false`. To halt
+  permanently, revert the `if:` blocks in the workflows back to
+  `workflow_dispatch`-only and keep the kill-switch flipped.
 - **Review bot-authored PRs the same as human-authored PRs.** Don't
   rubber-stamp.
 - **Watch costs.** API spend per fix-PR is non-trivial (Opus + many turns +


### PR DESCRIPTION
## Summary

Closes the gap between the analytical reviewers (A and B) and actual code change with three architectural additions: an **A↔B convergence loop**, a new **Stage 8: Address Review**, and a new **Stage 9: Senior Advisor** for deadlock resolution.

## The new flow

```
PR opens (or new SHA pushed)
    ↓
Reviewer A reviews → Reviewer B critiques A
    ↓
B decides: aligned with A?
    ├─ Aligned + verdict approve  → converged-approve   → loop ends
    ├─ Aligned + verdict changes  → converged-changes   → Stage 8 ↓
    └─ Not aligned → only round marker → A responds → B re-critiques
                                       (loop, cap 10)
                                              ↓
                                       At cap → :terminal marker
                                              ↓
                                       Stage 9: Senior Advisor (Opus) ↓
                                              ↓
                                       advisor's verdict → converged-* marker
                                       converged-approve → loop ends
                                       converged-changes → Stage 8 ↓
    ↓
Stage 8: Address Review reads consensus, applies changes, pushes new SHA
    ↓
New SHA → fresh Reviewer A → convergence loop restarts on new state
    ↓
Eventually: converged-approve OR outer-cap of 5 implementation rounds
```

## What's new

### 1. Reviewer A↔B convergence loop

- **`.github/workflows/bot-review-a.yml`** modified — adds an `issue_comment` trigger and dispatching logic. Pull-request events fire `/review-pr` (existing); comment events from `wheels-bot[bot]` matching a non-converged `wheels-bot:review-b:` marker fire the new `/respond-to-critique` prompt.
- **`.claude/commands/respond-to-critique.md`** NEW — Reviewer A's response-mode prompt. Engages with B's critique by conceding or defending each finding (with evidence).
- **`.claude/commands/review-the-review.md`** modified — adds the **convergence verdict** logic per round. Round cap raised from 3 to **10** per SHA.

### 2. Stage 8: Address Review (Opus, code-modifying)

- **`.github/workflows/bot-address-review.yml`** NEW — fires on `wheels-bot:converged-changes:` markers. Mirrors propose-fix's shape (Opus model, 60-min timeout, 1000-turn cap, broad allowlist with test runner). Checks out the PR's existing branch, commits and pushes to it.
- **`.claude/commands/address-review.md`** NEW — reads consensus from A↔B exchange, applies changes. Auto-downgrade safety on sensitive areas (security, migrations, deploy, DI). Branch-aware scope (`fix/bot-*` vs `docs/bot-*`). Outer-loop cap: 5 implementations per PR.

### 3. Stage 9: Senior Advisor (Opus, deadlock resolver) — *the cherry on top*

- **`.github/workflows/bot-advisor.yml`** NEW — fires on B's `:terminal` marker (cap reached without convergence). Opus + 30-min timeout + read-only allowlist (no writes — just analyzes and posts a verdict).
- **`.claude/commands/advise-on-deadlock.md`** NEW — reads the full A↔B exchange + the disputed code + canonical references; rules on each disputed point with concrete evidence; issues a tie-breaking verdict (`approve` or `changes`) that emits one of the existing convergence markers.

The advisor is the only stage running Opus on a non-coding task — its job is pure reasoning depth to break A↔B deadlocks. Without it, deadlocked PRs sit indefinitely waiting on humans. With it, even disagreement-prone reviews resolve automatically.

### 4. `docs/contributing/wheels-bot.md` updated

- Eight stages → nine stages
- Stage 6 (Reviewer A) — describes both initial-review and response-mode triggers
- Stage 7 (Reviewer B) — describes the convergence arbiter logic + 10-round cap + advisor handoff at terminal
- Stage 8 (Address Review) NEW
- Stage 9 (Senior Advisor) NEW
- Markers table — gains 6 new entries (`review-a-response`, `converged-approve`, `converged-changes`, `address-review`, `address-held`, `advisor`)
- Day-to-day Phase 4 paragraph — updated for all new auto-fire stages

## Model selection rationale

| Stage | Model | Why |
|---|---|---|
| Reviewer A — initial | Sonnet | Pure analytical |
| Reviewer A — respond | Sonnet | Still analytical |
| Reviewer B — critique + arbitrate | Sonnet | Convergence judgment |
| **Address Review** | **Opus** | Modifies real code |
| **Senior Advisor** | **Opus** | Adjudicates code disputes; reasoning depth required |

Per your call: *all coding-adjacent stages use Opus*. Sonnet for analysis, Opus for action and deep judgment.

## Cost expectations per PR

| Scenario | Cost |
|---|---|
| Smooth path (1 round of A+B, converged-approve) | ~$1.20 |
| Typical (1-2 inner rounds, 1 implementation) | ~$10–15 |
| Worst case before advisor (10 rounds × 5 implementations, no deadlock) | ~$90 |
| Worst case with advisor (deadlock at round 10, advisor breaks it, 5 implementations) | ~$95 |

Real safety net is `WHEELS_BOT_ENABLED=false` (kill switch) and the workflow `timeout-minutes` (5–60 min). The bounded round caps mean a single PR can't bankrupt the budget.

## Test plan

After merge, the next bot PR exercises the new flow naturally. Watch for:

- [ ] Initial Reviewer A review fires on PR open (unchanged behavior)
- [ ] Reviewer B's critique includes the `### Convergence` section + emits the right convergence marker
- [ ] If `converged-changes` fires, `bot-address-review.yml` runs, applies changes, pushes a commit
- [ ] New commit triggers fresh Reviewer A on `pull_request: synchronize`
- [ ] If A's response is needed, A submits a state-COMMENT review with the `respond-to-critique` format
- [ ] B re-critiques A's response, emits new convergence verdict
- [ ] **If 10 rounds pass without convergence:** `bot-advisor.yml` fires, posts a verdict, emits `converged-*`
- [ ] Loop terminates on converged-approve OR outer-loop cap hit (5 implementations)
- [ ] `bot-tdd-gate.yml` continues to skip on `docs/bot-*` branches
- [ ] All five new auto-fire conditions still respect the kill switch

## Coordinated repo-level changes

- The `wheels-bot push scope` ruleset (`16174270`) currently allows pushes to `bot/**`, `fix/bot-*/**`, and `docs/bot-*/**`. **No new scope needed** — address-review pushes to the same branches propose-fix and write-docs already use.

## Net effect

Before tonight: bot triages issues. Reviewers analyze PRs. Human translates feedback into edits.

After this PR: bot triages → fixes → reviews → iterates to consensus → applies consensus → reviews again → loops to converge. Even deadlocks resolve via Opus tie-breaker. The bot is now **end-to-end iterative**, with bounded effort and human-as-final-merge-gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)