### PR TITLE
docs: document GitHub Releases tilde-to-dot filename mangling

### DIFF
--- a/.github/RELEASE_PLAYBOOK.md
+++ b/.github/RELEASE_PLAYBOOK.md
@@ -144,6 +144,7 @@ If any pin to `<X.Y.Z`, open issues on those repos to widen the constraint.
 | brew tap PR doesn't open after release | `DOWNSTREAM_DISPATCH_TOKEN` expired or unset | Rotate token in repo secrets; re-run `release.yml` workflow_dispatch |
 | `brew install wheels` post-release fails | Formula sha256 mismatch | Re-run the tap bump workflow with `workflow_dispatch` to recompute |
 | Snapshot publish fails: "tag already exists" | Re-run after partial success | Delete the orphaned tag in `wheels-dev/wheels-snapshots`, re-run |
+| Linux package URL 404s when version has `~snapshot.N` | GitHub Releases silently rewrites `~` to `.` in uploaded asset filenames | Use `.` in the URL: `wheels_4.0.0.snapshot.1787_amd64.deb`, NOT `wheels_4.0.0~snapshot.1787_amd64.deb`. The on-disk filename keeps `~` (so `dpkg --compare-versions` orders pre-releases correctly), but the uploaded URL gets mangled. Downstream consumers (apt repo metadata generator, install scripts) must compute the `.`-form. See `tools/distribution-drafts/linux-packages/build-linux-packages.sh`. |
 
 ## See also
 

--- a/tools/distribution-drafts/linux-packages/README.md
+++ b/tools/distribution-drafts/linux-packages/README.md
@@ -21,9 +21,9 @@ opt in pre-Phase-2 do:
 curl -fsSLO https://github.com/wheels-dev/wheels/releases/download/v4.0.0/wheels_4.0.0_amd64.deb
 sudo apt install ./wheels_4.0.0_amd64.deb
 
