### PR TITLE
ci: gate ForgeBox publish to main; restore box.json for stable artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,10 +164,10 @@ jobs:
             fi
 
             # Locate the package manifest. Prefer wheels.json (post-rename in 4.0)
-            # over box.json (legacy CommandBox/ForgeBox format). The legacy
-            # ForgeBox-bound artifacts (wheels-base-template, wheels-cli,
-            # wheels-starter-app) still carry box.json; wheels-core now uses
-            # wheels.json. This validator handles both.
+            # over box.json (legacy CommandBox/ForgeBox format). All ForgeBox-bound
+            # artifacts (wheels-base-template, wheels-cli, wheels-starter-app)
+            # carry box.json; wheels-core ships both manifests during the
+            # transition window. This validator prefers wheels.json when present.
             local MANIFEST=""
             if [ -f "$PACKAGE_DIR/wheels.json" ]; then
               MANIFEST="$PACKAGE_DIR/wheels.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,13 @@ jobs:
         run: |
          ./tools/build/scripts/prepare-starterApp.sh "${{ env.WHEELS_VERSION }}"
 
+      # CommandBox is only needed for the ForgeBox publish below; it has no
+      # other consumer in this workflow. Develop snapshots no longer publish
+      # to ForgeBox (they go to wheels-dev/wheels-snapshots via Create Snapshot
+      # Pre-Release further down), so we save ~30s of CommandBox install on
+      # every snapshot run by gating this to stable releases only.
       - name: Install CommandBox
+        if: github.ref == 'refs/heads/main'
         run: |
           curl -fsSl https://downloads.ortussolutions.com/debs/gpg | sudo gpg --dearmor -o /usr/share/keyrings/ortussolutions.gpg
           echo "deb [signed-by=/usr/share/keyrings/ortussolutions.gpg] https://downloads.ortussolutions.com/debs/noarch /" | sudo tee /etc/apt/sources.list.d/ortussolutions.list
@@ -211,7 +217,14 @@ jobs:
           echo "All packages validated successfully!"
           echo "=========================================="
 
+      # ForgeBox publishing is stable-only (main branch). Snapshots publish to
+      # wheels-dev/wheels-snapshots via the Create Snapshot Pre-Release step
+      # downstream — that's the canonical bleeding-edge channel post-4.0.
+      # Once ForgeBox is fully deprecated, this entire step (and all the
+      # ForgeBox-shaped Prepare* / Install CommandBox / Validate steps above)
+      # can be deleted as cleanup.
       - name: Publish All Packages to ForgeBox
+        if: github.ref == 'refs/heads/main'
         run: |
           # Publish stable release and mark as current/stable version
           ./tools/build/scripts/publish-to-forgebox.sh "wheels-dev" "${{ secrets.FORGEBOX_PASS }}" "true" "true"

--- a/tools/build/core/box.json
+++ b/tools/build/core/box.json
@@ -1,0 +1,38 @@
+{
+    "name":"Wheels Core",
+    "version":"@build.version@",
+    "author":"Wheels Core Team and Community",
+    "shortDescription":"Wheels Framework Core Directory",
+    "location":"ForgeboxStorage",
+    "slug":"wheels-core",
+    "directory":"vendor/wheels",
+    "createPackageDirectory":true,
+    "packageDirectory":"vendor/wheels",
+    "homepage":"https://wheels.dev/",
+    "documentation":"https://wheels.dev/docs",
+    "changelog":"https://github.com/wheels-dev/wheels/blob/master/CHANGELOG.md",
+    "bugs":"https://github.com/wheels-dev/wheels/issues",
+		"contributors":[
+			"Peter Amiri <peter@alurium.com>"
+		],
+    "repository":{
+        "type":"git",
+        "URL":"https://github.com/wheels-dev/wheels"
+    },
+    "keywords":[
+        "mvc",
+        "rails",
+        "wheels",
+        "wheels.dev",
+        "core"
+    ],
+    "ignore":[],
+    "type":"mvc",
+    "private":false,
+    "license":[
+        {
+            "type":"Apache License 2.0",
+            "URL":"https://github.com/wheels-dev/wheels/blob/master/LICENSE"
+        }
+    ]
+}

--- a/tools/build/core/box.json
+++ b/tools/build/core/box.json
@@ -10,7 +10,7 @@
     "packageDirectory":"vendor/wheels",
     "homepage":"https://wheels.dev/",
     "documentation":"https://wheels.dev/docs",
