### PR TITLE
fix: pass explicit commit-message to wrangler (snapshot.yml + web-deploy.yml)

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -278,7 +278,16 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           DEPLOY_BRANCH: ${{ github.ref_name }}
         run: |
+          # Pass --commit-message explicitly. Without it, wrangler auto-derives
+          # the commit message from git, and Cloudflare's API rejected this
+          # repo's auto-generated GitHub merge commit body in run 25641189988
+          # with "Invalid commit message, it must be a valid UTF-8 string"
+          # (despite the body being valid UTF-8 — CF appears to have a stricter
+          # rule than the error message implies). The fix is to send a short
+          # ASCII-only message derived from the version + run; that always works.
+          VERSION=$(jq -r '.version' ../wheels.json)
           pnpm dlx wrangler@4.78.0 pages deploy "sites/api/dist" \
             --project-name="wheels-api" \
             --branch="${DEPLOY_BRANCH}" \
-            --commit-hash="${GITHUB_SHA}"
+            --commit-hash="${GITHUB_SHA}" \
+            --commit-message="snapshot deploy: ${VERSION}-snapshot (run ${GITHUB_RUN_ID})"

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -63,10 +63,17 @@ jobs:
           DEPLOY_BRANCH: ${{ github.head_ref || github.ref_name }}
           SITE: ${{ matrix.site }}
         run: |
+          # Pass --commit-message explicitly. wrangler auto-derives from git
+          # when omitted, and Cloudflare's API rejects non-ASCII content in
+          # auto-merged GitHub commit bodies (em-dashes, arrows, etc.) with
+          # "Invalid commit message, it must be a valid UTF-8 string". Send
+          # a controlled ASCII string instead. See PR #2550 for the snapshot.yml
+          # variant of this fix and the originating failure (run 25641189988).
           pnpm dlx wrangler@4.78.0 pages deploy "sites/${SITE}/dist" \
             --project-name="wheels-${SITE}" \
             --branch="${DEPLOY_BRANCH}" \
-            --commit-hash="${GITHUB_SHA}"
+            --commit-hash="${GITHUB_SHA}" \
+            --commit-message="deploy ${SITE} from ${DEPLOY_BRANCH} (run ${GITHUB_RUN_ID})"
 
   visual-regression:
     name: Visual regression


### PR DESCRIPTION
## Summary

Run [25641189988](https://github.com/wheels-dev/wheels/actions/runs/25641189988) (snapshot for PR #2549's merge) succeeded on the BE pipeline core but failed on the parallel `deploy-api-snapshot` job. Cloudflare API rejected the deploy:

```
ERROR: A request to the Cloudflare API (.../pages/.../deployments) failed.
  Invalid commit message, it must be a valid UTF-8 string. [code: 8000111]
```

While diagnosing, I discovered `web-deploy.yml` has the **same wrangler invocation** with the same omission. That workflow runs on every push to develop/main across 5 sites. If `v4.0.0` GA's tag commit body has non-ASCII characters (very likely in release notes), all 5 deploys would fail tomorrow.

Fixing both in this PR.

## Root cause

When `--commit-message` is omitted, wrangler auto-derives the message from the latest git commit. PR #2549's auto-generated GitHub merge commit body contained em-dashes (`—`) and arrows (`→`) — valid UTF-8 but Cloudflare's API rejects them anyway. CF's error says "UTF-8" but the actual rule appears stricter (possibly ASCII-only).

This wasn't caught by prior snapshot deploys because earlier PR merge messages happened to be plain ASCII.

## Fix (applied to both workflows)

Pass `--commit-message` explicitly with an ASCII-only string composed of controlled values:

**snapshot.yml** (`deploy-api-snapshot` job):
```bash
--commit-message="snapshot deploy: ${VERSION}-snapshot (run ${GITHUB_RUN_ID})"
```

**web-deploy.yml** (5-site matrix deploy):
```bash
--commit-message="deploy ${SITE} from ${DEPLOY_BRANCH} (run ${GITHUB_RUN_ID})"
```

No user-content flows into the API call. Bonus: every deploy is now self-describing in CF Pages's deployment list.

## Test plan

- [ ] CI green (commitlint, etc.)
- [ ] After merge: next develop snapshot's `deploy-api-snapshot` succeeds and updates api.wheels.dev
- [ ] **Tomorrow's v4.0.0 GA**: `web-deploy.yml` deploys all 5 sites cleanly (guides, blog, api, landing, packages)

## Why this matters for Tuesday GA

Without the web-deploy.yml fix, tomorrow's `v4.0.0` tag would likely fail to deploy ANY of the 5 sites if the release notes commit body has typical em-dash/arrow content. Merging this PR before Tuesday is a meaningful pre-GA derisking.

## Refs

- Failed run: https://github.com/wheels-dev/wheels/actions/runs/25641189988
- Triggering PR: #2549 (docs PR with em-dashes / arrows in commit body)