### PR TITLE
ci: unblock bot-triage for read-permission contributors

### DIFF
--- a/.github/workflows/bot-triage.yml
+++ b/.github/workflows/bot-triage.yml
@@ -3,12 +3,18 @@ name: Wheels Bot — Triage
 on:
   issues:
     types: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to triage (use when the original issues:opened event missed or failed)'
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: wheels-bot-triage-${{ github.event.issue.number }}
+  group: wheels-bot-triage-${{ github.event.issue.number || inputs.issue_number }}
   cancel-in-progress: false
 
 jobs:
@@ -18,7 +24,7 @@ jobs:
     timeout-minutes: 25
     if: |
       vars.WHEELS_BOT_ENABLED == 'true'
-      && github.event.issue.user.login != 'wheels-bot[bot]'
+      && (github.event_name != 'issues' || github.event.issue.user.login != 'wheels-bot[bot]')
     env:
       WHEELS_CI: "true"
     steps:
@@ -40,8 +46,8 @@ jobs:
         uses: ./.github/actions/wheels-bot-skip-check
         with:
           target-type: issue
-          target-number: ${{ github.event.issue.number }}
-          marker-pattern: 'wheels-bot:triage:${{ github.event.issue.number }}|wheels-bot:triage-class:'
+          target-number: ${{ github.event.issue.number || inputs.issue_number }}
+          marker-pattern: 'wheels-bot:triage:${{ github.event.issue.number || inputs.issue_number }}|wheels-bot:triage-class:'
           github-token: ${{ steps.app-token.outputs.token }}
 
       - name: Run Triage
@@ -52,10 +58,18 @@ jobs:
           # bot and github-actions[bot] in case an upstream automation creates
           # an issue we want to triage. Specific allowlist (not '*') — public repo.
           allowed_bots: 'wheels-bot[bot],github-actions[bot]'
+          # Public OSS bug tracker: issues come from contributors without write
+          # permission. The action's default actor-permission gate would reject
+          # them, so we bypass it here. This is safe because: (a) workflow has
+          # `contents: read` only, (b) the App token used for commenting is
+          # independent of the actor, (c) claude_args below restricts shell to
+          # gh + read-only git + file reads — no Write/Edit/general Bash. The
+          # action's docs name "issue labeling" as the canonical use case.
+          allowed_non_write_users: '*'
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           prompt: |
-            /triage-issue ${{ github.event.issue.number }}
+            /triage-issue ${{ github.event.issue.number || inputs.issue_number }}
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 200


### PR DESCRIPTION
## Summary

The wheels-bot triage workflow has been silently failing for issues opened by external contributors (read-permission users). 5 of the last 13 `bot-triage` runs ended in `failure` at the **Run Triage** step with `Actor does not have write permissions to the repository`.

**Pattern is clean:** every recent failure was an issue from `@zainforbjs` (read perms); every success was an issue from `@bpamiri` (write/admin). The `anthropics/claude-code-action@v1` defaults to rejecting non-write actors — sensible for PR automation, exactly backward for issue triage on a public OSS bug tracker.

## What changed

- **`allowed_non_write_users: '*'`** on the `Run Triage` step — the action input designed for this exact case. Its docs name "issue labeling" as the canonical example.
- **`workflow_dispatch` trigger** with `issue_number` input — so the 5 missed issues (and any future misses) can be re-triaged without the close/reopen dance.
- **`if:` guard hardened** so the wheels-bot self-loop check doesn't try to evaluate `github.event.issue` on dispatch events.

## Why it's safe

The override is scoped narrowly to the triage workflow:

1. Workflow-level `permissions: contents: read` — the action cannot mutate code.
2. Comments are posted via the GitHub App token, independent of the actor's permissions. An attacker can't escalate via prompt injection.
3. `claude_args` restricts the model's shell to `Bash(gh:*)` + read-only `git` + `Read`/`Grep`/`Glob`. No `Write`, no `Edit`, no general `Bash`.

Worst-case under prompt injection: a misleading triage comment under the bot's name — recoverable, bounded, and we're already reading the same untrusted content into the model today.

## Why only this workflow

| Workflow | Action needed? |
|---|---|
| **bot-triage** (`issues:opened`) | **Yes** — fixed here |
| `bot-research`, `bot-propose-fix`, `bot-advisor`, `bot-address-review`, `bot-write-docs` (`issue_comment` slash commands) | **No** — restricting these to write-permission users is correct (don't let randos invoke expensive runs) |
| `bot-review-a`, `bot-tdd-gate` (`pull_request`) | Eventually, if external contributors start opening PRs. None yet, so deferring. |

## Recovery for the 5 missed issues

Once this merges, re-trigger each via the new dispatch input:

```bash
for n in 2582 2577 2569 2568 2567; do
  gh workflow run bot-triage.yml --repo wheels-dev/wheels -f issue_number=$n
done
```

## Test plan

- [ ] CI green on this PR
- [ ] After merge, dispatch triage for #2582 (or any one of the missed issues) and verify a triage comment appears
- [ ] Backfill the remaining 4 missed issues via dispatch
- [ ] Watch the next external-contributor issue for a normal `issues:opened` triage run

🤖 Generated with [Claude Code](https://claude.com/claude-code)