### PR TITLE
ci(compat-matrix): make CF engine readiness diagnostics actionable on timeout

### DIFF
--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -77,18 +77,24 @@ jobs:
           fi
 
       - name: Wait for CF engine to be ready
+        env:
+          CFENGINE: ${{ matrix.cfengine }}
         run: |
-          PORT_VAR="PORT_${{ matrix.cfengine }}"
+          PORT_VAR="PORT_${CFENGINE}"
           PORT="${!PORT_VAR}"
-          CONTAINER="wheels-${{ matrix.cfengine }}-1"
+          CONTAINER="wheels-${CFENGINE}-1"
 
-          echo "Waiting for ${{ matrix.cfengine }} on port ${PORT}..."
+          echo "Waiting for ${CFENGINE} on port ${PORT}..."
 
-          # Wait for HTTP response, restarting container if it crashes
+          # Wait for HTTP response, restarting container if it crashes.
+          # Tracks the last HTTP status code so timeout diagnostics can
+          # distinguish "no response" (engine didn't bind) from "5xx"
+          # (engine bound but app returning errors — e.g. issue #2646).
           MAX_WAIT=60
           WAIT_COUNT=0
           RESTARTS=0
           MAX_RESTARTS=3
+          LAST_HTTP_CODE="000"
           while [ "$WAIT_COUNT" -lt "$MAX_WAIT" ]; do
             WAIT_COUNT=$((WAIT_COUNT + 1))
 
@@ -98,28 +104,54 @@ jobs:
               RESTARTS=$((RESTARTS + 1))
               if [ "$RESTARTS" -le "$MAX_RESTARTS" ]; then
                 echo "Container $CONTAINER has status '$CONTAINER_STATUS' — restarting (attempt $RESTARTS/$MAX_RESTARTS)..."
-                docker compose up -d ${{ matrix.cfengine }}
+                docker compose up -d "${CFENGINE}"
                 sleep 10
                 continue
               else
                 echo "::error::Container $CONTAINER failed to start after $MAX_RESTARTS restart attempts"
-                docker logs "$CONTAINER" 2>&1 | tail -50
+                docker logs "$CONTAINER" 2>&1 | tail -100
                 exit 1
               fi
             fi
 
-            if curl -s -o /dev/null --connect-timeout 2 --max-time 5 -w "%{http_code}" "http://localhost:${PORT}/" | grep -q "200\|404\|302"; then
-              echo "CF engine is ready!"
+            # curl with -w "%{http_code}" always prints the code (000 if no
+            # response). Don't add a `|| echo "000"` fallback — it would
+            # concatenate with curl's own 000 output and produce "000000".
+            LAST_HTTP_CODE=$(curl -s -o /dev/null --connect-timeout 2 --max-time 5 -w "%{http_code}" "http://localhost:${PORT}/" 2>/dev/null || true)
+            LAST_HTTP_CODE=${LAST_HTTP_CODE:-000}
+            if echo "$LAST_HTTP_CODE" | grep -qE "^(200|302|404)$"; then
+              echo "CF engine is ready! (HTTP $LAST_HTTP_CODE on attempt $WAIT_COUNT)"
               break
             fi
+
+            # Surface partial progress every 10 attempts so logs show
+            # whether we're stuck on "no response" or "5xx" early.
+            if [ $((WAIT_COUNT % 10)) -eq 0 ]; then
+              echo "  attempt $WAIT_COUNT/$MAX_WAIT: container=$CONTAINER_STATUS, http=$LAST_HTTP_CODE"
+            fi
+
             if [ "$WAIT_COUNT" -lt "$MAX_WAIT" ]; then
               sleep 5
             fi
           done
 
           if [ "$WAIT_COUNT" -ge "$MAX_WAIT" ]; then
