### PR TITLE
feat(ci): draft apt/yum bucket repo templates + wire release dispatch (#2605)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,14 @@ on:
       # of waiting for the daily cron. When absent, the step warns and exits 0.
       DOWNSTREAM_DISPATCH_TOKEN:
         required: false
+      # Optional — when present, the build job's "Dispatch Linux repo buckets"
+      # step fires repository_dispatch on apt-wheels-dev / yum-wheels-dev so
+      # their metadata regen workflows pick up the new .deb/.rpm and republish
+      # apt.wheels.dev / yum.wheels.dev within minutes. When absent, the step
+      # skips silently — the bucket repos can be populated manually via each
+      # repo's workflow_dispatch backfill in the meantime. See issue #2605.
+      LINUX_REPO_DISPATCH_TOKEN:
+        required: false
       # Required when this workflow is invoked from develop (snapshot context) so
       # the snapshot release can be published to wheels-dev/wheels-snapshots
       # instead of wheels-dev/wheels. Stable (main) builds don't use this and
@@ -550,6 +558,95 @@ jobs:
           done
 
           echo "Downstream package manager workflows dispatched (homebrew + chocolatey)."
+
+      #############################################
+      # Dispatch Linux repo buckets (apt.wheels.dev / yum.wheels.dev)
+      #
+      # Fires repository_dispatch on wheels-dev/apt-wheels-dev and
+      # wheels-dev/yum-wheels-dev so their metadata-regen workflows pick up
+      # the new .deb / .rpm asset and republish apt.wheels.dev /
+      # yum.wheels.dev within minutes. See issue #2605.
+      #
+      # Requires LINUX_REPO_DISPATCH_TOKEN — a fine-grained PAT with
+      # `actions: write` on the two bucket repos. If the secret is unset
+      # (which it will be until the bucket repos are created), this step
+      # skips silently — releases continue to land on the GitHub Release
+      # artifact stream regardless.
+      #
+      # Templates for the bucket repos live in
+      # tools/distribution-drafts/apt-repo/ and tools/distribution-drafts/yum-repo/.
+      #############################################
+      - name: Dispatch Linux repo buckets
+        if: steps.gh-release-final.outcome == 'success' || steps.gh-release-snapshot.outcome == 'success'
+        env:
+          GH_DISPATCH_TOKEN: ${{ secrets.LINUX_REPO_DISPATCH_TOKEN }}
+          WHEELS_RELEASE_VERSION: ${{ env.WHEELS_VERSION }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_DISPATCH_TOKEN:-}" ]; then
+            echo "LINUX_REPO_DISPATCH_TOKEN is not set — skipping apt/yum bucket dispatch (Phase 2 prerequisites not in place yet)."
+            exit 0
+          fi
+
+          # Same channel derivation as the homebrew/chocolatey dispatch.
+          # apt-wheels-dev / yum-wheels-dev route on `channel` in the payload
+          # to slot the .deb/.rpm into the right pool (stable vs bleeding-edge).
+          # RC releases aren't currently published to apt/yum, so we skip them.
+          if echo "${WHEELS_RELEASE_VERSION}" | grep -qiE '\-snapshot[\.\+]'; then
+            CHANNEL="bleeding-edge"
+          elif echo "${WHEELS_RELEASE_VERSION}" | grep -qE '\-rc\.'; then
+            echo "Skipping apt/yum dispatch for release candidate (RCs aren't pushed to apt/yum)."
+            exit 0
+          else
+            CHANNEL="stable"
+          fi
+          echo "Channel: ${CHANNEL}"
+
+          # Static event type, fixed repo list — no untrusted input flows into
+          # the curl arguments. WHEELS_RELEASE_VERSION is generated earlier in
+          # the same workflow from wheels.json + run number.
+          for repo in apt-wheels-dev yum-wheels-dev; do
+            echo "Dispatching wheels-released to wheels-dev/${repo}..."
+            http_status=$(curl -sS -o /tmp/linux-dispatch-resp.txt -w "%{http_code}" \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GH_DISPATCH_TOKEN}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/wheels-dev/${repo}/dispatches" \
+              -d "{\"event_type\":\"wheels-released\",\"client_payload\":{\"version\":\"${WHEELS_RELEASE_VERSION}\",\"channel\":\"${CHANNEL}\"}}" )
+
+            if [ "${http_status}" != "204" ]; then
+              echo "::warning::Dispatch to wheels-dev/${repo} returned HTTP ${http_status}: $(cat /tmp/linux-dispatch-resp.txt)"
+            else
+              echo "  ✓ ${repo} dispatched (channel=${CHANNEL})"
+            fi
+          done
+
+          echo "Linux repo bucket dispatch complete (apt + yum)."
+
+      - name: Bump develop after stable release
+        if: steps.gh-release-final.outcome == 'success' || steps.gh-release-snapshot.outcome == 'success'
+        env:
+          GH_DISPATCH_TOKEN: ${{ secrets.DOWNSTREAM_DISPATCH_TOKEN }}
+          WHEELS_RELEASE_VERSION: ${{ env.WHEELS_VERSION }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_DISPATCH_TOKEN:-}" ]; then
+            echo "DOWNSTREAM_DISPATCH_TOKEN is not set — skipping bump-develop dispatch."
+            exit 0
+          fi
+
+          # Reuse the same channel-derivation rule as the homebrew/chocolatey
+          # step so this stays in sync. Only stable GA releases bump develop.
+          if echo "${WHEELS_RELEASE_VERSION}" | grep -qiE '\-snapshot[\.\+]'; then
+            CHANNEL="bleeding-edge"
+          elif echo "${WHEELS_RELEASE_VERSION}" | grep -qE '\-rc\.'; then
+            CHANNEL="release-candidate"
+          else
+            CHANNEL="stable"
+          fi
 
           # Fire bump-develop at this repo to open the develop-bump PR.
           # Only stable GA releases bump develop; snapshots and RCs don't.

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -214,6 +214,11 @@ jobs:
       FORGEBOX_API_TOKEN: ${{ secrets.FORGEBOX_API_TOKEN }}
       FORGEBOX_PASS: ${{ secrets.FORGEBOX_PASS }}
       DOWNSTREAM_DISPATCH_TOKEN: ${{ secrets.DOWNSTREAM_DISPATCH_TOKEN }}
+      # Optional: when present, the build job's "Dispatch Linux repo buckets"
+      # step fires repository_dispatch on apt-wheels-dev / yum-wheels-dev so
+      # the bleeding-edge channel of apt.wheels.dev / yum.wheels.dev tracks
+      # every develop push. When absent, the step skips silently. See #2605.
+      LINUX_REPO_DISPATCH_TOKEN: ${{ secrets.LINUX_REPO_DISPATCH_TOKEN }}
       # Required: the snapshot-publish step in release.yml writes the GitHub
       # Release to wheels-dev/wheels-snapshots, which needs a PAT with
       # Contents:write on that repo. Stable (main) builds don't use this and

--- a/tools/distribution-drafts/apt-repo/README.md
+++ b/tools/distribution-drafts/apt-repo/README.md
@@ -1,0 +1,134 @@
+# `apt-wheels-dev` bucket repo template
+
+This directory is the **template** for the standalone `wheels-dev/apt-wheels-dev`
+repository that backs `https://apt.wheels.dev`. The bucket repo holds the static
+apt metadata tree plus the pooled `.deb` artifacts, and is auto-deployed to
+Cloudflare Pages on every push.
+
+Copy these files into the new repo when it's created — they are designed to
+work out of the box once the Phase 2 operational prerequisites (GPG key,
+secrets, CF Pages binding) are in place. See
+[../linux-packages/README.md § Phase 2](../linux-packages/README.md) for the
+end-to-end checklist.
+
+## Contents
+
+| File | Purpose |
+|------|---------|
+| `workflows/wheels-released.yml` | Receiver — listens for `repository_dispatch` (`wheels-released`) from `wheels-dev/wheels`'s release workflow, fetches the new `.deb` from the upstream GitHub Release, regenerates `Packages.gz` / `Release` / `InRelease`, signs with GPG, and commits to the bucket repo (CF Pages auto-deploys). |
+| `scripts/regenerate-apt-metadata.sh` | Pure-bash wrapper around `apt-ftparchive` + `gpg --clearsign`. Idempotent — safe to re-run by hand if a release event was lost. |
+| `templates/aptftparchive.conf` | apt-ftparchive config template. References the on-disk pool layout and emits `Packages` / `Release` files for each `(distribution, component, architecture)` triple. |
+| `templates/index.html` | Plain-HTML landing page served at the apex (`https://apt.wheels.dev/`). Documents the sources.list snippet so users hitting the site in a browser see install instructions. |
+| `templates/wheels.gpg.placeholder` | Placeholder reminding you that the **public** half of the signing key must live at `/wheels.gpg` so users can `curl https://apt.wheels.dev/wheels.gpg`. Replace with the real ASCII-armored public key. |
+
+## Distribution layout
+
+The bucket repo serves two distributions from the same site:
+
+```
+apt.wheels.dev/
+├── wheels.gpg                       # ASCII-armored public key
+├── dists/
+│   ├── stable/
+│   │   ├── Release
+│   │   ├── Release.gpg
+│   │   ├── InRelease                # inline-signed Release (preferred)
+│   │   └── main/
+│   │       └── binary-amd64/
+│   │           ├── Packages
+│   │           └── Packages.gz
+│   └── bleeding-edge/
+│       └── ... (mirror of the stable tree)
+└── pool/
+    ├── stable/
+    │   └── w/wheels/wheels_<v>_amd64.deb
+    └── bleeding-edge/
+        └── w/wheels-be/wheels-be_<v>_amd64.deb
+```
+
+User-facing setup post-Phase-2:
+
+```bash
+# Stable
+curl -fsSL https://apt.wheels.dev/wheels.gpg \
+  | sudo tee /usr/share/keyrings/wheels.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev stable main" \
+  | sudo tee /etc/apt/sources.list.d/wheels.list
+sudo apt update && sudo apt install wheels
+
+# Bleeding-edge — note: package name is `wheels-be`, not `wheels`,
+# so the two channels can coexist on the same host.
+echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev bleeding-edge main" \
+  | sudo tee /etc/apt/sources.list.d/wheels-be.list
+sudo apt update && sudo apt install wheels-be
+```
+
+## Package name & channel convention
+
+| Channel | Package name in `.deb` | Pool path | `apt install` invocation |
+|---------|------------------------|-----------|--------------------------|
+| Stable | `wheels` | `pool/stable/w/wheels/` | `apt install wheels` |
+| Bleeding-edge | `wheels-be` | `pool/bleeding-edge/w/wheels-be/` | `apt install wheels-be` |
+
+This mirrors the existing direct-install behaviour (you `apt install
+./wheels-be_*.deb` on BE today; Phase 2 just gives it a stable URL). The
+distinct names mean stable and BE can be installed side-by-side on the same
+host — useful for users who want a working stable CLI alongside a BE one for
+testing.
+
+## Filename: `~`-form vs `.`-form
+
+GitHub Releases silently rewrites `~` to `.` in uploaded asset filenames, so:
+
+- On disk locally (nfpm output): `wheels-be_4.0.1~snapshot.1787_amd64.deb`
+- GitHub Release URL: `wheels-be_4.0.1.snapshot.1787_amd64.deb`
+- Pool path (this repo): `pool/bleeding-edge/w/wheels-be/wheels-be_4.0.1~snapshot.1787_amd64.deb`
+
+The receiver workflow downloads using the `.`-form (the only form the GitHub
+Release URL exposes), then renames to the canonical `~`-form before publishing
+into the pool. The version field *inside* the `.deb` metadata always carries
+`~`, so `dpkg --compare-versions` orders snapshot releases below the next GA
+release correctly regardless of which form sits in `pool/`.
+
+Documented in [`build-linux-packages.sh:167`](../linux-packages/build-linux-packages.sh).
+
+## Operational prerequisites
+
+Before this bucket repo will function:
+
+1. **GPG signing key** — generate a 4096-bit RSA key (or Ed25519 if you prefer)
+   for `Wheels Distribution <hello@wheels.dev>`. Private key + passphrase go
+   into 1Password under `op://Infrastructure/wheels-linux-repo-signing/`.
+   Public key (ASCII-armored) overwrites `wheels.gpg` at the bucket-repo root.
+2. **Cloudflare Pages** — create a Pages project pointing at this repo, bind
+   the apex domain `apt.wheels.dev`. The build command is empty (the repo
+   *is* the static site); the output dir is `./`.
+3. **CI secrets** (set on the bucket repo at
+   `https://github.com/wheels-dev/apt-wheels-dev/settings/secrets/actions`):
+   - `WHEELS_REPO_GPG_PRIVATE_KEY` — ASCII-armored private key
+   - `WHEELS_REPO_GPG_PASSPHRASE` — passphrase
+4. **Upstream dispatch** — the release workflow in `wheels-dev/wheels`
+   fires a `repository_dispatch` (`wheels-released`) at this repo when a
+   new `.deb` is published to the GitHub Release. The token used by the
+   sender (`LINUX_REPO_DISPATCH_TOKEN` on `wheels-dev/wheels`) must have
+   `actions: write` on this repo.
+
+## Verifying
+
+```bash
+# From a fresh Debian/Ubuntu host:
+curl -fsSL https://apt.wheels.dev/wheels.gpg \
+  | sudo tee /usr/share/keyrings/wheels.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev stable main" \
+  | sudo tee /etc/apt/sources.list.d/wheels.list
+sudo apt update
+sudo apt-cache policy wheels   # should show the apt.wheels.dev origin
+sudo apt install wheels
+wheels --version
+```
+
+`apt update` reports `Get:N https://apt.wheels.dev stable InRelease` on
+success. A `NO_PUBKEY` error means the public key wasn't installed at
+`/usr/share/keyrings/wheels.gpg` (or it doesn't match the key the bucket
+signed with — `apt-key list` no longer applies; check
+`gpg --no-default-keyring --keyring /usr/share/keyrings/wheels.gpg --list-keys`).

--- a/tools/distribution-drafts/apt-repo/scripts/regenerate-apt-metadata.sh
+++ b/tools/distribution-drafts/apt-repo/scripts/regenerate-apt-metadata.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Regenerates apt metadata for both `stable` and `bleeding-edge` distributions
+# under dists/, then signs Release with GPG (detached → Release.gpg, inline →
+# InRelease). Both signed forms are required: older apt clients read Release +
+# Release.gpg, newer clients prefer InRelease.
+#
+# Inputs (env vars):
+#   GPG_PASSPHRASE  — passphrase for the imported signing key
+#   GPG_KEY_ID      — long-form key ID (set by the workflow after `gpg --import`)
+#
+# Idempotent: safe to run by hand against an existing tree to repair a torn
+# release. Re-reads everything in pool/ and rewrites dists/ from scratch.
+
+set -euo pipefail
+
+if [ -z "${GPG_KEY_ID:-}" ]; then
+  echo "::error::GPG_KEY_ID is unset — sign step would default to an arbitrary secret key."
+  exit 1
+fi
+
+ARCHITECTURES="amd64"
+COMPONENTS="main"
+DISTRIBUTIONS="stable bleeding-edge"
+
+# apt-ftparchive uses a config file to know where the pool lives. The same
+# config drives both distributions — only the dist-name and the scan path
+# change between invocations.
+APT_CONF_TEMPLATE="templates/aptftparchive.conf"
+
+if [ ! -f "$APT_CONF_TEMPLATE" ]; then
+  echo "::error::Missing $APT_CONF_TEMPLATE — template is expected to ship in the bucket repo."
+  exit 1
+fi
+
+for DIST in $DISTRIBUTIONS; do
+  echo "── Regenerating dists/${DIST}/ ──"
+  DIST_DIR="dists/${DIST}"
+  mkdir -p "$DIST_DIR"
+
+  for COMPONENT in $COMPONENTS; do
+    for ARCH in $ARCHITECTURES; do
+      BIN_DIR="${DIST_DIR}/${COMPONENT}/binary-${ARCH}"
+      mkdir -p "$BIN_DIR"
+
+      # apt-ftparchive packages <override> <pool-path> emits Packages on stdout.
+      # We don't use an override file (no priority overrides for now).
+      apt-ftparchive \
+        --arch "$ARCH" \
+        packages "pool/${DIST}" \
+        > "${BIN_DIR}/Packages"
+
+      gzip -9 --keep --force "${BIN_DIR}/Packages"
+    done
+  done
+
+  # apt-ftparchive release emits the Release file metadata. The config template
+  # provides Origin/Label/Codename/Description etc.; we override -o APT::FTPArchive::Release::Codename
+  # per distribution so a single conf can drive both.
+  apt-ftparchive \
+    -c "$APT_CONF_TEMPLATE" \
+    -o "APT::FTPArchive::Release::Codename=${DIST}" \
+    -o "APT::FTPArchive::Release::Suite=${DIST}" \
+    release "$DIST_DIR" \
+    > "${DIST_DIR}/Release"
+
+  # Detached signature → Release.gpg (legacy clients).
+  rm -f "${DIST_DIR}/Release.gpg" "${DIST_DIR}/InRelease"
+  gpg --batch --yes \
+    --pinentry-mode loopback \
+    --passphrase "${GPG_PASSPHRASE:-}" \
+    --default-key "$GPG_KEY_ID" \
+    --armor --detach-sign \
+    --output "${DIST_DIR}/Release.gpg" \
+    "${DIST_DIR}/Release"
+
+  # Inline-signed Release → InRelease (modern clients).
+  gpg --batch --yes \
+    --pinentry-mode loopback \
+    --passphrase "${GPG_PASSPHRASE:-}" \
+    --default-key "$GPG_KEY_ID" \
+    --clearsign \
+    --output "${DIST_DIR}/InRelease" \
+    "${DIST_DIR}/Release"
+
+  echo "  ✓ Release + Release.gpg + InRelease written for ${DIST}"
+done
+
+echo "Done."

--- a/tools/distribution-drafts/apt-repo/templates/aptftparchive.conf
+++ b/tools/distribution-drafts/apt-repo/templates/aptftparchive.conf
@@ -1,0 +1,25 @@
+// apt-ftparchive config — drives both `dists/stable/` and `dists/bleeding-edge/`.
+//
+// The Codename and Suite are overridden per-distribution on the command line
+// (`-o APT::FTPArchive::Release::Codename=...`) so a single conf file works
+// for both.
+//
+// References:
+//   https://manpages.debian.org/bookworm/apt-utils/apt-ftparchive.1.en.html
+//   https://wiki.debian.org/DebianRepository/Format
+
+APT::FTPArchive::Release::Origin       "wheels.dev";
+APT::FTPArchive::Release::Label        "Wheels";
+APT::FTPArchive::Release::Architectures "amd64";
+APT::FTPArchive::Release::Components   "main";
+APT::FTPArchive::Release::Description  "Wheels CFML framework apt repository";
+
+// Codename + Suite are set per-distribution from the wrapper script.
+//   stable        → Codename=stable        Suite=stable
+//   bleeding-edge → Codename=bleeding-edge Suite=bleeding-edge
+
+Default {
+  Packages::Compress ". gzip";
+  Sources::Compress  ". gzip";
+  Contents::Compress ". gzip";
+};

--- a/tools/distribution-drafts/apt-repo/templates/index.html
+++ b/tools/distribution-drafts/apt-repo/templates/index.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>apt.wheels.dev — Wheels Debian/Ubuntu repository</title>
+  <meta name="description" content="Native apt repository for the Wheels CFML framework CLI. Add the source once, then `apt update && apt upgrade wheels`.">
+  <style>
+    :root {
+      color-scheme: light dark;
+      --fg: #0f172a;
+      --bg: #fff;
+      --muted: #64748b;
+      --accent: #2563eb;
+      --code-bg: #f1f5f9;
+      --border: #e2e8f0;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --fg: #f1f5f9;
+        --bg: #0f172a;
+        --muted: #94a3b8;
+        --accent: #60a5fa;
+        --code-bg: #1e293b;
+        --border: #334155;
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font: 16px/1.6 system-ui, -apple-system, "Segoe UI", sans-serif;
+      color: var(--fg);
+      background: var(--bg);
+    }
+    main { max-width: 720px; margin: 4rem auto; padding: 0 1.5rem; }
+    h1 { font-size: 2rem; margin: 0 0 0.5rem; }
+    h2 { font-size: 1.25rem; margin: 2.5rem 0 0.75rem; }
+    p, li { margin: 0.5rem 0; }
+    a { color: var(--accent); }
+    pre {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 1rem;
+      overflow-x: auto;
+      font: 14px/1.5 ui-monospace, "SF Mono", Menlo, monospace;
+    }
+    code:not(pre code) {
+      background: var(--code-bg);
+      padding: 2px 5px;
+      border-radius: 3px;
+      font: 90% ui-monospace, "SF Mono", Menlo, monospace;
+    }
+    .muted { color: var(--muted); font-size: 0.9rem; }
+    footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--muted); font-size: 0.85rem; }
+  </style>
+</head>
+<body>
+<main>
+  <h1>apt.wheels.dev</h1>
+  <p>Native Debian/Ubuntu repository for the <a href="https://wheels.dev">Wheels</a> CFML framework CLI.</p>
+
+  <h2>Stable channel</h2>
+  <pre><code>curl -fsSL https://apt.wheels.dev/wheels.gpg \
+  | sudo tee /usr/share/keyrings/wheels.gpg &gt;/dev/null
+echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev stable main" \
+  | sudo tee /etc/apt/sources.list.d/wheels.list
+sudo apt update &amp;&amp; sudo apt install wheels</code></pre>
+
+  <h2>Bleeding-edge channel</h2>
+  <p>Published on every merge to <code>develop</code>. The package is named <code>wheels-be</code> so it can coexist with the stable <code>wheels</code> install on the same host.</p>
+  <pre><code>curl -fsSL https://apt.wheels.dev/wheels.gpg \
+  | sudo tee /usr/share/keyrings/wheels.gpg &gt;/dev/null
+echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev bleeding-edge main" \
+  | sudo tee /etc/apt/sources.list.d/wheels-be.list
+sudo apt update &amp;&amp; sudo apt install wheels-be</code></pre>
+
+  <h2>Upgrading</h2>
+  <pre><code>sudo apt update &amp;&amp; sudo apt upgrade wheels        # or wheels-be</code></pre>
+
+  <h2>Signing key</h2>
+  <p>The repository is signed with the Wheels project key. The public half is published at <a href="/wheels.gpg"><code>/wheels.gpg</code></a>. The fingerprint is committed to the <a href="https://github.com/wheels-dev/apt-wheels-dev">source repo</a> in <code>FINGERPRINT</code> for offline verification.</p>
+
+  <h2>Other platforms</h2>
+  <ul>
+    <li>macOS: <code>brew install wheels</code> — <a href="https://github.com/wheels-dev/homebrew-wheels">wheels-dev/homebrew-wheels</a></li>
+    <li>Windows: <code>scoop install wheels</code> — <a href="https://github.com/wheels-dev/scoop-wheels">wheels-dev/scoop-wheels</a></li>
+    <li>Fedora/RHEL: <code>dnf install wheels</code> — <a href="https://yum.wheels.dev">yum.wheels.dev</a></li>
+  </ul>
+
+  <footer>
+    <p>Hosted on Cloudflare Pages. Repository contents at <a href="https://github.com/wheels-dev/apt-wheels-dev">wheels-dev/apt-wheels-dev</a>.</p>
+  </footer>
+</main>
+</body>
+</html>

