### PR TITLE
docs: add release channels page; link from installing.mdx

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
@@ -30,6 +30,12 @@ The `wheels` CLI bundles a Lucee runtime — that's the easiest path for develop
   On macOS, `openjdk@21` is keg-only — Homebrew won't symlink it into `/opt/homebrew`. The `wheels` CLI handles this itself, but if you want to call `java` directly (or use it from an IDE, Maven, Gradle, etc.) you'll also need to set `JAVA_HOME` and add it to your `PATH`. See [Troubleshooting](#troubleshooting) below.
 </Aside>
 
+## Choose a channel
+
+Wheels ships on two parallel channels. The instructions below install **stable** (`wheels`) — the right pick for ~95% of users. If you want bleeding-edge (`wheels-be`, tracks every merge to `develop`), see [Release Channels](/v4-0-0-snapshot/start-here/release-channels/) for the comparison and install steps.
+
+The two are mutually exclusive — both expose the `wheels` binary. You install one, not both. You can switch later without losing any of your already-scaffolded apps.
+
 ## Install the CLI
 
 <Tabs>

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/release-channels.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/release-channels.mdx
@@ -1,0 +1,194 @@
+---
+title: Release Channels
+description: Choose between Wheels stable and bleeding-edge — and switch between them.
+type: explanation
+sidebar:
+  order: 5
+---
+
+import { Aside, Tabs, TabItem, Steps, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+Wheels ships on two parallel channels. Pick the one that matches how much churn you can absorb.
+
+## Stable vs bleeding-edge at a glance
+
+|  | **Stable** | **Bleeding-edge** |
+|---|---|---|
+| Package name | `wheels` | `wheels-be` |
+| Tracks | GA tags on `main` | Snapshot pre-releases on `develop` |
+| Update cadence | When a new GA ships (~quarterly) | On every merge to `develop` (multiple per day during active development) |
+| Source repo | [`wheels-dev/wheels`](https://github.com/wheels-dev/wheels) | [`wheels-dev/wheels-snapshots`](https://github.com/wheels-dev/wheels-snapshots) |
+| Best for | Production apps, teams that want predictability | Framework contributors, early adopters, validating fixes before they GA |
+| Version string shape | `4.0.0`, `4.1.0` | `4.0.1-snapshot.1700` |
+| `wheels --version` reports | `(stable)` | `(bleeding-edge)` |
+
+## How to tell which channel you're on
+
+```bash title="your shell"
+wheels --version
+```
+
+The output's parenthetical tells you the channel:
+
+```
+Wheels Version: 4.0.0 (stable)
+```
+
+…or:
+
+```
+Wheels Version: 4.0.0-snapshot.1787 (bleeding-edge)
+```
+
+If you see `(development)` instead, you're running from a dev checkout (cloned source repo) rather than an installed package — which is its own thing and not covered here.
+
+## Installing each channel
+
+<Tabs>
+
+<TabItem label="macOS" icon="apple">
+
+```bash title="your shell"
+brew tap wheels-dev/wheels
+
+# Stable
+brew install wheels
+
+# Bleeding-edge
+brew install wheels-be
+```
+
+The two formulas are mutually exclusive — both expose the `wheels` binary, so Homebrew refuses to install both at once. To switch channels, uninstall one and install the other (see [Switching channels](#switching-channels) below).
+
+</TabItem>
+
+<TabItem label="Windows" icon="seti:windows">
+
+A Scoop bucket is in the works. Until it lands, install manually from the corresponding releases page:
+
+- **Stable**: download `wheels-module-<version>.zip` from [github.com/wheels-dev/wheels/releases](https://github.com/wheels-dev/wheels/releases).
+- **Bleeding-edge**: download `wheels-module-<version>.zip` from [github.com/wheels-dev/wheels-snapshots/releases](https://github.com/wheels-dev/wheels-snapshots/releases).
+
+The rest of the install steps are identical — see [Installing Wheels → Windows](/v4-0-0-snapshot/start-here/installing/#install-the-cli) for the LuCLI launcher and module-extraction details.
+
+</TabItem>
+
+<TabItem label="Linux" icon="linux">
+
+Each channel ships `.deb` and `.rpm` packages on its respective releases page:
+
+- **Stable**: [github.com/wheels-dev/wheels/releases](https://github.com/wheels-dev/wheels/releases)
+- **Bleeding-edge**: [github.com/wheels-dev/wheels-snapshots/releases](https://github.com/wheels-dev/wheels-snapshots/releases)
+
+```bash title="Debian / Ubuntu (stable)"
+curl -fsSLO https://github.com/wheels-dev/wheels/releases/latest/download/wheels_<version>_amd64.deb
+sudo apt install ./wheels_<version>_amd64.deb
+```
+
+```bash title="Fedora / RHEL (bleeding-edge)"
+curl -fsSLO https://github.com/wheels-dev/wheels-snapshots/releases/latest/download/wheels-<version>.x86_64.rpm
+sudo dnf install ./wheels-<version>.x86_64.rpm
+```
+
+Apt and yum repos at `apt.wheels.dev` / `yum.wheels.dev` are coming — they'll let you `apt upgrade wheels` instead of re-downloading.
+
+</TabItem>
+
+</Tabs>
+
+<Aside type="caution" title="Version string format on .deb / .rpm">
+GitHub Releases doesn't allow `~` in asset filenames, so the SemVer pre-release tilde gets normalized to a dot. The on-disk filename for snapshot 1787 is `wheels_4.0.0.snapshot.1787_amd64.deb`, not `wheels_4.0.0~snapshot.1787_amd64.deb`. The package's *internal* version (what `dpkg --info` reports) keeps the tilde for correct precedence.
+</Aside>
+
+## Switching channels
+
+The `wheels` and `wheels-be` packages declare a Homebrew `conflicts_with` so they can't coexist. To switch:
+
+```bash title="stable → bleeding-edge"
+brew uninstall wheels
+brew install wheels-be
+```
+
+```bash title="bleeding-edge → stable"
+brew uninstall wheels-be
+brew install wheels
+```
+
+### What happens to your apps when you switch
+
+**Already-scaffolded apps are unaffected.** Each Wheels app commits its own copy of the framework into `vendor/wheels/` at scaffold time, so the version baked into your project is independent of what channel your CLI is on. Switching `wheels` → `wheels-be` only affects what *next* `wheels new` produces.
+
+If you want an existing app to follow the channel switch:
+
+```bash title="inside the app"
+wheels upgrade --to=<version>
+```
+
+…or just re-scaffold the app's `vendor/wheels/` from a fresh `wheels new`.
+
+## When to pick which
+
+**Pick stable (`wheels`) when:**
+- You're shipping a production app
+- You want predictable upgrade windows (one major release per ~quarter, see [Upgrading Wheels](/v4-0-0-snapshot/upgrading/))
+- You don't want to think about CI breaking from upstream churn
+- You're following the [tutorial](/v4-0-0-snapshot/start-here/tutorial/) — it's pinned to stable behavior
+
+**Pick bleeding-edge (`wheels-be`) when:**
+- You're contributing to Wheels and want to dogfood your changes
+- You're validating that an upcoming fix lands correctly before GA
+- You're early-adopting a feature that's merged but not yet released
+- You're OK with the occasional regression (we revert quickly, but the window exists)
+
+If you're not sure, install **stable**. You can always switch later — your apps come with you.
+
+## How the channels work under the hood
+
+This section is for the curious. If you just want to use Wheels, you can skip it.
+
+### What "snapshot" means
+
+A snapshot is an automated pre-release built and published on every merge to the [`develop`](https://github.com/wheels-dev/wheels/tree/develop) branch. The version string `4.0.0-snapshot.1787` decodes as:
+
+- `4.0.0` — the *target* of the next release (a baseline, not a commitment — the actual GA could end up being `4.0.0`, `4.0.1`, `4.1.0`, or whatever the maintainer picks at tag time)
+- `-snapshot` — SemVer pre-release identifier (sorts strictly less than `4.0.0`)
+- `.1787` — `github.run_number` of the workflow that built it (monotonically increasing)
+
+So `brew upgrade wheels-be` always lands on a numerically-newer snapshot, and any GA release sorts strictly higher than every snapshot that preceded it.
+
+### Where snapshots live
+
+Snapshots publish to [`wheels-dev/wheels-snapshots`](https://github.com/wheels-dev/wheels-snapshots) instead of the main repo's Releases page. The split keeps the main repo's Releases page focused on GA tags (~6–12 per year) instead of drowning them under snapshot churn (~200–500 per year). Snapshots auto-delete after 30 days; GA releases stay forever.
+
+### Auto-update propagation
+
+When a snapshot publishes:
+
+1. The release workflow on `wheels-dev/wheels` dispatches a `wheels-released` event to the brew tap with `channel=bleeding-edge` in the payload.
+2. The tap's `bleeding-edge-update.yml` workflow fires, computes fresh sha256s, opens an auto-bump PR for `Formula/wheels-be.rb`.
+3. Tap CI validates the formula (`brew audit` + `brew fetch`), maintainer rubberstamps, the PR auto-merges.
+4. `brew upgrade wheels-be` lands the new version on user machines.
+
+End-to-end latency: ~5–10 minutes from develop merge to user-installable.
+
+For stable releases, the same chain runs against `Formula/wheels.rb` and the `auto-update.yml` workflow.
+
+## Related guides
+
+<CardGrid>
+  <LinkCard
+    title="Installing Wheels"
+    href="/v4-0-0-snapshot/start-here/installing/"
+    description="The full install instructions for both channels."
+  />
+  <LinkCard
+    title="Upgrading Wheels"
+    href="/v4-0-0-snapshot/upgrading/"
+    description="Move between Wheels versions inside an existing app."
+  />
+  <LinkCard
+    title="Your First 15 Minutes"
+    href="/v4-0-0-snapshot/start-here/first-15-minutes/"
+    description="Zero to a running page."
+  />
+</CardGrid>


### PR DESCRIPTION
## Summary

Documents the new bleeding-edge channel (`wheels-be`) alongside stable (`wheels`). Doubles as the **end-to-end soft-launch validation** for the BE pipeline that just went live in #2545, #2547, #2548 + [homebrew-wheels#174](https://github.com/wheels-dev/homebrew-wheels/pull/174).

## What's in the diff

### New: `start-here/release-channels.mdx`

Self-contained guide covering:

- **Comparison table**: package name, tracking branch, update cadence, source repo, version string shape, what `wheels --version` reports
- **How to tell which channel you're on** — channel-aware `wheels --version` output
- **Install steps** for each channel on macOS / Windows / Linux
- **Switching channels** — uninstall one, install the other (mutually exclusive via brew's `conflicts_with`)
- **What happens to your apps** — already-scaffolded `vendor/wheels/` is unaffected; only next `wheels new` follows the channel switch
- **Decision guide**: when to pick stable vs bleeding-edge
- **Optional "How channels work under the hood"** section — snapshot version format, separate `wheels-snapshots` repo rationale, auto-update propagation chain (~5-10min from develop merge to user-installable)

### Modified: `start-here/installing.mdx`

Adds a "Choose a channel" section at the top of the install instructions, pointing at the new page. Doesn't disrupt the happy path — stable is still the default and all subsequent install steps are unchanged.

## Sidebar order

`release-channels.mdx` is `order: 5`, placed after the tutorial happy path:
1. Welcome
2. Why Wheels?
3. Installing Wheels
4. Your First 15 Minutes
5. **Release Channels** (new)
6. CFML Engines

Users new to Wheels follow 1→2→3→4→tutorial without bumping into channel discussion. Users who care about channels find the page from the install page's pointer or the sidebar.

## Validation goals (the soft-launch part)

When this merges to develop, **all of the following should happen automatically within ~10 minutes:**

1. ✅ `snapshot.yml` fires on the merge commit
2. ✅ `release.yml` builds artifacts, publishes `v4.0.0-snapshot.<run>` to [wheels-dev/wheels-snapshots](https://github.com/wheels-dev/wheels-snapshots/releases) (gates ForgeBox publish + CommandBox install on main)
3. ✅ Linux `.deb`/`.rpm` land in the release (path-resolution bug fixed in #2548)
4. ✅ Dispatch fires to homebrew-wheels with `channel=bleeding-edge` in payload
5. ✅ `bleeding-edge-update.yml` (the new tap workflow) fires — **NOT** `auto-update.yml`
6. ✅ Auto-bump PR opens against `Formula/wheels-be.rb` with the new version + sha256s
7. ✅ Tap CI validates (`brew audit` + `brew fetch`)
8. ✅ `brew upgrade wheels-be` lands the new snapshot

After this PR merges, I'll watch each step and surface any failure.

## Refs

- #2545 (BE channel pipeline + wheels.json migration + Linux packages)
- #2547 (LuCLI asset URL fix)
- #2548 (Linux package output path fix)
- [homebrew-wheels#174](https://github.com/wheels-dev/homebrew-wheels/pull/174) (wheels-be formula + bleeding-edge-update workflow)
- First validated snapshot: [v4.0.0-snapshot.1787](https://github.com/wheels-dev/wheels-snapshots/releases/tag/v4.0.0-snapshot.1787)

## Test plan

- [ ] CI green (commitlint, docs-validation, etc.)
- [ ] Docs site preview deploys correctly (Starlight build)
- [ ] After merge: validation chain steps 1-8 above all green
- [ ] Visit `https://guides.wheels.dev/v4-0-0-snapshot/start-here/release-channels/` after the docs site rebuild