### PR TITLE
chore: bump develop snapshot target to 4.0.1

### DIFF
--- a/wheels.json
+++ b/wheels.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://wheels.dev/schema/wheels.json/v1.json",
     "name": "Wheels.fw",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "description": "Wheels — CFML MVC framework",
     "homepage": "https://wheels.dev",
     "documentation": "https://wheels.dev/guides/",


### PR DESCRIPTION
Automated bump triggered by GA release `4.0.0` — but the trigger fired manually because `bump-develop-version.yml` didn't pick up the release event.

Sets `wheels.json` version to `4.0.1` so subsequent develop snapshots are tagged `4.0.1-snapshot.<run>`.

**This is a baseline, not a commitment.** If the next GA release ends up being a minor or major bump, the snapshot version strings still sort strictly lower than any of those, so the tap auto-bump and `brew upgrade` continue to work correctly. The maintainer makes the actual scope decision at the next GA's tag-cut time, not here.

## Why this is manual

`bump-develop-version.yml` listens for `release: types: [published]`. The v4.0.0 release was published by `release.yml` using the default `GITHUB_TOKEN`, which can't trigger downstream workflows (documented Actions limitation). A follow-up toggle (web UI and `gh release edit` both attempted) also failed to fire a fresh `release: published` event — possibly because GitHub doesn't re-fire `published` for a `release → pre-release → release` round-trip on the same release object.

Follow-up tracked separately: add `workflow_dispatch` to `bump-develop-version.yml` (so the maintainer can manually fire it next time) or switch its trigger to `repository_dispatch` (which `release.yml` already fires for the homebrew/scoop bumps and could fire for develop-bump too).

## Verification

```bash
$ jq -r '.version' wheels.json
4.0.1
```

Single-line diff (kept original 4-space indentation rather than letting `jq` reformat the file — that's the only deviation from what the workflow would have produced).