### PR TITLE
test(view): regression spec for inline-SVG icon convention in migrator view

### DIFF
--- a/vendor/wheels/tests/specs/migrator/MigratorViewIconsSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/MigratorViewIconsSpec.cfc
@@ -1,0 +1,73 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("Migrator view icons", () => {
+
+			// Convention guard for the migrator dashboard. The Database Error
+			// placeholder in vendor/wheels/public/views/migrator.cfm originally
+			// used a Semantic UI icon-font tag (an i element with class
+			// "database icon") while the rest of the file had been migrated
+			// to inline SVG. That one reference rendered as a broken glyph
+			// (#2427 / #2425) because semantic.min.css is included via
+			// cfinclude and its @font-face URLs resolved against the page
+			// URL rather than the CSS source path, so the icon font never
+			// loaded.
+			//
+			// The symptom was fixed by #2562 (swap to inline SVG on this line)
+			// and the root cause was fixed by #2563 (inline the Semantic UI
+			// icon font as a base64 data URI in _header.cfm). These tests
+			// enforce the inline-SVG convention going forward so the migrator
+			// view does not drift back to icon-font tags.
+			it("renders the database-error placeholder with an inline SVG icon, not a font-based glyph", () => {
+				var source = FileRead(ExpandPath("/wheels/public/views/migrator.cfm"));
+
+				// Anchor on the "Database Error" string the view emits when
+				// the datasource is unavailable.
+				var anchor = Find("Database Error", source);
+				expect(anchor).toBeGT(0, "migrator.cfm must contain a Database Error placeholder.");
+
+				// Examine ~1500 chars before the anchor — the inline-SVG path
+				// data for the database icon alone is ~700 chars, so the
+				// window has to be wide enough to capture it.
+				var windowStart = Max(anchor - 1500, 1);
+				var windowLen = anchor - windowStart;
+				var iconBlock = Mid(source, windowStart, windowLen);
+
+				// The placeholder must contain an inline svg tag (the project
+				// convention used everywhere else in this view), and must not
+				// contain an icon-font opener of the form `i class="...icon..."`.
+				expect(iconBlock).toInclude(
+					Chr(60) & "svg",
+					"Database error placeholder must use an inline svg icon to match the convention used elsewhere in migrator.cfm."
+				);
+
+				var fontIconHit = reFindNoCase(
+					Chr(60) & "i[\s>][^>]*\bicon\b",
+					iconBlock
+				);
+				expect(fontIconHit).toBe(
+					0,
+					"Database error placeholder must not use a Semantic UI icon-font tag. Use an inline svg to match the rest of the view."
+				);
+			});
+
+			// Belt-and-suspenders: the whole view should be free of icon-font
+			// tags. Every other glyph in the file is already an inline svg;
+			// adding any new icon-font usage would break the convention.
+			it("uses no Semantic UI icon-font tags anywhere in the migrator view", () => {
+				var source = FileRead(ExpandPath("/wheels/public/views/migrator.cfm"));
+				// reMatchNoCase returns every opener tag of the form i ...icon... in the file.
+				var pattern = Chr(60) & "i[\s>][^>]*\bicon\b[^>]*>";
+				var hits = reMatchNoCase(pattern, source);
+				expect(ArrayLen(hits)).toBe(
+					0,
+					"migrator.cfm should not contain any icon-font tags — convert them to inline svg to match the rest of the view. Found: " & ArrayToList(hits, " | ")
+				);
+			});
+
+		});
+
+	}
+
+}


### PR DESCRIPTION
## Summary

Adds a regression test (`vendor/wheels/tests/specs/migrator/MigratorViewIconsSpec.cfc`) that locks in the inline-SVG icon convention for the migrator dashboard.

The original bug (broken icon glyph on the Database Error placeholder, #2427 / #2425) has already been fixed on `develop` via two earlier PRs:

- [#2562](https://github.com/wheels-dev/wheels/pull/2562) replaced the offending Semantic UI icon-font tag on line 299 of [vendor/wheels/public/views/migrator.cfm](vendor/wheels/public/views/migrator.cfm) with an inline SVG that matches the sibling "No migration files found" placeholder.
- [#2563](https://github.com/wheels-dev/wheels/pull/2563) inlined the Semantic UI icon font globally (base64 data URI in `_header.cfm` / `_header_simple.cfm`), so font-based glyphs now render across every framework dev page (`/wheels/guides`, `/wheels/info`, `/wheels/migrator`, etc.).

This PR was originally opened against the unfixed state and conflicted with `develop` after #2562 / #2563 landed. Rebased to drop the duplicate view change + duplicate CHANGELOG entry and keep just the new regression spec — convention enforcement for `migrator.cfm` going forward.

## Related Issue

Closes #2427 (duplicate of #2425; substantive fix is on `develop`).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Documentation update
- [ ] Refactoring
- [x] Test-only (regression coverage)

## What this test asserts

1. The Database Error placeholder in `vendor/wheels/public/views/migrator.cfm` uses an inline `<svg>` (not an icon-font tag).
2. The whole file contains zero `<i ...icon...>` opener tags.

Both checks build their regex literals via `Chr(60) & ...` to avoid the Lucee tag-scanner trap documented in [.ai/wheels/testing/](https://github.com/wheels-dev/wheels/tree/develop/.ai/wheels/testing).

## Feature Completeness Checklist

- [x] **Tests** — The new spec at `vendor/wheels/tests/specs/migrator/MigratorViewIconsSpec.cfc` is the entire change.
- [ ] **Framework Docs** — n/a (test-only, no public API change)
- [ ] **AI Reference Docs** — n/a
- [ ] **CLAUDE.md** — n/a
- [ ] **CHANGELOG.md** — n/a (the user-facing fix already has an entry from #2563; this PR only adds a test)
- [x] **Test runner passes** — Verified with an equivalent Python regex run against the current `vendor/wheels/public/views/migrator.cfm` on develop: both checks pass (anchor found at byte ~16700, `<svg` present in the 1500-char window before it, zero icon-font hits in the 50KB file). CI will run the CFML spec end-to-end.

## Test Plan

```bash
# Local
bash tools/test-local.sh migrator

# CI
# Runs as part of every PR via pr.yml and snapshot.yml across the matrix.
```

The test reads `migrator.cfm` directly via `FileRead(ExpandPath("/wheels/public/views/migrator.cfm"))` — no database, no HTTP, no fixtures required. It will pass on every engine × DB combo so long as `migrator.cfm` keeps its inline-SVG convention.

<!-- wheels-bot opt-out: add the [skip-claude] label or include [skip-claude] in the title -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)