--- a/tools/distribution-drafts/apt-repo/templates/wheels.gpg.placeholder
+++ b/tools/distribution-drafts/apt-repo/templates/wheels.gpg.placeholder
@@ -1,0 +1,24 @@
+This file is a placeholder. The real `wheels.gpg` at the bucket-repo root must
+be the ASCII-armored *public* half of the signing key whose private half lives
+in 1Password at `op://Infrastructure/wheels-linux-repo-signing/private-key`.
+
+Once the key is minted:
+
+    op read 'op://Infrastructure/wheels-linux-repo-signing/public-key' > wheels.gpg
+    # or, from a host that has the secret key imported:
+    gpg --armor --export <KEY_ID> > wheels.gpg
+
+Commit `wheels.gpg` to the **root** of the bucket repo (not in `templates/`).
+Cloudflare Pages will serve it at `https://apt.wheels.dev/wheels.gpg`, which
+is the URL users `curl` during the one-time setup:
+
+    curl -fsSL https://apt.wheels.dev/wheels.gpg \
+      | sudo tee /usr/share/keyrings/wheels.gpg >/dev/null
+
+Also commit the key fingerprint to `FINGERPRINT` at the bucket-repo root so
+anyone can verify it out-of-band:
+
+    gpg --fingerprint <KEY_ID> > FINGERPRINT
+
+The fingerprint should be cross-published in the wheels.dev guides so users
+have a second source to compare against.