-    "changelog":"https://github.com/wheels-dev/wheels/blob/master/CHANGELOG.md",
+    "changelog":"https://github.com/wheels-dev/wheels/blob/main/CHANGELOG.md",
     "bugs":"https://github.com/wheels-dev/wheels/issues",
 		"contributors":[
 			"Peter Amiri <peter@alurium.com>"
@@ -32,7 +32,7 @@
     "license":[
         {
             "type":"Apache License 2.0",
-            "URL":"https://github.com/wheels-dev/wheels/blob/master/LICENSE"
+            "URL":"https://github.com/wheels-dev/wheels/blob/main/LICENSE"
         }
     ]
 }

--- a/tools/build/scripts/prepare-core.sh
+++ b/tools/build/scripts/prepare-core.sh
@@ -33,10 +33,19 @@ rm -rf "${BUILD_DIR}/wheels/docs"
 mkdir -p "${BUILD_DIR}/wheels/docs"
 cp -r docs/* "${BUILD_DIR}/wheels/docs/"
 
-# Copy template files. The manifest is now wheels.json (renamed from box.json
-# in 4.0.0 — the legacy box.json was a CommandBox/ForgeBox artifact). Slim
-# schema; no ForgeBox post-processing needed.
+# Copy template files. The package now ships TWO manifests:
+#
+#   wheels.json — the new Wheels-native manifest (slim schema, what the framework
+#                 reads at runtime via FrameworkInstaller, Module.runUpgradeCheck,
+#                 Global.$buildReleaseZip, etc.).
+#   box.json    — CommandBox/ForgeBox-shaped manifest, retained because
+#                 `forgebox publish` reads slug/version/type/etc. from box.json
+#                 natively — we can't make CommandBox polyglot without forking
+#                 it. Once ForgeBox publishing is fully retired (post-4.0
+#                 cleanup), the box.json template can be deleted alongside
+#                 publish-to-forgebox.sh.
 cp tools/build/core/wheels.json "${BUILD_DIR}/wheels/wheels.json"
+cp tools/build/core/box.json "${BUILD_DIR}/wheels/box.json"
 cp tools/build/core/README.md "${BUILD_DIR}/wheels/README.md"
 
 # Replace version placeholders


### PR DESCRIPTION
## Summary

Fixes the snapshot pipeline failure observed on develop after PR #2545 merged. The "Publish All Packages to ForgeBox" step failed with `ERROR: box.json not found in build-wheels-core/wheels` because PR #2545 renamed the manifest to `wheels.json` but `publish-to-forgebox.sh` reads `box.json` natively via CommandBox.

The cascade meant every step downstream of ForgeBox publish was skipped — including the new `Create Snapshot Pre-Release` that publishes to `wheels-dev/wheels-snapshots`. So the BE pipeline never produced its first snapshot.

## What changed

**Restore `tools/build/core/box.json`** (recovered from `fc128d693^`) so the wheels-core artifact ships BOTH manifests:
- `wheels.json` — Wheels-native, what the framework reads at runtime
- `box.json` — CommandBox/ForgeBox-shaped, what `forgebox publish` reads natively

`tools/build/scripts/prepare-core.sh` now copies both templates into the build dir. Comment explains both files exist for the transition window; once ForgeBox publishing is retired post-4.0, `box.json` template + `publish-to-forgebox.sh` can be deleted together.

**Gate ForgeBox publishing to main only** in `release.yml`:
- `Install CommandBox` step → `if: github.ref == 'refs/heads/main'`
- `Publish All Packages to ForgeBox` step → `if: github.ref == 'refs/heads/main'`

Develop snapshots now skip both steps cleanly. `Validate Package Structure and Versions` left ungated — it's pure bash/jq, format-agnostic since PR #2545, and useful as a sanity check on every build.

## Test plan

- [ ] CI green (commitlint will validate `ci:` type-no-scope)
- [ ] After merge to develop: next push to develop fires snapshot.yml → release.yml → builds artifacts, skips ForgeBox publish, runs `Create Snapshot Pre-Release` → first release lands at `https://github.com/wheels-dev/wheels-snapshots/releases`
- [ ] Tuesday GA: `v4.0.0` tag on main fires release.yml. Install CommandBox runs (gated condition true), validate runs, ForgeBox publish runs (finds box.json in wheels-core artifact), all good.

## Refs

#2545 (PR that introduced the box.json rename without restoring the legacy template for ForgeBox compat).