### PR TITLE
ci: let medium-confidence triages auto-fire propose-fix and write-docs

### DIFF
--- a/.claude/commands/research-frameworks.md
+++ b/.claude/commands/research-frameworks.md
@@ -166,7 +166,13 @@ Read `.claude/commands/_shared-rails.md` first. Highlights for this command:
 
    Where `<CONFIDENCE_MARKER>` is:
    - `<!-- wheels-bot:research-confidence:high -->` if confidence is high
-   - omitted otherwise
+   - `<!-- wheels-bot:research-confidence:medium -->` if confidence is medium
+   - omitted if confidence is low
+
+   Both `high` and `medium` markers trigger auto-fire of
+   `bot-propose-fix.yml`. Low stays manual — material framework
+   disagreement or new-infrastructure proposals warrant a human discussion
+   before any code is written.
 
 7. **Self-check before posting.**
    - Have you cited at least one URL per framework?

--- a/.claude/commands/triage-issue.md
+++ b/.claude/commands/triage-issue.md
@@ -102,14 +102,17 @@ below. Highlights for this command:
      existing structure under
      `web/sites/guides/src/content/docs/v4-0-0-snapshot/`, the work is
      mostly translation-of-code (not requiring deep design decisions).
-     High-confidence docs-requests trigger the auto-fire write-docs
-     workflow.
    - **`medium`**: the gap is real but the right page/path is ambiguous,
      OR a new top-level section is needed (a structural design decision),
      OR the docs require significant code investigation to write
      accurately.
    - **`low`**: the gap is vague, the scope is large (e.g. "rewrite the X
      chapter"), or it's not clear what concretely needs to exist.
+
+   **Auto-fire threshold:** both `high` and `medium` docs-requests trigger
+   the auto-fire write-docs workflow. Write-docs has its own safety net
+   for structural docs-architecture decisions (posts a `docs-held` marker
+   instead of opening a PR). Only `low` stays manual.
 
    Post the triage comment:
 
@@ -133,8 +136,11 @@ below. Highlights for this command:
 
    Where `<CONFIDENCE_MARKER>` is:
    - `<!-- wheels-bot:docs-confidence:high -->` if confidence is high
-     (triggers auto-fire of `bot-write-docs.yml`)
-   - omitted otherwise (medium/low confidence does not auto-trigger)
+   - `<!-- wheels-bot:docs-confidence:medium -->` if confidence is medium
+   - omitted if confidence is low (low does not auto-trigger)
+
+   Both `high` and `medium` markers trigger auto-fire of
+   `bot-write-docs.yml`.
 
    Then exit.
 
@@ -155,8 +161,7 @@ below. Highlights for this command:
 
    - **`high`**: the report has a clear "what happened / what I expected"
      description; the suspected layer is unambiguous; the fix sketch is
-     mechanical (one file, no design decisions). High-confidence bugs
-     trigger the auto-fire fix-PR workflow.
+     mechanical (one file, no design decisions).
    - **`medium`**: the report is clear but the fix has design trade-offs,
      OR cross-engine concerns may exist, OR more than one layer is
      plausibly involved.
@@ -164,7 +169,17 @@ below. Highlights for this command:
      environment-specific symptoms are suspected; the fix shape isn't
      obvious from the issue body alone.
 
-   **Auto-downgrade rules** (force at least one level lower):
+   **Auto-fire threshold:** both `high` and `medium` bugs trigger the
+   auto-fire propose-fix workflow. Propose-fix has its own step-4 safety
+   net for sensitive areas (security / middleware / migrations / deploy /
+   DI / cross-engine) — it posts a `fix-held` marker instead of opening a
+   PR. Reviewer A and B will critique whatever propose-fix produces. Only
+   `low` stays manual.
+
+   **Auto-downgrade rules** (force at least one level lower — these
+   downgrades are still informative for humans skimming the comment;
+   `medium` ratings still auto-fire, but propose-fix's safety net will
+   catch the sensitive-area cases):
    - The fix would touch `vendor/wheels/security/**`, auth flows, or any
      `vendor/wheels/middleware/**` → at most `medium`
    - Cross-engine concern detected (Lucee vs Adobe vs BoxLang behavior
@@ -199,7 +214,11 @@ below. Highlights for this command:
 
    Where `<CONFIDENCE_MARKER>` is:
    - `<!-- wheels-bot:triage-confidence:high -->` if confidence is high
-   - omitted otherwise (medium/low confidence does not auto-trigger fix-PR)
+   - `<!-- wheels-bot:triage-confidence:medium -->` if confidence is medium
+   - omitted if confidence is low (low does not auto-trigger fix-PR)
+
+   Both `high` and `medium` markers trigger auto-fire of
+   `bot-propose-fix.yml`.
 
 8. **Self-check before posting.**
    - Is the classification justified by quoted text from the issue?

--- a/.github/workflows/bot-propose-fix.yml
+++ b/.github/workflows/bot-propose-fix.yml
@@ -22,9 +22,12 @@ jobs:
     name: Propose fix
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # Phase 4 (auto-fire): runs from wheels-bot[bot] comments containing
-    # `wheels-bot:triage-confidence:high` (bug path) or
-    # `wheels-bot:research-confidence:high` (framework-design path).
+    # Phase 4 (auto-fire): runs from wheels-bot[bot] comments containing a
+    # high- OR medium-confidence triage marker (bug path) or research marker
+    # (framework-design path). Low-confidence stays manual.
+    # Medium fires because propose-fix's own step-4 safety net (sensitive
+    # areas: security / migrations / deploy / DI / cross-engine) aborts
+    # before any PR is opened — Reviewer A and B catch the rest.
     # workflow_dispatch is preserved for manual reruns.
     # The bot-identity check is load-bearing: prevents humans from
     # triggering propose-fix by quoting a marker in a comment reply.
@@ -35,7 +38,9 @@ jobs:
         || (github.event_name == 'issue_comment'
             && github.event.comment.user.login == 'wheels-bot[bot]'
             && (contains(github.event.comment.body, 'wheels-bot:triage-confidence:high')
-                || contains(github.event.comment.body, 'wheels-bot:research-confidence:high')))
+                || contains(github.event.comment.body, 'wheels-bot:triage-confidence:medium')
+                || contains(github.event.comment.body, 'wheels-bot:research-confidence:high')
+                || contains(github.event.comment.body, 'wheels-bot:research-confidence:medium')))
       )
     env:
       ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue-number }}