--- a/tools/distribution-drafts/apt-repo/workflows/wheels-released.yml
+++ b/tools/distribution-drafts/apt-repo/workflows/wheels-released.yml
@@ -1,0 +1,185 @@
+# Receiver workflow for `wheels-dev/apt-wheels-dev`.
+#
+# Listens for `repository_dispatch` from `wheels-dev/wheels`'s release workflow,
+# downloads the new `.deb` asset from the upstream GitHub Release, slots it
+# into `pool/<channel>/w/<pkg>/`, regenerates the apt metadata via
+# `apt-ftparchive`, signs `Release` + `InRelease` with GPG, and commits the
+# whole tree back to this repo. Cloudflare Pages auto-deploys on push.
+#
+# Trigger payload contract (sender: wheels-dev/wheels release.yml):
+#   event_type:    "wheels-released"
+#   client_payload:
+#     version: "<x.y.z>" or "<x.y.z>-snapshot.<n>"   # full SemVer, no leading v
+#     channel: "stable" | "bleeding-edge"             # routes into the pool
+#
+# Manual dispatch is also supported via `workflow_dispatch` for backfill /
+# disaster-recovery (re-add a missing version without waiting for a new release).
+
+name: Publish to apt.wheels.dev
+
+on:
+  repository_dispatch:
+    types: [wheels-released]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Wheels version (e.g. 4.0.1 or 4.0.1-snapshot.1700)'
+        required: true
+        type: string
+      channel:
+        description: 'Release channel'
+        required: true
+        default: stable
+        type: choice
+        options:
+          - stable
+          - bleeding-edge
+
+permissions:
+  contents: write   # the workflow commits the regenerated metadata back to this repo
+
+concurrency:
+  # Serialize across both channels — apt-ftparchive scans the whole pool, so
+  # parallel runs would race on Packages.gz / Release writes.
+  group: publish-apt
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish ${{ github.event.client_payload.version || inputs.version }} (${{ github.event.client_payload.channel || inputs.channel }})
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve inputs
+        id: inputs
+        run: |
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            VERSION="${{ github.event.client_payload.version }}"
+            CHANNEL="${{ github.event.client_payload.channel }}"
+          else
+            VERSION="${{ inputs.version }}"
+            CHANNEL="${{ inputs.channel }}"
+          fi
+          if [ -z "$VERSION" ] || [ -z "$CHANNEL" ]; then
+            echo "::error::Both version and channel are required."
+            exit 1
+          fi
+          # Reject "release-candidate" and other channels we don't yet plumb.
+          case "$CHANNEL" in
+            stable|bleeding-edge) ;;
+            *) echo "::error::Unsupported channel: $CHANNEL"; exit 1 ;;
+          esac
+          # Map channel → package name (mirrors nfpm-wheels.yaml / nfpm-wheels-be.yaml).
+          case "$CHANNEL" in
+            stable)        PKG="wheels" ;;
+            bleeding-edge) PKG="wheels-be" ;;
+          esac
+          # Map channel → upstream releases repo. Stable releases live in
+          # wheels-dev/wheels; snapshot/BE releases live in wheels-dev/wheels-snapshots.
+          case "$CHANNEL" in
+            stable)        UPSTREAM_REPO="wheels-dev/wheels" ;;
+            bleeding-edge) UPSTREAM_REPO="wheels-dev/wheels-snapshots" ;;
+          esac
+          echo "version=$VERSION"           >> "$GITHUB_OUTPUT"
+          echo "channel=$CHANNEL"           >> "$GITHUB_OUTPUT"
+          echo "pkg=$PKG"                   >> "$GITHUB_OUTPUT"
+          echo "upstream_repo=$UPSTREAM_REPO" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout bucket repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          # Persist the workflow token so the trailing `git push` works.
+          persist-credentials: true
+
+      - name: Install apt-ftparchive + gpg
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends apt-utils gnupg
+          apt-ftparchive --version
+          gpg --version | head -1
+
+      - name: Import GPG signing key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.WHEELS_REPO_GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.WHEELS_REPO_GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GPG_PRIVATE_KEY:-}" ]; then
+            echo "::error::WHEELS_REPO_GPG_PRIVATE_KEY is unset; cannot sign Release."
+            exit 1
+          fi
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --yes --import
+          # Trust the imported key ultimately so subsequent sign operations don't prompt.
+          KEY_ID=$(gpg --list-secret-keys --keyid-format=long --with-colons \
+            | awk -F: '/^sec:/ { print $5; exit }')
+          echo "Imported signing key: $KEY_ID"
+          echo "$KEY_ID:6:" | gpg --batch --yes --import-ownertrust
+          echo "GPG_KEY_ID=$KEY_ID" >> "$GITHUB_ENV"
+
+      - name: Download .deb from upstream Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.inputs.outputs.version }}
+          CHANNEL: ${{ steps.inputs.outputs.channel }}
+          PKG: ${{ steps.inputs.outputs.pkg }}
+          UPSTREAM_REPO: ${{ steps.inputs.outputs.upstream_repo }}
+        run: |
+          set -euo pipefail
+          mkdir -p incoming
+          # GitHub Release URLs rewrite `~` to `.` at upload time. The version
+          # passed in `client_payload.version` uses `-snapshot.N` (SemVer), but
+          # the on-URL filename uses `.snapshot.N`. Translate.
+          URL_VERSION="${VERSION/-snapshot./.snapshot.}"
+          ASSET="${PKG}_${URL_VERSION}_amd64.deb"
+          TAG="v${VERSION}"
+          echo "Fetching ${ASSET} from ${UPSTREAM_REPO}@${TAG}"
+          gh release download "$TAG" \
+            --repo "$UPSTREAM_REPO" \
+            --pattern "$ASSET" \
+            --dir incoming/
+          ls -l incoming/
+
+      - name: Slot .deb into pool/
+        env:
+          VERSION: ${{ steps.inputs.outputs.version }}
+          CHANNEL: ${{ steps.inputs.outputs.channel }}
+          PKG: ${{ steps.inputs.outputs.pkg }}
+        run: |
+          set -euo pipefail
+          # Canonical pool form uses `~` (SemVer pre-release separator).
+          POOL_DIR="pool/${CHANNEL}/${PKG:0:1}/${PKG}"
+          POOL_FILE="${POOL_DIR}/${PKG}_${VERSION}_amd64.deb"
+          mkdir -p "$POOL_DIR"
+          # The downloaded file uses `.` in the snapshot separator; rename to `~`.
+          URL_VERSION="${VERSION/-snapshot./.snapshot.}"
+          mv "incoming/${PKG}_${URL_VERSION}_amd64.deb" "$POOL_FILE"
+          echo "Placed: $POOL_FILE"
+          # Idempotency: if the pool already had this version, the mv overwrote
+          # it. Re-runs of the same dispatch are safe (last-writer-wins).
+
+      - name: Regenerate apt metadata + sign
+        env:
+          GPG_PASSPHRASE: ${{ secrets.WHEELS_REPO_GPG_PASSPHRASE }}
+          GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
+        run: |
+          set -euo pipefail
+          chmod +x scripts/regenerate-apt-metadata.sh
+          ./scripts/regenerate-apt-metadata.sh
+
+      - name: Commit + push
+        env:
+          VERSION: ${{ steps.inputs.outputs.version }}
+          CHANNEL: ${{ steps.inputs.outputs.channel }}
+          PKG: ${{ steps.inputs.outputs.pkg }}
+        run: |
+          set -euo pipefail
+          git config user.name  "wheels-release-bot"
+          git config user.email "hello@wheels.dev"
+          git add pool/ dists/
+          if git diff --cached --quiet; then
+            echo "No changes — dispatch must have been a no-op (same version re-published?)."
+            exit 0
+          fi
+          git commit -m "publish: ${PKG} ${VERSION} (${CHANNEL})"
+          git push origin HEAD:main

