### PR TITLE
docs(web/guides): replace nonexistent install.sh URL with working .deb/.rpm install

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/installation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Install the wheels binary via Homebrew, Scoop (Windows), or a manual JAR download, and verify your setup.
+description: Install the wheels binary via Homebrew (macOS), .deb/.rpm (Linux), Scoop (Windows), or a manual JAR download, and verify your setup.
 type: reference
 sidebar:
   order: 2
@@ -8,7 +8,7 @@ sidebar:
 
 import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-The `wheels` binary is distributed through three channels: Homebrew for macOS and Linux, Scoop for Windows, and a direct JAR download for anyone who wants to wire it up by hand. Each channel installs the same two artifacts — the LuCLI launcher and the Wheels Module that ships the framework commands.
+The `wheels` binary is distributed through four channels: Homebrew for macOS, `.deb`/`.rpm` packages for Linux, Scoop for Windows, and a direct JAR download for anyone who wants to wire it up by hand. Each channel installs the same two artifacts — the LuCLI launcher and the Wheels Module that ships the framework commands.
 
 **You'll use this for:**
 
@@ -19,7 +19,7 @@ The `wheels` binary is distributed through three channels: Homebrew for macOS an
 
 ## Requirements
 
-The CLI runs on Java 21. On macOS and Linux, the Homebrew formula installs `openjdk@21` for you and sets `JAVA_HOME` inside the `wheels` wrapper, so you don't have to wire up a system JDK. If you're installing manually — or on Windows without Scoop — grab a JDK 21 build from [Adoptium](https://adoptium.net/) or Homebrew:
+The CLI runs on Java 21. On macOS the Homebrew formula installs `openjdk@21` for you and sets `JAVA_HOME` inside the `wheels` wrapper. On Linux the `.deb`/`.rpm` package declares OpenJDK 21 as a runtime dependency, so `apt`/`dnf` pulls it in alongside `wheels`. The wrapper probes `/usr/lib/jvm/` for a Java 21 install and exports `JAVA_HOME` itself. If you're installing manually — or on Windows without Scoop — grab a JDK 21 build from [Adoptium](https://adoptium.net/) or Homebrew:
 
 ```bash title="illustrative — system JDK setup"
 brew install openjdk@21
@@ -28,7 +28,7 @@ java -version
 
 You should see `openjdk version "21.0.x"` in the output. On Apple Silicon macOS, Homebrew's `openjdk@21` isn't symlinked into `/usr/bin/java` by default — the wheels formula handles this by exporting `JAVA_HOME` itself, but if you call `java` directly you'll need to set it manually.
 
-## macOS and Linux (Homebrew)
+## macOS (Homebrew)
 
 Tap the formula repository and install:
 
@@ -48,6 +48,33 @@ The first time you invoke `wheels`, the wrapper:
 5. Execs the LuCLI launcher with your arguments.
 
 On upgrades (`brew upgrade wheels`), the staged module version bumps; the next `wheels` invocation notices the mismatch and refreshes `~/.wheels/modules/wheels/` in place.
+
+## Linux (`.deb` / `.rpm`)
+
+Wheels ships native packages for x86_64 Debian/Ubuntu (`.deb`) and Fedora/RHEL (`.rpm`) hosts on every release. Both are built by `nfpm` on the release workflow and uploaded to the GitHub Release alongside the zip/tar artifacts. The package declares an OpenJDK 21 runtime dependency so `apt`/`dnf` pulls a JDK in automatically when needed.
+
+Install the latest stable release:
+
+```bash title="illustrative — Debian / Ubuntu"
+WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
+  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
+curl -fsSLO "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels_${WHEELS_VERSION}_amd64.deb"
+sudo apt install "./wheels_${WHEELS_VERSION}_amd64.deb"
+```
+
+```bash title="illustrative — Fedora / RHEL"
+WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
+  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
+sudo dnf install "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels-${WHEELS_VERSION}.x86_64.rpm"
+```
+
+The package lays down `/usr/bin/wheels` (a shell wrapper), `/opt/wheels/lucli` (the LuCLI launcher), `/opt/wheels/module/` (the staged Wheels Module), and `/opt/wheels/sqlite-jdbc.jar` (auto-staged into Lucee Express on first run). The wrapper mirrors the Homebrew flow: probes `/usr/lib/jvm/` for OpenJDK 21, exports `LUCLI_HOME=$HOME/.wheels`, syncs the staged module into `~/.wheels/modules/wheels/` on first run or version mismatch, then execs LuCLI.
+
+For the bleeding-edge channel (every merge to `develop`), substitute `wheels-dev/wheels-snapshots` for `wheels-dev/wheels` in the URLs above. Snapshot filenames contain dots in place of the SemVer hyphen — `wheels_4.0.0.snapshot.1825_amd64.deb` for tag `v4.0.0-snapshot.1825`. The version metadata *inside* the `.deb`/`.rpm` preserves the canonical `~snapshot.N` form, so `dpkg --compare-versions` and `rpmvercmp` order it below the next GA correctly.
+
+<Aside type="note" title="Native apt/yum repositories">
+The download-and-install flow above is the v4.0 GA story. Native `apt`/`yum` repositories at `apt.wheels.dev` and `yum.wheels.dev` are on the v4.0.x roadmap — once they're live, you'll be able to add a sources list once and `sudo apt install wheels` / `sudo dnf install wheels` will pull new versions automatically via `apt update`. The package format on disk doesn't change.
+</Aside>
 
 ## Windows (Scoop)
 
@@ -102,7 +129,7 @@ Pick LuCLI and Wheels Module versions that are known to be paired — the Homebr
 
 ## Verifying installation
 
-After any of the three paths, confirm the binary resolves and reports a version:
+After any of the four paths, confirm the binary resolves and reports a version:
 
 ```bash {test:cli cmd="wheels --version" asserts-output="Wheels"}
 wheels --version
@@ -126,9 +153,11 @@ Once the version check passes, `wheels info` inside a Wheels project gives you a
 
 The Homebrew wrapper sets `JAVA_HOME` inside its own process, so a missing or wrong `JAVA_HOME` in your shell doesn't break `wheels`. But if you're calling `java` directly — or running a manual install — the CLI fails fast with a "Java 21 required" message when `JAVA_HOME` isn't pointed at a JDK 21 install. On Apple Silicon macOS, Homebrew stages `openjdk@21` at `/opt/homebrew/Cellar/openjdk@21/<version>/libexec/openjdk.jdk/Contents/Home`; export that path and re-run.
 
-### `wheels: command not found` after `brew install wheels`
+### `wheels: command not found` after install
 
-Homebrew's shim directory has to be on your `PATH`. On Apple Silicon macOS that's `/opt/homebrew/bin`; on Intel macOS and Linux it's `/usr/local/bin`. Run `brew --prefix` to confirm, check your `PATH`, and add the shim directory if it's missing. A fresh shell (`exec $SHELL -l`) often fixes this without any config change.
+On macOS, Homebrew's shim directory has to be on your `PATH` — `/opt/homebrew/bin` on Apple Silicon, `/usr/local/bin` on Intel. Run `brew --prefix` to confirm, check your `PATH`, and add the shim directory if it's missing. A fresh shell (`exec $SHELL -l`) often fixes this without any config change.
+
+On Linux, the `.deb`/`.rpm` package installs `/usr/bin/wheels`, which should be on every user's default `PATH`. If it isn't, run `dpkg -L wheels` (Debian/Ubuntu) or `rpm -ql wheels` (Fedora/RHEL) to confirm the package landed and the binary is at the expected path. A reopened shell (`exec $SHELL -l`) clears any stale `PATH` cache from the previous session.
 
 ### Conflict with a standalone LuCLI install sharing `~/.lucli/`
 

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/installation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/installation.mdx
@@ -93,6 +93,10 @@ The version metadata *inside* the `.deb`/`.rpm` preserves the canonical `~snapsh
 The download-and-install flow above is the v4.0 GA story. Native `apt`/`yum` repositories at `apt.wheels.dev` and `yum.wheels.dev` are on the v4.0.x roadmap — once they're live, you'll be able to add a sources list once and `sudo apt install wheels` / `sudo dnf install wheels` will pull new versions automatically via `apt update`. The package format on disk doesn't change.
 </Aside>
 
+<Aside type="caution" title="Trust model during Phase 1">
+Until the native repos are live, download integrity relies on GitHub's HTTPS transport — the `.deb`/`.rpm` artifacts ship without detached GPG signatures, so neither `apt-key` nor `rpm --checksig` has anything to verify against. Phase 2 introduces a GPG-signed apt/yum repository (the signing key will live in 1Password and be published at `apt.wheels.dev/wheels.gpg`), which will add cryptographic provenance on top of TLS. For now, treat `wheels-dev/wheels/releases` as the trust root.
+</Aside>
+
 ## Windows (Scoop)
 
 Wheels ships on Windows through [Scoop](https://scoop.sh) — a portable, sandboxed package manager that fits the project's release cadence (hourly autoupdate for both stable and bleeding-edge channels). The legacy Chocolatey path is no longer supported; the old v1.x `wheels` package at `community.chocolatey.org/packages/wheels` is the CommandBox-based release and won't drive a v4 tutorial.

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/installation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/command-line-tools/installation.mdx
@@ -70,7 +70,24 @@ sudo dnf install "https://github.com/wheels-dev/wheels/releases/download/v${WHEE
 
 The package lays down `/usr/bin/wheels` (a shell wrapper), `/opt/wheels/lucli` (the LuCLI launcher), `/opt/wheels/module/` (the staged Wheels Module), and `/opt/wheels/sqlite-jdbc.jar` (auto-staged into Lucee Express on first run). The wrapper mirrors the Homebrew flow: probes `/usr/lib/jvm/` for OpenJDK 21, exports `LUCLI_HOME=$HOME/.wheels`, syncs the staged module into `~/.wheels/modules/wheels/` on first run or version mismatch, then execs LuCLI.
 
-For the bleeding-edge channel (every merge to `develop`), substitute `wheels-dev/wheels-snapshots` for `wheels-dev/wheels` in the URLs above. Snapshot filenames contain dots in place of the SemVer hyphen — `wheels_4.0.0.snapshot.1825_amd64.deb` for tag `v4.0.0-snapshot.1825`. The version metadata *inside* the `.deb`/`.rpm` preserves the canonical `~snapshot.N` form, so `dpkg --compare-versions` and `rpmvercmp` order it below the next GA correctly.
+The bleeding-edge channel publishes `.deb`/`.rpm` to [`wheels-dev/wheels-snapshots`](https://github.com/wheels-dev/wheels-snapshots/releases) on every merge to `develop`. Every release there is a GitHub *pre-release*, so `api.github.com/.../releases/latest` returns nothing — use `/releases` and take the first entry. The asset filename also differs: snapshot tags use a SemVer hyphen (`v4.0.0-snapshot.1825`) but the on-disk asset name uses a dot (`wheels_4.0.0.snapshot.1825_amd64.deb`) because GitHub Releases rewrites the package's internal `~snapshot.N` form to `.` at upload time. The substitution converts the tag's hyphen-form to the URL's dot-form:
+
+```bash title="illustrative — Debian / Ubuntu (bleeding-edge)"
+SNAP_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
+  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
+SNAP_FILENAME_VER="${SNAP_TAG//-/.}"
+curl -fsSLO "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${SNAP_TAG}/wheels_${SNAP_FILENAME_VER}_amd64.deb"
+sudo apt install "./wheels_${SNAP_FILENAME_VER}_amd64.deb"
+```
+
+```bash title="illustrative — Fedora / RHEL (bleeding-edge)"
+SNAP_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
+  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
+SNAP_FILENAME_VER="${SNAP_TAG//-/.}"
+sudo dnf install "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${SNAP_TAG}/wheels-${SNAP_FILENAME_VER}.x86_64.rpm"
+```
+
+The version metadata *inside* the `.deb`/`.rpm` preserves the canonical `~snapshot.N` form, so `dpkg --compare-versions` and `rpmvercmp` order pre-releases below the next GA correctly.
 
 <Aside type="note" title="Native apt/yum repositories">
 The download-and-install flow above is the v4.0 GA story. Native `apt`/`yum` repositories at `apt.wheels.dev` and `yum.wheels.dev` are on the v4.0.x roadmap — once they're live, you'll be able to add a sources list once and `sudo apt install wheels` / `sudo dnf install wheels` will pull new versions automatically via `apt update`. The package format on disk doesn't change.

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
@@ -157,21 +157,11 @@ Pick LuCLI and Wheels Module versions that are known to be paired — see [CLI I
 
 <TabItem label="Linux" icon="linux">
 
-Wheels ships `.deb` and `.rpm` packages for x86_64 hosts. A native apt/yum repository at `apt.wheels.dev` / `yum.wheels.dev` is on the v4.0.x roadmap — until then, install the package directly from a GitHub Release. The package installs `/usr/bin/wheels`, depends on OpenJDK 21, and on first run syncs the framework module into `~/.wheels/`.
+Wheels ships `.deb` and `.rpm` packages for x86_64 hosts. A native apt/yum repository at `apt.wheels.dev` / `yum.wheels.dev` is on the v4.0.x roadmap — until then, install the package directly from a GitHub Release. The package installs `/usr/bin/wheels`, declares OpenJDK 21 as a runtime dependency (so `apt`/`dnf` pulls a JDK in automatically), and on first run syncs the framework module into `~/.wheels/`.
 
 <Steps>
 
-1. Install OpenJDK 21:
-
-   ```bash title="Debian / Ubuntu"
-   sudo apt install openjdk-21-jre-headless
-   ```
-
-   ```bash title="Fedora / RHEL"
-   sudo dnf install java-21-openjdk-headless
-   ```
-
-2. Download and install the latest Wheels release:
+1. Download and install the latest Wheels release:
 
    ```bash title="Debian / Ubuntu — stable"
    WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
@@ -187,10 +177,27 @@ Wheels ships `.deb` and `.rpm` packages for x86_64 hosts. A native apt/yum repos
    ```
 
    <Aside type="note" title="Want bleeding-edge?">
-   The bleeding-edge channel publishes a fresh `.deb`/`.rpm` on every merge to `develop`, in the [`wheels-dev/wheels-snapshots`](https://github.com/wheels-dev/wheels-snapshots/releases) repo. Substitute `wheels-dev/wheels-snapshots` for `wheels-dev/wheels` in the URLs above. Note that snapshot version strings in the *filename* use dots in place of the SemVer hyphen — e.g. `wheels_4.0.0.snapshot.1825_amd64.deb` for tag `v4.0.0-snapshot.1825`. The metadata inside the package keeps the canonical `~snapshot.N` form so `apt`/`dnf` orders the version correctly relative to GA. See [Release Channels](/v4-0-0-snapshot/start-here/release-channels/).
+   The bleeding-edge channel publishes a fresh `.deb`/`.rpm` on every merge to `develop`, in the [`wheels-dev/wheels-snapshots`](https://github.com/wheels-dev/wheels-snapshots/releases) repo. Because every release there is a GitHub *pre-release*, `api.github.com/.../releases/latest` returns nothing — use `/releases` and pick the first entry. Snapshot tags use a SemVer hyphen (`v4.0.0-snapshot.1825`); the on-disk asset filename uses a dot in the same slot (`wheels_4.0.0.snapshot.1825_amd64.deb`) because GitHub Releases rewrites the package's internal `~snapshot.N` form to `.` at upload time. Self-contained snippets:
+
+   ```bash title="Debian / Ubuntu — bleeding-edge"
+   SNAP_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
+     | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
+   SNAP_FILENAME_VER="${SNAP_TAG//-/.}"
+   curl -fsSLO "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${SNAP_TAG}/wheels_${SNAP_FILENAME_VER}_amd64.deb"
+   sudo apt install "./wheels_${SNAP_FILENAME_VER}_amd64.deb"
+   ```
+
+   ```bash title="Fedora / RHEL — bleeding-edge"
+   SNAP_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
+     | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
+   SNAP_FILENAME_VER="${SNAP_TAG//-/.}"
+   sudo dnf install "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${SNAP_TAG}/wheels-${SNAP_FILENAME_VER}.x86_64.rpm"
+   ```
+
+   The metadata inside the package keeps the canonical `~snapshot.N` form so `apt`/`dnf` order the version correctly relative to GA. See [Release Channels](/v4-0-0-snapshot/start-here/release-channels/).
    </Aside>
 
-3. Verify:
+2. Verify:
 
    ```bash title="your shell"
    wheels --version
@@ -249,6 +256,8 @@ WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/relea
   | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
 sudo dnf upgrade "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels-${WHEELS_VERSION}.x86_64.rpm"
 ```
+
+For the bleeding-edge channel, run the install snippet from the [bleeding-edge Aside](#install-the-cli) — it points at `wheels-dev/wheels-snapshots` and `apt`/`dnf` will treat each new snapshot as an upgrade.
 
 The first `wheels` invocation after upgrade syncs the new framework module into `~/.wheels/modules/wheels/` automatically.
 

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
@@ -159,6 +159,10 @@ Pick LuCLI and Wheels Module versions that are known to be paired — see [CLI I
 
 Wheels ships `.deb` and `.rpm` packages for x86_64 hosts. A native apt/yum repository at `apt.wheels.dev` / `yum.wheels.dev` is on the v4.0.x roadmap — until then, install the package directly from a GitHub Release. The package installs `/usr/bin/wheels`, declares OpenJDK 21 as a runtime dependency (so `apt`/`dnf` pulls a JDK in automatically), and on first run syncs the framework module into `~/.wheels/`.
 
+<Aside type="caution" title="Trust model during Phase 1">
+During Phase 1 (before `apt.wheels.dev` / `yum.wheels.dev` are live), download integrity relies on GitHub's HTTPS transport — the `.deb`/`.rpm` artifacts ship without detached GPG signatures, so there's nothing for `apt-key` / `rpm --checksig` to verify against. Phase 2 adds GPG-signed apt/yum repositories. For now, `wheels-dev/wheels/releases` is the trust root.
+</Aside>
+
 <Steps>
 
 1. Download and install the latest Wheels release:

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/installing.mdx
@@ -157,21 +157,38 @@ Pick LuCLI and Wheels Module versions that are known to be paired — see [CLI I
 
 <TabItem label="Linux" icon="linux">
 
+Wheels ships `.deb` and `.rpm` packages for x86_64 hosts. A native apt/yum repository at `apt.wheels.dev` / `yum.wheels.dev` is on the v4.0.x roadmap — until then, install the package directly from a GitHub Release. The package installs `/usr/bin/wheels`, depends on OpenJDK 21, and on first run syncs the framework module into `~/.wheels/`.
+
 <Steps>
 
-1. Install via the official installer script:
+1. Install OpenJDK 21:
 
-   ```bash title="your shell"
-   curl -fsSL https://get.wheels.dev/install.sh | bash
+   ```bash title="Debian / Ubuntu"
+   sudo apt install openjdk-21-jre-headless
    ```
 
-   The script downloads the latest release into `~/.wheels/bin/` and adds it to your `PATH`.
-
-2. Reload your shell or source the updated profile:
-
-   ```bash title="your shell"
-   exec "$SHELL"
+   ```bash title="Fedora / RHEL"
+   sudo dnf install java-21-openjdk-headless
    ```
+
+2. Download and install the latest Wheels release:
+
+   ```bash title="Debian / Ubuntu — stable"
+   WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
+     | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
+   curl -fsSLO "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels_${WHEELS_VERSION}_amd64.deb"
+   sudo apt install "./wheels_${WHEELS_VERSION}_amd64.deb"
+   ```
+
+   ```bash title="Fedora / RHEL — stable"
+   WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
+     | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
+   sudo dnf install "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels-${WHEELS_VERSION}.x86_64.rpm"
+   ```
+
+   <Aside type="note" title="Want bleeding-edge?">
+   The bleeding-edge channel publishes a fresh `.deb`/`.rpm` on every merge to `develop`, in the [`wheels-dev/wheels-snapshots`](https://github.com/wheels-dev/wheels-snapshots/releases) repo. Substitute `wheels-dev/wheels-snapshots` for `wheels-dev/wheels` in the URLs above. Note that snapshot version strings in the *filename* use dots in place of the SemVer hyphen — e.g. `wheels_4.0.0.snapshot.1825_amd64.deb` for tag `v4.0.0-snapshot.1825`. The metadata inside the package keeps the canonical `~snapshot.N` form so `apt`/`dnf` orders the version correctly relative to GA. See [Release Channels](/v4-0-0-snapshot/start-here/release-channels/).
+   </Aside>
 
 3. Verify:
 
@@ -218,11 +235,22 @@ scoop update wheels-be
 
 <TabItem label="Linux" icon="linux">
 
-Re-run the installer script — it detects existing installs and upgrades in place:
+Re-run the install command for your distro — `apt`/`dnf` upgrades the package in place when it sees a newer version:
 
-```bash title="your shell"
-curl -fsSL https://get.wheels.dev/install.sh | bash
+```bash title="Debian / Ubuntu"
+WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
+  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
+curl -fsSLO "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels_${WHEELS_VERSION}_amd64.deb"
+sudo apt install "./wheels_${WHEELS_VERSION}_amd64.deb"
 ```
+
+```bash title="Fedora / RHEL"
+WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
+  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
+sudo dnf upgrade "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels-${WHEELS_VERSION}.x86_64.rpm"
+```
+
+The first `wheels` invocation after upgrade syncs the new framework module into `~/.wheels/modules/wheels/` automatically.
 
 </TabItem>
 
@@ -232,7 +260,7 @@ curl -fsSL https://get.wheels.dev/install.sh | bash
 
 **`wheels: command not found`**
 
-Your shell's `PATH` doesn't include the CLI. Restart your shell, or on Linux source `~/.wheels/env` manually. On macOS, confirm Homebrew's bin path is in `PATH`: `echo $PATH | tr ':' '\n' | grep brew`.
+Your shell's `PATH` doesn't include the CLI. Restart your shell first — most installs only put the binary on `PATH` for new shell sessions. On macOS, confirm Homebrew's bin path is in `PATH`: `echo $PATH | tr ':' '\n' | grep brew`. On Linux, the `.deb`/`.rpm` package installs `/usr/bin/wheels`, which should be on every user's default `PATH`; if it's not, check `dpkg -L wheels` (Debian) or `rpm -ql wheels` (RHEL) to confirm the package installed and the binary is where expected.
 
 **`Error: unable to find Java runtime`**
 

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/release-channels.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/release-channels.mdx
@@ -81,13 +81,18 @@ Each channel ships `.deb` and `.rpm` packages on its respective releases page:
 - **Bleeding-edge**: [github.com/wheels-dev/wheels-snapshots/releases](https://github.com/wheels-dev/wheels-snapshots/releases)
 
 ```bash title="Debian / Ubuntu (stable)"
-curl -fsSLO https://github.com/wheels-dev/wheels/releases/latest/download/wheels_<version>_amd64.deb
-sudo apt install ./wheels_<version>_amd64.deb
+WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
+  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
+curl -fsSLO "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels_${WHEELS_VERSION}_amd64.deb"
+sudo apt install "./wheels_${WHEELS_VERSION}_amd64.deb"
 ```
 
 ```bash title="Fedora / RHEL (bleeding-edge)"
-curl -fsSLO https://github.com/wheels-dev/wheels-snapshots/releases/latest/download/wheels-<version>.x86_64.rpm
-sudo dnf install ./wheels-<version>.x86_64.rpm
+# The bleeding-edge channel publishes only pre-releases, so use /releases (not /releases/latest).
+WHEELS_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
+  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
+WHEELS_FILENAME_VER="${WHEELS_TAG//-/.}"  # GitHub Releases rewrites ~ to . in filenames
+sudo dnf install "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${WHEELS_TAG}/wheels-${WHEELS_FILENAME_VER}.x86_64.rpm"
 ```
 
 Apt and yum repos at `apt.wheels.dev` / `yum.wheels.dev` are coming — they'll let you `apt upgrade wheels` instead of re-downloading.
@@ -102,16 +107,27 @@ GitHub Releases doesn't allow `~` in asset filenames, so the SemVer pre-release 
 
 ## Switching channels
 
-The `wheels` and `wheels-be` packages declare a Homebrew `conflicts_with` so they can't coexist. To switch:
+The `wheels` and `wheels-be` packages can't coexist — they both install a binary named `wheels`. Homebrew enforces this via `conflicts_with`; the Linux `.deb`/`.rpm` packages declare `Conflicts:` / `Replaces:` so `apt`/`dnf` does the replacement in one step. Scoop refuses to install both at once.
 
-```bash title="stable → bleeding-edge"
+```bash title="macOS — stable → bleeding-edge"
 brew uninstall wheels
 brew install wheels-be
 ```
 
-```bash title="bleeding-edge → stable"
+```bash title="macOS — bleeding-edge → stable"
 brew uninstall wheels-be
 brew install wheels
+```
+
+```bash title="Linux — switch by installing the other package"
+# apt/dnf sees the Conflicts: + Replaces: metadata and swaps the packages atomically.
+# Use the install snippet from the appropriate channel above with wheels-be / wheels
+# substituted in the URL — apt/dnf removes the old one as part of the transaction.
+```
+
+```powershell title="Windows (Scoop) — stable → bleeding-edge"
+scoop uninstall wheels
+scoop install wheels-be
 ```
 
 ### What happens to your apps when you switch

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/release-channels.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/release-channels.mdx
@@ -87,13 +87,27 @@ curl -fsSLO "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VE
 sudo apt install "./wheels_${WHEELS_VERSION}_amd64.deb"
 ```
 
-```bash title="Fedora / RHEL (bleeding-edge)"
+```bash title="Fedora / RHEL (stable)"
+WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
+  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
+sudo dnf install "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels-${WHEELS_VERSION}.x86_64.rpm"
+```
+
+```bash title="Debian / Ubuntu (bleeding-edge)"
 # The bleeding-edge channel publishes only pre-releases, so use /releases (not /releases/latest).
 WHEELS_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
   | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
 # Tag uses a SemVer hyphen (4.0.0-snapshot.N). The on-disk asset name uses a dot
 # in the same slot because GitHub Releases rewrites the package's internal
 # ~snapshot.N form to . at upload time. So translate hyphen → dot for the URL.
+WHEELS_FILENAME_VER="${WHEELS_TAG//-/.}"
+curl -fsSLO "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${WHEELS_TAG}/wheels_${WHEELS_FILENAME_VER}_amd64.deb"
+sudo apt install "./wheels_${WHEELS_FILENAME_VER}_amd64.deb"
+```
+
+```bash title="Fedora / RHEL (bleeding-edge)"
+WHEELS_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
+  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
 WHEELS_FILENAME_VER="${WHEELS_TAG//-/.}"
 sudo dnf install "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${WHEELS_TAG}/wheels-${WHEELS_FILENAME_VER}.x86_64.rpm"
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/release-channels.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/release-channels.mdx
@@ -91,7 +91,10 @@ sudo apt install "./wheels_${WHEELS_VERSION}_amd64.deb"
 # The bleeding-edge channel publishes only pre-releases, so use /releases (not /releases/latest).
 WHEELS_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
   | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
-WHEELS_FILENAME_VER="${WHEELS_TAG//-/.}"  # GitHub Releases rewrites ~ to . in filenames
+# Tag uses a SemVer hyphen (4.0.0-snapshot.N). The on-disk asset name uses a dot
+# in the same slot because GitHub Releases rewrites the package's internal
+# ~snapshot.N form to . at upload time. So translate hyphen → dot for the URL.
+WHEELS_FILENAME_VER="${WHEELS_TAG//-/.}"
 sudo dnf install "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${WHEELS_TAG}/wheels-${WHEELS_FILENAME_VER}.x86_64.rpm"
 ```
 
@@ -107,7 +110,9 @@ GitHub Releases doesn't allow `~` in asset filenames, so the SemVer pre-release 
 
 ## Switching channels
 
-The `wheels` and `wheels-be` packages can't coexist — they both install a binary named `wheels`. Homebrew enforces this via `conflicts_with`; the Linux `.deb`/`.rpm` packages declare `Conflicts:` / `Replaces:` so `apt`/`dnf` does the replacement in one step. Scoop refuses to install both at once.
+On **macOS and Windows**, the channels publish two differently-named packages (`wheels` vs `wheels-be`) that both install a binary called `wheels`, so the package managers refuse to install both at once — Homebrew enforces this via `conflicts_with`, Scoop refuses outright.
+
+On **Linux**, only a single package name (`wheels`) is published per channel today; the channel distinction lives in the source repo (`wheels-dev/wheels` vs `wheels-dev/wheels-snapshots`). Switching = installing the package from the other repo. `apt`/`dnf` then treats the install as an upgrade or downgrade depending on the version comparison.
 
 ```bash title="macOS — stable → bleeding-edge"
 brew uninstall wheels
@@ -119,10 +124,25 @@ brew uninstall wheels-be
 brew install wheels
 ```
 
-```bash title="Linux — switch by installing the other package"
-# apt/dnf sees the Conflicts: + Replaces: metadata and swaps the packages atomically.
-# Use the install snippet from the appropriate channel above with wheels-be / wheels
-# substituted in the URL — apt/dnf removes the old one as part of the transaction.
+```bash title="Linux — stable → bleeding-edge"
+# Use the bleeding-edge install snippet from "Installing each channel" above
+# (the wheels-dev/wheels-snapshots URLs). apt/dnf sees a newer version
+# (e.g. 4.0.1~snapshot.500 sorts above the most recent stable 4.0.0) and
+# upgrades in place — no uninstall step needed.
+SNAP_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
+  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
+SNAP_FILENAME_VER="${SNAP_TAG//-/.}"
+curl -fsSLO "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${SNAP_TAG}/wheels_${SNAP_FILENAME_VER}_amd64.deb"
+sudo apt install "./wheels_${SNAP_FILENAME_VER}_amd64.deb"
+```
+
+```bash title="Linux — bleeding-edge → stable"
+# apt treats this as a downgrade (4.0.0 sorts below 4.0.1~snapshot.500) so add
+# --allow-downgrades. dnf handles downgrades transparently with `dnf downgrade`.
+WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
+  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
+curl -fsSLO "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels_${WHEELS_VERSION}_amd64.deb"
+sudo apt install --allow-downgrades "./wheels_${WHEELS_VERSION}_amd64.deb"
 ```
 
 ```powershell title="Windows (Scoop) — stable → bleeding-edge"

--- a/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/release-channels.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0-snapshot/start-here/release-channels.mdx
@@ -124,11 +124,9 @@ brew uninstall wheels-be
 brew install wheels
 ```
 
-```bash title="Linux — stable → bleeding-edge"
-# Use the bleeding-edge install snippet from "Installing each channel" above
-# (the wheels-dev/wheels-snapshots URLs). apt/dnf sees a newer version
-# (e.g. 4.0.1~snapshot.500 sorts above the most recent stable 4.0.0) and
-# upgrades in place — no uninstall step needed.
+```bash title="Linux — stable → bleeding-edge (Debian / Ubuntu)"
+# apt sees a newer version (e.g. 4.0.1~snapshot.500 sorts above the most
+# recent stable 4.0.0) and upgrades in place — no uninstall step needed.
 SNAP_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
   | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
 SNAP_FILENAME_VER="${SNAP_TAG//-/.}"
@@ -136,18 +134,37 @@ curl -fsSLO "https://github.com/wheels-dev/wheels-snapshots/releases/download/v$
 sudo apt install "./wheels_${SNAP_FILENAME_VER}_amd64.deb"
 ```
 
-```bash title="Linux — bleeding-edge → stable"
-# apt treats this as a downgrade (4.0.0 sorts below 4.0.1~snapshot.500) so add
-# --allow-downgrades. dnf handles downgrades transparently with `dnf downgrade`.
+```bash title="Linux — stable → bleeding-edge (Fedora / RHEL)"
+SNAP_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
+  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
+SNAP_FILENAME_VER="${SNAP_TAG//-/.}"
+sudo dnf install "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${SNAP_TAG}/wheels-${SNAP_FILENAME_VER}.x86_64.rpm"
+```
+
+```bash title="Linux — bleeding-edge → stable (Debian / Ubuntu)"
+# apt treats this as a downgrade (4.0.0 sorts below 4.0.1~snapshot.500), so add
+# --allow-downgrades.
 WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
   | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
 curl -fsSLO "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels_${WHEELS_VERSION}_amd64.deb"
 sudo apt install --allow-downgrades "./wheels_${WHEELS_VERSION}_amd64.deb"
 ```
 
+```bash title="Linux — bleeding-edge → stable (Fedora / RHEL)"
+# Use `dnf downgrade` — dnf handles the older-version transition transparently.
+WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
+  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
+sudo dnf downgrade "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels-${WHEELS_VERSION}.x86_64.rpm"
+```
+
 ```powershell title="Windows (Scoop) — stable → bleeding-edge"
 scoop uninstall wheels
 scoop install wheels-be
+```
+
+```powershell title="Windows (Scoop) — bleeding-edge → stable"
+scoop uninstall wheels-be
+scoop install wheels
 ```
 
 ### What happens to your apps when you switch


### PR DESCRIPTION
## Summary

- The Linux tab in the start-here install guide pointed at `https://get.wheels.dev/install.sh` — a URL planned for the Phase 2 universal installer but never deployed. Users on Linux hit a 404.
- The release pipeline already produces `.deb` and `.rpm` packages on every release (`release.yml` lines 282-287; verified live at [v4.0.0-snapshot.1825](https://github.com/wheels-dev/wheels-snapshots/releases/tag/v4.0.0-snapshot.1825) which ships both `wheels_4.0.0.snapshot.1825_amd64.deb` and `wheels-4.0.0.snapshot.1825.x86_64.rpm`). The docs just weren't pointing at them.
- Rewrites three guides to use the working `.deb`/`.rpm` flow with API-driven version resolution so the snippets stay correct as releases roll over.

## What changed

- **`start-here/installing.mdx`** — Linux install + upgrade tabs now use `apt install ./*.deb` / `dnf install <url>` against the GitHub Release. Troubleshooting no longer references the never-existed `~/.wheels/env` file.
- **`command-line-tools/installation.mdx`** — split the conflated "macOS and Linux (Homebrew)" section. Linux now has its own `.deb`/`.rpm` section documenting the on-disk layout (`/usr/bin/wheels`, `/opt/wheels/lucli`, `/opt/wheels/module/`) and an `<Aside>` flagging the planned native apt/yum repos as a v4.0.x follow-up.
- **`start-here/release-channels.mdx`** — replaced literal `<version>` placeholders (not copy-paste runnable) with the API curl pattern. Extended "Switching channels" beyond Homebrew: Linux uses `Conflicts:` / `Replaces:` metadata in the `.deb`/`.rpm`, Scoop refuses dual install.

## Why this is fine without Phase 2

Phase 2 (`apt.wheels.dev` / `yum.wheels.dev` native repos served from Cloudflare Pages) is fully scoped in `tools/distribution-drafts/linux-packages/README.md` — needs a GPG signing key, two new Cloudflare Pages repos under `wheels-dev/`, and a metadata-generator workflow. That's worth its own PR (and its own decision about key custody). This PR ships the Phase 1 install story — which has worked end-to-end on Linux since `release.yml` line 287 landed — and stops the docs from sending users to a dead URL.

I'll file the Phase 2 work as a separate `v4.0.x` follow-up issue.

## Test plan

- [ ] Read the rendered `installing.mdx` Linux tab in the preview build — confirm the three code blocks (Debian/Ubuntu install, Fedora/RHEL install, the bleeding-edge Aside) render and explain themselves
- [ ] Manually run the Debian/Ubuntu snippet on a fresh Ubuntu VM against [`wheels-dev/wheels-snapshots`](https://github.com/wheels-dev/wheels-snapshots) (substituted per the bleeding-edge Aside) — confirm `wheels --version` reports a real version
- [ ] After v4.0.0 GA tags, re-run the snippet against the stable `wheels-dev/wheels` URL to confirm it resolves (currently 404s pre-GA because `wheels-dev/wheels`'s latest release is `v3.0.0+50`, which predates the linux packaging — first stable `.deb`/`.rpm` will appear on `v4.0.0`)
- [ ] Confirm `release-channels.mdx` and `command-line-tools/installation.mdx` Linux sections agree on the install URL pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)