### PR TITLE
docs: drop Chocolatey path, switch to Scoop; banner v2/v3 as historical

### DIFF
--- a/web/sites/guides/src/content/docs/v2-5-0/index.md
+++ b/web/sites/guides/src/content/docs/v2-5-0/index.md
@@ -5,6 +5,10 @@ description: Install CFWheels and get a local development server running
 
 # Getting Started
 
+:::caution[Historical version]
+You are reading the **CFWheels v2.5** documentation. CFWheels was renamed to **Wheels** at v3.0, and the CommandBox-based CLI was replaced by the LuCLI-based `wheels` CLI at v4.0. References to CommandBox, ForgeBox, and `box install` on this page are accurate for v2.5 but no longer reflect current install or distribution paths. For new projects, start with [v4.0 → Installing Wheels](/v4-0-0-snapshot/start-here/installing/).
+:::
+
 By far the quickest way to get started with CFWheels is via [CommandBox](https://www.ortussolutions.com/products/commandbox). CommandBox brings a whole host of command line capabilities to the CFML developer. It allows you to write scripts that can be executed at the command line written entirely in CFML. It allows you to start a CFML server from any directory on your machine and wire up the code in that directory as the web root of the server. What's more is, those servers can be either Lucee servers or Adobe ColdFusion servers. You can even specify what version of each server to launch. Lastly, CommandBox is a package manager for CFML. That means you can take some CFML code and package it up into a module, host it on ForgeBox.io, and make it available to other CFML developers. In fact we make extensive use of these capabilities to distribute CFWheels plugins and templates. More on that later.
 
 One module that we have created is a module that extends CommandBox itself with commands and features specific to the CFWheels framework. The CFWheels CLI module for CommandBox is modeled after the Ruby on Rails CLI module and gives similar capabilities to the CFWheels developer.

--- a/web/sites/guides/src/content/docs/v3-0-0/index.md
+++ b/web/sites/guides/src/content/docs/v3-0-0/index.md
@@ -5,6 +5,10 @@ description: Install Wheels and get a local development server running
 
 # Getting Started
 
+:::caution[Historical version]
+You are reading the **Wheels v3.0** documentation. v3.0 used a CommandBox-based CLI module; that path is preserved here for users still on v3 but is no longer how new projects install Wheels. v4.0 ships a self-contained `wheels` CLI (LuCLI-based) that replaces CommandBox entirely. For new projects, start with [v4.0 → Installing Wheels](/v4-0-0-snapshot/start-here/installing/).
+:::
+
 By far the quickest way to get started with Wheels is via [CommandBox](https://www.ortussolutions.com/products/commandbox). CommandBox brings a whole host of command line capabilities to the CFML developer. It allows you to write scripts that can be executed at the command line written entirely in CFML. It allows you to start a CFML server from any directory on your machine and wire up the code in that directory as the web root of the server. What's more is, those servers can be either Lucee servers or Adobe ColdFusion servers. You can even specify what version of each server to launch. Lastly, CommandBox is a package manager for CFML. That means you can take some CFML code and package it up into a module, host it on ForgeBox.io, and make it available to other CFML developers. In fact we make extensive use of these capabilities to distribute Wheels plugins and templates. More on that later.
 
 One module that we have created is a module that extends CommandBox itself with commands and features specific to the Wheels framework. The Wheels CLI module for CommandBox is modeled after the Ruby on Rails CLI module and gives similar capabilities to the Wheels developer.

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/installation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Install the wheels binary via Homebrew, Chocolatey, or a manual JAR download, and verify your setup.
+description: Install the wheels binary via Homebrew, Scoop (Windows), or a manual JAR download, and verify your setup.
 type: reference
 sidebar:
   order: 2
@@ -8,7 +8,7 @@ sidebar:
 
 import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-The `wheels` binary is distributed through three channels: Homebrew for macOS and Linux, Chocolatey for Windows, and a direct JAR download for anyone who wants to wire it up by hand. Each channel installs the same two artifacts — the LuCLI launcher and the Wheels Module that ships the framework commands.
+The `wheels` binary is distributed through three channels: Homebrew for macOS and Linux, Scoop for Windows, and a direct JAR download for anyone who wants to wire it up by hand. Each channel installs the same two artifacts — the LuCLI launcher and the Wheels Module that ships the framework commands.
 
 **You'll use this for:**
 
@@ -19,7 +19,7 @@ The `wheels` binary is distributed through three channels: Homebrew for macOS an
 
 ## Requirements
 
-The CLI runs on Java 21. On macOS and Linux, the Homebrew formula installs `openjdk@21` for you and sets `JAVA_HOME` inside the `wheels` wrapper, so you don't have to wire up a system JDK. If you're installing manually — or on Windows outside the Chocolatey package — grab a JDK 21 build from [Adoptium](https://adoptium.net/) or Homebrew:
+The CLI runs on Java 21. On macOS and Linux, the Homebrew formula installs `openjdk@21` for you and sets `JAVA_HOME` inside the `wheels` wrapper, so you don't have to wire up a system JDK. If you're installing manually — or on Windows without Scoop — grab a JDK 21 build from [Adoptium](https://adoptium.net/) or Homebrew:
 
 ```bash title="illustrative — system JDK setup"
 brew install openjdk@21

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/installation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/installation.mdx
@@ -49,24 +49,36 @@ The first time you invoke `wheels`, the wrapper:
 
 On upgrades (`brew upgrade wheels`), the staged module version bumps; the next `wheels` invocation notices the mismatch and refreshes `~/.wheels/modules/wheels/` in place.
 
-## Windows (Chocolatey)
+## Windows (Scoop)
 
-<Aside type="caution" title="LuCLI-based package is not yet on the Chocolatey community feed">
-The `wheels` package at [community.chocolatey.org/packages/wheels](https://community.chocolatey.org/packages/wheels) is still the v1.x legacy (CommandBox-based) release. The v2.x LuCLI-based package is built and tested in [`wheels-dev/chocolatey-wheels`](https://github.com/wheels-dev/chocolatey-wheels) but has not been pushed to the public feed yet. Until it is, Windows users should install via the manual JAR path below.
-</Aside>
+Wheels ships on Windows through [Scoop](https://scoop.sh) — a portable, sandboxed package manager that fits the project's release cadence (hourly autoupdate for both stable and bleeding-edge channels). The legacy Chocolatey path is no longer supported; the old v1.x `wheels` package at `community.chocolatey.org/packages/wheels` is the CommandBox-based release and won't drive a v4 tutorial.
 
-Once the LuCLI-based v2 package ships, installation will be:
+```powershell
+scoop bucket add wheels https://github.com/wheels-dev/scoop-wheels
 
-```powershell title="illustrative — Chocolatey install (not yet available)"
-choco install wheels
+# Pick a channel:
+scoop install wheels        # stable - tracks GA tags
+scoop install wheels-be     # bleeding-edge - tracks every develop merge
+
 wheels --version
 ```
 
-The Chocolatey install script downloads the LuCLI Windows launcher and the matching Wheels Module tarball from GitHub Releases, extracts the module under the package's `tools/module/` directory, and adds `wheels.cmd` to your `PATH`. Java 21 is declared as a Chocolatey dependency (`openjdk`), so `choco` installs a JDK if one isn't already present.
+Both packages depend on `java/openjdk21` (Scoop pulls it automatically) and expose the same `wheels` PATH shim — Scoop refuses to install both at once. To switch channels:
+
+```powershell
+scoop uninstall wheels && scoop install wheels-be
+scoop uninstall wheels-be && scoop install wheels
+```
+
+See [Release Channels](/v4-0-0-snapshot/start-here/release-channels/) for the full channel comparison.
+
+The Scoop bucket lives at [`wheels-dev/scoop-wheels`](https://github.com/wheels-dev/scoop-wheels). The bucket's `checkver`/`autoupdate` blocks pull new versions from GitHub Releases hourly via the community [Excavator](https://github.com/ScoopInstaller/Excavator) bot — no manual maintenance per release.
+
+WinGet support (`winget install Wheels.Wheels`) is planned for post-v4.0.0 GA once a proper installer artifact is built. Until then, use Scoop.
 
 ## Manual JAR install
 
-If Homebrew and Chocolatey don't fit your environment — a locked-down CI host, a Docker image, or a Windows box before the v2 Chocolatey package ships — you can wire the pieces up directly. The install has two independent artifacts:
+If Homebrew and Scoop don't fit your environment — a locked-down CI host, a Docker image, or a Windows box where Scoop isn't an option — you can wire the pieces up directly. The install has two independent artifacts:
 
 1. **LuCLI launcher.** Download from [github.com/cybersonic/LuCLI/releases](https://github.com/cybersonic/LuCLI/releases). Pick the asset matching your OS — `lucli-<version>-macos`, `lucli-<version>-linux`, or `lucli-<version>.bat` on Windows. Rename it to `wheels` (or `wheels.bat`) so LuCLI's binary-name detection activates the Wheels branding, and drop it somewhere on your `PATH`.
 

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
@@ -113,29 +113,31 @@ The two are mutually exclusive — both expose the `wheels` binary. You install 
 
 <TabItem label="Windows" icon="seti:windows">
 
-<Aside type="caution" title="Do not run `choco install wheels` yet">
-The `wheels` package on the public Chocolatey feed is still the v1.x legacy (CommandBox-based) release and **cannot drive this tutorial**. The v2.x LuCLI-based package is built and tested in [`wheels-dev/chocolatey-wheels`](https://github.com/wheels-dev/chocolatey-wheels) but has not been pushed to the community feed yet. Use the manual JAR steps below until then. See [CLI Installation](/v4-0-0-snapshot/command-line-tools/installation/#windows-chocolatey) for context.
+<Aside type="caution" title="Don't run `choco install wheels`">
+The legacy `wheels` package on chocolatey.org is the CommandBox-based v1.x release and **cannot drive this tutorial**. Wheels v4 ships on Windows through [Scoop](https://scoop.sh) instead — see [CLI Installation](/v4-0-0-snapshot/command-line-tools/installation/#windows-scoop) for the full rationale.
 </Aside>
 
 <Steps>
 
-1. Download the LuCLI Windows launcher (`lucli-<version>.bat`) from [github.com/cybersonic/LuCLI/releases](https://github.com/cybersonic/LuCLI/releases). Rename it to `wheels.bat` and place it on your `PATH` (for example, `C:\Tools\wheels\wheels.bat`).
-
-2. Download `wheels-module-<version>.zip` from [github.com/wheels-dev/wheels/releases](https://github.com/wheels-dev/wheels/releases) and extract it into `%USERPROFILE%\.wheels\modules\wheels\`:
+1. Install Scoop if you don't have it (skip if `scoop --version` already works):
 
    ```powershell title="PowerShell"
-   New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.wheels\modules\wheels" | Out-Null
-   Expand-Archive -Path "wheels-module-*.zip" -DestinationPath "$env:USERPROFILE\.wheels\modules\wheels"
+   Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+   Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
    ```
 
-3. Set `JAVA_HOME` to your JDK 21 install and `LUCLI_HOME` to your Wheels directory (persist via System Properties → Environment Variables):
+2. Add the Wheels bucket and install a channel:
 
    ```powershell title="PowerShell"
-   setx JAVA_HOME "C:\Program Files\Eclipse Adoptium\jdk-21"
-   setx LUCLI_HOME "$env:USERPROFILE\.wheels"
+   scoop bucket add wheels https://github.com/wheels-dev/scoop-wheels
+   scoop install wheels        # stable - tracks v4.0.0 GA tags
+   # OR:
+   scoop install wheels-be     # bleeding-edge - tracks every develop merge
    ```
 
-4. Open a new PowerShell (so PATH and the new env vars pick up) and verify:
+   Scoop pulls `java/openjdk21` automatically as a dependency. Both packages expose the same `wheels` shim on PATH — Scoop refuses to install both at once. See [Release Channels](/v4-0-0-snapshot/start-here/release-channels/) for the comparison.
+
+3. Verify:
 
    ```powershell title="PowerShell"
    wheels --version

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
@@ -206,14 +206,13 @@ brew upgrade wheels
 
 <TabItem label="Windows" icon="seti:windows">
 
-Until the v2 Chocolatey package ships, upgrade by re-downloading the launcher and module from GitHub Releases:
+Upgrade through Scoop — it pulls the latest LuCLI launcher and Wheels Module from the [`wheels-dev/scoop-wheels`](https://github.com/wheels-dev/scoop-wheels) bucket:
 
-1. Replace `wheels.bat` on your `PATH` with the latest `lucli-<version>.bat` from [github.com/cybersonic/LuCLI/releases](https://github.com/cybersonic/LuCLI/releases).
-2. Re-extract the latest `wheels-module-<version>.zip` from [github.com/wheels-dev/wheels/releases](https://github.com/wheels-dev/wheels/releases) over `%USERPROFILE%\.wheels\modules\wheels\`:
-
-   ```powershell title="PowerShell"
-   Expand-Archive -Path "wheels-module-*.zip" -DestinationPath "$env:USERPROFILE\.wheels\modules\wheels" -Force
-   ```
+```powershell title="PowerShell"
+scoop update wheels
+# or, for the bleeding-edge channel:
+scoop update wheels-be
+```
 
 </TabItem>
 


### PR DESCRIPTION
## Summary

Two parallel cleanups from the master plan:

**v4 docs:** the Windows install section in `installing.mdx` and `installation.mdx` had been pointing at a non-existent v2.x LuCLI Chocolatey package that was never going to ship. Replace with the real path now that the Scoop bucket is live at [`wheels-dev/scoop-wheels`](https://github.com/wheels-dev/scoop-wheels). Includes the channel-switch flow and a forward-pointer to the [Release Channels](https://guides.wheels.dev/v4-0-0-snapshot/start-here/release-channels/) page.

**v2-5-0 + v3-0-0 index pages:** add a Starlight `:::caution:::` banner clarifying these docs are historical and that CommandBox-based references are accurate for those versions but no longer reflect current install paths. Banner only — does NOT touch the body content. Those refs are correct in context (v2/v3 used CommandBox); the banner just steers new users toward v4.

## Files changed

| File | Change |
|---|---|
| `web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/installation.mdx` | Replace Chocolatey section with Scoop bucket instructions + WinGet "planned post-GA" mention |
| `web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx` | Windows tab: 3 steps (install Scoop, add bucket, install + verify) instead of 4 manual-JAR steps |
| `web/sites/guides/src/content/docs/v2-5-0/index.md` | One-paragraph historical banner |
| `web/sites/guides/src/content/docs/v3-0-0/index.md` | One-paragraph historical banner |

## What I deliberately did NOT change

- Body content of v2/v3 pages — those CommandBox references are correct for those versions and rewriting them would be revisionist
- Cross-references in v4 like "if your team already uses CommandBox for non-Wheels things" — those are legitimate ecosystem mentions
- `wheels modules` / `wheels deps` ForgeBox mentions — ForgeBox is still a supported dep source

## Test plan

- [x] Local diff review
- [ ] Astro/Starlight build on this PR (web-build CI step)
- [ ] After merge: confirm guides.wheels.dev renders the Scoop section correctly on the v4 install page