### PR TITLE
fix(scoop): write wheels.cmd in pre_install so Scoop's bin shim step succeeds

### DIFF
--- a/tools/distribution-drafts/scoop/README.md
+++ b/tools/distribution-drafts/scoop/README.md
@@ -23,8 +23,12 @@ Each install lands four payloads under Scoop's per-version app dir (`$dir`):
 | `lucli-0.3.7.bat` | cybersonic/LuCLI release | `$dir\` |
 | `sqlite-jdbc-3.49.1.0.jar` | Maven Central | `$dir\` |
 
-The `post_install` PowerShell block emits a generated `$dir\wheels.cmd` wrapper.
-That wrapper is what Scoop's `bin` directive shims onto PATH as `wheels`.
+The `pre_install` PowerShell block emits a generated `$dir\wheels.cmd` wrapper.
+That wrapper is what Scoop's `bin` directive shims onto PATH as `wheels`. We use
+`pre_install` (not `post_install`) because Scoop's install order is
+`pre_install` → `bin` shim creation → `post_install` — writing `wheels.cmd` in
+`post_install` would fail the shim step with `Can't shim 'wheels.cmd': File
+doesn't exist.` and abort the install before the wrapper is ever created.
 
 The wrapper, on every invocation:
 
@@ -110,7 +114,7 @@ statements. To pull out the literal CMD content and review it:
 python3 -c '
 import json, re
 m = json.load(open("tools/distribution-drafts/scoop/wheels-be.json"))
-for stmt in m["post_install"]:
+for stmt in m["pre_install"]:
     mm = re.match(r"\$lines\.Add\(\x27(.*)\x27\)", stmt)
     if mm:
         print(mm.group(1).replace("\x27\x27", "\x27"))'

--- a/tools/distribution-drafts/scoop/build-manifests.py
+++ b/tools/distribution-drafts/scoop/build-manifests.py
@@ -134,8 +134,14 @@ def ps_quote_for_addcontent(line: str) -> str:
     return "$lines.Add('" + line.replace("'", "''") + "')"
 
 
-def build_post_install(channel: str) -> list[str]:
-    """Generate the post_install PowerShell array for the given channel."""
+def build_pre_install(channel: str) -> list[str]:
+    """Generate the pre_install PowerShell array for the given channel.
+
+    Emitted as `pre_install` rather than `post_install` because Scoop creates the
+    `bin` shim after pre_install but before post_install. The wheels.cmd launcher
+    must exist at shim-creation time, otherwise the install aborts with
+    `Can't shim 'wheels.cmd': File doesn't exist.` and no further hooks run.
+    """
     lines = cmd_wrapper(channel)
     return [
         # Use the .NET List to avoid PowerShell's slow array-realloc pattern
@@ -183,7 +189,7 @@ def manifest_be() -> dict:
             }
         },
         "bin": [["wheels.cmd", "wheels"]],
-        "post_install": build_post_install("bleeding-edge"),
+        "pre_install": build_pre_install("bleeding-edge"),
         "checkver": {
             "url": "https://api.github.com/repos/wheels-dev/wheels-snapshots/releases?per_page=1",
             "jsonpath": "$[0].tag_name",
@@ -250,7 +256,7 @@ def manifest_stable() -> dict:
             }
         },
         "bin": [["wheels.cmd", "wheels"]],
-        "post_install": build_post_install("stable"),
+        "pre_install": build_pre_install("stable"),
         "checkver": {"github": "https://github.com/wheels-dev/wheels"},
         "autoupdate": {
             "architecture": {

--- a/tools/distribution-drafts/scoop/validate.py
+++ b/tools/distribution-drafts/scoop/validate.py
@@ -47,10 +47,10 @@ def info(msg: str) -> None:
 
 
 def extract_cmd_lines(manifest: dict) -> list[str]:
-    """Pull the literal CMD lines back out of the post_install array."""
+    """Pull the literal CMD lines back out of the pre_install array."""
     cmd_lines: list[str] = []
     pattern = re.compile(r"^\$lines\.Add\('(.*)'\)$")
-    for stmt in manifest.get("post_install", []):
+    for stmt in manifest.get("pre_install", []):
         m = pattern.match(stmt)
         if m:
             # PowerShell single-quote escape: '' -> '
@@ -107,7 +107,7 @@ def check_url_reachable(url: str, name: str) -> None:
 def check_wrapper(name: str, m: dict) -> None:
     cmd_lines = extract_cmd_lines(m)
     if not cmd_lines:
-        fail(f"{name}: post_install emits no CMD wrapper lines")
+        fail(f"{name}: pre_install emits no CMD wrapper lines")
         return
 
     joined = "\n".join(cmd_lines)

--- a/tools/distribution-drafts/scoop/wheels-be.json
+++ b/tools/distribution-drafts/scoop/wheels-be.json
@@ -44,7 +44,7 @@
             "wheels"
         ]
     ],