@@ -98,8 +103,8 @@ jobs:
         if: steps.gate.outputs.skip == 'false'
         uses: anthropics/claude-code-action@v1
         with:
-          # When un-gated at Phase 4a/4b, this workflow fires from wheels-bot[bot]
-          # comments containing high-confidence triage or research markers. Allow
+          # This workflow fires from wheels-bot[bot] comments containing
+          # high- or medium-confidence triage or research markers. Allow
           # that bot identity (and github-actions[bot] for consistency).
           allowed_bots: 'wheels-bot[bot],github-actions[bot]'
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/bot-write-docs.yml
+++ b/.github/workflows/bot-write-docs.yml
@@ -1,8 +1,11 @@
 name: Wheels Bot — Write Docs
 
 # Phase 4 (auto-fire): runs from wheels-bot[bot] comments containing
-# `wheels-bot:docs-confidence:high` (the docs-request path's auto-fire
-# marker). workflow_dispatch is preserved for manual reruns.
+# `wheels-bot:docs-confidence:high` OR `wheels-bot:docs-confidence:medium`
+# (the docs-request path's auto-fire markers). Medium fires because
+# write-docs has its own step-2 safety net for structural docs-architecture
+# decisions (posts `wheels-bot:docs-held:<issue>` instead of opening a PR).
+# workflow_dispatch is preserved for manual reruns.
 on:
   issue_comment:
     types: [created]