--- a/tools/distribution-drafts/linux-packages/README.md
+++ b/tools/distribution-drafts/linux-packages/README.md
@@ -109,20 +109,55 @@ sudo dnf install wheels
 
 ### What you'll need to do for Phase 2 (when ready)
 
-1. **Mint a GPG signing key** for the Wheels project. Store the private key in
-   1Password (or another secret store), the public key as
-   `tools/distribution-drafts/linux-packages/wheels-public.gpg`.
-2. **Create two CF Pages projects** pointing at:
+Bucket-repo templates are now drafted in:
+
+- [`tools/distribution-drafts/apt-repo/`](../apt-repo/) — receiver workflow,
+  `apt-ftparchive` regen + GPG sign script, `aptftparchive.conf`, landing
+  page HTML.
+- [`tools/distribution-drafts/yum-repo/`](../yum-repo/) — receiver workflow,
+  `createrepo_c` regen + GPG sign script, `.repo` files for both channels,
+  landing page HTML.
+
+The remaining work is operational:
+
+1. **Mint a GPG signing key** for the Wheels project (one key signs both
+   `Release` / `InRelease` and `repomd.xml.asc`). Store the private key +
+   passphrase in 1Password under
+   `op://Infrastructure/wheels-linux-repo-signing/`. Commit the public half
+   to the root of *each* bucket repo as `wheels.gpg` (template placeholders
+   live at `<bucket>/templates/wheels.gpg.placeholder`).
+2. **Create the two bucket repos** under `wheels-dev`:
+   - `wheels-dev/apt-wheels-dev` — copy contents of `apt-repo/` template
+   - `wheels-dev/yum-wheels-dev` — copy contents of `yum-repo/` template
+3. **Create two CF Pages projects** pointing at the new repos, binding the
+   apex domains:
    - `wheels-dev/apt-wheels-dev` → `apt.wheels.dev`
    - `wheels-dev/yum-wheels-dev` → `yum.wheels.dev`
