### PR TITLE
feat(cli): scaffold Dockerfile and .dockerignore in wheels deploy init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 
 ## [Unreleased]
 
+### Added
+
+- `wheels deploy init` now scaffolds a starter `Dockerfile` (Lucee 7 + Java 21 multi-stage, `/up` HEALTHCHECK aligned with the generated `kamal-proxy` healthcheck) and a `.dockerignore` alongside `config/deploy.yml` and `.kamal/secrets`. `--force` also gates the `Dockerfile` — an existing user-authored Dockerfile aborts the init without `--force`, while an existing `.dockerignore` is silently preserved (since it's commonly user-curated even before adopting `wheels deploy`). The npm builder stage works for any Wheels app — projects without a JS pipeline pass through unchanged; projects with a `package.json` install + build automatically. Secrets (reload password, DB password, registry password) are injected at deploy time via `.kamal/secrets`, never baked into the image (#2673)
+
 ### Changed
 
 - `lockingSpec` now consults the new `$supportsAdvisoryLocks()` model adapter capability and skips the `withAdvisoryLock` describe block via `beforeEach { skip(...) }` instead of erroring on adapters that don't support standalone advisory locks (H2, SQL Server, Oracle, CockroachDB). PostgreSQL, MySQL, and SQLite (no-op) report `true`; SQL Server reports `false` until its lock path grows an implicit-transaction wrapper. Compat-matrix can now distinguish "lock implementation broken" from "lock not applicable to this DB"

--- a/cli/lucli/services/deploy/cli/DeployMainCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployMainCli.cfc
@@ -362,11 +362,15 @@ component {
         fileWrite(dockerfilePath, mustache.render(fileRead(tplDir & "/Dockerfile.mustache"), ctx));
         // .dockerignore source filename is `dockerignore.mustache` so the
         // template doesn't itself get hidden by tooling that ignores dotfiles.
-        if (force || !fileExists(dockerignorePath)) {
+        var dockerignoreWritten = (force || !fileExists(dockerignorePath));
+        if (dockerignoreWritten) {
             fileWrite(dockerignorePath, mustache.render(fileRead(tplDir & "/dockerignore.mustache"), ctx));
         }
 
-        return "Created config/deploy.yml, .kamal/secrets, Dockerfile, and .dockerignore." & chr(10)
+        var summary = dockerignoreWritten
+            ? "Created config/deploy.yml, .kamal/secrets, Dockerfile, and .dockerignore."
+            : "Created config/deploy.yml, .kamal/secrets, and Dockerfile (preserved existing .dockerignore).";
+        return summary & chr(10)
              & "Next steps:" & chr(10)
              & "  1. Edit config/deploy.yml — update servers, proxy host, registry username." & chr(10)
              & "  2. Review the generated Dockerfile — adjust COPY paths and the Lucee/CFML base if your app needs it." & chr(10)

--- a/cli/lucli/services/deploy/cli/DeployMainCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployMainCli.cfc
@@ -325,11 +325,19 @@ component {
         var force = arguments.opts.force ?: false;
         var deployYmlPath = cwd & "config/deploy.yml";
         var secretsPath = cwd & ".kamal/secrets";
+        var dockerfilePath = cwd & "Dockerfile";
+        var dockerignorePath = cwd & ".dockerignore";
 
         if (!force && fileExists(deployYmlPath)) {
             throw(
                 type = "DeployMainCli.InitAlreadyExists",
                 message = "config/deploy.yml already exists at " & deployYmlPath & "; pass --force to overwrite"
+            );
+        }
+        if (!force && fileExists(dockerfilePath)) {
+            throw(
+                type = "DeployMainCli.InitAlreadyExists",
+                message = "Dockerfile already exists at " & dockerfilePath & "; pass --force to overwrite"
             );
         }
 
@@ -351,11 +359,19 @@ component {
         if (!directoryExists(cwd & ".kamal/hooks")) directoryCreate(cwd & ".kamal/hooks", true, true);
         fileWrite(secretsPath, mustache.render(fileRead(tplDir & "/secrets.mustache"), ctx));
 
-        return "Created config/deploy.yml and .kamal/secrets." & chr(10)
+        fileWrite(dockerfilePath, mustache.render(fileRead(tplDir & "/Dockerfile.mustache"), ctx));
+        // .dockerignore source filename is `dockerignore.mustache` so the
+        // template doesn't itself get hidden by tooling that ignores dotfiles.
+        if (force || !fileExists(dockerignorePath)) {
+            fileWrite(dockerignorePath, mustache.render(fileRead(tplDir & "/dockerignore.mustache"), ctx));
+        }
+
+        return "Created config/deploy.yml, .kamal/secrets, Dockerfile, and .dockerignore." & chr(10)
              & "Next steps:" & chr(10)
              & "  1. Edit config/deploy.yml — update servers, proxy host, registry username." & chr(10)
-             & "  2. Populate .kamal/secrets with real values (or $(cmd) substitutions)." & chr(10)
-             & "  3. wheels deploy setup";
+             & "  2. Review the generated Dockerfile — adjust COPY paths and the Lucee/CFML base if your app needs it." & chr(10)
+             & "  3. Populate .kamal/secrets with real values (or $(cmd) substitutions)." & chr(10)
+             & "  4. wheels deploy setup";
     }
 
     private string function $basename(required string path) {

--- a/cli/lucli/templates/deploy/init/Dockerfile.mustache
+++ b/cli/lucli/templates/deploy/init/Dockerfile.mustache
@@ -7,8 +7,9 @@
 # ships Lucee 7 on Java 21 — the framework's primary CI target.
 #
 # Adjust the COPY lines to match your project's directory layout. The
-# health check assumes a `/health` route exists (add one to keep liveness
-# probes off your slow paths). See:
+# health check probes `/up` — the same path `kamal-proxy` polls per the
+# generated `config/deploy.yml`. Add a lightweight `/up` route that
+# returns 200 without touching slow dependencies. See:
 #   /v4-0-1-snapshot/deployment/docker-deployment/
 #   /v4-0-1-snapshot/deployment/first-deploy/
 
@@ -69,4 +70,4 @@ COPY --from=builder /build/vendor         ./vendor
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
-    CMD curl -fsS http://127.0.0.1:8080/health || exit 1
+    CMD curl -fsS http://127.0.0.1:8080/up || exit 1

--- a/cli/lucli/templates/deploy/init/Dockerfile.mustache
+++ b/cli/lucli/templates/deploy/init/Dockerfile.mustache
@@ -19,11 +19,13 @@ FROM node:20-bookworm-slim AS builder
 
 WORKDIR /build
 
-# Install front-end dependencies first so layer cache survives source edits.
-COPY package.json package-lock.json* ./
-RUN if [ -f package.json ]; then npm ci --no-audit --no-fund; fi
-
+# Copy the whole build context. The npm steps below run only when
+# `package.json` exists, so Wheels apps without a JS pipeline pass through
+# this stage unchanged. (A separate `COPY package.json ...` would fail the
+# build for apps that don't have one.)
 COPY . .
+
+RUN if [ -f package.json ]; then npm ci --no-audit --no-fund; fi
 
 # Skip silently if there is no build script defined.
 RUN if [ -f package.json ] && node -e "process.exit(require('./package.json').scripts && require('./package.json').scripts.build ? 0 : 1)"; then \
@@ -37,9 +39,14 @@ FROM lucee/lucee:7-tomcat10-jre21
 LABEL org.opencontainers.image.title="{{service_name}}"
 
 # Wheels reads these at boot. Override per-environment at `docker run` time.
+#
+# Secrets (reload password, DB password, API keys) are NOT baked here — they
+# are injected at deploy time from `.kamal/secrets` via `config/deploy.yml`.
+# The bundled secrets template exposes `WHEELS_RELOAD_PASSWORD`; wire your
+# `config/settings.cfm` reloadPassword to `getenv("WHEELS_RELOAD_PASSWORD")`
+# to pick it up.
 ENV WHEELS_ENV=production \
     WHEELS_DATASOURCE=app \
-    RELOAD_PASSWORD=change-me \
     CATALINA_OPTS="-Xms256m -Xmx1g -XX:MaxMetaspaceSize=256m"
 
 WORKDIR /var/www
@@ -50,7 +57,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the app. Vendor code (framework + activated packages) ships inside the
-# image so production boot needs no network access.
+# image so production boot needs no network access. If you still use the
+# deprecated `plugins/` directory, add `COPY --from=builder /build/plugins ./plugins`.
 COPY --from=builder /build/app            ./app
 COPY --from=builder /build/config         ./config
 COPY --from=builder /build/public         ./public

--- a/cli/lucli/templates/deploy/init/Dockerfile.mustache
+++ b/cli/lucli/templates/deploy/init/Dockerfile.mustache
@@ -1,0 +1,64 @@
+# syntax=docker/dockerfile:1.7
+#
+# Production Dockerfile for {{service_name}}.
+#
+# Built by `wheels deploy init`. Multi-stage: a builder that installs
+# front-end build dependencies (Node, npm), and a slim runtime layer that
+# ships Lucee 7 on Java 21 — the framework's primary CI target.
+#
+# Adjust the COPY lines to match your project's directory layout. The
+# health check assumes a `/health` route exists (add one to keep liveness
+# probes off your slow paths). See:
+#   /v4-0-1-snapshot/deployment/docker-deployment/
+#   /v4-0-1-snapshot/deployment/first-deploy/
+
+# --- Stage 1: builder ---------------------------------------------------------
+# Compile front-end assets and prune anything the runtime doesn't need.
+# Drop this stage if your app has no npm build step.
+FROM node:20-bookworm-slim AS builder
+
+WORKDIR /build
+
+# Install front-end dependencies first so layer cache survives source edits.
+COPY package.json package-lock.json* ./
+RUN if [ -f package.json ]; then npm ci --no-audit --no-fund; fi
+
+COPY . .
+
+# Skip silently if there is no build script defined.
+RUN if [ -f package.json ] && node -e "process.exit(require('./package.json').scripts && require('./package.json').scripts.build ? 0 : 1)"; then \
+        npm run build; \
+    fi
+
+# --- Stage 2: runtime ---------------------------------------------------------
+# Lucee 7 on Java 21. The lucee/lucee image ships a ready webroot at /var/www.
+FROM lucee/lucee:7-tomcat10-jre21
+
+LABEL org.opencontainers.image.title="{{service_name}}"
+
+# Wheels reads these at boot. Override per-environment at `docker run` time.
+ENV WHEELS_ENV=production \
+    WHEELS_DATASOURCE=app \
+    RELOAD_PASSWORD=change-me \
+    CATALINA_OPTS="-Xms256m -Xmx1g -XX:MaxMetaspaceSize=256m"
+
+WORKDIR /var/www
+
+# Install curl for the HEALTHCHECK probe.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the app. Vendor code (framework + activated packages) ships inside the
+# image so production boot needs no network access.
+COPY --from=builder /build/app            ./app
+COPY --from=builder /build/config         ./config
+COPY --from=builder /build/public         ./public
+COPY --from=builder /build/vendor         ./vendor
+
+# Tomcat listens on 8080 in the lucee/lucee image — matches the default
+# proxy.app_port in config/deploy.yml.
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD curl -fsS http://127.0.0.1:8080/health || exit 1

--- a/cli/lucli/templates/deploy/init/dockerignore.mustache
+++ b/cli/lucli/templates/deploy/init/dockerignore.mustache
@@ -1,0 +1,40 @@
+# Keep the build context lean. Anything matched here is invisible to
+# COPY . . in the Dockerfile — fewer bytes shipped, faster builds.
+
+# VCS / CI
+.git
+.gitignore
+.github
+
+# Secrets — never bake them into an image. Pass at runtime instead.
+.env
+.env.*
+.kamal/secrets
+.kamal/secrets.*
+
+# Local-only artifacts
+node_modules
+.CommandBox
+logs
+tmp
+*.log
+
+# Test suites — production doesn't need them.
+tests
+vendor/wheels/tests
+
+# Build / docs / IDE noise
+public/assets/*.map
+README.md
+docs
+.ai
+.claude
+.vscode
+.idea
+.DS_Store
+Thumbs.db
+
+# Don't ship the Dockerfiles themselves.
+Dockerfile
+docker-compose*.yml
+.dockerignore

--- a/cli/lucli/tests/specs/deploy/cli/DeployMainCliSpec.cfc
+++ b/cli/lucli/tests/specs/deploy/cli/DeployMainCliSpec.cfc
@@ -146,7 +146,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                 expect(findNoCase("hook post-deploy", joined)).toBe(0);
             });
 
-            it("init_stub writes config/deploy.yml and .kamal/secrets to the target cwd", () => {
+            it("init_stub writes config/deploy.yml, .kamal/secrets, Dockerfile, and .dockerignore to the target cwd", () => {
                 var tmpCwd = getTempDirectory() & "/wheels-deploy-init-" & createUUID();
                 directoryCreate(tmpCwd, true, true);
 
@@ -157,7 +157,32 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                 expect(fileExists(tmpCwd & "/config/deploy.yml")).toBeTrue();
                 expect(fileExists(tmpCwd & "/.kamal/secrets")).toBeTrue();
                 expect(directoryExists(tmpCwd & "/.kamal/hooks")).toBeTrue();
+                expect(fileExists(tmpCwd & "/Dockerfile")).toBeTrue();
+                expect(fileExists(tmpCwd & "/.dockerignore")).toBeTrue();
                 expect(msg).toInclude("config/deploy.yml");
+                expect(msg).toInclude("Dockerfile");
+
+                directoryDelete(tmpCwd, true);
+            });
+
+            it("init_stub renders a Lucee 7 multi-stage Dockerfile with the service name in the label", () => {
+                var tmpCwd = getTempDirectory() & "/wheels-deploy-init-" & createUUID();
+                directoryCreate(tmpCwd, true, true);
+
+                var localCli = new cli.lucli.services.deploy.cli.DeployMainCli(
+                    new cli.lucli.services.deploy.lib.FakeSshPool()
+                );
+                localCli.init_stub({cwd: tmpCwd, service: "myapp", image: "acme/myapp"});
+
+                var df = fileRead(tmpCwd & "/Dockerfile");
+                expect(df).toInclude("FROM lucee/lucee:7-tomcat10-jre21");
+                expect(df).toInclude("EXPOSE 8080");
+                expect(df).toInclude("HEALTHCHECK");
+                expect(df).toInclude("myapp");
+
+                var di = fileRead(tmpCwd & "/.dockerignore");
+                expect(di).toInclude(".kamal/secrets");
+                expect(di).toInclude("vendor/wheels/tests");
 
                 directoryDelete(tmpCwd, true);
             });
@@ -192,10 +217,28 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                 directoryDelete(tmpCwd, true);
             });
 
+            it("init_stub refuses to overwrite an existing Dockerfile without force", () => {
+                var tmpCwd = getTempDirectory() & "/wheels-deploy-init-" & createUUID();
+                directoryCreate(tmpCwd, true, true);
+                fileWrite(tmpCwd & "/Dockerfile", "FROM scratch");
+
+                var localCli = new cli.lucli.services.deploy.cli.DeployMainCli(
+                    new cli.lucli.services.deploy.lib.FakeSshPool()
+                );
+                expect(() => localCli.init_stub({cwd: tmpCwd, service: "x", image: "y/z"}))
+                    .toThrow();
+
+                // Existing Dockerfile must be untouched after the abort.
+                expect(fileRead(tmpCwd & "/Dockerfile")).toBe("FROM scratch");
+
+                directoryDelete(tmpCwd, true);
+            });
+
             it("init_stub overwrites when force=true", () => {
                 var tmpCwd = getTempDirectory() & "/wheels-deploy-init-" & createUUID();
                 directoryCreate(tmpCwd & "/config", true, true);
                 fileWrite(tmpCwd & "/config/deploy.yml", "old content");
+                fileWrite(tmpCwd & "/Dockerfile", "FROM scratch");
 
                 var localCli = new cli.lucli.services.deploy.cli.DeployMainCli(
                     new cli.lucli.services.deploy.lib.FakeSshPool()
@@ -203,6 +246,8 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                 localCli.init_stub({cwd: tmpCwd, service: "new", image: "new/web", force: true});
                 var yml = fileRead(tmpCwd & "/config/deploy.yml");
                 expect(yml).toInclude("service: new");
+                var df = fileRead(tmpCwd & "/Dockerfile");
+                expect(df).toInclude("FROM lucee/lucee");
 
                 directoryDelete(tmpCwd, true);
             });
@@ -221,6 +266,8 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 
                 expect(directoryExists(root & "templates/deploy/init")).toBeTrue();
                 expect(fileExists(root & "templates/deploy/init/deploy.yml.mustache")).toBeTrue();
+                expect(fileExists(root & "templates/deploy/init/Dockerfile.mustache")).toBeTrue();
+                expect(fileExists(root & "templates/deploy/init/dockerignore.mustache")).toBeTrue();
             });
 
             it("audit dispatches tail of audit log to every host", () => {

--- a/cli/lucli/tests/specs/deploy/cli/DeployMainCliSpec.cfc
+++ b/cli/lucli/tests/specs/deploy/cli/DeployMainCliSpec.cfc
@@ -239,15 +239,38 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                 directoryCreate(tmpCwd & "/config", true, true);
                 fileWrite(tmpCwd & "/config/deploy.yml", "old content");
                 fileWrite(tmpCwd & "/Dockerfile", "FROM scratch");
+                fileWrite(tmpCwd & "/.dockerignore", "## sentinel — pre-existing dockerignore");
 
                 var localCli = new cli.lucli.services.deploy.cli.DeployMainCli(
                     new cli.lucli.services.deploy.lib.FakeSshPool()
                 );
-                localCli.init_stub({cwd: tmpCwd, service: "new", image: "new/web", force: true});
+                var summary = localCli.init_stub({cwd: tmpCwd, service: "new", image: "new/web", force: true});
                 var yml = fileRead(tmpCwd & "/config/deploy.yml");
                 expect(yml).toInclude("service: new");
                 var df = fileRead(tmpCwd & "/Dockerfile");
                 expect(df).toInclude("FROM lucee/lucee");
+                // force=true exercises the `force ||` branch of the dockerignore guard.
+                var di = fileRead(tmpCwd & "/.dockerignore");
+                expect(di).notToInclude("sentinel");
+                expect(summary).toInclude(".dockerignore");
+                expect(summary).notToInclude("preserved");
+
+                directoryDelete(tmpCwd, true);
+            });
+
+            it("init_stub silently preserves an existing .dockerignore without force", () => {
+                var tmpCwd = getTempDirectory() & "/wheels-deploy-init-" & createUUID();
+                directoryCreate(tmpCwd, true, true);
+                var sentinel = "## sentinel — user's dockerignore must survive";
+                fileWrite(tmpCwd & "/.dockerignore", sentinel);
+
+                var localCli = new cli.lucli.services.deploy.cli.DeployMainCli(
+                    new cli.lucli.services.deploy.lib.FakeSshPool()
+                );
+                var summary = localCli.init_stub({cwd: tmpCwd, service: "x", image: "y/z"});
+
+                expect(fileRead(tmpCwd & "/.dockerignore")).toBe(sentinel);
+                expect(summary).toInclude("preserved existing .dockerignore");
 
                 directoryDelete(tmpCwd, true);
             });

--- a/web/sites/guides/src/content/docs/v4-0-1-snapshot/command-line-tools/commands/deploy/init.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-1-snapshot/command-line-tools/commands/deploy/init.mdx
@@ -29,7 +29,7 @@ wheels deploy init [--service=<name>] [--image=<path>] [--registry-username=<use
 - `config/deploy.yml` — a starter manifest with `service`, `image`, `servers`, `registry`, `env` stubs.
 - `.kamal/secrets` — key/value placeholders for the registry password and any app secrets.
 - `.kamal/hooks/` — empty directory. Drop executable `pre-deploy`, `post-deploy`, or `post-deploy-failure` scripts here later.
-- `Dockerfile` — multi-stage build targeting Lucee 7 on Java 21 with a `/health` HEALTHCHECK and `EXPOSE 8080` (matches the default `proxy.app_port` in `deploy.yml`). Adjust the `COPY` lines and base image to match your app.
+- `Dockerfile` — multi-stage build targeting Lucee 7 on Java 21 with a `/up` HEALTHCHECK (aligned with the `proxy.healthcheck.path` in the generated `deploy.yml`) and `EXPOSE 8080` (matches the default `proxy.app_port`). Adjust the `COPY` lines and base image to match your app.
 - `.dockerignore` — keeps secrets, test fixtures, and IDE noise out of the build context. Only written if one doesn't already exist (unless `--force`).
 
 Add `.kamal/secrets*` to `.gitignore` before running.

--- a/web/sites/guides/src/content/docs/v4-0-1-snapshot/command-line-tools/commands/deploy/init.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-1-snapshot/command-line-tools/commands/deploy/init.mdx
@@ -7,7 +7,7 @@ sidebar:
   order: 6
 ---
 
-Scaffold the files `wheels deploy` reads: `config/deploy.yml` and `.kamal/secrets`. Also creates `.kamal/hooks/` (empty) for optional hook scripts.
+Scaffold the files `wheels deploy` reads: `config/deploy.yml`, `.kamal/secrets`, `Dockerfile`, and `.dockerignore`. Also creates `.kamal/hooks/` (empty) for optional hook scripts.
 
 ## Synopsis
 
@@ -22,13 +22,15 @@ wheels deploy init [--service=<name>] [--image=<path>] [--registry-username=<use
 | `--service=<name>` | Service name to bake in. Defaults to the project directory basename. |
 | `--image=<path>` | Image path. Defaults to `<service>/web`. |
 | `--registry-username=<user>` | Registry username. Defaults to `changeme` — you'll edit it. |
-| `--force` | Overwrite existing files. Without this, an existing `config/deploy.yml` aborts with `DeployMainCli.InitAlreadyExists`. |
+| `--force` | Overwrite existing files. Without this, an existing `config/deploy.yml` or `Dockerfile` aborts with `DeployMainCli.InitAlreadyExists`. |
 
 ## What it creates
 
 - `config/deploy.yml` — a starter manifest with `service`, `image`, `servers`, `registry`, `env` stubs.
 - `.kamal/secrets` — key/value placeholders for the registry password and any app secrets.
 - `.kamal/hooks/` — empty directory. Drop executable `pre-deploy`, `post-deploy`, or `post-deploy-failure` scripts here later.
+- `Dockerfile` — multi-stage build targeting Lucee 7 on Java 21 with a `/health` HEALTHCHECK and `EXPOSE 8080` (matches the default `proxy.app_port` in `deploy.yml`). Adjust the `COPY` lines and base image to match your app.
+- `.dockerignore` — keeps secrets, test fixtures, and IDE noise out of the build context. Only written if one doesn't already exist (unless `--force`).
 
 Add `.kamal/secrets*` to `.gitignore` before running.
 

--- a/web/sites/guides/src/content/docs/v4-0-1-snapshot/deployment/first-deploy.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-1-snapshot/deployment/first-deploy.mdx
@@ -27,7 +27,7 @@ Three quick checks before running anything:
 
 - **SSH works.** `ssh deploy@your-host "uname -a"` succeeds without a password prompt.
 - **Registry login works.** `docker login <registry>` succeeds locally.
-- **Your app has a `Dockerfile`.** It builds and runs locally (`docker build . && docker run <image>`). If not, write the `Dockerfile` first — `wheels deploy` doesn't generate one.
+- **You can build a Docker image of your app.** `wheels deploy init` (next step) scaffolds a starter `Dockerfile` targeting Lucee 7 on Java 21. Verify it builds and runs locally with `docker build . && docker run <image>`, and tweak the `COPY` paths or base image if your app needs it.
 
 ## Walk-through
 
@@ -41,10 +41,12 @@ Three quick checks before running anything:
    wheels deploy init
    ```
 
-   Creates two files:
+   Creates four files:
 
    - `config/deploy.yml` — the deploy manifest. Under git.
    - `.kamal/secrets` — secret values. **Never under git.** Add `.kamal/secrets` to `.gitignore` immediately.
+   - `Dockerfile` — multi-stage build (Lucee 7 + Java 21) the deploy will push to your registry. Edit `COPY` paths and the base image to match your app.
+   - `.dockerignore` — keeps the build context lean and secrets out of the image. Only written if one doesn't already exist.
 
    A `.kamal/hooks/` directory is also created for optional local hook scripts. It's empty and safe to leave that way.
 


### PR DESCRIPTION
## Summary

Closes #2673.

`wheels deploy init` now emits a starter `Dockerfile` and `.dockerignore` alongside `config/deploy.yml` and `.kamal/secrets`, so the init → setup walkthrough no longer dead-ends at "no `Dockerfile` to build from."

## What changed

- **New templates** under `cli/lucli/templates/deploy/init/`:
  - `Dockerfile.mustache` — multi-stage build (Node builder + `lucee/lucee:7-tomcat10-jre21` runtime), matching the canonical pattern documented at `deployment/docker-deployment.mdx`. `EXPOSE 8080` lines up with the default `proxy.app_port` in `deploy.yml`. Includes a `/up` HEALTHCHECK aligned with the generated deploy.yml's `proxy.healthcheck.path`, and production env defaults (`WHEELS_ENV`, `WHEELS_DATASOURCE`, `CATALINA_OPTS`). The builder stage works for any Wheels app — projects without an npm pipeline pass through unchanged; projects with a `package.json` install + build automatically. Secrets (reload password, DB password, registry password) are injected at deploy time via `.kamal/secrets`, not baked into the image.
  - `dockerignore.mustache` — keeps `.kamal/secrets`, `.env*`, `vendor/wheels/tests`, sourcemaps, and IDE noise out of the build context. (Filename keeps the leading dot off so the template isn't hidden from tooling that filters dotfiles.)
- `DeployMainCli.init_stub()` renders both files. `--force` now also gates an existing `Dockerfile` (same `DeployMainCli.InitAlreadyExists` abort as `deploy.yml`). An existing `.dockerignore` is preserved unless `--force` is passed — users often have their own. The success message reports `.dockerignore` as either "created" or "preserved existing" accordingly.
- Updated success message + next-steps output to list the Dockerfile review step.
- Tests:
  - Existing `init_stub` happy-path spec now asserts `Dockerfile` and `.dockerignore` are emitted.
  - New spec verifies the rendered Dockerfile uses `lucee/lucee:7-tomcat10-jre21`, `EXPOSE 8080`, has a `HEALTHCHECK`, and contains the service name.
  - New spec guards `--force` on an existing `Dockerfile` (aborts and leaves the file untouched).
  - Existing `force=true` spec extended to pre-create `.dockerignore` with sentinel content and verify both Dockerfile and `.dockerignore` are overwritten (exercising the `force ||` branch).
  - New spec verifies the silent-preservation path: an existing `.dockerignore` survives a no-force init, and the success message reflects "preserved" rather than "created".
  - `$cliInstallDir()` regression spec now also checks the two new templates exist on disk.
- Docs:
  - `command-line-tools/commands/deploy/init.mdx` — flag table and "What it creates" section list the new files.
  - `deployment/first-deploy.mdx` — "Before you start" precondition rewritten (no longer says you must write a Dockerfile yourself); Step 1 enumerates the four files now emitted.
  - `CHANGELOG.md` — `[Unreleased] / Added` entry under the canonical Keep-a-Changelog ordering.
  - `v4-0-0/` docs untouched — that's the released-stable line and reflects the older behavior.

## Test plan

- [ ] `bash tools/test-cli-local.sh` — runs the deploy CLI specs that cover `init_stub` (cannot run from this sandbox; CI will exercise).
- [ ] CI matrix: Lucee 6/7, Adobe 2023/2025, BoxLang. Only CFML touched is `DeployMainCli.cfc` + the spec; no engine-specific surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UjyFJvdupfz9weUaQ9X192)_