@@ -25,7 +28,8 @@ jobs:
     name: Write docs
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Auto-fires from wheels-bot[bot] comments with docs-confidence:high.
+    # Auto-fires from wheels-bot[bot] comments with docs-confidence:high
+    # OR docs-confidence:medium. Low stays manual.
     # The bot-identity check is load-bearing: prevents humans from
     # triggering write-docs by quoting a marker in a reply.
     if: |
@@ -34,7 +38,8 @@ jobs:
         github.event_name == 'workflow_dispatch'
         || (github.event_name == 'issue_comment'
             && github.event.comment.user.login == 'wheels-bot[bot]'
-            && contains(github.event.comment.body, 'wheels-bot:docs-confidence:high'))
+            && (contains(github.event.comment.body, 'wheels-bot:docs-confidence:high')
+                || contains(github.event.comment.body, 'wheels-bot:docs-confidence:medium')))
       )
     env:
       ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue-number }}
@@ -90,9 +95,9 @@ jobs:
         if: steps.gate.outputs.skip == 'false'
         uses: anthropics/claude-code-action@v1
         with:
-          # Triggered by wheels-bot[bot] comments containing the
-          # docs-confidence:high marker. Allow the bot identity (and
-          # github-actions[bot] for consistency).
+          # Triggered by wheels-bot[bot] comments containing a
+          # docs-confidence:high or docs-confidence:medium marker.
+          # Allow the bot identity (and github-actions[bot] for consistency).
           allowed_bots: 'wheels-bot[bot],github-actions[bot]'
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/bot-write-docs.yml
+++ b/.github/workflows/bot-write-docs.yml
@@ -3,7 +3,7 @@ name: Wheels Bot — Write Docs
 # Phase 4 (auto-fire): runs from wheels-bot[bot] comments containing
 # `wheels-bot:docs-confidence:high` OR `wheels-bot:docs-confidence:medium`
 # (the docs-request path's auto-fire markers). Medium fires because
-# write-docs has its own step-2 safety net for structural docs-architecture
+# write-docs has its own step-4 safety net for structural docs-architecture
 # decisions (posts `wheels-bot:docs-held:<issue>` instead of opening a PR).
 # workflow_dispatch is preserved for manual reruns.
 on:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1060,13 +1060,13 @@ Workflow orchestration (multi-step planning, feature development) is not a frame
 |---|---|---|---|
 | Triage | issue opened/reopened | Opus | Comment classifying as `bug` / `framework-design` / `other` (+ confidence on `bug` path). Reads code with the allowlisted tools to resolve uncertainty before rating. |
 | Research | bot triage emits `framework-design` marker | Opus | Comment comparing Rails / Laravel / Django / Phoenix / Spring Boot / +1 and recommending a Wheels-idiomatic path (+ confidence). |
-| Propose Fix | bot triage emits `triage-confidence:high` OR research emits `research-confidence:high` (or `workflow_dispatch`) | Opus | TDD-mandatory draft PR on branch `fix/bot-<issue>-<slug>`. Spec-then-implementation, both required by `bot-tdd-gate.yml`. |
+| Propose Fix | bot triage emits `triage-confidence:high\|medium` OR research emits `research-confidence:high\|medium` (or `workflow_dispatch`) | Opus | TDD-mandatory draft PR on branch `fix/bot-<issue>-<slug>`. Spec-then-implementation, both required by `bot-tdd-gate.yml`. |
 | Reviewer A | PR opened / synchronized / ready_for_review | Sonnet | Single PR review with line comments, verdict, and `wheels-bot:review-a:<pr>:<sha>` marker. |
 | Reviewer B | Reviewer A submits a review | Sonnet | PR comment critiquing A for sycophancy, false positives, and missed issues. Loop cap = 3 rounds. |
 
 **Marker conventions** (HTML comments, used for idempotency):