-3. **Add CI secrets** to `wheels-dev/wheels`:
-   - `LINUX_REPO_GPG_PRIVATE_KEY` — ASCII-armored private key
-   - `LINUX_REPO_GPG_PASSPHRASE` — passphrase for the private key
-   - `LINUX_REPO_DISPATCH_TOKEN` — fine-grained PAT with write access to the
-     two repo-bucket repos
-4. **Author the repo-build workflows** in each bucket repo. Templates will be
-   in `tools/distribution-drafts/apt-repo/` and `tools/distribution-drafts/yum-repo/`
-   when Phase 2 lands.
+4. **Add CI secrets** to `wheels-dev/wheels` (for the dispatch sender) and to
+   each bucket repo (for the signing receiver):
+   - On `wheels-dev/wheels`:
+     - `LINUX_REPO_DISPATCH_TOKEN` — fine-grained PAT with `actions: write`
+       on both bucket repos. The dispatch step in `release.yml` skips
+       silently when this secret is unset, so it's safe to land the wiring
+       before the bucket repos exist.
+   - On each bucket repo (`apt-wheels-dev`, `yum-wheels-dev`):
+     - `WHEELS_REPO_GPG_PRIVATE_KEY` — ASCII-armored private key
+     - `WHEELS_REPO_GPG_PASSPHRASE` — passphrase
+5. **Smoke-test** by running the bucket-repo workflows manually (each
+   supports `workflow_dispatch` for backfill). For the apt bucket:
+   ```
+   gh workflow run wheels-released.yml \
+     --repo wheels-dev/apt-wheels-dev \
+     -f version=4.0.0 -f channel=stable
+   ```
+   then verify the published tree on a fresh Debian/Ubuntu host. Do the same
+   for the yum bucket on a Fedora host.
+6. **Update docs** — once `apt.wheels.dev` and `yum.wheels.dev` resolve,
+   replace the GitHub-Release download snippets in
+   `web/sites/guides/src/content/docs/v4-0-1-snapshot/start-here/installing.mdx`
+   and `command-line-tools/installation.mdx` with the sources.list /
+   `dnf config-manager` snippets, and remove the "native apt/yum repos coming"
+   `<Aside>` blocks.
 
 ### Why split into two CF Pages sites instead of one
 

