### PR TITLE
fix(web/blog): quote title in wheels-4-closing-the-maturity-gap (recover failed auto-deploy)

### DIFF
--- a/web/content/blog/posts/wheels-4-closing-the-maturity-gap.md
+++ b/web/content/blog/posts/wheels-4-closing-the-maturity-gap.md
@@ -1,5 +1,5 @@
 ---
-title: Wheels 4.0: Closing the Maturity Gap
+title: 'Wheels 4.0: Closing the Maturity Gap'
 slug: wheels-4-closing-the-maturity-gap
 publishedAt: '2026-05-12T14:00:00.000Z'
 updatedAt: '2026-05-07T02:00:09.000Z'


### PR DESCRIPTION
## Summary

- Single-line fix: quote the title in [web/content/blog/posts/wheels-4-closing-the-maturity-gap.md](web/content/blog/posts/wheels-4-closing-the-maturity-gap.md) line 2 so js-yaml can parse the frontmatter.

## Why

Today's scheduled blog post auto-deployed at 07:00 PDT ([wheels@2b908f6b8](https://github.com/wheels-dev/wheels/commit/2b908f6b8)), but the downstream Astro build ([run 25739405600](https://github.com/wheels-dev/wheels/actions/runs/25739405600)) failed:

```
bad indentation of a mapping entry
  Location: web/content/blog/posts/wheels-4-closing-the-maturity-gap.md:1:17
  at safeParseFrontmatter (.../astro/dist/content/utils.js:295:12)
```

The title `Wheels 4.0: Closing the Maturity Gap` contains two colons. Unquoted, js-yaml reads `Wheels 4.0` as a key and rejects the rest. blog.wheels.dev has been stuck on the previous post since 07:00 because of this.

Same root cause as the manual recovery on 2026-05-06 for `wheels-deploy-kamal-port` ([wheels#2434](https://github.com/wheels-dev/wheels/pull/2434)). The upstream exporter fix to prevent recurrence is in [wheels-publishing-admin#4](https://github.com/wheels-dev/wheels-publishing-admin/pull/4); this PR just unblocks today's already-pushed file.

## Test plan

- [ ] `Deploy static sites` workflow passes the YAML parse for this post.
- [ ] blog.wheels.dev shows "Wheels 4.0: Closing the Maturity Gap" once Cloudflare Pages rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)