### PR TITLE
build: WinGet manifest drafts for Wheels.Wheels + Wheels.WheelsBE

### DIFF
--- a/tools/distribution-drafts/winget/README.md
+++ b/tools/distribution-drafts/winget/README.md
@@ -1,0 +1,104 @@
+# WinGet manifest drafts — `microsoft/winget-pkgs`
+
+Two package identifiers, one per channel:
+
+| Identifier | Channel | Source |
+|---|---|---|
+| `Wheels.Wheels` | stable | `wheels-dev/wheels` GA tags |
+| `Wheels.WheelsBE` | bleeding-edge | `wheels-dev/wheels-snapshots` pre-releases |
+
+WinGet manifests are 3-file YAML triplets per version, submitted as PRs to
+[microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under
+`manifests/w/Wheels/Wheels/<version>/` (and a parallel `WheelsBE/`).
+
+## Why these are *drafts*, not ready-to-ship
+
+WinGet's installer types (`exe`, `msi`, `msix`, `inno`, `nullsoft`, `wix`,
+`portable`, `zip`) all assume one of:
+
+1. A signed installer that drops files in a deterministic location and
+   adds itself to PATH (msi/msix/wix/inno/nullsoft).
+2. A portable binary that goes onto PATH as-is (portable).
+3. A zip whose contents look like one of the above.
+
+Wheels doesn't fit cleanly into any of them out of the box — our
+`wheels.cmd` wrapper needs to sync `share/module/` and
+`share/framework/wheels/` into `~/.wheels/` on first run, the same way the
+brew formula's wrapper does. None of the portable or zip types run setup
+scripts on the user's machine the way `pre_install` / `post_install` do
+in Scoop.
+
+There are two paths forward:
+
+1. **Build a real WiX MSI.** Largest cost, best UX, supports proper
+   uninstall via Add/Remove Programs. Need a build pipeline that bundles
+   the wrapper, the LuCLI `.bat`, the SQLite JDBC, and runs the SRC→DST
+   sync as a custom action. Probably a week of WiX work.
+
+2. **Wrap a portable install in a self-extracting EXE.** Smaller cost.
+   Pack `wheels-module`, `wheels-core`, `lucli-0.3.7.bat`, and
+   `sqlite-jdbc-*.jar` into a single signed `.exe` (e.g., via 7-Zip SFX
+   or NSIS). Manifest type = `nullsoft` or `inno`. On install it
+   extracts to `%ProgramFiles%\Wheels\` and registers the wrapper on
+   PATH. First-run sync still needs to happen in the wrapper itself.
+
+Until we pick a path and ship the installer artifact, these manifests
+are scaffolding — they document the metadata + identifier conventions
+so the day-one PR to `microsoft/winget-pkgs` is mechanical.
+
+## Submission flow (once an installer is built)
+
+```bash
+# Fork microsoft/winget-pkgs
+gh repo fork microsoft/winget-pkgs
+git clone git@github.com:<you>/winget-pkgs
+cd winget-pkgs
+
+# Copy our drafts in
+mkdir -p manifests/w/Wheels/Wheels/4.0.0
+cp ../wheels-dev/wheels/tools/distribution-drafts/winget/Wheels.Wheels/4.0.0/*.yaml manifests/w/Wheels/Wheels/4.0.0/
+
+# Update InstallerUrl + InstallerSha256 with the real GA artifact + hash
+$EDITOR manifests/w/Wheels/Wheels/4.0.0/Wheels.Wheels.installer.yaml
+
+# Validate (Microsoft ship a CLI tool):
+winget validate --manifest manifests/w/Wheels/Wheels/4.0.0/
+
+# Open PR
+git checkout -b add-wheels-stable
+git add manifests/w/Wheels/Wheels/4.0.0/
+git commit -m "New version: Wheels.Wheels version 4.0.0"
+git push -u origin add-wheels-stable
+gh pr create --repo microsoft/winget-pkgs ...
+```
+
+WinGet's PR review is fairly automated — a bot validates the manifest
+schema, runs `winget install` in a sandbox, and merges if green. Manual
+review only when the bot's heuristics catch something.
+
+## How autoupdate works for WinGet
+
+Unlike Scoop's per-bucket Excavator bot, WinGet has **no autoupdate** —
+every new version is a new PR to `microsoft/winget-pkgs`. We can
+automate the PR creation from our own release workflow using
+[`vedantmgoyal2009/winget-releaser`](https://github.com/vedantmgoyal2009/winget-releaser)
+or similar, but the upstream merge cadence is on the WinGet team's
+schedule.
+
+This is the main argument for prioritizing Scoop over WinGet for
+bleeding-edge — daily WinGet PRs for snapshot bumps are noise. Scoop's
+hourly autoupdate fits the BE cadence; WinGet fits the stable cadence
+where new versions are infrequent (GA tags).
+
+Plan: ship `Wheels.Wheels` (stable) on WinGet, leave `Wheels.WheelsBE`
+on Scoop only. The BE manifest in this directory is kept for symmetry +
+documentation, not for active submission.
+
+## Identifier rationale
+
+`Wheels.Wheels` follows WinGet's convention of
+`<Publisher>.<PackageName>`. `Wheels` is short, descriptive, and not
+yet claimed in the registry (verified 2026-05).
+
+We deliberately don't use `WheelsDev.Wheels` — the publisher name
+should be the brand users recognize, not the org slug.

--- a/tools/distribution-drafts/winget/Wheels.Wheels/4.0.0/Wheels.Wheels.installer.yaml
+++ b/tools/distribution-drafts/winget/Wheels.Wheels/4.0.0/Wheels.Wheels.installer.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+#
+# Installer manifest. DRAFT — InstallerUrl + InstallerSha256 below are
+# placeholders. Before submitting this PR to microsoft/winget-pkgs we
+# need to:
+#
+#   1. Build an actual installer artifact (see ../README.md for options
+#      — MSI via WiX or NSIS-wrapped self-extracting EXE).
+#   2. Upload it to the v4.0.0 GitHub release on wheels-dev/wheels.
+#   3. Compute its SHA-256 and update InstallerSha256 below.
+#   4. Update InstallerType to match what we built (nullsoft / inno /
+#      msi / wix).
+#
+# Until then this file is reference scaffolding — captures the metadata
+# we WILL ship so the actual submission becomes mechanical.
+
+PackageIdentifier: Wheels.Wheels
+PackageVersion: 4.0.0
+MinimumOSVersion: 10.0.17763.0  # Windows 10 1809 — required by openjdk21
+InstallerType: zip  # TODO: change to nullsoft|inno|msi|wix once installer built
+NestedInstallerType: portable  # placeholder; revisit when installer chosen
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-05-12
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: EclipseAdoptium.Temurin.21.JDK
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/wheels-dev/wheels/releases/download/v4.0.0/wheels-windows-x64-4.0.0.zip  # PLACEHOLDER — build artifact does not yet exist
+  InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000  # PLACEHOLDER
+  NestedInstallerFiles:
+  - RelativeFilePath: wheels\bin\wheels.cmd
+    PortableCommandAlias: wheels
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/tools/distribution-drafts/winget/Wheels.Wheels/4.0.0/Wheels.Wheels.locale.en-US.yaml
+++ b/tools/distribution-drafts/winget/Wheels.Wheels/4.0.0/Wheels.Wheels.locale.en-US.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+#
+# Default-locale manifest. Describes the package to end users for
+# `winget search`, `winget show`, and the WinGet website.
+
+PackageIdentifier: Wheels.Wheels
+PackageVersion: 4.0.0
+PackageLocale: en-US
+Publisher: Wheels Dev
+PublisherUrl: https://wheels.dev
+PublisherSupportUrl: https://github.com/wheels-dev/wheels/issues
+PrivacyUrl: https://wheels.dev/privacy
+Author: Wheels Dev Contributors
+PackageName: Wheels
+PackageUrl: https://wheels.dev
+License: Apache-2.0
+LicenseUrl: https://github.com/wheels-dev/wheels/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Wheels Dev
+ShortDescription: CFML MVC framework with code generation, migrations, testing, and server management.
+Description: |
+  Wheels is a full-stack MVC framework for CFML (ColdFusion / Lucee / BoxLang),
+  similar in spirit to Rails and Laravel. The Wheels CLI provides code generators,
+  database migrations, a test runner, a background-job worker, and a development
+  server, all wrapped in a single self-contained command.
+
+  This is the stable channel. For bleeding-edge snapshots from develop, install
+  Wheels.WheelsBE instead. Only one channel can be installed at a time.
+Moniker: wheels
+Tags:
+- cfml
+- coldfusion
+- lucee
+- boxlang
+- mvc
+- framework
+- cli
+- rails
+- web-development
+ReleaseNotesUrl: https://github.com/wheels-dev/wheels/releases/tag/v4.0.0
+Documentations:
+- DocumentLabel: Guides
+  DocumentUrl: https://guides.wheels.dev
+- DocumentLabel: API Reference
+  DocumentUrl: https://api.wheels.dev
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/tools/distribution-drafts/winget/Wheels.Wheels/4.0.0/Wheels.Wheels.yaml
+++ b/tools/distribution-drafts/winget/Wheels.Wheels/4.0.0/Wheels.Wheels.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+#
+# Top-level version manifest. Points to the locale + installer files.
+# This file is what WinGet's client reads first.
+
+PackageIdentifier: Wheels.Wheels
+PackageVersion: 4.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/tools/distribution-drafts/winget/Wheels.WheelsBE/4.0.0-snapshot.1789/Wheels.WheelsBE.installer.yaml
+++ b/tools/distribution-drafts/winget/Wheels.WheelsBE/4.0.0-snapshot.1789/Wheels.WheelsBE.installer.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+#
+# DRAFT — same caveats as Wheels.Wheels/.../installer.yaml. See
+# ../README.md for the installer-strategy decision still pending.
+#
+# NOTE: per the README, bleeding-edge may end up never shipping on WinGet
+# at all. WinGet's manual-merge cadence is incompatible with the
+# per-develop-merge BE release frequency — daily snapshot PRs to
+# microsoft/winget-pkgs would be noise. Scoop's hourly autoupdate
+# bucket-update bot is the better fit for BE.
+#
+# This file is kept for symmetry with the stable manifest + as a record
+# of the metadata convention if we ever change our minds.
+
+PackageIdentifier: Wheels.WheelsBE
+PackageVersion: 4.0.0-snapshot.1789
+MinimumOSVersion: 10.0.17763.0
+InstallerType: zip
+NestedInstallerType: portable
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-05-10
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: EclipseAdoptium.Temurin.21.JDK
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/wheels-dev/wheels-snapshots/releases/download/v4.0.0-snapshot.1789/wheels-windows-x64-4.0.0-snapshot.1789.zip  # PLACEHOLDER
+  InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000  # PLACEHOLDER
+  NestedInstallerFiles:
+  - RelativeFilePath: wheels\bin\wheels.cmd
+    PortableCommandAlias: wheels
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/tools/distribution-drafts/winget/Wheels.WheelsBE/4.0.0-snapshot.1789/Wheels.WheelsBE.locale.en-US.yaml
+++ b/tools/distribution-drafts/winget/Wheels.WheelsBE/4.0.0-snapshot.1789/Wheels.WheelsBE.locale.en-US.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Wheels.WheelsBE
+PackageVersion: 4.0.0-snapshot.1789
+PackageLocale: en-US
+Publisher: Wheels Dev
+PublisherUrl: https://wheels.dev
+PublisherSupportUrl: https://github.com/wheels-dev/wheels/issues
+PrivacyUrl: https://wheels.dev/privacy
+Author: Wheels Dev Contributors
+PackageName: Wheels (Bleeding-Edge)
+PackageUrl: https://wheels.dev
+License: Apache-2.0
+LicenseUrl: https://github.com/wheels-dev/wheels/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Wheels Dev
+ShortDescription: Wheels CFML MVC framework - bleeding-edge channel (develop snapshots).
+Description: |
+  Wheels is a full-stack MVC framework for CFML (ColdFusion / Lucee / BoxLang),
+  similar in spirit to Rails and Laravel.
+
+  This is the BLEEDING-EDGE channel. Tracks every merge to develop on
+  wheels-dev/wheels via the wheels-dev/wheels-snapshots release feed. New builds
+  publish multiple times per day. For stable use, install Wheels.Wheels instead.
+
+  Only one channel can be installed at a time. Switching channels:
+    winget uninstall Wheels.WheelsBE
+    winget install Wheels.Wheels
+Moniker: wheels-be
+Tags:
+- cfml
+- coldfusion
+- lucee
+- boxlang
+- mvc
+- framework
+- cli
+- bleeding-edge
+- snapshot
+ReleaseNotesUrl: https://github.com/wheels-dev/wheels-snapshots/releases/tag/v4.0.0-snapshot.1789
+Documentations:
+- DocumentLabel: Guides
+  DocumentUrl: https://guides.wheels.dev
+- DocumentLabel: Release Channels
+  DocumentUrl: https://guides.wheels.dev/v4-0-0-snapshot/start-here/release-channels/
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/tools/distribution-drafts/winget/Wheels.WheelsBE/4.0.0-snapshot.1789/Wheels.WheelsBE.yaml
+++ b/tools/distribution-drafts/winget/Wheels.WheelsBE/4.0.0-snapshot.1789/Wheels.WheelsBE.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+#
+# Top-level version manifest for the bleeding-edge channel.
+
+PackageIdentifier: Wheels.WheelsBE
+PackageVersion: 4.0.0-snapshot.1789
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/tools/distribution-drafts/winget/validate.py
+++ b/tools/distribution-drafts/winget/validate.py
@@ -119,7 +119,7 @@ def validate_version(version_dir: Path, expected_id: str) -> None:
             url = s.split(":", 1)[1].strip().split("#")[0].strip()
             if not url.startswith("https://"):
                 fail(f"{installer}: InstallerUrl must use https: {url}")
-            if "PLACEHOLDER" in line or "wheels-windows-x64" in url:
+            if "PLACEHOLDER" in line:
                 warn(f"{installer}: InstallerUrl is a PLACEHOLDER (real artifact does not yet exist)")
         if s.startswith("InstallerSha256:"):
             h = s.split(":", 1)[1].strip().split("#")[0].strip()

--- a/tools/distribution-drafts/winget/validate.py
+++ b/tools/distribution-drafts/winget/validate.py
@@ -57,7 +57,7 @@ def parse_yaml_lite(path: Path) -> dict[str, str]:
         if ":" not in line:
             continue
         key, _, val = line.partition(":")
-        out[key.strip()] = val.strip()
+        out[key.strip()] = val.split("#")[0].strip()
     return out
 
 

--- a/tools/distribution-drafts/winget/validate.py
+++ b/tools/distribution-drafts/winget/validate.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 """
 Static validation for the WinGet manifest drafts. Catches schema-level
-mistakes (missing required fields, identifier/version mismatches across the
+mistakes (missing required files, identifier/version mismatches across the
 3-file triplet) without needing the Windows `winget validate` tool.
 
 The official validator is Windows-only; this is the macOS/linux fallback.
 Run before pushing changes to the manifest content.
 
 Checks:
-- Each version dir contains exactly the 3 files: <Id>.yaml, <Id>.locale.en-US.yaml, <Id>.installer.yaml
+- Each version dir contains at least the 3 required files: <Id>.yaml, <Id>.locale.en-US.yaml, <Id>.installer.yaml
 - PackageIdentifier in all three files matches the package directory name (e.g. Wheels.Wheels)
 - PackageVersion matches the parent dir name
+- ManifestType in each file matches its role (version / defaultLocale / installer)
 - DefaultLocale (in top manifest) matches the locale file's PackageLocale
 - Installer URLs use https
 - License is in SPDX form

--- a/tools/distribution-drafts/winget/validate.py
+++ b/tools/distribution-drafts/winget/validate.py
@@ -9,7 +9,7 @@ Run before pushing changes to the manifest content.
 
 Checks:
 - Each version dir contains exactly the 3 files: <Id>.yaml, <Id>.locale.en-US.yaml, <Id>.installer.yaml
-- PackageIdentifier matches the directory path (manifests/w/Wheels/<Name>/)
+- PackageIdentifier in all three files matches the package directory name (e.g. Wheels.Wheels)
 - PackageVersion matches the parent dir name
 - DefaultLocale (in top manifest) matches the locale file's PackageLocale
 - Installer URLs use https

--- a/tools/distribution-drafts/winget/validate.py
+++ b/tools/distribution-drafts/winget/validate.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Static validation for the WinGet manifest drafts. Catches schema-level
+mistakes (missing required fields, identifier/version mismatches across the
+3-file triplet) without needing the Windows `winget validate` tool.
+
+The official validator is Windows-only; this is the macOS/linux fallback.
+Run before pushing changes to the manifest content.
+
+Checks:
+- Each version dir contains exactly the 3 files: <Id>.yaml, <Id>.locale.en-US.yaml, <Id>.installer.yaml
+- PackageIdentifier matches the directory path (manifests/w/Wheels/<Name>/)
+- PackageVersion matches the parent dir name
+- DefaultLocale (in top manifest) matches the locale file's PackageLocale
+- Installer URLs use https
+- License is in SPDX form
+- Placeholder hashes are flagged (loud — these are submit-blockers)
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).parent
+ERRORS: list[str] = []
+WARNINGS: list[str] = []
+
+
+def fail(msg: str) -> None:
+    ERRORS.append(msg)
+    print(f"FAIL: {msg}")
+
+
+def warn(msg: str) -> None:
+    WARNINGS.append(msg)
+    print(f"WARN: {msg}")
+
+
+def info(msg: str) -> None:
+    print(f"ok:   {msg}")
+
+
+def parse_yaml_lite(path: Path) -> dict[str, str]:
+    """Tiny YAML reader — only handles top-level `key: value` pairs.
+
+    WinGet manifests have some nested structure (Installers, Documentations)
+    but for validation we only need the top-level scalars. PyYAML isn't in
+    the default Python install, so we stay dependency-free.
+    """
+    out: dict[str, str] = {}
+    for line in path.read_text().splitlines():
+        # Skip comments + empty lines + nested entries
+        if not line or line.startswith("#") or line.startswith(" ") or line.startswith("-"):
+            continue
+        if ":" not in line:
+            continue
+        key, _, val = line.partition(":")
+        out[key.strip()] = val.strip()
+    return out
+
+
+def validate_package(pkg_dir: Path, expected_id: str) -> None:
+    """Validate all version dirs under a package dir."""
+    for version_dir in sorted(p for p in pkg_dir.iterdir() if p.is_dir()):
+        validate_version(version_dir, expected_id)
+
+
+def validate_version(version_dir: Path, expected_id: str) -> None:
+    version = version_dir.name
+    info(f"validating {expected_id} {version}")
+
+    top = version_dir / f"{expected_id}.yaml"
+    locale = version_dir / f"{expected_id}.locale.en-US.yaml"
+    installer = version_dir / f"{expected_id}.installer.yaml"
+
+    for f in (top, locale, installer):
+        if not f.exists():
+            fail(f"{version_dir}: missing {f.name}")
+            return
+
+    top_m = parse_yaml_lite(top)
+    locale_m = parse_yaml_lite(locale)
+    installer_m = parse_yaml_lite(installer)
+
+    # Identifier consistency
+    for name, m in (("top", top_m), ("locale", locale_m), ("installer", installer_m)):
+        if m.get("PackageIdentifier") != expected_id:
+            fail(f"{version_dir}: {name} PackageIdentifier '{m.get('PackageIdentifier')}' != expected '{expected_id}'")
+
+    # Version consistency
+    for name, m in (("top", top_m), ("locale", locale_m), ("installer", installer_m)):
+        if m.get("PackageVersion") != version:
+            fail(f"{version_dir}: {name} PackageVersion '{m.get('PackageVersion')}' != dir '{version}'")
+
+    # Manifest type tags
+    if top_m.get("ManifestType") != "version":
+        fail(f"{top}: ManifestType must be 'version'")
+    if locale_m.get("ManifestType") != "defaultLocale":
+        fail(f"{locale}: ManifestType must be 'defaultLocale'")
+    if installer_m.get("ManifestType") != "installer":
+        fail(f"{installer}: ManifestType must be 'installer'")
+
+    # Locale match
+    if top_m.get("DefaultLocale") != locale_m.get("PackageLocale"):
+        fail(f"{version_dir}: top DefaultLocale '{top_m.get('DefaultLocale')}' != locale PackageLocale '{locale_m.get('PackageLocale')}'")
+
+    # License is SPDX
+    license = locale_m.get("License", "")
+    if license and license not in {"Apache-2.0", "MIT", "BSD-3-Clause", "GPL-2.0", "GPL-3.0", "LGPL-2.1", "LGPL-3.0", "MPL-2.0", "ISC"}:
+        warn(f"{locale}: License '{license}' is not a common SPDX ID — double-check before submitting")
+
+    # Installer URL must be https
+    # (parse_yaml_lite skips list entries so we have to grep raw text for InstallerUrl/Sha256)
+    installer_text = installer.read_text()
+    for line in installer_text.splitlines():
+        s = line.strip()
+        if s.startswith("InstallerUrl:"):
+            url = s.split(":", 1)[1].strip().split("#")[0].strip()
+            if not url.startswith("https://"):
+                fail(f"{installer}: InstallerUrl must use https: {url}")
+            if "PLACEHOLDER" in line or "wheels-windows-x64" in url:
+                warn(f"{installer}: InstallerUrl is a PLACEHOLDER (real artifact does not yet exist)")
+        if s.startswith("InstallerSha256:"):
+            h = s.split(":", 1)[1].strip().split("#")[0].strip()
+            if h == "0" * 64:
+                warn(f"{installer}: InstallerSha256 is a zero-placeholder — must be filled before submitting")
+            elif len(h) != 64:
+                fail(f"{installer}: InstallerSha256 must be 64 hex chars, got {len(h)}")
+
+
+def main() -> int:
+    print("Validating WinGet manifest drafts in", HERE)
+    print()
+
+    pkgs = [
+        (HERE / "Wheels.Wheels", "Wheels.Wheels"),
+        (HERE / "Wheels.WheelsBE", "Wheels.WheelsBE"),
+    ]
+    for pkg_dir, expected_id in pkgs:
+        if not pkg_dir.exists():
+            warn(f"{pkg_dir.name} does not exist — skipping")
+            continue
+        validate_package(pkg_dir, expected_id)
+
+    print()
+    print(f"Warnings: {len(WARNINGS)}, Errors: {len(ERRORS)}")
+    if ERRORS:
+        return 1
+    if WARNINGS:
+        print("(warnings are expected pre-build; errors are real schema problems)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Scaffolds the 3-file YAML triplet per channel for eventual submission to [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs). Includes a dependency-free Python validator that catches schema-level mistakes without needing the Windows-only `winget validate` tool.

These are **drafts**, not ready-to-submit:
- `InstallerUrl` + `InstallerSha256` are zero-placeholders
- The actual installer artifact (WiX MSI vs NSIS self-extracting EXE) is a separate build job — see the [README](../blob/peter/winget-manifest-drafts/tools/distribution-drafts/winget/README.md) for the strategy decision

## Why both channels are drafted, but only stable may ship

WinGet's manual-merge cadence (~24-48hr per PR through `microsoft/winget-pkgs`) is incompatible with per-develop-merge snapshot publish frequency. Daily snapshot PRs to the WinGet registry would be noise.

Plan:
- `Wheels.Wheels` → ships on WinGet, slow stable cadence fits
- `Wheels.WheelsBE` → kept on Scoop only (hourly autoupdate via Excavator)

The BE manifest in this PR is kept for symmetry + as a record of metadata conventions if we ever change our minds.

## What lands

| Path | Purpose |
|---|---|
| `tools/distribution-drafts/winget/Wheels.Wheels/4.0.0/*.yaml` | Stable channel triplet (top + locale + installer) |
| `tools/distribution-drafts/winget/Wheels.WheelsBE/4.0.0-snapshot.1789/*.yaml` | BE channel triplet (kept for symmetry) |
| `tools/distribution-drafts/winget/validate.py` | Schema + cross-file consistency checker |
| `tools/distribution-drafts/winget/README.md` | Submission flow + installer-strategy decision pending |

## Test plan

- [x] `python3 tools/distribution-drafts/winget/validate.py` — 0 errors, 4 warnings (all placeholder-related, expected)
- [ ] Post-GA: build installer artifact, fill InstallerUrl + InstallerSha256, re-run validate, submit PR to `microsoft/winget-pkgs`