-    "post_install": [
+    "pre_install": [
         "$lines = New-Object System.Collections.Generic.List[string]",
         "$lines.Add('@echo off')",
         "$lines.Add('setlocal enabledelayedexpansion')",

--- a/tools/distribution-drafts/scoop/wheels.json
+++ b/tools/distribution-drafts/scoop/wheels.json
@@ -47,7 +47,7 @@
             "wheels"
         ]
     ],
-    "post_install": [
+    "pre_install": [
         "$lines = New-Object System.Collections.Generic.List[string]",
         "$lines.Add('@echo off')",
         "$lines.Add('setlocal enabledelayedexpansion')",


### PR DESCRIPTION
## Summary

- Scoop's install order is **`pre_install` → `bin` shim creation → `post_install`**. Both scoop manifests emitted the `wheels.cmd` launcher in `post_install`, so the shim step ran first, failed with `Can't shim 'wheels.cmd': File doesn't exist.`, and aborted the install before the launcher was ever written.
- Move the launcher-creation block to `pre_install` in `tools/distribution-drafts/scoop/build-manifests.py`. Validator (`validate.py`) and README pick up the same rename.
- The emitted JSON manifests change by exactly one key per file; everything else (wrapper content, URLs, hashes, extract paths, banners) is byte-identical.

## Repro (before the fix)

```powershell
scoop bucket add wheels https://github.com/wheels-dev/scoop-wheels
scoop install wheels-be
# ... downloads + hash checks succeed, extraction succeeds, then:
# Creating shim for 'wheels'.
# Get-Command : The term 'wheels.cmd' is not recognized ...
# Can't shim 'wheels.cmd': File doesn't exist.
# (post_install never runs, so wheels.cmd is never written)
```

Hit on Windows by anyone trying `scoop install wheels-be` today. The stable channel (`wheels`) would have failed identically the moment GA cuts, since it shares the same generator.

## Fix

In ``tools/distribution-drafts/scoop/build-manifests.py``:

- Rename `build_post_install` → `build_pre_install` and expand its docstring to explain *why* this has to be `pre_install` (so future readers don't ``fix'' it back).
- Both ``manifest_be()`` and ``manifest_stable()`` now set ``\"pre_install\": build_pre_install(...)`` instead of ``\"post_install\": ...``.
- ``validate.py`` reads the key as ``pre_install``.
- ``README.md`` documents the ordering rationale inline.

## Diff shape

```
 tools/distribution-drafts/scoop/README.md          | 10 +++++++---
 tools/distribution-drafts/scoop/build-manifests.py | 14 ++++++++++----
 tools/distribution-drafts/scoop/validate.py        |  6 +++---
 tools/distribution-drafts/scoop/wheels-be.json     |  2 +-
 tools/distribution-drafts/scoop/wheels.json        |  2 +-
```

The two JSON diffs are literally one line each:

```diff
-    \"post_install\": [
+    \"pre_install\": [
```

## Follow-up (separate PR)

The live bucket at ``wheels-dev/scoop-wheels`` still ships the broken manifests. After this lands, I'll open a companion PR on that repo copying the regenerated ``wheels.json`` and ``wheels-be.json`` into ``bucket/``. Both PRs are independently merge-safe — this one corrects the source of truth; the bucket PR delivers the fix to end users.

## Test plan

- [x] ``python3 tools/distribution-drafts/scoop/build-manifests.py`` regenerates both manifests; diff is one key per file
- [x] ``python3 tools/distribution-drafts/scoop/validate.py --offline`` passes (24 ok lines, 0 failures)
- [ ] After the scoop-wheels companion PR merges, end-to-end ``scoop install wheels-be`` on Windows succeeds and ``wheels --version`` prints the channel-tagged banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)