-- `<!-- wheels-bot:triage:<issue> -->` + `<!-- wheels-bot:triage-class:<bug|framework-design|other> -->` (+ optional `<!-- wheels-bot:triage-confidence:high -->`)
-- `<!-- wheels-bot:research:<issue> -->` (+ optional `<!-- wheels-bot:research-confidence:high -->`)
+- `<!-- wheels-bot:triage:<issue> -->` + `<!-- wheels-bot:triage-class:<bug|framework-design|other> -->` (+ optional `<!-- wheels-bot:triage-confidence:high|medium -->` — either fires propose-fix; low omitted)
+- `<!-- wheels-bot:research:<issue> -->` (+ optional `<!-- wheels-bot:research-confidence:high|medium -->` — either fires propose-fix; low omitted)
 - `<!-- wheels-bot:fix:<issue> -->` / `<!-- wheels-bot:fix-held:<issue> -->`
 - `<!-- wheels-bot:review-a:<pr>:<sha> -->`
 - `<!-- wheels-bot:review-b:<pr>:<sha>:<round> -->`
@@ -1076,4 +1076,4 @@ Workflow orchestration (multi-step planning, feature development) is not a frame
 
 **Kill switch**: flip the repo variable `WHEELS_BOT_ENABLED` to `false` to halt every bot workflow without code changes. Add the `[skip-claude]` label (or `[skip-claude]` in the title) to halt activity on a single issue/PR.
 
-**Auto-fire safety net**: the bot is permitted to chain stages (triage → research → propose-fix), but each handoff requires `*-confidence:high` and the propose-fix prompt auto-downgrades on sensitive areas (security, migrations, deploy, DI). All bot PRs land as `--draft` and require a human approving review on `develop`.
+**Auto-fire safety net**: the bot is permitted to chain stages (triage → research → propose-fix), and handoff fires on `*-confidence:high` OR `*-confidence:medium`. Low stays manual. Sensitive areas (security, middleware, migrations, deploy, DI, cross-engine) are caught by the propose-fix prompt's own step-4 safety net, which posts a `fix-held` marker instead of opening a PR. Reviewer A and B then critique whatever propose-fix produces, escalating to the Senior Advisor on deadlock. All bot PRs land as `--draft` and require a human approving review on `develop`.

--- a/docs/contributing/wheels-bot.md
+++ b/docs/contributing/wheels-bot.md
@@ -333,7 +333,7 @@ they make every workflow safely retryable.
 | `wheels-bot:triage-confidence:high` | Triggers propose-fix on the bug path. |
 | `wheels-bot:triage-confidence:medium` | Triggers propose-fix on the bug path. Sensitive areas are caught by propose-fix's step-4 safety net. |
 | `wheels-bot:docs-confidence:high` | Triggers write-docs on the docs-request path. |
-| `wheels-bot:docs-confidence:medium` | Triggers write-docs on the docs-request path. Structural docs decisions are caught by write-docs's safety net. |
+| `wheels-bot:docs-confidence:medium` | Triggers write-docs on the docs-request path. Structural docs decisions are caught by write-docs's step-4 safety net. |
 | `wheels-bot:research:<issue>` | Research stage processed this issue. |
 | `wheels-bot:research-confidence:high` | Triggers propose-fix on the framework-design path. |
 | `wheels-bot:research-confidence:medium` | Triggers propose-fix on the framework-design path. |

--- a/docs/contributing/wheels-bot.md
+++ b/docs/contributing/wheels-bot.md
@@ -41,11 +41,15 @@ posts a comment classifying it as one of:
 - **`other`** — non-actionable docs feedback, support, or general
   discussion. No further automation.
 
