### PR TITLE
fix(security): use Adobe-safe 3-arg mid() in MCP command parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 ### Fixed
 
 - Stop the generated app's `_gitignore` and `app/plugins/README.md` from advertising the broken `wheels packages install` / `wheels install` verbs; point users at the canonical `wheels packages add` verb (#2610)
+- Use the Adobe-safe 3-argument `mid()` form when stripping the `wheels` prefix in the MCP command executor and its security spec; the prior 2-arg call crashed the entire `security/` test bundle on Adobe ColdFusion (#2613)
 
 ----
 

--- a/vendor/wheels/public/mcp/McpServer.cfc
+++ b/vendor/wheels/public/mcp/McpServer.cfc
@@ -1281,7 +1281,7 @@ Provide migration code following Wheels conventions."
 		}
 
 		// Strip "wheels " prefix once — used by both primary and fallback paths.
-		// 3-arg mid() is required for Adobe CF compatibility (issue #2613); Lucee/BoxLang accept 2 args.
+		// 3-arg mid() is required for Adobe CF compatibility; Lucee/BoxLang accept 2 args.
 		local.strippedArgs = trim(mid(arguments.command, 7, len(arguments.command)));
 
 		if (!len(local.strippedArgs)) {

--- a/vendor/wheels/public/mcp/McpServer.cfc
+++ b/vendor/wheels/public/mcp/McpServer.cfc
@@ -1280,8 +1280,9 @@ Provide migration code following Wheels conventions."
 			return "Error: Only 'wheels' commands are allowed.";
 		}
 
-		// Strip "wheels " prefix once — used by both primary and fallback paths
-		local.strippedArgs = trim(mid(arguments.command, 7));
+		// Strip "wheels " prefix once — used by both primary and fallback paths.
+		// 3-arg mid() is required for Adobe CF compatibility (issue #2613); Lucee/BoxLang accept 2 args.
+		local.strippedArgs = trim(mid(arguments.command, 7, len(arguments.command)));
 
 		if (!len(local.strippedArgs)) {
 			return "Error: Missing subcommand. Allowed: #allowedSubcommands#";

--- a/vendor/wheels/tests/specs/security/McpCommandInjectionSpec.cfc
+++ b/vendor/wheels/tests/specs/security/McpCommandInjectionSpec.cfc
@@ -163,8 +163,8 @@ component extends="wheels.WheelsTest" {
 				});
 
 				it("strips wheels prefix using Adobe-safe 3-arg mid()", () => {
-					// Regression guard for issue #2613: Adobe CF requires mid(string, start, count).
-					// The 2-arg form crashes Adobe with "Parameter validation error for the MID function".
+					// Adobe CF requires mid(string, start, count); the 2-arg form causes a compile-time
+					// "Parameter validation error for the MID function" that crashes the entire test bundle.
 					var command = "wheels generate model User";
 					var stripped = trim(mid(command, 7, len(command)));
 					expect(stripped).toBe("generate model User");

--- a/vendor/wheels/tests/specs/security/McpCommandInjectionSpec.cfc
+++ b/vendor/wheels/tests/specs/security/McpCommandInjectionSpec.cfc
@@ -102,7 +102,9 @@ component extends="wheels.WheelsTest" {
 				});
 
 				it("rejects wheels without a subcommand", () => {
-					expect(len(trim(mid("wheels ", 7))) > 0).toBeFalse();
+					// Adobe CF requires mid(string, start, count); Lucee/BoxLang accept 2 args.
+					// All MCP command-parsing call sites must pass three arguments.
+					expect(len(trim(mid("wheels ", 7, len("wheels ")))) > 0).toBeFalse();
 				});
 
 			});
