### PR TITLE
fix: update blob/master to blob/main in base template manifest

### DIFF
--- a/tools/build/base/box.json
+++ b/tools/build/base/box.json
@@ -44,7 +44,7 @@
     "license":[
         {
             "type":"Apache License 2.0",
-            "URL":"https://github.com/wheels-dev/wheels/blob/master/LICENSE"
+            "URL":"https://github.com/wheels-dev/wheels/blob/main/LICENSE"
         }
     ],
     "scripts":{


### PR DESCRIPTION
## Summary

- The `wheels-base-template` ForgeBox package's `license[].URL` in `tools/build/base/box.json` still pointed at `blob/master/LICENSE`. The repo's default branch has been `main` since the v3.0 rebrand, so the link soft-404s on the ForgeBox package page.
- [PR #2546](https://github.com/wheels-dev/wheels/pull/2546) fixed the same issue in the sister `tools/build/core/box.json`. Reviewer A flagged the base file as a pre-existing issue out of scope for that PR — this catches it.
- No `changelog` field exists in this manifest; the LICENSE URL is the only `blob/master/` reference.

## Test plan

- [x] `grep -n master tools/build/base/box.json` returns nothing after the change
- [ ] Next ForgeBox publish of `wheels-base-template` renders the license link as a working `https://github.com/wheels-dev/wheels/blob/main/LICENSE`