-For high-confidence `bug` triages the bot emits an additional marker
-(`<!-- wheels-bot:triage-confidence:high -->`) which is the trigger for
-the propose-fix stage. For high-confidence `docs-request` triages the
-bot emits `<!-- wheels-bot:docs-confidence:high -->`, which is the
-trigger for the write-docs stage.
+For `bug` triages rated `high` or `medium` the bot emits an additional
+marker (`<!-- wheels-bot:triage-confidence:high -->` or
+`<!-- wheels-bot:triage-confidence:medium -->`) which is the trigger for
+the propose-fix stage. For `docs-request` triages rated `high` or `medium`
+the bot emits `<!-- wheels-bot:docs-confidence:high -->` or
+`<!-- wheels-bot:docs-confidence:medium -->`, which is the trigger for
+the write-docs stage. Low-confidence triages emit no trigger marker and
+stay manual — the downstream stages can still be invoked via
+`workflow_dispatch` once a human reviews the triage.
 
 ### 2. Cross-framework research (`bot-research.yml`)
 
@@ -63,15 +67,23 @@ Fires when triage classifies as `framework-design`. The bot:
    rules: any conflict with a CLAUDE.md anti-pattern caps at `medium`;
    material framework disagreement caps at `low`.
 
-For high-confidence research the bot emits
-`<!-- wheels-bot:research-confidence:high -->`, which is the trigger for
-the propose-fix stage on the framework-design path.
+For research rated `high` or `medium` the bot emits
+`<!-- wheels-bot:research-confidence:high -->` or
+`<!-- wheels-bot:research-confidence:medium -->`, either of which is the
+trigger for the propose-fix stage on the framework-design path. Low
+confidence (material framework disagreement, or proposals that require
+new infrastructure) emits no marker — those warrant a human discussion
+before code is written.
 
 ### 3. Propose Fix (`bot-propose-fix.yml`)
 
-Fires on the high-confidence triage marker (bug path) or the high-confidence
-research marker (framework-design path). Also runnable manually via
-`workflow_dispatch`.
+Fires on the triage marker (bug path) or the research marker
+(framework-design path) when rated `high` or `medium`. Low-confidence
+triages and research stay manual. Sensitive-area fixes (security,
+middleware, migrations, deploy, DI, cross-engine) are caught by
+propose-fix's own step-4 safety net before any PR is opened — see the
+auto-downgrade list in `.claude/commands/propose-fix.md`. Also runnable
+manually via `workflow_dispatch`.
 
 The bot:
 
@@ -97,9 +109,11 @@ for docs-only bot PRs (`docs/bot-*` branches from the write-docs stage).
 ### 4. Write Docs (`bot-write-docs.yml`)
 
 The docs-path counterpart to propose-fix. Fires from triage's
-`wheels-bot:docs-confidence:high` marker on issues classified as
-`docs-request`. Sonnet, 30-turn budget — doc work is pattern-recognition,
-not reasoning-heavy. Also runnable manually via `workflow_dispatch`.
+`wheels-bot:docs-confidence:high` or `wheels-bot:docs-confidence:medium`
+marker on issues classified as `docs-request`. Low-confidence
+docs-requests stay manual. Sonnet, 30-turn budget — doc work is
+pattern-recognition, not reasoning-heavy. Also runnable manually via
+`workflow_dispatch`.
 
 The bot:
 
@@ -317,9 +331,12 @@ they make every workflow safely retryable.
 | `wheels-bot:triage:<issue>` | Triage stage processed this issue. |
 | `wheels-bot:triage-class:<bug\|framework-design\|docs-request\|other>` | Triage classification. |
 | `wheels-bot:triage-confidence:high` | Triggers propose-fix on the bug path. |
+| `wheels-bot:triage-confidence:medium` | Triggers propose-fix on the bug path. Sensitive areas are caught by propose-fix's step-4 safety net. |
 | `wheels-bot:docs-confidence:high` | Triggers write-docs on the docs-request path. |
+| `wheels-bot:docs-confidence:medium` | Triggers write-docs on the docs-request path. Structural docs decisions are caught by write-docs's safety net. |
 | `wheels-bot:research:<issue>` | Research stage processed this issue. |
 | `wheels-bot:research-confidence:high` | Triggers propose-fix on the framework-design path. |