@@ -114,7 +116,7 @@ component extends="wheels.WheelsTest" {
 
 					expect(reFind("^wheels\s", command) > 0).toBeTrue();
 
-					var stripped = trim(mid(command, 7));
+					var stripped = trim(mid(command, 7, len(command)));
 					var parts = ListToArray(stripped, " ");
 					expect(ListFindNoCase(allowedSubcommands, parts[1]) > 0).toBeTrue();
 
@@ -130,7 +132,7 @@ component extends="wheels.WheelsTest" {
 				it("rejects a command with injected subcommand and metacharacters", () => {
 					var command = "wheels exec;rm -rf /";
 
-					var stripped = trim(mid(command, 7));
+					var stripped = trim(mid(command, 7, len(command)));
 					var parts = ListToArray(stripped, " ");
 					var subcommandAllowed = ListFindNoCase(allowedSubcommands, parts[1]) > 0;
 
@@ -147,7 +149,7 @@ component extends="wheels.WheelsTest" {
 				it("rejects a valid subcommand with unsafe arguments", () => {
 					var command = "wheels test run;whoami";
 
-					var stripped = trim(mid(command, 7));
+					var stripped = trim(mid(command, 7, len(command)));
 					var parts = ListToArray(stripped, " ");
 					expect(ListFindNoCase(allowedSubcommands, parts[1]) > 0).toBeTrue();
 
@@ -158,6 +160,14 @@ component extends="wheels.WheelsTest" {
 						}
 					}
 					expect(argsSafe).toBeFalse();
+				});
+
+				it("strips wheels prefix using Adobe-safe 3-arg mid()", () => {
+					// Regression guard for issue #2613: Adobe CF requires mid(string, start, count).
+					// The 2-arg form crashes Adobe with "Parameter validation error for the MID function".
+					var command = "wheels generate model User";
+					var stripped = trim(mid(command, 7, len(command)));
+					expect(stripped).toBe("generate model User");
 				});
 
 			});


### PR DESCRIPTION
## Summary

Adobe ColdFusion requires `mid(string, start, count)` with all three arguments; Lucee and BoxLang accept the 2-arg form and default `count` to the remainder of the string. The MCP command executor in `vendor/wheels/public/mcp/McpServer.cfc:1284` and its security spec (`vendor/wheels/tests/specs/security/McpCommandInjectionSpec.cfc`) both used the 2-arg form to strip the `wheels ` prefix, which:

1. Crashed the entire `vendor/wheels/tests/specs/security/` test bundle on Adobe CF at compile time (`Parameter validation error for the MID function. The function takes 3 parameters.`)
2. Would also crash any MCP command execution at runtime on Adobe CF

Switch all five call sites — one in production code and four in the security spec — to `mid(s, 7, len(s))`, which works identically on every supported engine (Adobe / Lucee / BoxLang).

Add a new regression-guard spec (`strips wheels prefix using Adobe-safe 3-arg mid()`) that explicitly documents the cross-engine constraint so the bug cannot silently return.

## Related Issue

Closes #2613

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Documentation update
- [ ] Refactoring

## Feature Completeness Checklist

- [x] **DCO sign-off** -- Every commit carries `Signed-off-by:`
- [x] **Tests** -- Modified four existing specs + added an explicit regression guard
- [ ] **Framework Docs** -- handled separately by `bot-update-docs.yml`
- [ ] **AI Reference Docs** -- `.ai/wheels/cross-engine-compatibility.md` could grow a `Mid() Three-Argument Requirement` section; left to `bot-update-docs.yml` so the convention is centralized
- [ ] **CLAUDE.md** -- handled separately by `bot-update-docs.yml`
- [x] **CHANGELOG.md** -- entry added under `[Unreleased]` / `### Fixed`
- [x] **Test runner passes** -- see test plan below

## Test Plan

Verified locally on both engines via SQLite:

| Engine                | Before fix              | After fix          |
|-----------------------|-------------------------|--------------------|
| Lucee 7 + SQLite      | 174/174 pass            | 174/174 pass       |
| Adobe CF 2023 + SQLite| 0 pass — bundle crash   | 174/174 pass       |

Commands used:

```bash
# Lucee verification
PORT=60099 bash tools/test-local.sh security

# Adobe CF verification
tools/test-matrix.sh adobe2023 sqlite
curl -s "http://localhost:62023/wheels/core/tests?db=sqlite&format=json&directory=wheels.tests.specs.security"
```

`McpCommandInjectionSpec.cfc` itself: 26/26 specs pass on both engines, including the new regression guard.

## Notes for Reviewer

- This is a strictly mechanical cross-engine compatibility fix — no behavior change on Lucee or BoxLang.
- The triage comment flagged this as a single-file change in the spec, but the same 2-arg `mid()` bug existed in the production `McpServer.cfc` line 1284 that the spec was indirectly auditing. Both were fixed.
- The broader test suite on Adobe CF still hits a pre-existing unrelated `DirectoryCreate()` 2-arg bug (issue #2567, already documented in `.ai/wheels/cross-engine-compatibility.md`). Outside the scope of this PR.

<!-- wheels-bot:fix:2613 -->