--- a/tools/distribution-drafts/yum-repo/README.md
+++ b/tools/distribution-drafts/yum-repo/README.md
@@ -1,0 +1,103 @@
+# `yum-wheels-dev` bucket repo template
+
+This directory is the **template** for the standalone `wheels-dev/yum-wheels-dev`
+repository that backs `https://yum.wheels.dev`. The bucket repo holds the
+static yum metadata tree plus the pooled `.rpm` artifacts, and is auto-deployed
+to Cloudflare Pages on every push.
+
+Copy these files into the new repo when it's created — they are designed to
+work out of the box once the Phase 2 operational prerequisites (GPG key,
+secrets, CF Pages binding) are in place. See
+[../linux-packages/README.md § Phase 2](../linux-packages/README.md) for the
+end-to-end checklist.
+
+## Contents
+
+| File | Purpose |
+|------|---------|
+| `workflows/wheels-released.yml` | Receiver — listens for `repository_dispatch` (`wheels-released`) from `wheels-dev/wheels`'s release workflow, fetches the new `.rpm` from the upstream GitHub Release, regenerates `repodata/repomd.xml` via `createrepo_c`, signs with GPG, and commits to the bucket repo. |
+| `scripts/regenerate-yum-metadata.sh` | Pure-bash wrapper around `createrepo_c` + `gpg --detach-sign`. Idempotent. |
+| `templates/wheels.repo` | The `.repo` file users grab via `dnf config-manager --add-repo`. Hosted at `https://yum.wheels.dev/wheels.repo`. |
+| `templates/wheels-be.repo` | Bleeding-edge variant of the `.repo` file. |
+| `templates/index.html` | Plain-HTML landing page served at the apex (`https://yum.wheels.dev/`). |
+| `templates/wheels.gpg.placeholder` | Reminder that the **public** half of the signing key must live at `/wheels.gpg`. |
+
+## Distribution layout
+
+Two distributions, single GPG key, parallel to the apt repo:
+
+```
+yum.wheels.dev/
+├── wheels.gpg                                       # ASCII-armored public key
+├── wheels.repo                                      # stable channel .repo file
+├── wheels-be.repo                                   # bleeding-edge .repo file
+├── stable/
+│   ├── repodata/
+│   │   ├── repomd.xml
+│   │   ├── repomd.xml.asc                           # detached GPG signature
+│   │   ├── repomd.xml.key                           # public key copy (some clients fetch this)
+│   │   ├── primary.xml.gz
+│   │   ├── filelists.xml.gz
+│   │   └── other.xml.gz
+│   └── packages/
+│       └── wheels-<v>.x86_64.rpm
+└── bleeding-edge/
+    └── ... (mirror of the stable tree)
+```
+
+User-facing setup post-Phase-2:
+
+```bash
+# Stable
+sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels.repo
+sudo dnf install wheels
+
+# Bleeding-edge — distinct package name (`wheels-be`) so it coexists with stable
+sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels-be.repo
+sudo dnf install wheels-be
+```
+
+## Package name & channel convention
+
+Identical to the apt side:
+
+| Channel | Package name | Pool path | `dnf install` invocation |
+|---------|--------------|-----------|--------------------------|
+| Stable | `wheels` | `stable/packages/` | `dnf install wheels` |
+| Bleeding-edge | `wheels-be` | `bleeding-edge/packages/` | `dnf install wheels-be` |
+
+## Filename: `~`-form vs `.`-form
+
+Same gotcha as apt — GitHub Releases rewrites `~` to `.` on upload. The
+receiver workflow downloads the `.`-form (the only form the GitHub Release
+URL exposes), then renames to the canonical `~`-form before slotting into
+`packages/`. The version field *inside* the RPM metadata always carries `~`,
+so `rpmvercmp` orders snapshot releases below the next GA correctly.
+
+## Operational prerequisites
+
+Same GPG key as the apt repo (one key for both, importable on both clients
+via `https://apt.wheels.dev/wheels.gpg` or `https://yum.wheels.dev/wheels.gpg`).
+
+CI secrets on `https://github.com/wheels-dev/yum-wheels-dev/settings/secrets/actions`:
+- `WHEELS_REPO_GPG_PRIVATE_KEY` — ASCII-armored private key
+- `WHEELS_REPO_GPG_PASSPHRASE` — passphrase
+
+The upstream dispatch token (`LINUX_REPO_DISPATCH_TOKEN` on
+`wheels-dev/wheels`) must have `actions: write` on this repo.
+
+## Verifying
+
+```bash
+# From a fresh Fedora/RHEL host:
+sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels.repo
+sudo dnf install wheels
+wheels --version
+# To verify GPG signing is actually happening (the .repo file has gpgcheck=1):
+sudo dnf --refresh check-update wheels
+# yum/dnf prints "Importing GPG key 0x<keyid>: ..." on first refresh.
+```
+
+A `repomd.xml.asc verify failed` error means the bucket's GPG signing step
+didn't run, or the public key at `/wheels.gpg` doesn't match the private key
+that signed.

--- a/tools/distribution-drafts/yum-repo/scripts/regenerate-yum-metadata.sh
+++ b/tools/distribution-drafts/yum-repo/scripts/regenerate-yum-metadata.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Regenerates yum metadata for both `stable` and `bleeding-edge` channels
+# under the bucket-repo root, then signs `repomd.xml` with GPG (detached →
+# `repomd.xml.asc`).
+#
+# Inputs (env vars):
+#   GPG_PASSPHRASE  — passphrase for the imported signing key
+#   GPG_KEY_ID      — long-form key ID (set by the workflow after `gpg --import`)
+#
+# Idempotent: safe to run by hand against an existing tree. `createrepo_c`
+# rebuilds the metadata from the current state of <channel>/packages/, so
+# stale entries get cleared automatically.
+
+set -euo pipefail
+
+if [ -z "${GPG_KEY_ID:-}" ]; then
+  echo "::error::GPG_KEY_ID is unset — sign step would default to an arbitrary secret key."
+  exit 1
+fi
+
+CHANNELS="stable bleeding-edge"
+
+for CHANNEL in $CHANNELS; do
+  CHANNEL_DIR="$CHANNEL"
+  PKG_DIR="${CHANNEL_DIR}/packages"
+
+  # Skip channels that don't have any packages yet (first run after bucket creation).
+  if [ ! -d "$PKG_DIR" ] || [ -z "$(ls -A "$PKG_DIR" 2>/dev/null | grep -E '\.rpm$' || true)" ]; then
+    echo "── Skipping ${CHANNEL} (no .rpm files in ${PKG_DIR}) ──"
+    continue
+  fi
+
+  echo "── Regenerating ${CHANNEL_DIR}/repodata/ ──"
+
+  # createrepo_c scans <channel>/packages/ and writes <channel>/repodata/.
+  # --update reuses existing metadata where possible (faster on large pools).
+  createrepo_c \
+    --update \
+    --workers 2 \
+    --general-compress-type=gz \
+    --xz \
+    "$CHANNEL_DIR"
+
+  REPOMD="${CHANNEL_DIR}/repodata/repomd.xml"
+  if [ ! -f "$REPOMD" ]; then
+    echo "::error::createrepo_c didn't produce ${REPOMD}"
+    exit 1
+  fi
+
+  # Detached signature on repomd.xml is the trust root — package checksums
+  # live inside the metadata, so signing repomd.xml signs the whole tree
+  # transitively.
+  rm -f "${REPOMD}.asc"
+  gpg --batch --yes \
+    --pinentry-mode loopback \
+    --passphrase "${GPG_PASSPHRASE:-}" \
+    --default-key "$GPG_KEY_ID" \
+    --armor --detach-sign \
+    --output "${REPOMD}.asc" \
+    "$REPOMD"
+
+  # Some dnf clients fetch repomd.xml.key alongside repomd.xml.asc on first
+  # refresh. Export the public key there so installs don't fail with
+  # "GPG key not available" on hosts that don't pre-trust the key.
+  gpg --armor --export "$GPG_KEY_ID" > "${CHANNEL_DIR}/repodata/repomd.xml.key"
+
+  echo "  ✓ repodata + repomd.xml.asc + repomd.xml.key written for ${CHANNEL}"
+done
+
+echo "Done."

