### PR TITLE
fix: resolve Linux package output path before cd-ing into build dir

### DIFF
--- a/tools/distribution-drafts/linux-packages/build-linux-packages.sh
+++ b/tools/distribution-drafts/linux-packages/build-linux-packages.sh
@@ -144,9 +144,16 @@ NFPM_EXTRA_EOF
 # they live alongside lucli in /opt/wheels/.
 
 # ── Run nfpm ─────────────────────────────────────────────────────────────
-cd "${BUILD_DIR}"
+# Resolve the output path BEFORE cd-ing into BUILD_DIR. OUT_DIR is documented
+# as repo-root-relative (the workflow passes "artifacts/wheels/${WHEELS_VERSION}")
+# but we have to `cd "${BUILD_DIR}"` for nfpm to find the staged content
+# (the nfpm config references ./build/lucli, ./build/module/, etc.). If we
+# resolved NFPM_OUT after the cd, it would land inside .linux-pkg-build/
+# instead of the repo's artifacts/ tree — and the GitHub Release upload glob
+# would silently match nothing. (Yes, this was a real bug. Run 25637518317.)
 mkdir -p "${OUT_DIR}"
-NFPM_OUT="$(pwd)/${OUT_DIR}"
+NFPM_OUT="$(cd "${OUT_DIR}" && pwd)"
+cd "${BUILD_DIR}"
 
 if ! command -v nfpm >/dev/null 2>&1; then
   echo "nfpm not found on PATH. Install from https://github.com/goreleaser/nfpm/releases" >&2


### PR DESCRIPTION
## Summary

The first successful develop snapshot publish (run [25637518317](https://github.com/wheels-dev/wheels/actions/runs/25637518317)) landed at https://github.com/wheels-dev/wheels-snapshots/releases/tag/v4.0.0-snapshot.1786 with **18 assets** ✅ — but the .deb and .rpm Linux packages are missing from the asset list. This PR fixes the path-resolution bug that caused them to land in the wrong directory.

## Root cause

`build-linux-packages.sh` lines 147-149 (pre-fix):
```bash
cd "${BUILD_DIR}"
mkdir -p "${OUT_DIR}"
NFPM_OUT="$(pwd)/${OUT_DIR}"
```

`OUT_DIR` is documented as repo-root-relative (workflow passes `artifacts/wheels/${WHEELS_VERSION}`). But the script `cd`s into `${BUILD_DIR}` (which is absolute, `${repo}/.linux-pkg-build`) BEFORE resolving `NFPM_OUT`. After the cd:

- `pwd` returns `${repo}/.linux-pkg-build`
- `mkdir -p "${OUT_DIR}"` creates `${repo}/.linux-pkg-build/artifacts/wheels/${VERSION}/` (wrong place)
- `NFPM_OUT` becomes `${repo}/.linux-pkg-build/artifacts/wheels/${VERSION}` (wrong place)
- nfpm writes the .deb/.rpm there
- GitHub Release upload glob `artifacts/wheels/${VERSION}/wheels_*_amd64.deb` (repo-root-relative) matches nothing
- softprops/action-gh-release silently no-ops on empty globs → release publishes without the packages

Build log line 4453 confirms:
```
created package: /home/runner/work/wheels/wheels/.linux-pkg-build/artifacts/wheels/4.0.0-snapshot.1786/wheels_4.0.0~snapshot.1786_amd64.deb
```

## Fix

Resolve `OUT_DIR` to absolute path BEFORE the `cd`. The `cd` is still required so nfpm can find staged content referenced relatively in the nfpm YAML config (`./build/lucli`, `./build/module/`, etc.).

```bash
mkdir -p "${OUT_DIR}"
NFPM_OUT="$(cd "${OUT_DIR}" && pwd)"   # absolute, captured before cd-ing
cd "${BUILD_DIR}"
```

## Why this matters for Tuesday

Stable (main) runs the same nfpm step. Without this fix, `v4.0.0` GA would also be missing its `.deb`/`.rpm` Linux packages — Linux users would have no install path on day one.

## Refs

#2545 (introduced the bug — `build-linux-packages.sh`)
#2547 (fixed an unrelated URL bug in the same script)