### PR TITLE
test(migrator): drop migrator system tables between specs (fixes #2664)

### DIFF
--- a/vendor/wheels/tests/specs/migrator/migratorSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/migratorSpec.cfc
@@ -60,6 +60,13 @@ component extends="wheels.WheelsTest" {
 				for (local.table in ["c_o_r_e_bunyips", "c_o_r_e_dropbears", "c_o_r_e_hoopsnakes", "migrations"]) {
 					migration.dropTable(local.table)
 				}
+				// #2664: drop the migrator system tables (which own fk_wheels_level)
+				// so re-runs don't collide with "duplicate constraint name" on
+				// MySQL / H2 / SQL Server / Oracle. Child tables first so the
+				// FK back-reference is gone before the parent levels table.
+				for (local.t in ["wheels_migrator_versions", "c_o_r_e_migrator_versions", "wheels_levels", "c_o_r_e_levels"]) {
+					try { migration.dropTable(local.t); } catch (any e) {}
+				}
 				deleteMigratorVersions(2);
 				$cleanSqlDirectory()
 				originalWriteMigratorSQLFiles = Duplicate(application.wheels.writeMigratorSQLFiles)
@@ -71,6 +78,9 @@ component extends="wheels.WheelsTest" {
 				// revert to orginal values
 				application.wheels.writeMigratorSQLFiles = originalWriteMigratorSQLFiles
 				application.wheels.migratorTableName = originalMigratorTableName
+				for (local.t in ["wheels_migrator_versions", "c_o_r_e_migrator_versions", "wheels_levels", "c_o_r_e_levels"]) {
+					try { migration.dropTable(local.t); } catch (any e) {}
+				}
 			})
 
 			it("is migrating up from 0 to 001", () => {
@@ -155,6 +165,16 @@ component extends="wheels.WheelsTest" {
 				expected = "version"
 
 				expect(actual.column_name).toBe(expected)
+			})
+
+			// Regression for #2664. Without per-spec cleanup the previous test
+			// leaves c_o_r_e_migrator_versions + the fk_wheels_level FK behind;
+			// matrix re-runs then collide with "duplicate constraint name" on
+			// MySQL / H2 / SQL Server / Oracle (engine-scoped FK namespaces).
+			it("drops the migrator system tables between specs (regression: ##2664)", () => {
+				if (_isCockroachDB) return;
+				var info = g.$dbinfo(datasource = application.wheels.dataSourceName, type = "tables", pattern = "c_o_r_e_migrator_versions")
+				expect(listFindNoCase(ValueList(info.table_name), "c_o_r_e_migrator_versions")).toBe(0)
 			})
 		})
 

--- a/vendor/wheels/tests/specs/migrator/migratorSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/migratorSpec.cfc
@@ -64,8 +64,8 @@ component extends="wheels.WheelsTest" {
 				// so re-runs don't collide with "duplicate constraint name" on
 				// MySQL / H2 / SQL Server / Oracle. Child tables first so the
 				// FK back-reference is gone before the parent levels table.
-				for (local.t in ["wheels_migrator_versions", "c_o_r_e_migrator_versions", "wheels_levels", "c_o_r_e_levels"]) {
-					try { migration.dropTable(local.t); } catch (any e) {}
+				for (local.table in ["wheels_migrator_versions", "c_o_r_e_migrator_versions", "wheels_levels", "c_o_r_e_levels"]) {
+					try { migration.dropTable(local.table); } catch (any e) {}
 				}
 				deleteMigratorVersions(2);
 				$cleanSqlDirectory()
@@ -78,8 +78,8 @@ component extends="wheels.WheelsTest" {
 				// revert to orginal values
 				application.wheels.writeMigratorSQLFiles = originalWriteMigratorSQLFiles
 				application.wheels.migratorTableName = originalMigratorTableName
-				for (local.t in ["wheels_migrator_versions", "c_o_r_e_migrator_versions", "wheels_levels", "c_o_r_e_levels"]) {
-					try { migration.dropTable(local.t); } catch (any e) {}
+				for (local.table in ["wheels_migrator_versions", "c_o_r_e_migrator_versions", "wheels_levels", "c_o_r_e_levels"]) {
+					try { migration.dropTable(local.table); } catch (any e) {}
 				}
 			})
 
@@ -171,8 +171,9 @@ component extends="wheels.WheelsTest" {
 			// leaves c_o_r_e_migrator_versions + the fk_wheels_level FK behind;
 			// matrix re-runs then collide with "duplicate constraint name" on
 			// MySQL / H2 / SQL Server / Oracle (engine-scoped FK namespaces).
+			// Runs on every engine — the afterEach drops the table on all of
+			// them, so a regression here would catch a cleanup gap anywhere.
 			it("drops the migrator system tables between specs (regression: ##2664)", () => {
-				if (_isCockroachDB) return;
 				var info = g.$dbinfo(datasource = application.wheels.dataSourceName, type = "tables", pattern = "c_o_r_e_migrator_versions")
 				expect(listFindNoCase(ValueList(info.table_name), "c_o_r_e_migrator_versions")).toBe(0)
 			})


### PR DESCRIPTION
Fixes #2664.

## Summary

`migratorSpec.cfc`'s `"Tests that migrateTo :: uses specified versions table name"` case creates `c_o_r_e_migrator_versions` with the `fk_wheels_level` foreign key but never tears it down. When the matrix re-runs the spec against the same database, the FK creation collides with "duplicate constraint name" on MySQL / H2 / SQL Server / Oracle (engine-scoped FK namespaces). Cockroach + Postgres silently tolerate the redefinition, which is why this only surfaces on a subset of matrix rows ([run #25837380625](https://github.com/wheels-dev/wheels/actions/runs/25837380625)).

This is a pure test-cleanup bug — production migrator logic is correct.

## Fix shape

- Extend the `"Tests that migrateTo"` describe block's `beforeEach` / `afterEach` with the same cleanup pattern the neighbouring `"F15 Phase 1"` block already uses (`vendor/wheels/tests/specs/migrator/migratorSpec.cfc:163-182`). Versions tables first, levels tables last, so the `fk_wheels_level` back-reference is gone before the parent. Dropping the table drops the FK with it, sidestepping per-DB `DROP CONSTRAINT` syntax differences.
- Add a regression spec immediately after `"uses specified versions table name"` asserting that `c_o_r_e_migrator_versions` is dropped between specs.

## Why this over the issue's other options

- **Option 1 (drop in teardown)** — chosen. Mechanical, matches the F15 Phase 1 / Phase 2 blocks already in this file, no production-code touch.
- **Option 2 (unique constraint name per run)** — would require `vendor/wheels/Migrator.cfc:470` to accept a configurable FK name, which is a real API change.
- **Option 3 (down migration)** — the spec only calls `migrateTo(001)` without a paired down step, so this would need a new fixture.

## Test plan

- [ ] Compat-matrix is green across Lucee 6 / Lucee 7 / Adobe 2023 / Adobe 2025 / BoxLang on `sqlite`, `h2`, `mysql`, `postgres`, `sqlserver`, `cockroachdb` (Oracle is soft-fail per #2663).
- [ ] `migratorSpec` reports 0 errors on MySQL / H2 / SQL Server (was 1 error each on Lucee 6 in run #25837380625).
- [ ] New regression spec `"drops the migrator system tables between specs (regression: #2664)"` passes.

Related: #2649, #2663.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TUS7xQBEUdCJCR15cSz6id)_