### PR TITLE
feat(cli): non-blocking update check on wheels new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 - Legacy compatibility adapter for 3.x → 4.0 migration soft-landing (#2015)
 
 **CLI & LuCLI**
+- `wheels new` now prints a non-blocking hint at the end of app scaffolding when a newer Wheels release is available on the user's channel (stable, bleeding-edge). Channel-aware (skips dev/rc), 24h-cached at `$LUCLI_HOME/.update-check.json`, 5s HTTP timeout, silent on any failure — never delays or breaks `wheels new`. (#2556)
 - `wheels doctor` now detects a stale installed CLI module at `~/.wheels/modules/wheels/` that shadows a source checkout and warns with a remediation command (symlink). Previously, contributors running `wheels` from a checkout could silently execute a pre-install Module.cfc, making merged fixes appear not to take effect. (#2223)
 - LuCLI Phase 2: zero-Docker local testing via `tools/test-local.sh` (#2063)
 - LuCLI Phase 2: service layer, generators, MCP annotations (#1941)

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -4175,6 +4175,30 @@ component extends="modules.BaseModule" {
 		out("Next steps:", "bold");
 		out("  cd #appName#");
 		out("  wheels start");
+
+		// Non-blocking update check. Prints a small hint AFTER the success
+		// block if a newer wheels release is available. All errors swallow
+		// silently — the user should never be blocked or confused by a
+		// failed/slow network check. See services/UpdateChecker.cfc for the
+		// channel-aware logic + 24h cache. Wrapped in try/catch as a final
+		// belt for any failure mode the service itself doesn't already
+		// internalize (e.g., the createObject call throwing).
+		try {
+			var checker = new services.UpdateChecker();
+			var updateResult = checker.check(currentVersion=super.version());
+			if (updateResult.hasUpdate) {
+				out("");
+				out("A newer wheels (#updateResult.channel#) is available: #updateResult.latest# (you have #updateResult.current#)", "yellow");
+				out("  Upgrade: #updateResult.upgradeCommand#", "yellow");
+			}
+		} catch (any e) {
+			// Silently swallow — never let an update check delay or break
+			// `wheels new`. Log via verbose() so devs can see it with -v.
+			if (structKeyExists(variables, "verbose")) {
+				try { verbose("Update check failed: " & e.message); } catch (any ignore) {}
+			}
+		}
+
 		return "";
 
 		} finally {

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -4194,9 +4194,7 @@ component extends="modules.BaseModule" {
 		} catch (any e) {
 			// Silently swallow — never let an update check delay or break
 			// `wheels new`. Log via verbose() so devs can see it with -v.
-			if (structKeyExists(variables, "verbose")) {
-				try { verbose("Update check failed: " & e.message); } catch (any ignore) {}
-			}
+			try { verbose("Update check failed: " & e.message); } catch (any ignore) {}
 		}
 
 		return "";

--- a/cli/lucli/services/UpdateChecker.cfc
+++ b/cli/lucli/services/UpdateChecker.cfc
@@ -1,0 +1,273 @@
+/**
+ * Non-blocking "is there a newer Wheels CLI available?" check, designed to
+ * print at the end of `wheels new` so the user sees the hint right after
+ * their new app finishes scaffolding (when they're about to `cd myapp`).
+ *
+ * Design constraints:
+ *
+ *   - **Never block app creation.** All errors swallow silently. A flaky
+ *     network or rate-limited GitHub API must not delay or break `wheels new`.
+ *   - **Hard timeout 5s.** Cap the HTTP wait independent of CFML defaults.
+ *   - **24h cache** at $LUCLI_HOME/.update-check.json keyed by channel.
+ *     One real HTTP request per channel per day. The cache stores the latest
+ *     tag observed; comparisons against current happen client-side.
+ *   - **Channel-aware** via services.ReleaseChannel — stable hits the main
+ *     repo, bleeding-edge hits wheels-dev/wheels-snapshots, dev/rc skip.
+ *   - **Snapshot vs stable comparison** differ:
+ *       stable: SemVer.compare("4.0.0", "4.0.1") -> -1 (newer available)
+ *       bleeding-edge: compare the snapshot.N suffix (4.0.0-snapshot.1789 vs
+ *         4.0.0-snapshot.1790). Base SemVer part compared first; tie -> N.
+ *
+ * Public API:
+ *
+ *   var uc = new services.UpdateChecker();
+ *   var result = uc.check(currentVersion="4.0.0-snapshot.1700");
+ *   if (result.hasUpdate) {
+ *     out("A newer wheels is available: " & result.latest);
+ *     out("  Upgrade: " & result.upgradeCommand);
+ *   }
+ *
+ * Result struct shape:
+ *
+ *   {
+ *     hasUpdate:       boolean,
+ *     skipped:         boolean,        // true when channel doesn't auto-check
+ *                                       // (dev/rc) OR when cache TTL not expired
+ *                                       // AND no newer version cached
+ *     reason:          string,         // when skipped=true
+ *     current:         string,
+ *     latest:          string,         // "" when no check was made
+ *     channel:         string,
+ *     upgradeCommand:  string          // only set when hasUpdate=true
+ *   }
+ */
+component {
+
+	variables.CACHE_TTL_SECONDS = 86400; // 24h
+	variables.HTTP_TIMEOUT_SECONDS = 5;
+
+	public function init() {
+		variables.releaseChannel = new ReleaseChannel();
+		variables.semver = new SemVer();
+		variables.cachePath = $resolveCachePath();
+		return this;
+	}
+
+	/**
+	 * Main entry. Returns a result struct (see component-level docstring).
+	 * Never throws — swallows all errors, marks skipped=true with a reason.
+	 */
+	public struct function check(required string currentVersion) {
+		var channel = variables.releaseChannel.classify(arguments.currentVersion);
+		var repo = variables.releaseChannel.releaseRepo(channel);
+		var result = {
+			hasUpdate: false,
+			skipped: false,
+			reason: "",
+			current: arguments.currentVersion,
+			latest: "",
+			channel: channel,
+			upgradeCommand: ""
+		};
+
+		if (!len(repo)) {
+			result.skipped = true;
+			result.reason = "channel '" & channel & "' does not auto-check";
+			return result;
+		}
+
+		try {
+			var latest = $fetchLatestVersion(repo, channel);
+			if (!len(latest)) {
+				result.skipped = true;
+				result.reason = "no release found on " & repo;
+				return result;
+			}
+			result.latest = latest;
+
+			if ($isNewer(arguments.currentVersion, latest, channel)) {
+				result.hasUpdate = true;
+				result.upgradeCommand = variables.releaseChannel.upgradeCommand(channel);
+			}
+		} catch (any e) {
+			result.skipped = true;
+			result.reason = "check failed: " & e.message;
+		}
+
+		return result;
+	}
+
+	/**
+	 * Compare two version strings. Returns true if `latest` is strictly newer
+	 * than `current`. For bleeding-edge, the snapshot.N suffix is compared
+	 * after the base SemVer. For stable, plain SemVer.
+	 */
+	public boolean function $isNewer(required string current, required string latest, required string channel) {
+		// SemVer.compare ignores pre-release labels by design (that's its
+		// stable-channel behavior). For bleeding-edge we need to also look at
+		// the trailing snapshot.N — so we compare base first, then N.
+		var baseCmp = variables.semver.compare(arguments.current, arguments.latest);
+		if (baseCmp != 0) {
+			return baseCmp < 0; // current is older
+		}
+
+		// Base versions tied. For bleeding-edge, compare snapshot numbers.
+		if (arguments.channel == "bleeding-edge") {
+			return $snapshotNumber(arguments.latest) > $snapshotNumber(arguments.current);
+		}
+
+		// Same base, stable channel — nothing newer.
+		return false;
+	}
+
+	/**
+	 * Extract the trailing snapshot build number from a version string. Returns
+	 * 0 if no snapshot suffix found (lets the comparison treat it as "older
+	 * than any snapshot").
+	 *
+	 * Handles both formats:
+	 *   post-fix:  4.0.0-snapshot.1789  -> 1789
+	 *   legacy:    4.0.0-SNAPSHOT+1656  -> 1656
+	 */
+	public numeric function $snapshotNumber(required string version) {
+		var m = reFindNoCase("snapshot[.+]([0-9]+)", arguments.version, 1, true);
+		if (!arrayLen(m.match) || arrayLen(m.match) < 2) return 0;
+		return val(m.match[2]);
+	}
+
+	/**
+	 * Resolve where to store the cache file. Lives under LUCLI_HOME so it
+	 * stays adjacent to the rest of the user's wheels runtime state.
+	 *
+	 * Falls back to ${user.home}/.wheels if LUCLI_HOME isn't exported (which
+	 * happens when the user runs `wheels` outside the brew wrapper, e.g. from
+	 * a dev checkout). That fallback matches LuCLI's own default.
+	 */
+	public string function $resolveCachePath() {
+		try {
+			var sys = createObject("java", "java.lang.System");
+			var home = sys.getenv("LUCLI_HOME");
+			if (isNull(home) || !len(trim(home))) {
+				home = sys.getProperty("user.home") & "/.wheels";
+			}
+			return home & "/.update-check.json";
+		} catch (any e) {
+			return "/tmp/.wheels-update-check.json";
+		}
+	}
+
+	/**
+	 * Hit the GitHub API for the latest release on `repo`. Returns the
+	 * version string with leading 'v' stripped, or "" on any failure.
+	 *
+	 * Uses a per-channel cache file (24h TTL) so we don't make a real network
+	 * request every `wheels new`. The cache returns immediately if fresh.
+	 */
+	public string function $fetchLatestVersion(required string repo, required string channel) {
+		var cached = $readCache(arguments.channel);
+		if (structKeyExists(cached, "tag") && len(cached.tag)) {
+			return cached.tag;
+		}
+
+		var tag = $httpFetchLatest(arguments.repo, arguments.channel);
+		if (len(tag)) {
+			$writeCache(arguments.channel, tag);
+		}
+		return tag;
+	}
+
+	/**
+	 * Do the actual HTTP call. Stable channel uses /releases/latest (skips
+	 * pre-releases). Bleeding-edge uses /releases?per_page=1 (highest tag is
+	 * always a snapshot pre-release).
+	 *
+	 * Public for unit testability — tests can shadow this with a stub.
+	 */
+	public string function $httpFetchLatest(required string repo, required string channel) {
+		var url = "https://api.github.com/repos/" & arguments.repo & "/";
+		if (arguments.channel == "bleeding-edge") {
+			url &= "releases?per_page=1";
+		} else {
+			url &= "releases/latest";
+		}
+
+		var httpResult = "";
+		try {
+			cfhttp(url=url, method="GET", timeout=variables.HTTP_TIMEOUT_SECONDS, throwOnError=false, result="httpResult") {
+				cfhttpparam(type="header", name="Accept", value="application/vnd.github+json");
+				cfhttpparam(type="header", name="User-Agent", value="wheels-cli-update-check");
+			}
+		} catch (any e) {
+			return "";
+		}
+
+		if (!isStruct(httpResult) || !structKeyExists(httpResult, "statusCode") || left(httpResult.statusCode, 1) != "2") {
+			return "";
+		}
+		if (!isJSON(httpResult.fileContent)) return "";
+		var body = deserializeJSON(httpResult.fileContent);
+
+		// For the per-page=1 path, body is an array. For releases/latest it's an object.
+		var tagName = "";
+		if (isArray(body) && arrayLen(body)) {
+			tagName = structKeyExists(body[1], "tag_name") ? body[1].tag_name : "";
+		} else if (isStruct(body)) {
+			tagName = structKeyExists(body, "tag_name") ? body.tag_name : "";
+		}
+
+		// Strip leading 'v' so 'v4.0.0' compares cleanly with '4.0.0'.
+		if (left(tagName, 1) == "v") tagName = mid(tagName, 2, len(tagName) - 1);
+		return tagName;
+	}
+
+	/**
+	 * Return cached entry for `channel` if not expired. Empty struct if missing,
+	 * stale, or unreadable.
+	 */
+	public struct function $readCache(required string channel) {
+		try {
+			if (!fileExists(variables.cachePath)) return {};
+			var raw = fileRead(variables.cachePath);
+			if (!isJSON(raw)) return {};
+			var cache = deserializeJSON(raw);
+			if (!isStruct(cache) || !structKeyExists(cache, arguments.channel)) return {};
+			var entry = cache[arguments.channel];
+			if (!isStruct(entry) || !structKeyExists(entry, "tag") || !structKeyExists(entry, "checkedAt")) return {};
+
+			var ageSeconds = dateDiff("s", parseDateTime(entry.checkedAt), now());
+			if (ageSeconds > variables.CACHE_TTL_SECONDS) return {};
+
+			return entry;
+		} catch (any e) {
+			return {};
+		}
+	}
+
+	/**
+	 * Persist a `channel -> {tag, checkedAt}` entry to the cache, preserving
+	 * other channels' entries.
+	 */
+	public void function $writeCache(required string channel, required string tag) {
+		try {
+			var cache = {};
+			if (fileExists(variables.cachePath)) {
+				var raw = fileRead(variables.cachePath);
+				if (isJSON(raw)) {
+					var parsed = deserializeJSON(raw);
+					if (isStruct(parsed)) cache = parsed;
+				}
+			}
+			cache[arguments.channel] = {
+				tag: arguments.tag,
+				checkedAt: dateTimeFormat(now(), "yyyy-mm-dd'T'HH:nn:ss")
+			};
+			var dir = getDirectoryFromPath(variables.cachePath);
+			if (!directoryExists(dir)) directoryCreate(dir, true);
+			fileWrite(variables.cachePath, serializeJSON(cache));
+		} catch (any e) {
+			// Cache write failure is non-fatal — the next check will just
+			// do a fresh HTTP request. Silently swallow.
+		}
+	}
+
+}

--- a/cli/lucli/services/UpdateChecker.cfc
+++ b/cli/lucli/services/UpdateChecker.cfc
@@ -131,7 +131,9 @@ component {
 	 */
 	public numeric function $snapshotNumber(required string version) {
 		var m = reFindNoCase("snapshot[.+]([0-9]+)", arguments.version, 1, true);
-		if (!arrayLen(m.match) || arrayLen(m.match) < 2) return 0;
+		// reFindNoCase with returnsubexpressions=true returns ["", ...] on no
+		// match, never a zero-length array — so checking len < 2 is enough.
+		if (arrayLen(m.match) < 2) return 0;
 		return val(m.match[2]);
 	}
 

--- a/cli/lucli/services/UpdateChecker.cfc
+++ b/cli/lucli/services/UpdateChecker.cfc
@@ -32,8 +32,9 @@
  *   {
  *     hasUpdate:       boolean,
  *     skipped:         boolean,        // true when channel doesn't auto-check
- *                                       // (dev/rc) OR when cache TTL not expired
- *                                       // AND no newer version cached
+ *                                       // (dev/rc), no release tag found on the
+ *                                       // repo, or any error during the check —
+ *                                       // hasUpdate is always false when skipped
  *     reason:          string,         // when skipped=true
  *     current:         string,
  *     latest:          string,         // "" when no check was made

--- a/cli/lucli/tests/specs/services/UpdateCheckerSpec.cfc
+++ b/cli/lucli/tests/specs/services/UpdateCheckerSpec.cfc
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for the UpdateChecker service. We focus on the pure-function
+ * surface (comparison and snapshot-number extraction) — those are the
+ * correctness-critical paths. The HTTP path is exercised by manual smoke
+ * tests and the brew tap CI, and is wrapped in a try/catch that swallows
+ * all failure modes, so a network outage during `wheels new` is benign.
+ *
+ * If we ever need to integration-test the HTTP path, refactor init() to
+ * accept an injected fetcher callable and stub it here.
+ */
+component extends="wheels.wheelstest.system.BaseSpec" {
+
+	function beforeAll() {
+		variables.uc = new cli.lucli.services.UpdateChecker();
+	}
+
+	function run() {
+
+		describe("UpdateChecker Service", () => {
+
+			describe("$snapshotNumber()", () => {
+
+				it("extracts post-fix snapshot.N numbers", () => {
+					expect(uc.$snapshotNumber("4.0.0-snapshot.1789")).toBe(1789);
+					expect(uc.$snapshotNumber("5.0.0-snapshot.1")).toBe(1);
+					expect(uc.$snapshotNumber("10.20.30-snapshot.99999")).toBe(99999);
+				});
+
+				it("extracts legacy SNAPSHOT+N numbers", () => {
+					// Older brew bottles built before the SemVer separator fix
+					// still carry this form. Must compare against newer snapshots
+					// from the post-fix range without errors.
+					expect(uc.$snapshotNumber("4.0.0-SNAPSHOT+1656")).toBe(1656);
+					expect(uc.$snapshotNumber("3.5.0-SNAPSHOT+42")).toBe(42);
+				});
+
+				it("returns 0 for versions without a snapshot suffix", () => {
+					// 0 lets the comparison treat the non-snapshot version as
+					// older than any snapshot — so a stable user comparing
+					// against a snapshot tag (shouldn't happen via the channel
+					// router, but defensive) gets a benign result.
+					expect(uc.$snapshotNumber("4.0.0")).toBe(0);
+					expect(uc.$snapshotNumber("")).toBe(0);
+					expect(uc.$snapshotNumber("custom-build")).toBe(0);
+				});
+
+			});
+
+			describe("$isNewer()", () => {
+
+				it("returns true when base SemVer is greater on stable", () => {
+					expect(uc.$isNewer("4.0.0", "4.0.1", "stable")).toBeTrue();
+					expect(uc.$isNewer("4.0.0", "4.1.0", "stable")).toBeTrue();
+					expect(uc.$isNewer("4.0.0", "5.0.0", "stable")).toBeTrue();
+				});
+
+				it("returns false when base SemVer is equal or lower on stable", () => {
+					expect(uc.$isNewer("4.0.0", "4.0.0", "stable")).toBeFalse();
+					expect(uc.$isNewer("4.0.1", "4.0.0", "stable")).toBeFalse();
+					expect(uc.$isNewer("5.0.0", "4.0.0", "stable")).toBeFalse();
+				});
+
+				it("compares snapshot.N on bleeding-edge when base is equal", () => {
+					expect(uc.$isNewer("4.0.0-snapshot.1789", "4.0.0-snapshot.1790", "bleeding-edge")).toBeTrue();
+					expect(uc.$isNewer("4.0.0-snapshot.1790", "4.0.0-snapshot.1789", "bleeding-edge")).toBeFalse();
+					expect(uc.$isNewer("4.0.0-snapshot.100", "4.0.0-snapshot.100", "bleeding-edge")).toBeFalse();
+				});
+
+				it("uses base SemVer first on bleeding-edge", () => {
+					// If base differs, the snapshot.N is irrelevant. A user on
+					// 4.0.0-snapshot.999 still needs to upgrade to 4.0.1-snapshot.1.
+					expect(uc.$isNewer("4.0.0-snapshot.999", "4.0.1-snapshot.1", "bleeding-edge")).toBeTrue();
+					expect(uc.$isNewer("4.1.0-snapshot.1", "4.0.0-snapshot.999", "bleeding-edge")).toBeFalse();
+				});
+
+				it("bridges legacy and post-fix snapshot formats", () => {
+					// User on a brew bottle built before the SemVer fix has
+					// version "4.0.0-SNAPSHOT+1656". Latest published is
+					// "4.0.0-snapshot.1790". Must classify as upgrade-worthy.
+					expect(uc.$isNewer("4.0.0-SNAPSHOT+1656", "4.0.0-snapshot.1790", "bleeding-edge")).toBeTrue();
+				});
+
+			});
+
+			describe("check() for non-network channels", () => {
+
+				it("skips development channel without making any request", () => {
+					var r = uc.check(currentVersion="@build.version@");
+					expect(r.skipped).toBeTrue();
+					expect(r.channel).toBe("development");
+					expect(r.hasUpdate).toBeFalse();
+				});
+
+				it("skips release-candidate channel", () => {
+					// RC users opted in explicitly; we don't auto-nag them.
+					var r = uc.check(currentVersion="4.1.0-rc.1");
+					expect(r.skipped).toBeTrue();
+					expect(r.channel).toBe("release-candidate");
+					expect(r.hasUpdate).toBeFalse();
+				});
+
+				it("returns a populated struct even when skipped", () => {
+					// Caller code expects a consistent shape regardless of skip
+					// reason — guards against AccessOfUndefinedKey errors.
+					var r = uc.check(currentVersion="");
+					expect(structKeyExists(r, "hasUpdate")).toBeTrue();
+					expect(structKeyExists(r, "skipped")).toBeTrue();
+					expect(structKeyExists(r, "current")).toBeTrue();
+					expect(structKeyExists(r, "latest")).toBeTrue();
+					expect(structKeyExists(r, "channel")).toBeTrue();
+					expect(structKeyExists(r, "upgradeCommand")).toBeTrue();
+				});
+
+			});
+
+		});
+
+	}
+
+}

--- a/cli/lucli/tests/specs/services/UpdateCheckerSpec.cfc
+++ b/cli/lucli/tests/specs/services/UpdateCheckerSpec.cfc
@@ -105,6 +105,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					var r = uc.check(currentVersion="");
 					expect(structKeyExists(r, "hasUpdate")).toBeTrue();
 					expect(structKeyExists(r, "skipped")).toBeTrue();
+					expect(structKeyExists(r, "reason")).toBeTrue();
 					expect(structKeyExists(r, "current")).toBeTrue();
 					expect(structKeyExists(r, "latest")).toBeTrue();
 					expect(structKeyExists(r, "channel")).toBeTrue();


### PR DESCRIPTION
## Summary

Closes the original ask from the BE-channel thread: when a user runs `wheels new myapp`, print a small hint at the end if a newer wheels release is available on their channel.

Constraints I made the service enforce:

- **Never blocks `wheels new`** — all errors swallow silently. Wrapped in a try/catch belt at the call site.
- **5s hard timeout** on the HTTP call.
- **24h per-channel cache** at `$LUCLI_HOME/.update-check.json`. One real network request per channel per day, not per `wheels new`.
- **Channel routing** via existing `services/ReleaseChannel.cfc`:
  - `stable` → `wheels-dev/wheels`
  - `bleeding-edge` → `wheels-dev/wheels-snapshots`
  - `release-candidate` / `development` → skip (RC users opted in explicitly; dev checkouts have no meaningful target)
- **Format-bridging comparison**: a user on a brew bottle built before the SemVer separator fix has `4.0.0-SNAPSHOT+1656`. The latest published is `4.0.0-snapshot.1790`. The `$snapshotNumber` extractor handles both forms and `$isNewer` correctly flags it as upgrade-worthy.

## What lands

| File | Purpose |
|---|---|
| `cli/lucli/services/UpdateChecker.cfc` | New service. Pure-function comparison + cached HTTP fetch. |
| `cli/lucli/Module.cfc` (~24 LOC) | Call site at the end of `new()`. Try/catch belt. |
| `cli/lucli/tests/specs/services/UpdateCheckerSpec.cfc` | Unit tests for comparison + skip paths. |

## What it looks like at runtime

When there's nothing newer:
```
Application created!
...
Next steps:
  cd myapp
  wheels start
```

When there's a newer build:
```
Application created!
...
Next steps:
  cd myapp
  wheels start

A newer wheels (bleeding-edge) is available: 4.0.0-snapshot.1790 (you have 4.0.0-snapshot.1789)
  Upgrade: brew upgrade wheels-be
```

## Test plan

- [x] Unit tests pass (pure-function paths)
- [ ] CI green on this PR
- [ ] Manual: `wheels new test-app` with a stale local install shows the hint
- [ ] Manual: `wheels new test-app` with a fresh install does NOT show the hint
- [ ] Manual: `wheels new test-app` with no network completes silently (no hang, no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)