### PR TITLE
ci: harden wheels-bot Reviewer A against placeholder submissions

### DIFF
--- a/.claude/commands/respond-to-critique.md
+++ b/.claude/commands/respond-to-critique.md
@@ -68,6 +68,13 @@ Read `.claude/commands/_shared-rails.md` first. Highlights:
    for the initial review's verdict; responses use COMMENT so the
    verdict tracking stays consistent across rounds).
 
+   **Submit exactly one `gh pr review` call per session.** Never probe
+   the command with a placeholder body before issuing the real response —
+   every invocation is publicly visible. The post-submission guard in
+   `bot-review-a.yml` auto-dismisses wheels-bot reviews missing the
+   canonical marker or shorter than 200 characters (issue #2558); do not
+   rely on it as a safety net.
+
    Format:
 
    ```

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -96,6 +96,16 @@ below. Highlights for this command:
    `gh pr review` invocation with `--body` containing line-anchored Markdown
    if line comments are not feasible.
 
+   **Submit exactly one `gh pr review` call per session.** Never probe the
+   command with a placeholder (`--body "test body"`, `--body ""`, etc.)
+   before issuing the real review — every `gh pr review` invocation is
+   visible to humans and counts as a public review. If you need to verify
+   syntax or auth, use `gh auth status` or `gh pr view`; do not exercise
+   `gh pr review` until you have the final body ready. A post-submission
+   guard in `bot-review-a.yml` auto-dismisses any wheels-bot review missing
+   the canonical marker or shorter than 200 characters (issue #2558) — do
+   not rely on it as a safety net.
+
    The review body must:
    - Open with `## Wheels Bot — Reviewer A`
    - Have a one-paragraph **TL;DR** that names the PR's purpose and your

--- a/.github/workflows/bot-review-a.yml
+++ b/.github/workflows/bot-review-a.yml
@@ -93,7 +93,11 @@ jobs:
         with:
           target-type: pr
           target-number: ${{ steps.pr.outputs.pr_num }}
-          marker-pattern: 'wheels-bot:review-a:${{ steps.pr.outputs.pr_num }}:${{ steps.pr.outputs.sha }}:'
+          # No trailing colon: the initial review marker is
+          # `wheels-bot:review-a:<pr>:<sha>` with no suffix. Adding a trailing
+          # `:` made this a no-op gate (issue #2558). Response markers use the
+          # distinct `wheels-bot:review-a-response:` prefix and won't false-match.
+          marker-pattern: 'wheels-bot:review-a:${{ steps.pr.outputs.pr_num }}:${{ steps.pr.outputs.sha }}'
           github-token: ${{ steps.app-token.outputs.token }}
 
       - name: Determine prompt
@@ -121,3 +125,54 @@ jobs:
             --model claude-sonnet-4-6
             --max-turns 250
             --allowedTools "Bash(gh:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git grep:*),Bash(git status),Read,Grep,Glob"
+
+      # Post-submission guard (issue #2558). Reviewer A is trusted to issue a
+      # single, substantive `gh pr review` per session. When the model misbehaves
+      # — e.g. probing the CLI with `--body "test body"` before issuing the
+      # real review — the placeholder leaks out as a public review. This step
+      # scans wheels-bot reviews on the current SHA after the model exits and
+      # auto-dismisses any that look like probes (too short, or missing the
+      # canonical `wheels-bot:review-a` marker). Runs on `always()` so it still
+      # fires when the Claude step itself failed mid-session.
+      - name: Validate Reviewer A output
+        if: always() && (github.event_name == 'issue_comment' || steps.gate.outputs.skip == 'false')
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_num }}
+          HEAD_SHA: ${{ steps.pr.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          reviews=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" --paginate \
+            | jq -c --arg sha "$HEAD_SHA" \
+                '[.[] | select(.user.login == "wheels-bot[bot]") | select(.commit_id == $sha) | select(.state != "DISMISSED")]')
+
+          count=$(echo "$reviews" | jq 'length')
+          if [[ "$count" == "0" ]]; then
+            echo "::notice::No active wheels-bot reviews on ${HEAD_SHA} to validate"
+            exit 0
+          fi
+
+          dismissed=0
+          while IFS= read -r row; do
+            id=$(echo "$row" | jq -r '.id')
+            body=$(echo "$row" | jq -r '.body')
+            body_len=${#body}
+
+            if [[ "$body_len" -lt 200 ]] || ! grep -q 'wheels-bot:review-a' <<<"$body"; then
+              echo "::warning::Dismissing bogus Reviewer A review id=${id} len=${body_len}"
+              gh api -X PUT \
+                "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews/${id}/dismissals" \
+                -f message="Auto-dismissed by Reviewer A guard: body is shorter than 200 characters or missing the canonical \`wheels-bot:review-a\` marker. See wheels-dev/wheels#2558 for context."
+              dismissed=$((dismissed + 1))
+            fi
+          done < <(echo "$reviews" | jq -c '.[]')
+
+          if [[ "$dismissed" -gt 0 ]]; then
+            short_sha=${HEAD_SHA:0:7}
+            gh pr comment "$PR_NUMBER" --body "## Wheels Bot — Reviewer A guard
+
+          Detected and dismissed ${dismissed} bogus Reviewer A review(s) on commit \`${short_sha}\`. Cause: review body shorter than 200 characters or missing the canonical \`wheels-bot:review-a\` marker. See [wheels-dev/wheels#2558](https://github.com/wheels-dev/wheels/issues/2558) for context.
+
+          <!-- wheels-bot:review-a-guard:${PR_NUMBER}:${HEAD_SHA} -->"
+          fi

--- a/.github/workflows/bot-review-a.yml
+++ b/.github/workflows/bot-review-a.yml
@@ -153,6 +153,13 @@ jobs:
             exit 0
           fi
 
+          # Dismissal criteria: body must be (a) >= 200 chars AND (b) contain
+          # `wheels-bot:review-a` as a substring. Both conditions are required —
+          # a long body without the marker still gets dismissed, because a
+          # marker-less review breaks downstream idempotency (the skip-check
+          # action greps for the marker on subsequent runs) and is itself a
+          # signal that the prompt was not followed. Belt-and-suspenders: the
+          # guard treats prompt compliance as load-bearing, not advisory.
           dismissed=0
           while IFS= read -r row; do
             id=$(echo "$row" | jq -r '.id')
@@ -169,10 +176,22 @@ jobs:
           done < <(echo "$reviews" | jq -c '.[]')
 
           if [[ "$dismissed" -gt 0 ]]; then
-            short_sha=${HEAD_SHA:0:7}
-            gh pr comment "$PR_NUMBER" --body "## Wheels Bot — Reviewer A guard
+            # Idempotency check: a manual workflow re-trigger combined with
+            # new bogus reviews on the same SHA could otherwise produce
+            # duplicate guard comments. Skip if a guard comment for this
+            # exact PR + SHA already exists.
+            guard_marker="wheels-bot:review-a-guard:${PR_NUMBER}:${HEAD_SHA}"
+            existing=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+              | jq -r --arg m "$guard_marker" '[.[] | select(.body | contains($m))] | length')
+
+            if [[ "$existing" == "0" ]]; then
+              short_sha=${HEAD_SHA:0:7}
+              gh pr comment "$PR_NUMBER" --body "## Wheels Bot — Reviewer A guard
 
           Detected and dismissed ${dismissed} bogus Reviewer A review(s) on commit \`${short_sha}\`. Cause: review body shorter than 200 characters or missing the canonical \`wheels-bot:review-a\` marker. See [wheels-dev/wheels#2558](https://github.com/wheels-dev/wheels/issues/2558) for context.
 
-          <!-- wheels-bot:review-a-guard:${PR_NUMBER}:${HEAD_SHA} -->"
+          <!-- ${guard_marker} -->"
+            else
+              echo "::notice::Guard comment already present for ${PR_NUMBER}@${HEAD_SHA}; skipping duplicate"
+            fi
           fi


### PR DESCRIPTION
## Summary

Three changes harden the wheels-bot Reviewer A pipeline against the placeholder-submission failure mode observed on [#2546](https://github.com/wheels-dev/wheels/pull/2546):

- **Post-submission guard** (`bot-review-a.yml`): new "Validate Reviewer A output" step runs after the Claude action (with `if: always()`). Scans all active wheels-bot reviews on the head SHA and auto-dismisses any whose body is shorter than 200 characters or missing the canonical `wheels-bot:review-a` marker. Posts a one-line comment summarizing dismissals. This is the load-bearing fix — prompt instructions alone cannot prevent the model from probing `gh pr review` with a placeholder.
- **Marker gate trailing-colon fix** (`bot-review-a.yml:96`): the initial review marker is `<!-- wheels-bot:review-a:<pr>:<sha> -->` with no suffix, but the idempotency `marker-pattern` ended with `:`, making the skip check a no-op. Response markers use `wheels-bot:review-a-response:` (different prefix) so removing the trailing colon doesn't false-match them.
- **Prompt tightening** (`review-pr.md`, `respond-to-critique.md`): explicit instruction to issue exactly one `gh pr review` per session and never probe the command with a placeholder body. Belt-and-suspenders on top of the guard.

## Related Issue

Closes #2558

## Type of Change

- [x] Bug fix

## Feature Completeness Checklist

- [ ] **Tests** — Bot-infrastructure change; not exercised by `bash tools/test-local.sh`. Manual verification plan below.
- [ ] **Framework Docs** — N/A (bot infra)
- [ ] **AI Reference Docs** — N/A (bot infra)
- [ ] **CLAUDE.md** — Not changed; the "Wheels Bot" section's high-level description still applies. The new guard step is referenced in the inline comment in `bot-review-a.yml` and in the prompt files.
- [ ] **CHANGELOG.md** — Not added; this is bot infra, not a user-facing framework change.
- [ ] **Test runner passes** — Same reason as above; no framework code touched.

## Test Plan

The guard cannot be exercised pre-merge because Reviewer A only runs on PRs that match its `if:` conditions. Verification once merged:

- [ ] Trigger a normal review pass (open a real PR). Confirm the guard step appears in the workflow run with `::notice::No active wheels-bot reviews on <sha> to validate` OR no dismissals.
- [ ] Confirm the marker-pattern gate now matches: open a PR, force a second `synchronize` push without changing the SHA (via `git commit --amend --no-edit && git push --force-with-lease` on the same head), confirm Reviewer A's second invocation skips with `idempotency marker already present`.
- [ ] Negative test (controlled): on a throwaway test PR, manually submit a wheels-bot review with body `test body` via `gh pr review` impersonating the bot (or trigger Reviewer A with a deliberate placeholder injection if convenient), confirm the next workflow run dismisses it and posts the guard comment.

## Reviewer notes

- The guard runs against the wheels-bot identity using the same App token that submitted the reviews — dismissal requires `pull_requests: write`, which the App already has (it submits reviews via the same token).
- Dismissed reviews remain visible in the GitHub UI marked "dismissed" with the explanatory message; verdicts no longer count toward branch protection. This is the right semantic — we don't want placeholder approvals to satisfy a "1 approving review" requirement.
- Reviewer B's lookup of A's latest review (in `review-the-review.md`) is **not** updated in this PR to skip dismissed reviews. Worth a follow-up — when a real placeholder happens, B still sees the dismissed review as A's "latest" and may critique it. Listed as a checkbox in issue #2558.
- Adding bot infrastructure to the auto-downgrade list in `propose-fix.md` (so future bot-infra issues are held for human review instead of attempting TDD on workflow YAML) is the orthogonal follow-up from #2558 — not in this PR.

<!-- wheels-bot opt-out: add the [skip-claude] label or include [skip-claude] in the title -->