-            echo "::error::CF engine not ready after ${MAX_WAIT} attempts"
-            docker logs "$CONTAINER" 2>&1 | tail -50
+            echo "::error::CF engine not ready after ${MAX_WAIT} attempts (last HTTP code: $LAST_HTTP_CODE)"
+            if [ "$LAST_HTTP_CODE" = "000" ]; then
+              echo "::notice::No HTTP response received — engine likely never bound to port $PORT."
+            else
+              echo "::notice::HTTP $LAST_HTTP_CODE received — engine bound to port $PORT but app is returning errors."
+              echo "=== Final response body (first 500 bytes) ==="
+              curl -s --max-time 5 "http://localhost:${PORT}/" 2>/dev/null | head -c 500 || true
+              echo
+              echo "=== /end response body ==="
+            fi
+            echo "=== Container logs (stack frames stripped, last 100 lines) ==="
+            docker logs "$CONTAINER" 2>&1 | grep -vE '^\s*at\s|runwar\.context -[[:space:]]+at[[:space:]]' | tail -100
+            echo "=== /end filtered logs ==="
+            echo "=== Container logs (raw, last 200 lines) ==="
+            docker logs "$CONTAINER" 2>&1 | tail -200
+            echo "=== /end raw logs ==="
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 ### Changed
 
 - Reconcile upgrade docs: blog skeleton now lists all eleven canonical breaking changes (matching the canonical upgrade guide), fixes the `wheels.Test` → `wheels.WheelsTest` test-base-class rename description (previously mislabeled as a "testbox namespace" move), and adds the previously-missing `application.wirebox` → `application.wheelsdi` and Vite manifest strictness entries; stats table "Breaking defaults hardened | 7" corrected to "Breaking changes | 11" with four detail-row delta labels updated from Changed/Renamed/New to Breaking (#2632)
+- Compat-matrix CF-engine readiness probe now tracks the last observed HTTP status, surfaces partial progress every 10 attempts, and on timeout distinguishes "engine never bound" (HTTP 000) from "engine bound but returning 5xx" (e.g. issue #2646's `$blockInProduction` symptom) — printing the response body and a stack-frame-stripped log slice when the latter occurs. Previously a 5-minute timeout dumped `tail -50` of raw container logs, dominated by ~30 lines of undertow/runwar stack frames, hiding the actual root cause
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

When the compat-matrix `Wait for CF engine to be ready` step times out (5 minutes), it currently dumps `docker logs ... | tail -50`. On BoxLang+Wheels that output is dominated by ~30 lines of undertow/runwar request-pipeline stack frames, with the actual exception buried earlier in the log. A maintainer staring at the CI log can't tell whether:

- the engine never bound a port (container broken), or
- the engine is bound but returning 5xx to every request (app broken — e.g. [#2646](https://github.com/wheels-dev/wheels/issues/2646)'s `$blockInProduction not found` symptom on BoxLang).

This PR makes that distinction obvious without changing the success-path behavior.

### What changed

The probe now tracks the **last observed HTTP status code** across attempts. Every 10 attempts it logs partial state (`container=running, http=500`) so progress is visible mid-loop. On timeout:

- Classifies as **"no response received"** (HTTP 000) or **"engine bound but returning errors"** (5xx).
- For the 5xx case, prints the first **500 bytes of the response body** — surfacing the actual exception class instead of just stack frames.
- Dumps both a **stack-frame-stripped 100-line slice** (anything matching `^\s*at\s` or `runwar.context -   at` is filtered out) **and** the raw `tail -200`. Signal-to-noise is much better, but raw logs are still available for deeper digging.

Also moves `${{ matrix.cfengine }}` interpolation into an `env:` block and references it as `$CFENGINE` in the shell — the standard workflow-hardening pattern from [GitHub's workflow-injection guide](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/). Matrix values are hardcoded (`[lucee6, lucee7, adobe2023, adobe2025, boxlang]`) so this is not a security fix — just keeps the script consistent with the recommended pattern as it grows.

### Background

While investigating [#2649](https://github.com/wheels-dev/wheels/issues/2649) (BoxLang test failure rate) I discovered the BoxLang job in compat-matrix has been failing at `CF engine not ready after 60 attempts` on the last three scheduled runs ([2026-05-03](https://github.com/wheels-dev/wheels/actions/runs/25268355232), [2026-05-10](https://github.com/wheels-dev/wheels/actions/runs/25618291177), [2026-05-12](https://github.com/wheels-dev/wheels/actions/runs/25710659583)). The root cause was the `$blockInProduction` bug ([#2646](https://github.com/wheels-dev/wheels/issues/2646)) — every `GET /` was returning 500, so the probe's HTTP-status check (`200|404|302`) timed out forever. That underlying defect is already fixed by [#2648](https://github.com/wheels-dev/wheels/pull/2648) (merged into `develop` earlier today), and a local docker run of the post-#2648 BoxLang image now returns 200 OK on `GET /`. But the CI never re-ran on develop after that merge, and even if it had succeeded, the *previous* failures were unnecessarily hard to debug. This PR closes that diagnostic gap so the next regression of this shape is one CI log read instead of a half-hour archaeology dig.

### Verification

Local simulation against three scenarios (a Python `http.server` returning HTTP 200, HTTP 500 with a fake `BoxRuntimeException` body, and no server at all):

```
--- Scenario 3: no server (port 58997) ---
TIMEOUT (last code: 000 -> engine never bound to 58997)

--- Scenario 1: HTTP 200 (port 58998) ---
READY (HTTP 200 on attempt 1)

--- Scenario 2: HTTP 500 (port 58999) ---
TIMEOUT (last code: 500 -> engine bound but returning errors)
  body sample: BoxRuntimeException: Function blockInProduction not found
```

Also validated:
- `actionlint`/`shellcheck` clean on the modified `run:` block (existing SC2086 hits elsewhere in the file are pre-existing and out of scope).
- A naive port of the original probe-with-`|| echo "000"` produced `last code: 000000` on the no-server scenario; the local test caught that and the fix went in before commit (the comment above the curl call explains the trap).

### What this PR is NOT

- **Not a fix for #2649 itself.** That issue is an aggregate report (~160 failures) classified as `other` by the bot's triage. Decomposition into individual per-failure issues is still required — see the [fix-held comment](https://github.com/wheels-dev/wheels/issues/2649#issuecomment-4445491473).
- **Not the BoxLang readiness fix.** That landed in #2648. This PR just makes the next failure of this class diagnose-able from CI logs.

Related: #2646, #2648, #2649

## Test plan

- [x] `actionlint` + shellcheck pass on the edited block (verified via `rhysd/actionlint:latest` Docker image)
- [x] Local probe simulation: 200 → READY, 500 → TIMEOUT with body sample, no-server → TIMEOUT with "engine never bound"
- [x] Diff reviewed: no changes to success-path output beyond appending `(HTTP $LAST_HTTP_CODE on attempt $N)` to the ready message
- [ ] Triggered compat-matrix on develop or this branch — **not done locally; requires shared-infrastructure permission**. Recommend a manual `workflow_dispatch` run on this branch before marking ready, OR merge as-is and observe via the next scheduled Sunday run

🤖 Generated with [Claude Code](https://claude.com/claude-code)