--- a/tools/distribution-drafts/yum-repo/templates/index.html
+++ b/tools/distribution-drafts/yum-repo/templates/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>yum.wheels.dev — Wheels Fedora/RHEL repository</title>
+  <meta name="description" content="Native yum/dnf repository for the Wheels CFML framework CLI. Add the source once, then `dnf upgrade wheels`.">
+  <style>
+    :root {
+      color-scheme: light dark;
+      --fg: #0f172a;
+      --bg: #fff;
+      --muted: #64748b;
+      --accent: #2563eb;
+      --code-bg: #f1f5f9;
+      --border: #e2e8f0;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --fg: #f1f5f9;
+        --bg: #0f172a;
+        --muted: #94a3b8;
+        --accent: #60a5fa;
+        --code-bg: #1e293b;
+        --border: #334155;
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font: 16px/1.6 system-ui, -apple-system, "Segoe UI", sans-serif;
+      color: var(--fg);
+      background: var(--bg);
+    }
+    main { max-width: 720px; margin: 4rem auto; padding: 0 1.5rem; }
+    h1 { font-size: 2rem; margin: 0 0 0.5rem; }
+    h2 { font-size: 1.25rem; margin: 2.5rem 0 0.75rem; }
+    p, li { margin: 0.5rem 0; }
+    a { color: var(--accent); }
+    pre {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 1rem;
+      overflow-x: auto;
+      font: 14px/1.5 ui-monospace, "SF Mono", Menlo, monospace;
+    }
+    code:not(pre code) {
+      background: var(--code-bg);
+      padding: 2px 5px;
+      border-radius: 3px;
+      font: 90% ui-monospace, "SF Mono", Menlo, monospace;
+    }
+    footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--border); color: var(--muted); font-size: 0.85rem; }
+  </style>
+</head>
+<body>
+<main>
+  <h1>yum.wheels.dev</h1>
+  <p>Native Fedora/RHEL repository for the <a href="https://wheels.dev">Wheels</a> CFML framework CLI.</p>
+
+  <h2>Stable channel</h2>
+  <pre><code>sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels.repo
+sudo dnf install wheels</code></pre>
+
+  <h2>Bleeding-edge channel</h2>
+  <p>Published on every merge to <code>develop</code>. The package is named <code>wheels-be</code> so it can coexist with the stable <code>wheels</code> install on the same host.</p>
+  <pre><code>sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels-be.repo
+sudo dnf install wheels-be</code></pre>
+
+  <h2>Upgrading</h2>
+  <pre><code>sudo dnf upgrade wheels        # or wheels-be</code></pre>
+
+  <h2>Signing key</h2>
+  <p>The repository is signed with the Wheels project key. The public half is published at <a href="/wheels.gpg"><code>/wheels.gpg</code></a>. Both <code>.repo</code> files reference it via <code>gpgkey=</code>, so <code>dnf</code> imports it automatically on first refresh. The fingerprint is committed to the <a href="https://github.com/wheels-dev/yum-wheels-dev">source repo</a> in <code>FINGERPRINT</code> for offline verification.</p>
+
+  <h2>Other platforms</h2>
+  <ul>
+    <li>macOS: <code>brew install wheels</code> — <a href="https://github.com/wheels-dev/homebrew-wheels">wheels-dev/homebrew-wheels</a></li>
+    <li>Windows: <code>scoop install wheels</code> — <a href="https://github.com/wheels-dev/scoop-wheels">wheels-dev/scoop-wheels</a></li>
+    <li>Debian/Ubuntu: <code>apt install wheels</code> — <a href="https://apt.wheels.dev">apt.wheels.dev</a></li>
+  </ul>
+
+  <footer>
+    <p>Hosted on Cloudflare Pages. Repository contents at <a href="https://github.com/wheels-dev/yum-wheels-dev">wheels-dev/yum-wheels-dev</a>.</p>
+  </footer>
+</main>
+</body>
+</html>

--- a/tools/distribution-drafts/yum-repo/templates/wheels-be.repo
+++ b/tools/distribution-drafts/yum-repo/templates/wheels-be.repo
@@ -1,0 +1,7 @@
+[wheels-be]
+name=Wheels CFML framework (bleeding-edge)
+baseurl=https://yum.wheels.dev/bleeding-edge
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.wheels.dev/wheels.gpg
+repo_gpgcheck=1

--- a/tools/distribution-drafts/yum-repo/templates/wheels.gpg.placeholder
+++ b/tools/distribution-drafts/yum-repo/templates/wheels.gpg.placeholder
@@ -1,0 +1,17 @@
+This file is a placeholder. The real `wheels.gpg` at the bucket-repo root must
+be the ASCII-armored *public* half of the same key used by the apt bucket
+repo. One key signs both apt's `Release` / `InRelease` and yum's
+`repomd.xml.asc`; users only need to import it once if they run mixed
+distributions.
+
+Once the key is minted:
+
+    op read 'op://Infrastructure/wheels-linux-repo-signing/public-key' > wheels.gpg
+
+Commit `wheels.gpg` to the **root** of the bucket repo (not in `templates/`).
+Cloudflare Pages will serve it at `https://yum.wheels.dev/wheels.gpg`, which
+is the URL the `.repo` files reference via `gpgkey=`.
+
+Also commit the key fingerprint to `FINGERPRINT` at the bucket-repo root:
+
+    gpg --fingerprint <KEY_ID> > FINGERPRINT

--- a/tools/distribution-drafts/yum-repo/templates/wheels.repo
+++ b/tools/distribution-drafts/yum-repo/templates/wheels.repo
@@ -1,0 +1,7 @@
+[wheels]
+name=Wheels CFML framework (stable)
+baseurl=https://yum.wheels.dev/stable
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.wheels.dev/wheels.gpg
+repo_gpgcheck=1