+| `wheels-bot:research-confidence:medium` | Triggers propose-fix on the framework-design path. |
 | `wheels-bot:fix:<issue>` | Fix PR has been opened for this issue. |
 | `wheels-bot:fix-held:<issue>` | Fix would have been proposed but the safety net held it for a human. |
 | `wheels-bot:write-docs:<issue>` | Write Docs stage opened a docs PR for this issue. |
@@ -371,10 +388,10 @@ they make every workflow safely retryable.
   and Reviewer A verdicts; flip `WHEELS_BOT_ENABLED=false` if anything
   looks off.
 - **Auto-fire (Phase 4) is on.** propose-fix runs from
-  `wheels-bot:triage-confidence:high` and
-  `wheels-bot:research-confidence:high` markers; research runs from
+  `wheels-bot:triage-confidence:high|medium` and
+  `wheels-bot:research-confidence:high|medium` markers; research runs from
   `wheels-bot:triage-class:framework-design`; write-docs runs from
-  `wheels-bot:docs-confidence:high`; bot-update-docs runs on
+  `wheels-bot:docs-confidence:high|medium`; bot-update-docs runs on
   `pull_request: opened` for `wheels-bot[bot]` PRs (excluding
   `docs/bot-*` branches); **address-review runs on
   `wheels-bot:converged-changes:` markers from Reviewer B**;


### PR DESCRIPTION
## Summary

- Widen the auto-fire gate on `bot-propose-fix.yml` and `bot-write-docs.yml` so medium-confidence triage / research / docs-request markers fire the next stage. Low-confidence still stays manual.
- Triage and research prompts now emit a `:medium` marker alongside `:high`.
- The triage auto-downgrade rules are preserved as informational metadata; medium ratings auto-fire, but `propose-fix.md` step 4 and `write-docs.md` step 4 (the existing sensitive-area safety nets) keep the actual halt.

## Why

Previously the gate doubled as a halt: medium meant "don't auto-fire," which stopped useful work on ambiguous-but-actionable issues. Reviewer A and Reviewer B (with the Senior Advisor on deadlock) are better suited to filter borderline fixes than the triage rating is. Human approval on `develop` is still the merge gate, so nothing merges autonomously.

## Files

- `.github/workflows/bot-propose-fix.yml` — `if:` now accepts `triage-confidence:high|medium` and `research-confidence:high|medium`
- `.github/workflows/bot-write-docs.yml` — `if:` now accepts `docs-confidence:high|medium`
- `.claude/commands/triage-issue.md` — emits `:medium` marker for medium-confidence triages (docs-request + bug paths)
- `.claude/commands/research-frameworks.md` — emits `:medium` marker for medium-confidence research
- `CLAUDE.md` + `docs/contributing/wheels-bot.md` — pipeline table, marker conventions, and narrative updated

## Test plan

### Propose-fix path (bug + framework-design)

- [ ] YAML parses (verified locally with PyYAML).
- [ ] Real medium-confidence bug triage fires `bot-propose-fix.yml` from the bot's `:medium` marker comment.
- [ ] Sensitive-area medium triage (security / middleware / migrations / deploy / DI / cross-engine) produces a `wheels-bot:fix-held:<issue>` comment from propose-fix's step-4 safety net, not a draft PR.
- [ ] Real medium-confidence research comment fires `bot-propose-fix.yml` on the framework-design path.
- [ ] Low-confidence bug + research triages remain manual (no auto-fire).

### Write-docs path (docs-request)

- [ ] Real medium-confidence docs-request triage fires `bot-write-docs.yml` from the bot's `:medium` marker comment.
- [ ] Structural-docs-decision medium triage (>5 files, new top-level section, significant code-reading needed) produces a `wheels-bot:docs-held:<issue>` comment from write-docs's step-4 safety net, not a draft PR.
- [ ] Low-confidence docs-request triages remain manual (no auto-fire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)