### PR TITLE
ci: unblock Oracle in compat matrix and fix Lucee 6 datasource

### DIFF
--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -270,6 +270,10 @@ jobs:
           RESULTS_JSON="{"
           FIRST=true
 
+          # Databases whose failures are logged but don't block CI.
+          # oracle: tracked in #2663 — datasource registration, DBMS_LOCK, and constraint cleanup.
+          SOFT_FAIL_DBS="oracle"
+
           mkdir -p /tmp/test-results
           mkdir -p /tmp/junit-results
 
@@ -416,10 +420,6 @@ jobs:
               f.write(tostring(root))
           " || { echo "JUnit conversion failed for ${db} (non-fatal)"; rm -f "$JUNIT_FILE"; }
             fi
-
-            # Databases whose failures are logged but don't block CI.
-            # oracle: tracked in #2663 — datasource registration, DBMS_LOCK, and constraint cleanup.
-            SOFT_FAIL_DBS="oracle"
 
             # Track per-database result
             if [ "$HTTP_CODE" = "200" ]; then

--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -418,7 +418,8 @@ jobs:
             fi
 
             # Databases whose failures are logged but don't block CI.
-            SOFT_FAIL_DBS=""
+            # oracle: tracked in #2663 — datasource registration, DBMS_LOCK, and constraint cleanup.
+            SOFT_FAIL_DBS="oracle"
 
             # Track per-database result
             if [ "$HTTP_CODE" = "200" ]; then
@@ -466,7 +467,7 @@ jobs:
           echo "| Database | Result |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|--------|" >> $GITHUB_STEP_SUMMARY
 
-          SOFT_FAIL_DBS=""
+          SOFT_FAIL_DBS="oracle"
           IFS=',' read -ra DBS <<< "${{ steps.db-list.outputs.databases }}"
           for db in "${DBS[@]}"; do
             RESULT_FILE="/tmp/test-results/${{ matrix.cfengine }}-${db}-result.txt"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -639,7 +639,7 @@ curl -s "http://localhost:62023/wheels/core/tests?db=mysql&format=json" | \
 - **`private` mixin functions not integrated**: `$integrateComponents()` only copies `public` methods into model/controller objects. ALL helper functions in mixin CFCs (`vendor/wheels/model/*.cfc`, view helpers, etc.) MUST use `public` access. Use `$` prefix for internal scope instead of `private` keyword. BoxLang handles this differently, so `private` may pass BoxLang tests but fail Lucee/Adobe.
 
 ### CI soft-fail databases
-`SOFT_FAIL_DBS` appears twice in `.github/workflows/compat-matrix.yml` — once in the "Run test suites" step (before the per-database loop) and once in the "Generate per-engine summary" step (before the summary loop). Both must be kept in sync since the steps don't share shell state. It currently contains `"oracle"` — Oracle failures log as warnings rather than blocking the matrix while #2663 (datasource registration, DBMS_LOCK, constraint cleanup) is resolved. All other databases, including CockroachDB, are hard-gated. Remove a database from both occurrences once its tests are fixed.
+`SOFT_FAIL_DBS` appears twice in `.github/workflows/compat-matrix.yml` — once in the "Run test suites for all databases" step (before the per-database loop) and once in the "Generate per-engine summary" step (before the summary loop). Both must be kept in sync since the steps don't share shell state. It currently contains `"oracle"` — Oracle failures log as warnings rather than blocking the matrix while #2663 (datasource registration, DBMS_LOCK, constraint cleanup) is resolved. All other databases, including CockroachDB, are hard-gated. Remove a database from both occurrences once its tests are fixed.
 
 ### Cleanup
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -639,7 +639,7 @@ curl -s "http://localhost:62023/wheels/core/tests?db=mysql&format=json" | \
 - **`private` mixin functions not integrated**: `$integrateComponents()` only copies `public` methods into model/controller objects. ALL helper functions in mixin CFCs (`vendor/wheels/model/*.cfc`, view helpers, etc.) MUST use `public` access. Use `$` prefix for internal scope instead of `private` keyword. BoxLang handles this differently, so `private` may pass BoxLang tests but fail Lucee/Adobe.
 
 ### CI soft-fail databases
