### PR TITLE
test(migrator): clean migrator-version tables to fix FK collision (#2663 sub-cluster 3, #2664)

### DIFF
--- a/vendor/wheels/tests/specs/migrator/migratorSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/migratorSpec.cfc
@@ -60,15 +60,7 @@ component extends="wheels.WheelsTest" {
 				for (local.table in ["c_o_r_e_bunyips", "c_o_r_e_dropbears", "c_o_r_e_hoopsnakes", "migrations"]) {
 					migration.dropTable(local.table)
 				}
-				// Drop both migrator-version table families so the bootstrap path
-				// in $getVersionsPreviouslyMigrated() can recreate them cleanly.
-				// The "uses specified versions table name" test swaps the configured
-				// table to `c_o_r_e_migrator_versions`, and its bootstrap adds an FK
-				// constraint named `fk_wheels_level`. Without this cleanup the
-				// constraint collides with the one already created on
-				// `wheels_migrator_versions` by earlier tests, since MySQL, H2,
-				// SQL Server, and Oracle scope FK names per-schema rather than
-				// per-table (ORA-02264 / "Duplicate foreign key constraint name").
+				// Drop both FK-bearing tables — MySQL/H2/SQLServer/Oracle scope FK names per-schema so fk_wheels_level collides otherwise.
 				for (local.table in ["c_o_r_e_migrator_versions", "wheels_migrator_versions"]) {
 					try { migration.dropTable(local.table); } catch (any e) {}
 				}

--- a/vendor/wheels/tests/specs/migrator/migratorSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/migratorSpec.cfc
@@ -60,6 +60,18 @@ component extends="wheels.WheelsTest" {
 				for (local.table in ["c_o_r_e_bunyips", "c_o_r_e_dropbears", "c_o_r_e_hoopsnakes", "migrations"]) {
 					migration.dropTable(local.table)
 				}
+				// Drop both migrator-version table families so the bootstrap path
+				// in $getVersionsPreviouslyMigrated() can recreate them cleanly.
+				// The "uses specified versions table name" test swaps the configured
+				// table to `c_o_r_e_migrator_versions`, and its bootstrap adds an FK
+				// constraint named `fk_wheels_level`. Without this cleanup the
+				// constraint collides with the one already created on
+				// `wheels_migrator_versions` by earlier tests, since MySQL, H2,
+				// SQL Server, and Oracle scope FK names per-schema rather than
+				// per-table (ORA-02264 / "Duplicate foreign key constraint name").
+				for (local.table in ["c_o_r_e_migrator_versions", "wheels_migrator_versions"]) {
+					try { migration.dropTable(local.table); } catch (any e) {}
+				}
 				deleteMigratorVersions(2);
 				$cleanSqlDirectory()
 				originalWriteMigratorSQLFiles = Duplicate(application.wheels.writeMigratorSQLFiles)


### PR DESCRIPTION
## Summary

Closes the third and final sub-cluster of #2663 and resolves #2664. The migrator spec's `migrateTo` describe block was leaking `wheels_migrator_versions` / `c_o_r_e_migrator_versions` tables (plus their `fk_wheels_level` FK constraint) between tests. When the *"uses specified versions table name"* test swaps `migratorTableName` to `c_o_r_e_migrator_versions`, the bootstrap path in `Migrator.cfc::$getVersionsPreviouslyMigrated()` adds the same `fk_wheels_level` constraint to a different table — MySQL, H2, SQL Server, and Oracle scope FK names per-schema rather than per-table, so the second CREATE failed:

- MySQL: `Duplicate foreign key constraint name 'fk_wheels_level'`
- H2: `Constraint "FK_WHEELS_LEVEL" already exists`
- SQL Server: `There is already an object named 'fk_wheels_level' in the database.`
- Oracle: `ORA-02264: name already used by an existing constraint`

The Oracle cascade also produces `ORA-01003: no statement parsed` in `bulkOperationsSpec` because the partially-committed DDL leaves the JDBC session in a broken state.

## Fix

Mirror the cleanup pattern already used by the **F15 Phase 1** describe block (`migratorSpec.cfc:170`): in `beforeEach`, drop both table-name families inside try/catch so the bootstrap recreates them cleanly per test. `wheels_levels` is left in place — it is referenced by the FK, not the source of it, and the bootstrap is happy to reuse it.

## #2663 status

This completes the three-cluster fix for #2663:
- ✅ Sub-cluster 1 (Lucee 6 Oracle JDBC URL) — #2683
- ✅ Sub-cluster 2 (DBMS_LOCK / lockingSpec guard) — #2670
- ✅ Sub-cluster 3 (constraint cleanup) — **this PR**

Removing `oracle` from `SOFT_FAIL_DBS` in `compat-matrix.yml` is intentionally left for a follow-up once a green Oracle matrix run is observed.

## Test plan

- [ ] `compat-matrix` workflow passes on Lucee 6/7, Adobe 2023/2025, BoxLang
- [ ] Oracle errors drop to zero for `migratorSpec` and `bulkOperationsSpec`
- [ ] MySQL/H2/SQL Server `migratorSpec` errors drop from 1 → 0 each on Lucee 6 (per #2664 evidence)
- [ ] No regression in the existing F15 Phase 1 / Phase 2 / redomigration describe blocks (they have their own teardown)

Local SQLite / Docker matrix runs were not possible in this environment (no Docker daemon, no `wheels` CLI). Relying on CI.

https://claude.ai/code/session_01XWJ2m7SfxhuK7N6YCWv4E3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWJ2m7SfxhuK7N6YCWv4E3)_