### PR TITLE
chore: expand NOTICE attribution and bundle it in base artifact

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,8 +1,23 @@
 Wheels Framework
-================
+Copyright 2006-2026 The Wheels Framework Authors
 
-This product is licensed under the Apache License, Version 2.0
-(see LICENSE in the repository root).
+This product includes software developed by:
+
+  - Per Djurner and the original CFWheels contributors (2006-)
+    https://github.com/cfwheels/cfwheels
+
+  - Andy Bellenie, Tony Petruzzi, Chris Peters, and the broader
+    CFWheels community of contributors and maintainers
+
+  - Tom King and contributors to the original Wheels CLI (2016-)
+    (see "Wheels CLI MIT relicensing" below)
+
+For the full list of contributors, see the project's Git history:
+  git log --format='%aN <%aE>' | sort -u
+
+------------------------------------------------------------------
+
+Wheels CLI MIT relicensing
 
 Portions of the cli/ directory derive from wheels-cli, originally
 released as a standalone CommandBox module by Tom King under the
@@ -15,3 +30,6 @@ relicensed under the Apache License, Version 2.0. The original MIT
 copyright notice is retained here in accordance with the MIT
 License's notice-retention clause and Apache License 2.0,
 Section 4(c).
+
+This product is licensed under the Apache License, Version 2.0
+(see LICENSE).

--- a/tools/build/scripts/prepare-base.sh
+++ b/tools/build/scripts/prepare-base.sh
@@ -45,8 +45,9 @@ cp CLAUDE.md "${BUILD_DIR}/"
 cp -r .claude "${BUILD_DIR}/"
 cp -r .opencode "${BUILD_DIR}/" 2>/dev/null || true
 
-# Copy Apache License how are you?
+# Apache 2.0 §4(d) requires NOTICE to propagate to derivatives.
 cp LICENSE "${BUILD_DIR}/"
+cp NOTICE "${BUILD_DIR}/"
 
 # Copy VS Code snippets
 echo "Copying VS Code snippets..."


### PR DESCRIPTION
## Summary

Closes #2573.

[PR #2594](https://github.com/wheels-dev/wheels/pull/2594) landed first with a NOTICE focused on the `cli/LICENSE` MIT→Apache reconciliation. This PR extends the same `NOTICE` with the broader contributor attribution called for in #2573, and bundles the file into the release scaffold so Apache 2.0 §4(d) propagation actually happens.

- Extends `NOTICE` with attribution to original CFWheels contributors (Per Djurner et al.) and named long-running contributors (Andy Bellenie, Tony Petruzzi, Chris Peters) — preserves #2594's Tom King / wheels-cli MIT relicensing section as a dedicated subsection.
- Updates `tools/build/scripts/prepare-base.sh` to `cp NOTICE "${BUILD_DIR}/"` alongside the existing `cp LICENSE`. Apache 2.0 §4(d) requires downstream redistributors to propagate NOTICE; bundling it in the base-template artifact is what makes that work in practice for ForgeBox installs and any scaffold-based redistribution.
- NOTICE footer is a single-line reference to `LICENSE` rather than restating the Apache 2.0 boilerplate (Reviewer A nit) — matches the ASF canonical NOTICE template convention.

## Why this matters

Apache License 2.0 §4(d) requires that when a Work includes a `NOTICE` file, any Derivative Works that get distributed must include a readable copy of the attribution notices it contains. Until #2594 landed, the repo had none; this PR finishes the job by addressing the broader contributor attribution that #2594's narrower scope deliberately deferred.

## Scope decisions

- **`LICENSE` intentionally not modified.** The existing `LICENSE` is verbatim Apache 2.0 text. License-detection tooling (FOSSA, ScanCode, GitHub linguist) fingerprints that exact body — adding a footer or header risks false negatives in compliance scans. The issue notes the cross-reference is optional ("Apache 2.0 doesn't require it"); skipping it preserves detection accuracy with no real legal cost.
- **Release tarball.** GitHub's auto-generated source tarballs include all repo-rooted files, so `NOTICE` ships in those automatically — no workflow change needed.
- **Homebrew / Chocolatey / nfpm Linux packages.** None of those downstream packagers currently bundle `LICENSE` either (they declare `license: Apache-2.0` as metadata only). That's a separate compliance pass; this PR keeps scope tight to the monorepo's `NOTICE` story plus the base-template artifact.
- **`prepare-core.sh` / `prepare-cli.sh` / `prepare-starterApp.sh`** don't currently copy `LICENSE` either — leaving them untouched matches the existing convention. Reviewer A flagged this as a scope gap worth tracking; will open a follow-up issue after merge.

## Test plan

- [ ] CI: `Build & Publish Release` workflow on `develop` runs `prepare-base.sh` and validates the base-template artifact — confirm `NOTICE` lands in `build-wheels-base/` next to `LICENSE`.
- [ ] Visual: open `NOTICE` on the PR diff and confirm formatting renders correctly and both attribution sections coexist.
- [ ] Compliance: confirm GitHub's license-detection still identifies the repo as Apache-2.0 after merge (the badge should not flip to "Other").

🤖 Generated with [Claude Code](https://claude.com/claude-code)