-`SOFT_FAIL_DBS` in `.github/workflows/compat-matrix.yml` (lines 389, 519) is currently empty (`""`) — **all databases, including CockroachDB, are hard-gated in CI**. To mark a database as soft-fail (failures logged as warnings but not blocking the build), add it to `SOFT_FAIL_DBS` in both locations. Remove a database from the list once its tests are fixed.
+`SOFT_FAIL_DBS` in `.github/workflows/compat-matrix.yml` (lines ~421, ~469) currently contains `"oracle"` — Oracle failures log as warnings rather than blocking the matrix while #2663 (datasource registration, DBMS_LOCK, constraint cleanup) is resolved. All other databases, including CockroachDB, are hard-gated. To mark a database as soft-fail, add it to `SOFT_FAIL_DBS` in both locations. Remove a database from the list once its tests are fixed.
 
 ### Cleanup
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -639,7 +639,7 @@ curl -s "http://localhost:62023/wheels/core/tests?db=mysql&format=json" | \
 - **`private` mixin functions not integrated**: `$integrateComponents()` only copies `public` methods into model/controller objects. ALL helper functions in mixin CFCs (`vendor/wheels/model/*.cfc`, view helpers, etc.) MUST use `public` access. Use `$` prefix for internal scope instead of `private` keyword. BoxLang handles this differently, so `private` may pass BoxLang tests but fail Lucee/Adobe.
 
 ### CI soft-fail databases
-`SOFT_FAIL_DBS` in `.github/workflows/compat-matrix.yml` (lines ~421, ~469) currently contains `"oracle"` — Oracle failures log as warnings rather than blocking the matrix while #2663 (datasource registration, DBMS_LOCK, constraint cleanup) is resolved. All other databases, including CockroachDB, are hard-gated. To mark a database as soft-fail, add it to `SOFT_FAIL_DBS` in both locations. Remove a database from the list once its tests are fixed.
+`SOFT_FAIL_DBS` appears twice in `.github/workflows/compat-matrix.yml` — once in the "Run test suites" step (before the per-database loop) and once in the "Generate per-engine summary" step (before the summary loop). Both must be kept in sync since the steps don't share shell state. It currently contains `"oracle"` — Oracle failures log as warnings rather than blocking the matrix while #2663 (datasource registration, DBMS_LOCK, constraint cleanup) is resolved. All other databases, including CockroachDB, are hard-gated. Remove a database from both occurrences once its tests are fixed.
 
 ### Cleanup
 ```bash

--- a/tools/docker/lucee6/CFConfig.json
+++ b/tools/docker/lucee6/CFConfig.json
@@ -135,7 +135,7 @@
 			"connectionLimit": "-1",
 			"connectionTimeout": "20",
 			"database": "wheelstestdb",
-			"dbdriver": "Oracle",
+			"dbdriver": "Other",
 			"dsn": "jdbc:oracle:thin:@//{host}:{port}/{database}",
 			"host": "oracle",
 			"password": "wheelstestdb",


### PR DESCRIPTION
## Summary
Two of the three sub-clusters from #2663. Sub-cluster 2 (lockingSpec guard) already landed on develop via #2670 — its `$supportsAdvisoryLocks()` capability supersedes the manual skip list this PR originally proposed, and that change has been dropped on rebase.

1. **Lucee 6 datasource registration** — Switch `dbdriver` from `"Oracle"` to `"Other"` in [tools/docker/lucee6/CFConfig.json](tools/docker/lucee6/CFConfig.json). The Lucee Oracle extension was re-templating the JDBC URL and emitting `java.sql.SQLException: Invalid Oracle URL specified`. Adobe 2023/2025 and BoxLang already use `"Other"` and work fine; this is the minimum diff between the working configs and Lucee 6.

   **Lucee 7 retains `"dbdriver": "Oracle"`** — its Oracle extension does not re-template the JDBC URL, so it connects successfully with the current config. The `Invalid Oracle URL specified` failure in the compat matrix is Lucee-6-only (per the issue's CI evidence). Leaving Lucee 7 alone avoids risking a regression on a path that works today.

2. **`SOFT_FAIL_DBS="oracle"`** — Set once before the per-database loop and read inside it. Oracle's remaining constraint-cleanup failures (ORA-02264 / ORA-01003 in `migratorSpec` / `bulkOperationsSpec`) now log as warnings instead of breaking each engine job while a follow-up addresses the teardown drift.

CLAUDE.md's `SOFT_FAIL_DBS` section is updated to reflect the new state.

## Out of scope (follow-up)
Sub-cluster 3 from the issue — Oracle ORA-02264 constraint cleanup in `migratorSpec` / `bulkOperationsSpec` — needs the same shape of fix as #2664's MySQL/H2/SQL Server FK collision work. Leaving it for a separate PR keeps each change reviewable on its own.

## Test plan
- [x] `bash tools/test-local.sh model` — 815 pass on Lucee 7 + SQLite (verified pre-rebase)
- [ ] Trigger compat-matrix on this branch — Lucee 6 + Oracle should now register the datasource and run specs; remaining Oracle failures log as warnings rather than breaking the engine job
- [ ] Confirm CLAUDE.md SOFT_FAIL_DBS line-number references match the merged state

Refs: #2649 (rollup), #2670 (lockingSpec already merged), #2664 (FK constraint cleanup, related shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)