-# Bleeding-edge
-curl -fsSLO https://github.com/wheels-dev/wheels-snapshots/releases/download/v4.0.1-snapshot.1700/wheels-be_4.0.1~snapshot.1700_amd64.deb
-sudo apt install ./wheels-be_4.0.1~snapshot.1700_amd64.deb
+# Bleeding-edge — note the `.` (not `~`) in the URL; see "Tilde mangling" below
+curl -fsSLO https://github.com/wheels-dev/wheels-snapshots/releases/download/v4.0.1-snapshot.1700/wheels-be_4.0.1.snapshot.1700_amd64.deb
+sudo apt install ./wheels-be_4.0.1.snapshot.1700_amd64.deb
 ```
 
 Same for RPM via `dnf install`.
@@ -32,6 +32,33 @@ The `~snapshot` tilde is required: `.deb` and `.rpm` use `~` (not `-`) as the
 pre-release separator. The build script translates `-snapshot.N` to
 `~snapshot.N` automatically. Both result in the snapshot package sorting
 *below* the next GA version per `dpkg --compare-versions` and `rpmvercmp`.
+
+### Tilde mangling on GitHub Releases (sharp edge)
+
+The on-disk filename produced by nfpm is `wheels_4.0.0~snapshot.1787_amd64.deb`
+(correct SemVer pre-release form with `~`). However, **GitHub Releases silently
+rewrites `~` to `.` in uploaded asset filenames**, so the downloadable URL is
+`wheels_4.0.0.snapshot.1787_amd64.deb`.
+
+This is a one-way mangling at upload time — the URL form is the only form
+consumers can `curl`. The metadata *inside* the package still contains `~`
+(verifiable via `dpkg-deb -I` or `rpm -qip`), so once installed, `apt`/`dpkg`
+order the version correctly relative to GA releases. Only the delivery handle
+changes.
+
+Verify on any snapshot:
+```bash
+gh release view v4.0.0-snapshot.1787 --repo wheels-dev/wheels-snapshots \
+  --json assets -q '.assets[].name' | grep -E '\.(deb|rpm)$'
+# wheels-4.0.0.snapshot.1787.x86_64.rpm
+# wheels_4.0.0.snapshot.1787_amd64.deb
+```
+
+Practical impact for this directory:
+- `build-linux-packages.sh` writes the `~`-form to disk (correct for nfpm and
+  on-server `dpkg`). Uploading the artifact is what produces the `.`-form URL.
+- Anyone publishing a download URL (docs, install scripts, brew formulae,
+  Phase 2 apt repo metadata) MUST use the `.`-form or hit 404.
 
 ## Phase 2: apt.wheels.dev / yum.wheels.dev (post-Tuesday)
 
@@ -46,6 +73,23 @@ the `.deb` / `.rpm` files in a `pool/` directory. A CI workflow listens for
 `repository_dispatch` from the source repo's release workflows, fetches new
 artifacts, regenerates metadata, signs with GPG, commits and pushes — CF Pages
 auto-deploys on push.
+
+**Filename gotcha for the metadata generator**: when fetching snapshot
+artifacts from the source repo's GitHub Release, the URL filenames have `.`
+where the nfpm-produced names had `~` (see "Tilde mangling" above). The
+metadata generator must compute the `.`-form filename to actually fetch the
+file, then either:
+
+1. Rename to the `~`-form in `pool/` so `Packages.gz` `Filename:` fields use
+   the canonical SemVer pre-release name (preferred — matches what users see
+   from `apt-cache show`), or
+2. Keep the `.`-form on disk in `pool/` and emit `.`-form in `Packages.gz`
+   (simpler — fewer renames in the pipeline).
+
+Either way is correct on the `apt`/`dpkg` ordering side, since the version
+field inside the `.deb`'s control metadata still has `~`. Pick one and stay
+consistent; option 1 reads more naturally if a user pokes around at
+`apt.wheels.dev/pool/` directly.
 
 User setup post-Phase-2:
 

--- a/tools/distribution-drafts/linux-packages/build-linux-packages.sh
+++ b/tools/distribution-drafts/linux-packages/build-linux-packages.sh
@@ -163,6 +163,21 @@ fi
 # Translate WHEELS_VERSION (with -snapshot.N) into a SemVer-friendly form for
 # .deb/.rpm. Both formats accept a tilde for pre-release ordering: `4.0.1~snapshot.1700`
 # sorts BELOW 4.0.1 (which is correct — snapshot 1700 ships before GA 4.0.1).
+#
+# Sharp edge — disk filename vs upload filename diverge:
+#   The output below is written to disk as `wheels_<v>~snapshot.<N>_amd64.deb`,
+#   which is the correct on-server name (apt/dpkg use `~` for pre-release
+#   ordering). HOWEVER, when this artifact is uploaded to a GitHub Release,
+#   GitHub silently rewrites `~` to `.` in the asset filename — the download
+#   URL ends up as `wheels_<v>.snapshot.<N>_amd64.deb`. Verified on snapshot
+#   v4.0.0-snapshot.1787 (the assets list shows `.snapshot.`, not `~snapshot.`).
+#
+#   Consequence: any consumer that constructs a download URL (Phase 2 apt repo
+#   metadata generator, install scripts, docs) MUST use the `.`-form, even
+#   though the file written here has `~`. The metadata *inside* the .deb/.rpm
+#   still contains `~`, so once installed, version ordering is correct.
+#   See tools/distribution-drafts/linux-packages/README.md § "Tilde mangling"
+#   and .github/RELEASE_PLAYBOOK.md § "Common failure modes".
 DEB_RPM_VERSION="$(echo "${WHEELS_VERSION}" | sed 's/-snapshot/~snapshot/')"
 
 WHEELS_VERSION="${DEB_RPM_VERSION}" nfpm pkg \

--- a/tools/distribution-drafts/scoop/build-manifests.py
+++ b/tools/distribution-drafts/scoop/build-manifests.py
@@ -308,7 +308,10 @@ def main() -> None:
         ("wheels.json", manifest_stable()),
     ]
     if check_mode:
-        drift = any(check_manifest(n, d) for n, d in manifests)
+        # Force a list, not a generator: any() short-circuits, which would skip the
+        # second manifest's check_manifest() (and its DRIFT log line) whenever the
+        # first one drifts. CI needs to see *all* drifting manifests in one run.
+        drift = any([check_manifest(n, d) for n, d in manifests])
         sys.exit(1 if drift else 0)
     for n, d in manifests:
         write_manifest(n, d)

--- a/tools/distribution-drafts/scoop/build-manifests.py
+++ b/tools/distribution-drafts/scoop/build-manifests.py
@@ -308,10 +308,13 @@ def main() -> None:
         ("wheels.json", manifest_stable()),
     ]
     if check_mode:
-        # Force a list, not a generator: any() short-circuits, which would skip the
-        # second manifest's check_manifest() (and its DRIFT log line) whenever the
-        # first one drifts. CI needs to see *all* drifting manifests in one run.
-        drift = any([check_manifest(n, d) for n, d in manifests])
+        # Materialize the list before any() so every check_manifest() runs and emits
+        # its DRIFT log line. any() short-circuits on generators, which would skip
+        # the second manifest whenever the first one drifts. CI needs to see *all*
+        # drifting manifests in one run. The named binding also sidesteps ruff
+        # `any(comprehension)` warnings without obscuring intent.
+        results = [check_manifest(n, d) for n, d in manifests]
+        drift = any(results)
         sys.exit(1 if drift else 0)
     for n, d in manifests:
         write_manifest(n, d)


### PR DESCRIPTION
## Summary

Two unrelated documentation/correctness fixes that fell out of validating snapshot [v4.0.0-snapshot.1787](https://github.com/wheels-dev/wheels-snapshots/releases/tag/v4.0.0-snapshot.1787):

1. **Document a sharp edge in the BE pipeline** — GitHub Releases silently rewrites `~` to `.` in uploaded asset filenames. nfpm produces `wheels_4.0.0~snapshot.1787_amd64.deb` on disk (correct SemVer pre-release form), but the downloadable URL is `wheels_4.0.0.snapshot.1787_amd64.deb`. Current behavior is correct — the `~`-form lives on disk and inside the package metadata (so `dpkg --compare-versions` orders snapshots below GA), and the `.`-form is only the URL handle. Downstream consumers (Phase 2 apt repo metadata generator, install scripts) just need to know which form to construct.
2. **Force full evaluation of manifest drift checks in the Scoop generator** — `build-manifests.py --check` used `any(check_manifest(n, d) for n, d in manifests)`. `any()` short-circuits on generators, so if `wheels-be.json` drifts, `wheels.json` is never evaluated and the second drift is silently skipped. Switched to a list comprehension so CI surfaces all drifting manifests in one run. Caught by Reviewer A; converged by Reviewer B; applied by the bot's address-review pass.

## Changes

Tilde-mangling docs:
- **[`.github/RELEASE_PLAYBOOK.md`](.github/RELEASE_PLAYBOOK.md)** — new row in "Common failure modes" table.
- **[`tools/distribution-drafts/linux-packages/README.md`](tools/distribution-drafts/linux-packages/README.md)** — new "Tilde mangling" section in Phase 1; metadata-generator note in Phase 2; fix the BE example URL (the Phase 1 example was showing the `~`-form, which 404s).
- **[`tools/distribution-drafts/linux-packages/build-linux-packages.sh`](tools/distribution-drafts/linux-packages/build-linux-packages.sh)** — extend the existing `~snapshot` translation comment with the upload-side divergence and cross-references.

Scoop drift-check fix:
- **[`tools/distribution-drafts/scoop/build-manifests.py`](tools/distribution-drafts/scoop/build-manifests.py)** — replace generator with list comprehension at the `--check` short-circuit, with an inline comment explaining why so the next reader doesn't re-introduce the generator form.

The original Scoop hardening commit (`c0f847af`) that landed on this branch before I started was squash-merged to develop independently via [wheels#2552](https://github.com/wheels-dev/wheels/pull/2552). Rebased to drop the duplicate from this PR — only the bot's `any()` fix remains on top of develop's version.

Homebrew formula and bleeding-edge update workflow were verified: they only reference `.zip` / binary artifacts (`wheels-cli-*.zip`, `wheels-core-*.zip`, lucli, sqlite-jdbc), none of which carry `~` in their version strings, so the mangling doesn't apply there — no change.

## Test plan

- [ ] Markdown renders cleanly on GitHub (tables, fenced blocks, cross-file relative links).
- [ ] `commitlint` passes: both commits are `docs:` / `fix:` (no scope, ≤100 chars).
- [ ] No CI workflows touch these paths in a way that would break (effectively docs-only + a one-line tooling fix).
- [ ] Wiring `build-manifests.py --check` into a CI job (Reviewer A's secondary suggestion) is **out of scope** for this PR — flagged for a follow-up.

## Follow-ups (not in this PR)

- [ ] Add `python3 build-manifests.py --check && python3 validate.py --offline` as a CI job so manifest drift is caught automatically. Reviewer A surfaced this; Reviewer B narrowed convergence to the `any()` fix only, so it's deferred.