### PR TITLE
ci: fix detect-scope dying on content-only PRs + harden silent-skip

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -96,7 +96,15 @@ jobs:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          set -uo pipefail
+          # Disable -e (GitHub Actions sets it by default for bash steps).
+          # Plain `grep -v` with no matches exits 1, which is normal — but
+          # under `set -e` it would kill the script. For a content-only PR
+          # — the exact case we want to skip — every line matches the
+          # content patterns, the filter returns empty + exit 1, and the
+          # detector dies. Keep -u for typo protection, drop -e.
+          set +e
+          set -u
+          set -o pipefail
           # Resolve the diff range. For PRs we compare base vs head; for
           # pushes we compare the previous tip vs the new tip (falling back
           # to HEAD~1 on first-push / force-push when `before` is zeros).
@@ -145,9 +153,13 @@ jobs:
           #   web/sites/*/src/content/  — Astro content collections (guides, api)
           #   web/sites/*/public/       — static images/assets the sites serve
           #   web/**/*.md, web/**/*.mdx — markdown anywhere under web/
+          # `|| true` guards against the empty-match exit-1 case even if a
+          # future change reintroduces `set -e`. Belt-and-suspenders with the
+          # `set +e` above.
           non_content=$(echo "$changed" \
             | grep -v '^$' \
-            | grep -vE '^(web/content/.+|web/sites/[^/]+/src/content/.+|web/sites/[^/]+/public/.+|web/.+\.mdx?)$')
+            | grep -vE '^(web/content/.+|web/sites/[^/]+/src/content/.+|web/sites/[^/]+/public/.+|web/.+\.mdx?)$' \
+            || true)
 
           if [ -z "$non_content" ]; then
             echo "All changes are content-only — visual regression will be skipped."
@@ -177,10 +189,18 @@ jobs:
     # runs. If the blog index drifts because of the content change, the
     # pre-refresh step below regenerates the baseline before comparison.
     #
+    # Safety: when detect-scope itself fails (not success), fall through
+    # to running visual regression rather than silently skipping. The
+    # `always()` guard is required so this `if:` is evaluated even when
+    # the `needs:` dependency fails — without it, Actions auto-skips us.
+    #
     # If this job fails on an intentional layout change, download the
     # `visual-regression-diffs` artifact and copy each *.actual.png over
     # the matching web/tests/visual-baselines/*.png, commit, and push.
-    if: needs.detect-scope.outputs.content_only != 'true'
+    if: |
+      always() &&
+      (needs.detect-scope.result != 'success' ||
+       needs.detect-scope.outputs.content_only != 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

PR #2583 (a content-only blog post polish — exactly the case #2581 introduced the content-only skip for) became the first PR to exercise the new logic, and surfaced two real bugs:

1. **detect-scope dies on its intended happy path.** The script used \`set -uo pipefail\` but GitHub Actions runs bash with \`-e\` by default — \`set -uo\` does NOT touch \`-e\`. On a content-only diff, every changed file matches the content patterns, so the final \`grep -vE\` filters out everything and exits 1 (normal grep \"no matches\" behavior). With \`-e\` still on, that one exit-1 killed the whole detector. Fix: explicit \`set +e\` early in the script plus a \`|| true\` guard on the offending grep chain. Belt and suspenders.

2. **Silent skip when detect-scope fails.** \`visual-regression\` has \`needs: detect-scope\`. When detect-scope failed (as in bug #1), Actions auto-skipped visual-regression — the layout gate just disappeared. That's the exact silent-bypass the safety-default comments in the job were trying to prevent. Fix: change visual-regression's \`if:\` to:

   \`\`\`yaml
   if: |
     always() &&
     (needs.detect-scope.result != 'success' ||
      needs.detect-scope.outputs.content_only != 'true')
   \`\`\`

   The \`always()\` is required so the \`if:\` is evaluated even when the dependency failed. Now: detect-scope healthy + content_only=true → skip; detect-scope healthy + content_only=false → run; detect-scope failed (any reason) → run. There is no path that silently skips.

## Why this should land before #2583 is rebased

Without this hotfix, every content-only PR (the whole point of #2581) hits the same exit-1 trap. #2583 will be the validation that the hotfix works.

## Test plan

- [ ] CI on this PR: detect-scope runs (this PR touches the workflow file → not content-only → \`content_only=false\` expected); visual-regression runs and passes (no baseline drift in workflow-only changes).
- [ ] After merge: rebase #2583 on develop. Expected outcome — detect-scope succeeds, emits \`content_only=true\`, visual-regression shows as skipped (not pending, not pass, not fail) on the PR checks list.

## Local validation

Reran the same logic locally with bash 5.x (\`set -e\` enabled) — confirmed the original script dies at the grep step on a content-only changeset, and the fixed version completes and emits \`content_only=true\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)