### PR TITLE
ci(release): fire bump-develop via repository_dispatch (fix #2609)

### DIFF
--- a/.github/RELEASE_PLAYBOOK.md
+++ b/.github/RELEASE_PLAYBOOK.md
@@ -50,8 +50,17 @@ git push origin main --tags
 
 The tag push triggers:
 - `release.yml` builds artifacts, publishes to `wheels-dev/wheels/releases`
-- `bump-develop-version.yml` opens a PR against develop bumping `box.json` to
-  next-patch
+- `release.yml`'s "Dispatch downstream package managers" step then fires
+  three `repository_dispatch` events via `DOWNSTREAM_DISPATCH_TOKEN` (a PAT):
+  - `wheels-released` → `wheels-dev/homebrew-wheels` (brew formula bump)
+  - `wheels-released` → `wheels-dev/chocolatey-wheels` (choco package bump)
+  - `bump-develop` → `wheels-dev/wheels` itself (this repo) — only for
+    `CHANNEL=stable` (snapshots and RCs don't bump develop)
+- `bump-develop-version.yml` fires on the `bump-develop` dispatch and opens
+  a PR against develop bumping `wheels.json` to next-patch. (We use
+  `repository_dispatch` rather than `release: published` because the
+  release-publish step uses the default `GITHUB_TOKEN`, which by design
+  cannot trigger downstream workflows. See [#2609](https://github.com/wheels-dev/wheels/issues/2609).)
 - The brew tap's `wheels-bump.yml` (parallel to `wheels-be-bump.yml`) opens a
   PR bumping `Formula/wheels.rb`
 - Same for scoop bucket and (eventually) the WinGet manifest PR
@@ -142,6 +151,7 @@ If any pin to `<X.Y.Z`, open issues on those repos to widen the constraint.
 | `release.yml` fails: "CHANGELOG contains TBD" | Forgot to update changelog | Add release date to `# [X.Y.Z]` line, push, re-run workflow |
 | `release.yml` fails: "version contains -SNAPSHOT" | `box.json` has `-SNAPSHOT` suffix on main | Strip suffix, push (release.yml asserts clean main versions) |
 | brew tap PR doesn't open after release | `DOWNSTREAM_DISPATCH_TOKEN` expired or unset | Rotate token in repo secrets; re-run `release.yml` workflow_dispatch |
+| develop-bump PR doesn't open after GA | `DOWNSTREAM_DISPATCH_TOKEN` expired/unset, OR the `bump-develop` dispatch step warned and exited 0 | Fire it manually: Actions → "Bump Develop Version" → "Run workflow" → enter the just-released version (e.g. `4.0.0`). The workflow has a `workflow_dispatch` fallback for exactly this case. |
 | `brew install wheels` post-release fails | Formula sha256 mismatch | Re-run the tap bump workflow with `workflow_dispatch` to recompute |
 | Snapshot publish fails: "tag already exists" | Re-run after partial success | Delete the orphaned tag in `wheels-dev/wheels-snapshots`, re-run |
 | Linux package URL 404s when version has `~snapshot.N` | GitHub Releases silently rewrites `~` to `.` in uploaded asset filenames | Use `.` in the URL: `wheels_4.0.0.snapshot.1787_amd64.deb`, NOT `wheels_4.0.0~snapshot.1787_amd64.deb`. The on-disk filename keeps `~` (so `dpkg --compare-versions` orders pre-releases correctly), but the uploaded URL gets mangled. Downstream consumers (apt repo metadata generator, install scripts) must compute the `.`-form. See `tools/distribution-drafts/linux-packages/build-linux-packages.sh`. |

--- a/.github/workflows/bump-develop-version.yml
+++ b/.github/workflows/bump-develop-version.yml
@@ -68,9 +68,17 @@ jobs:
           # no 'v' prefix (release.yml sources from wheels.json, which is
           # bare SemVer), but workflow_dispatch input might.
           STRIPPED="${RAW_RELEASED_VERSION#v}"
+          # Fail loud on bad input — the primary repository_dispatch path is
+          # guaranteed bare SemVer (release.yml only fires this for
+          # CHANNEL=stable, which has already filtered out -snapshot/-rc
+          # suffixes), so a mismatch here means the workflow_dispatch fallback
+          # was used with an unparseable version. Exiting 0 would let the
+          # downstream "Update wheels.json" step write '"version": ""' and
+          # open a malformed PR; exit 1 keeps the run red so the operator
+          # can re-fire with corrected input. See #2615 review.
           if [[ ! "${STRIPPED}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-            echo "Released version '${RAW_RELEASED_VERSION}' doesn't match SemVer M.m.p — skipping bump."
-            exit 0
+            echo "::error::Released version '${RAW_RELEASED_VERSION}' doesn't match SemVer M.m.p — cannot bump."
+            exit 1
           fi
           MAJOR="${BASH_REMATCH[1]}"
           MINOR="${BASH_REMATCH[2]}"

--- a/.github/workflows/bump-develop-version.yml
+++ b/.github/workflows/bump-develop-version.yml
@@ -2,12 +2,23 @@
 #
 # Workflow:
 #   1. Maintainer cuts v4.0.1 (or whatever) on main.
-#   2. release.yml publishes to wheels-dev/wheels Releases.
-#   3. THIS workflow fires on the published release event, opens a PR against
-#      develop bumping wheels.json's version to (just-released-patch + 1).
+#   2. release.yml publishes to wheels-dev/wheels Releases AND fires a
+#      `bump-develop` repository_dispatch at this repo (only for stable
+#      channel — snapshots and RCs don't bump develop).
+#   3. THIS workflow fires on that dispatch, opens a PR against develop
+#      bumping wheels.json's version to (just-released-patch + 1).
 #   4. Maintainer rubberstamps the PR.
-#   5. Next develop merge fires snapshot.yml with the new target
-#      embedded in the snapshot version string.
+#   5. Next develop merge fires snapshot.yml with the new target embedded
+#      in the snapshot version string.
+#
+# Why repository_dispatch instead of `release: published`?
+#   release.yml's "Create GitHub Release" step uses the default GITHUB_TOKEN,
+#   and per GitHub Actions docs, events emitted by GITHUB_TOKEN don't trigger
+#   downstream workflows (with exceptions for workflow_dispatch and
+#   repository_dispatch). The release:published event therefore never reached
+#   us on the v4.0.0 GA. release.yml already fires repository_dispatch with
+#   DOWNSTREAM_DISPATCH_TOKEN (a PAT) for homebrew/scoop, so we piggyback
+#   on that proven channel. See #2609.
 #
 # This is the "no version decisions ahead of time" piece — the maintainer
 # decides at GA tag time whether the release is a patch / minor / major;
@@ -17,8 +28,17 @@
 name: Bump Develop Version
 
 on:
-  release:
-    types: [published]
+  repository_dispatch:
+    types: [bump-develop]
+  # Manual fallback — if release.yml's dispatch step ever fails or the
+  # maintainer wants to re-run after a missed event, they can fire this
+  # by hand with the version they want to bump *from* (e.g., 4.0.0).
+  workflow_dispatch:
+    inputs:
+      released_version:
+        description: 'Version that was just released (bare SemVer, e.g. 4.0.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -28,46 +48,28 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     env:
-      # All event payload fields hoisted to env. Eligibility (non-prerelease,
-      # main branch) is enforced inside the run: block below — keeping it out
-      # of the if: clause to satisfy the workflow-injection security hook.
-      RELEASE_TAG: ${{ github.event.release.tag_name }}
-      RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
-      RELEASE_TARGET_COMMITISH: ${{ github.event.release.target_commitish }}
+      # repository_dispatch carries the version in client_payload.version
+      # (set by release.yml's dispatch step). workflow_dispatch supplies it
+      # via inputs.released_version. One of the two is always present.
+      # Hoisted to env to keep ${{ ... }} interpolation out of run: blocks,
+      # per the workflow-injection security hook. The value is regex-validated
+      # in "Compute next snapshot target" before downstream use.
+      RAW_RELEASED_VERSION: ${{ github.event.client_payload.version || inputs.released_version }}
     steps:
-      - name: Check eligibility
-        id: gate
-        run: |
-          # Skip if it's a pre-release or wasn't cut from main. The native
-          # if: clause would do this with cleaner syntax but tripped the
-          # workflow-injection hook by referencing ${ {github.event.release.*} }.
-          if [ "${RELEASE_PRERELEASE}" = "true" ]; then
-            echo "Skipping pre-release: ${RELEASE_TAG}"
-            echo "eligible=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          if [ "${RELEASE_TARGET_COMMITISH}" != "main" ]; then
-            echo "Skipping release from non-main branch: ${RELEASE_TARGET_COMMITISH}"
-            echo "eligible=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          echo "eligible=true" >> $GITHUB_OUTPUT
-
       - name: Checkout develop
-        if: steps.gate.outputs.eligible == 'true'
         uses: actions/checkout@v6
         with:
           ref: develop
           fetch-depth: 1
 
       - name: Compute next snapshot target
-        if: steps.gate.outputs.eligible == 'true'
         run: |
-          # Strip leading 'v' if present (we tag as v4.0.1 but version field
-          # is bare 4.0.1 in wheels.json).
-          RELEASED_VERSION="${RELEASE_TAG#v}"
-          if [[ ! "${RELEASED_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-            echo "Released tag ${RELEASE_TAG} doesn't match SemVer M.m.p — skipping bump."
+          # Strip leading 'v' if present. The dispatch payload normally has
+          # no 'v' prefix (release.yml sources from wheels.json, which is
+          # bare SemVer), but workflow_dispatch input might.
+          STRIPPED="${RAW_RELEASED_VERSION#v}"
+          if [[ ! "${STRIPPED}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "Released version '${RAW_RELEASED_VERSION}' doesn't match SemVer M.m.p — skipping bump."
             exit 0
           fi
           MAJOR="${BASH_REMATCH[1]}"
@@ -75,12 +77,11 @@ jobs:
           PATCH="${BASH_REMATCH[3]}"
           NEXT_PATCH=$((PATCH + 1))
           NEW_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}"
-          echo "Released: ${RELEASED_VERSION} -> next snapshot target: ${NEW_VERSION}"
+          echo "Released: ${STRIPPED} -> next snapshot target: ${NEW_VERSION}"
           echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
-          echo "RELEASED_VERSION=${RELEASED_VERSION}" >> $GITHUB_ENV
+          echo "RELEASED_VERSION=${STRIPPED}" >> $GITHUB_ENV
 
       - name: Update wheels.json
-        if: steps.gate.outputs.eligible == 'true'
         run: |
           jq --arg v "${NEW_VERSION}" '.version = $v' wheels.json > wheels.json.tmp
           mv wheels.json.tmp wheels.json
@@ -88,7 +89,6 @@ jobs:
           jq '.version' wheels.json
 
       - name: Open bump PR
-        if: steps.gate.outputs.eligible == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
           branch: "auto-bump/develop-${{ env.NEW_VERSION }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -551,6 +551,33 @@ jobs:
 
           echo "Downstream package manager workflows dispatched (homebrew + chocolatey)."
 
+          # Fire bump-develop at this repo to open the develop-bump PR.
+          # Only stable GA releases bump develop; snapshots and RCs don't.
+          # Same workaround as the homebrew/chocolatey dispatches above:
+          # the release-publish step runs under the default workflow token,
+          # which cannot trigger downstream workflows. We dispatch from
+          # this step (which runs under DOWNSTREAM_DISPATCH_TOKEN, a PAT)
+          # instead. The bump-develop-version.yml workflow listens for
+          # repository_dispatch types=[bump-develop]. See issue #2609.
+          if [ "${CHANNEL}" = "stable" ]; then
+            echo "Dispatching bump-develop to wheels-dev/wheels..."
+            http_status=$(curl -sS -o /tmp/dispatch-resp.txt -w "%{http_code}" \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GH_DISPATCH_TOKEN}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/wheels-dev/wheels/dispatches" \
+              -d "{\"event_type\":\"bump-develop\",\"client_payload\":{\"version\":\"${WHEELS_RELEASE_VERSION}\"}}" )
+
+            if [ "${http_status}" != "204" ]; then
+              echo "::warning::bump-develop dispatch returned HTTP ${http_status}: $(cat /tmp/dispatch-resp.txt)"
+            else
+              echo "  ✓ bump-develop dispatched to wheels-dev/wheels (version=${WHEELS_RELEASE_VERSION})"
+            fi
+          else
+            echo "Skipping bump-develop dispatch (channel=${CHANNEL}, not stable)."
+          fi
+
   #############################################
   # Smoke-test the built module against a clean install.
   #


### PR DESCRIPTION
## Summary

- `release.yml`'s existing "Dispatch downstream package managers" step now also fires a `bump-develop` `repository_dispatch` at `wheels-dev/wheels` itself when `CHANNEL=stable`. It reuses the existing `DOWNSTREAM_DISPATCH_TOKEN` PAT (already proven on every homebrew/chocolatey dispatch), so no new auth surface.
- `bump-develop-version.yml` switches from `release: published` to `repository_dispatch: types: [bump-develop]` with a `workflow_dispatch` manual fallback. The prerelease/target-branch eligibility gates are deleted because the dispatcher only fires for stable (which by construction comes from main and is never a prerelease).
- `.github/RELEASE_PLAYBOOK.md` documents the new chain under "Cutting a GA release" and adds a manual-fallback entry in the failure-modes table.

## Why

The release-publish step uses the default `GITHUB_TOKEN`, and per [GitHub Actions documentation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow), events emitted by `GITHUB_TOKEN` do not trigger downstream workflows (with exceptions only for `workflow_dispatch` and `repository_dispatch`). On the v4.0.0 GA this meant `bump-develop-version.yml` never fired and the bump PR had to be opened manually (#2608).

This is option 1 from the issue analysis — lowest blast radius, reuses an existing channel.

## Acceptance (from #2609)

- [x] On the next GA cut, `bump-develop-version.yml` fires automatically and opens the bump PR against `develop` within ~5 minutes of the release publish. *(The dispatch fires in the same workflow run that publishes the release, so latency is bounded by the bump workflow itself.)*
- [x] No manual intervention required (no toggling, no manual PR).
- [x] Documented in `.github/RELEASE_PLAYBOOK.md` under "Cutting a GA release" so future maintainers know the chain.

## Test plan

- [ ] CI green on this PR (yaml-lint, no other suites touch these files).
- [ ] On next GA cut: verify Actions tab shows `release.yml` dispatching `bump-develop`, then "Bump Develop Version" auto-firing on `repository_dispatch` within seconds, then an `auto-bump/develop-X.Y.(Z+1)` PR opens.
- [ ] Manual fallback rehearsal: in Actions tab, "Bump Develop Version" → "Run workflow" with `released_version=4.0.0` → confirm it would open a no-op PR (`4.0.1` is already the current develop snapshot target, so the file change is empty and `peter-evans/create-pull-request` skips the PR — that's expected behavior, not a failure).

## Out of scope (deferred follow-ups)

- `RELEASE_PLAYBOOK.md` still references `box.json` (legacy) in spots and shows the manual `git tag && git push --tags` flow that no longer works under the PR-required-on-main ruleset. Both are tracked in the v4.0.0-shipped retro memo; intentionally not bundled here to keep this PR scoped to #2609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)