--- a/tools/distribution-drafts/yum-repo/workflows/wheels-released.yml
+++ b/tools/distribution-drafts/yum-repo/workflows/wheels-released.yml
@@ -1,0 +1,171 @@
+# Receiver workflow for `wheels-dev/yum-wheels-dev`.
+#
+# Listens for `repository_dispatch` from `wheels-dev/wheels`'s release workflow,
+# downloads the new `.rpm` asset from the upstream GitHub Release, slots it
+# into `<channel>/packages/`, regenerates the repodata via `createrepo_c`,
+# signs `repomd.xml` with GPG (detached → repomd.xml.asc), and commits the
+# whole tree back to this repo. Cloudflare Pages auto-deploys on push.
+#
+# Trigger payload contract (sender: wheels-dev/wheels release.yml):
+#   event_type:    "wheels-released"
+#   client_payload:
+#     version: "<x.y.z>" or "<x.y.z>-snapshot.<n>"   # full SemVer, no leading v
+#     channel: "stable" | "bleeding-edge"             # routes into the pool
+#
+# Manual dispatch is also supported via `workflow_dispatch`.
+
+name: Publish to yum.wheels.dev
+
+on:
+  repository_dispatch:
+    types: [wheels-released]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Wheels version (e.g. 4.0.1 or 4.0.1-snapshot.1700)'
+        required: true
+        type: string
+      channel:
+        description: 'Release channel'
+        required: true
+        default: stable
+        type: choice
+        options:
+          - stable
+          - bleeding-edge
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-yum
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish ${{ github.event.client_payload.version || inputs.version }} (${{ github.event.client_payload.channel || inputs.channel }})
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve inputs
+        id: inputs
+        run: |
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            VERSION="${{ github.event.client_payload.version }}"
+            CHANNEL="${{ github.event.client_payload.channel }}"
+          else
+            VERSION="${{ inputs.version }}"
+            CHANNEL="${{ inputs.channel }}"
+          fi
+          if [ -z "$VERSION" ] || [ -z "$CHANNEL" ]; then
+            echo "::error::Both version and channel are required."
+            exit 1
+          fi
+          case "$CHANNEL" in
+            stable|bleeding-edge) ;;
+            *) echo "::error::Unsupported channel: $CHANNEL"; exit 1 ;;
+          esac
+          case "$CHANNEL" in
+            stable)        PKG="wheels" ;;
+            bleeding-edge) PKG="wheels-be" ;;
+          esac
+          case "$CHANNEL" in
+            stable)        UPSTREAM_REPO="wheels-dev/wheels" ;;
+            bleeding-edge) UPSTREAM_REPO="wheels-dev/wheels-snapshots" ;;
+          esac
+          echo "version=$VERSION"           >> "$GITHUB_OUTPUT"
+          echo "channel=$CHANNEL"           >> "$GITHUB_OUTPUT"
+          echo "pkg=$PKG"                   >> "$GITHUB_OUTPUT"
+          echo "upstream_repo=$UPSTREAM_REPO" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout bucket repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: true
+
+      - name: Install createrepo_c + gpg
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends createrepo-c gnupg
+          createrepo_c --version
+          gpg --version | head -1
+
+      - name: Import GPG signing key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.WHEELS_REPO_GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.WHEELS_REPO_GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GPG_PRIVATE_KEY:-}" ]; then
+            echo "::error::WHEELS_REPO_GPG_PRIVATE_KEY is unset; cannot sign repomd.xml."
+            exit 1
+          fi
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --yes --import
+          KEY_ID=$(gpg --list-secret-keys --keyid-format=long --with-colons \
+            | awk -F: '/^sec:/ { print $5; exit }')
+          echo "Imported signing key: $KEY_ID"
+          echo "$KEY_ID:6:" | gpg --batch --yes --import-ownertrust
+          echo "GPG_KEY_ID=$KEY_ID" >> "$GITHUB_ENV"
+
+      - name: Download .rpm from upstream Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.inputs.outputs.version }}
+          CHANNEL: ${{ steps.inputs.outputs.channel }}
+          PKG: ${{ steps.inputs.outputs.pkg }}
+          UPSTREAM_REPO: ${{ steps.inputs.outputs.upstream_repo }}
+        run: |
+          set -euo pipefail
+          mkdir -p incoming
+          URL_VERSION="${VERSION/-snapshot./.snapshot.}"
+          ASSET="${PKG}-${URL_VERSION}.x86_64.rpm"
+          TAG="v${VERSION}"
+          echo "Fetching ${ASSET} from ${UPSTREAM_REPO}@${TAG}"
+          gh release download "$TAG" \
+            --repo "$UPSTREAM_REPO" \
+            --pattern "$ASSET" \
+            --dir incoming/
+          ls -l incoming/
+
+      - name: Slot .rpm into packages/
+        env:
+          VERSION: ${{ steps.inputs.outputs.version }}
+          CHANNEL: ${{ steps.inputs.outputs.channel }}
+          PKG: ${{ steps.inputs.outputs.pkg }}
+        run: |
+          set -euo pipefail
+          PKG_DIR="${CHANNEL}/packages"
+          mkdir -p "$PKG_DIR"
+          URL_VERSION="${VERSION/-snapshot./.snapshot.}"
+          # Rename to the canonical `~`-form for pool storage.
+          mv "incoming/${PKG}-${URL_VERSION}.x86_64.rpm" \
+             "${PKG_DIR}/${PKG}-${VERSION}.x86_64.rpm"
+          echo "Placed: ${PKG_DIR}/${PKG}-${VERSION}.x86_64.rpm"
+
+      - name: Regenerate yum metadata + sign
+        env:
+          GPG_PASSPHRASE: ${{ secrets.WHEELS_REPO_GPG_PASSPHRASE }}
+          GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
+          CHANNEL: ${{ steps.inputs.outputs.channel }}
+        run: |
+          set -euo pipefail
+          chmod +x scripts/regenerate-yum-metadata.sh
+          ./scripts/regenerate-yum-metadata.sh
+
+      - name: Commit + push
+        env:
+          VERSION: ${{ steps.inputs.outputs.version }}
+          CHANNEL: ${{ steps.inputs.outputs.channel }}
+          PKG: ${{ steps.inputs.outputs.pkg }}
+        run: |
+          set -euo pipefail
+          git config user.name  "wheels-release-bot"
+          git config user.email "hello@wheels.dev"
+          git add stable/ bleeding-edge/
+          if git diff --cached --quiet; then
+            echo "No changes — dispatch must have been a no-op."
+            exit 0
+          fi
+          git commit -m "publish: ${PKG} ${VERSION} (${CHANNEL})"
+          git push origin HEAD:main


### PR DESCRIPTION
## Summary

Lands the code-side deliverables for [#2605](https://github.com/wheels-dev/wheels/issues/2605) (Phase 2 — native `apt.wheels.dev` / `yum.wheels.dev` repositories). The remaining work is operational and tracked in the updated checklist (mint GPG key, create the two bucket repos, set up Cloudflare Pages, store secrets).

- **`tools/distribution-drafts/apt-repo/`** — drop-in template for the `wheels-dev/apt-wheels-dev` bucket repo: receiver workflow listening for `repository_dispatch` from this repo's release flow, `apt-ftparchive` regen + GPG sign script, `aptftparchive.conf`, landing page.
- **`tools/distribution-drafts/yum-repo/`** — drop-in template for the `wheels-dev/yum-wheels-dev` bucket repo: same shape but with `createrepo_c` + `.repo` files for both channels.
- **`.github/workflows/release.yml`** — declares the new optional `LINUX_REPO_DISPATCH_TOKEN` secret and adds a "Dispatch Linux repo buckets" step. **Skips silently when the secret is unset**, so it's safe to merge before the bucket repos exist. The original bump-develop dispatch is split into its own step so the three downstream targets (homebrew/choco, apt/yum, bump-develop) are each independently visible in the Actions UI.
- **`.github/workflows/snapshot.yml`** — passes the new secret through so bleeding-edge releases also reach the bucket repos.
- **`tools/distribution-drafts/linux-packages/README.md`** — Phase 2 section rewritten to point at the new template dirs and list the remaining operational steps.

## Channel + package-name convention

The two channels live in the same bucket repo but use distinct package names so they coexist on a single host (matches the existing direct-install behaviour where BE is `wheels-be_*.deb`):

| Channel       | Package    | apt                       | dnf                       |
|---------------|------------|---------------------------|---------------------------|
| Stable        | `wheels`   | `apt install wheels`      | `dnf install wheels`      |
| Bleeding-edge | `wheels-be`| `apt install wheels-be`   | `dnf install wheels-be`   |

## Remaining operational work (cannot be done from a PR)

Tracked in [`tools/distribution-drafts/linux-packages/README.md`](tools/distribution-drafts/linux-packages/README.md):

1. Mint a GPG signing key, store private half in 1Password (`op://Infrastructure/wheels-linux-repo-signing/`).
2. Create `wheels-dev/apt-wheels-dev` + `wheels-dev/yum-wheels-dev`, copy the corresponding template directory into each.
3. Create Cloudflare Pages projects pointing the apex domains at the two repos.
4. Add CI secrets:
   - On `wheels-dev/wheels`: `LINUX_REPO_DISPATCH_TOKEN` (a fine-grained PAT with `actions: write` on both bucket repos).
   - On each bucket repo: `WHEELS_REPO_GPG_PRIVATE_KEY`, `WHEELS_REPO_GPG_PASSPHRASE`.
5. Smoke-test via each bucket's `workflow_dispatch` backfill, then verify install on fresh Debian/Ubuntu and Fedora hosts.
6. Update install docs once `apt.wheels.dev` / `yum.wheels.dev` resolve.

## Test plan

- [x] `release.yml` parses as valid YAML
- [x] `snapshot.yml` parses as valid YAML
- [x] `apt-repo/workflows/wheels-released.yml` parses as valid YAML
- [x] `yum-repo/workflows/wheels-released.yml` parses as valid YAML
- [x] `regenerate-apt-metadata.sh` passes `bash -n` syntax check
- [x] `regenerate-yum-metadata.sh` passes `bash -n` syntax check
- [ ] CI green on this PR
- [ ] **Behavioural verification has to wait for the bucket repos to exist.** Until `LINUX_REPO_DISPATCH_TOKEN` is set, the new dispatch step skips and logs "Phase 2 prerequisites not in place yet" — that's the intended dormant state for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)