### PR TITLE
ci: switch wheels-bot triage from Sonnet to Opus

### DIFF
--- a/.github/workflows/bot-triage.yml
+++ b/.github/workflows/bot-triage.yml
@@ -71,6 +71,6 @@ jobs:
           prompt: |
             /triage-issue ${{ github.event.issue.number || inputs.issue_number }}
           claude_args: |
-            --model claude-sonnet-4-6
+            --model claude-opus-4-7
             --max-turns 200
             --allowedTools "Bash(gh:*),Bash(git status),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git grep:*),Read,Grep,Glob"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1057,7 +1057,7 @@ Workflow orchestration (multi-step planning, feature development) is not a frame
 
 | Stage | Trigger | Model | Output |
 |---|---|---|---|
-| Triage | issue opened/reopened | Sonnet | Comment classifying as `bug` / `framework-design` / `other` (+ confidence on `bug` path). |
+| Triage | issue opened/reopened | Opus | Comment classifying as `bug` / `framework-design` / `other` (+ confidence on `bug` path). Reads code with the allowlisted tools to resolve uncertainty before rating. |
 | Research | bot triage emits `framework-design` marker | Opus | Comment comparing Rails / Laravel / Django / Phoenix / Spring Boot / +1 and recommending a Wheels-idiomatic path (+ confidence). |
 | Propose Fix | bot triage emits `triage-confidence:high` OR research emits `research-confidence:high` (or `workflow_dispatch`) | Opus | TDD-mandatory draft PR on branch `fix/bot-<issue>-<slug>`. Spec-then-implementation, both required by `bot-tdd-gate.yml`. |
 | Reviewer A | PR opened / synchronized / ready_for_review | Sonnet | Single PR review with line comments, verdict, and `wheels-bot:review-a:<pr>:<sha>` marker. |

--- a/docs/contributing/wheels-bot.md
+++ b/docs/contributing/wheels-bot.md
@@ -221,7 +221,8 @@ loop on the updated PR state.
 
 This is a *coding* stage — Opus model, 60-minute timeout, broad
 allowlist with the test runner (mirrors propose-fix's setup). Different
-from the analytical Sonnet stages above.
+from Reviewer A and Reviewer B, which remain Sonnet-based analytical
+stages.
 
 The bot:
 
@@ -257,11 +258,11 @@ round 11). The advisor reads the full A↔B exchange, the disputed
 code, and the canonical references (`CLAUDE.md`, `.ai/wheels/`),
 then issues a tie-breaking verdict.
 
-**This is the only stage that runs Opus on a non-coding task.** The
-reasoning depth is justified because the advisor's verdict overrides
-the analytical reviewers' deadlock — it must be right. Address-
-review uses Opus because it modifies code; advisor uses Opus because
-it adjudicates code-related disputes Sonnet couldn't resolve.
+**The advisor and triage are the two stages that run Opus on
+non-coding tasks.** Triage justifies the cost by reading code to
+resolve uncertainty before rating confidence; advisor justifies it
+because its verdict overrides a deadlocked A↔B exchange — it must be
+right. Address-review and propose-fix run Opus for code edits.
 
 The advisor:
 


### PR DESCRIPTION
## Summary

Path B from this morning's discussion about confidence gating: rather than building a separate Opus advisor for medium-confidence triages, just run triage on Opus to begin with. Simpler workflow, one stage to reason about, and the model that ends up reading the code is the same model that rates confidence.

## Why

Triage isn't a pure classification task — when the model rates `medium`, it's often because:
- The reporter's symptoms suggest a layer but the model can't verify the hypothesis without reading code
- An inconsistency in the report (e.g. one command works while another routing through the same function fails) needs deeper investigation to resolve

Opus is better at this kind of "resolve an inconsistency by reading the relevant code" reasoning, which matters precisely on the cases that determine whether propose-fix auto-fires.

**Concrete example from today's [#2582](https://github.com/wheels-dev/wheels/issues/2582):** Sonnet rated `medium` because the reporter listed `/env` as working even though it routes through the same `consoleExec` function as the failing commands. With Opus, the triage pass could have read `consoleExec` to resolve that inconsistency (likely `high`, since the fix is mechanical) or confirmed the inconsistency as genuine scope-initialization weirdness (justified `medium` with sharper rationale). Either way: better signal.

## What changed

- `.github/workflows/bot-triage.yml`: `--model claude-sonnet-4-6` → `--model claude-opus-4-7` (one line)
- `CLAUDE.md`: bot stages table updated so future sessions see the right model

**Unchanged (deliberately):**
- `--max-turns 200` — Opus on triage prompts typically converges in <50 turns, plenty of headroom
- `--allowedTools` — same read-only allowlist (`gh`, read-only `git`, `Read`/`Grep`/`Glob`). Not broadening tools; if we wanted Opus to reproduce bugs we'd need test-runner access, which we're explicitly not doing here
- Auto-downgrade rules in `.claude/commands/triage-issue.md` — `vendor/wheels/security/**`, auth flows, `vendor/wheels/middleware/**`, migrations still force at most `medium`. The guard-rails are about *where* the bot can auto-fire, not *which model* rates confidence
- Marker contract (`<!-- wheels-bot:triage-confidence:high -->`) — propose-fix's `if:` keeps grepping for the same string

## Cost expectations

Roughly 5× tokens per triage vs. Sonnet. Volume is modest:
- Recent rate: ~3-4 issues/day
- Triage prompt is short (~2K input tokens), output is structured (~1K)
- Opus pricing → on the order of cents-per-triage, dollars-per-week

The kill switch (`WHEELS_BOT_ENABLED=false`) still halts everything if the cost ever surprises.

## What to watch for after merge

- **More `high` ratings on bug-class issues** — that's the intended effect; propose-fix will auto-fire more often. Watch the first 3-5 draft PRs carefully for quality regression.
- **Same `medium` ratings on auto-downgrade-protected surfaces** — sanity check that security/middleware/migration touches still rate `medium` even when Opus would otherwise rate `high`. The downgrade rules are in the prompt, not the model.
- **Triage latency** — Opus is slower per token. If a triage run pushes against the 25-minute `timeout-minutes` cap, we'd need to look at the prompt budget. Current Sonnet runs finish in 1-3 minutes; expect Opus to land around 3-8 minutes.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, the next external-contributor issue's triage uses Opus (verify via the workflow run logs showing `claude-opus-4-7` in the env dump)
- [ ] Spot-check 2-3 of the first Opus triages for: reasonable classification, calibrated confidence, auto-downgrade rules still enforced on sensitive areas
- [ ] Watch for any timeout-minute pressure in the first week

🤖 Generated with [Claude Code](https://claude.com/claude-code)