### PR TITLE
fix(cli): deploy verbs must surface remote nonzero exit codes (#2696)

### DIFF
--- a/cli/lucli/services/deploy/cli/DeployAccessoryCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployAccessoryCli.cfc
@@ -26,10 +26,12 @@ component {
     public string function boot(required struct opts)     { return $forEach(arguments.opts, "run",     "Booted accessory"); }
     public string function reboot(required struct opts)   { return $forEach(arguments.opts, "reboot",  "Rebooted accessory"); }
     public string function start(required struct opts)    { return $forEach(arguments.opts, "start",   "Started accessory"); }
-    public string function stop(required struct opts)     { return $forEach(arguments.opts, "stop",    "Stopped accessory"); }
+    // `stop` and `remove` are idempotent teardowns — a missing accessory
+    // container should not block the rest of the flow. #2696.
+    public string function stop(required struct opts)     { return $forEach(arguments.opts, "stop",    "Stopped accessory",  {}, true); }
     public string function restart(required struct opts)  { return $forEach(arguments.opts, "restart", "Restarted accessory"); }
     public string function details(required struct opts)  { return $forEach(arguments.opts, "details", "Collected accessory details"); }
-    public string function remove(required struct opts)   { return $forEach(arguments.opts, "remove",  "Removed accessory"); }
+    public string function remove(required struct opts)   { return $forEach(arguments.opts, "remove",  "Removed accessory",  {}, true); }
 
     public string function logs(required struct opts) {
         var logOpts = {
@@ -41,7 +43,7 @@ component {
 
     // ── Private plumbing ───────────────────────────────────────
 
-    private string function $forEach(required struct opts, required string method, required string verbLabel, struct methodOpts = {}) {
+    private string function $forEach(required struct opts, required string method, required string verbLabel, struct methodOpts = {}, boolean allowFail = false) {
         arrayClear(variables.dryRunBuffer);
         if (!len(arguments.opts.name ?: "")) {
             throw(
@@ -64,7 +66,7 @@ component {
             var cmd = structIsEmpty(arguments.methodOpts)
                 ? invoke(accCmds, arguments.method, [acc])
                 : invoke(accCmds, arguments.method, [acc, arguments.methodOpts]);
-            $dispatch(acc.hosts(), cmd, dryRun);
+            $dispatch(acc.hosts(), cmd, dryRun, arguments.allowFail);
             arrayAppend(names, acc.name());
         }
 
@@ -81,12 +83,15 @@ component {
         return arguments.summary;
     }
 
-    private void function $dispatch(required array hosts, required string cmd, required boolean dryRun) {
+    private void function $dispatch(required array hosts, required string cmd, required boolean dryRun, boolean allowFail = false) {
         if (arguments.dryRun) {
             for (var h in arguments.hosts) arrayAppend(variables.dryRunBuffer, "[" & h & "] " & arguments.cmd);
             return;
         }
+        // #2696: raise defaults to true; only the explicit idempotent teardowns
+        // (remove, stop) opt in to allowFail.
         var c = arguments.cmd;
-        variables.sshPool.onEach(arguments.hosts, function(ssh, host) { ssh.run(c); });
+        var doRaise = !arguments.allowFail;
+        variables.sshPool.onEach(arguments.hosts, function(ssh, host) { ssh.run(c, {raise: doRaise}); });
     }
 }

--- a/cli/lucli/services/deploy/cli/DeployAppCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployAppCli.cfc
@@ -134,12 +134,15 @@ component {
         return arguments.summary;
     }
 
-    private void function $dispatch(required array hosts, required string cmd, required boolean dryRun) {
+    private void function $dispatch(required array hosts, required string cmd, required boolean dryRun, boolean allowFail = false) {
         if (arguments.dryRun) {
             for (var h in arguments.hosts) arrayAppend(variables.dryRunBuffer, "[" & h & "] " & arguments.cmd);
             return;
         }
+        // raise defaults to true so nonzero remote exits surface as
+        // Wheels.Deploy.RemoteExecutionFailed instead of silently passing — #2696.
         var c = arguments.cmd;
-        variables.sshPool.onEach(arguments.hosts, function(ssh, host) { ssh.run(c); });
+        var doRaise = !arguments.allowFail;
+        variables.sshPool.onEach(arguments.hosts, function(ssh, host) { ssh.run(c, {raise: doRaise}); });
     }
 }

--- a/cli/lucli/services/deploy/cli/DeployBuildCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployBuildCli.cfc
@@ -122,13 +122,16 @@ component {
         }
     }
 
-    private void function $dispatchSsh(required array hosts, required string cmd, required boolean dryRun) {
+    private void function $dispatchSsh(required array hosts, required string cmd, required boolean dryRun, boolean allowFail = false) {
         if (arguments.dryRun) {
             for (var h in arguments.hosts) arrayAppend(variables.dryRunBuffer, "[" & h & "] " & arguments.cmd);
             return;
         }
+        // #2696: raise defaults to true. Build/push failures (image not found,
+        // registry unreachable) must surface as errors, not silent success.
         var c = arguments.cmd;
-        variables.sshPool.onEach(arguments.hosts, function(ssh, host) { ssh.run(c); });
+        var doRaise = !arguments.allowFail;
+        variables.sshPool.onEach(arguments.hosts, function(ssh, host) { ssh.run(c, {raise: doRaise}); });
     }
 
     private array function $allHosts(required any cfg) {

--- a/cli/lucli/services/deploy/cli/DeployLockCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployLockCli.cfc
@@ -35,7 +35,9 @@ component {
         var dryRun = arguments.opts.dryRun ?: false;
         arrayClear(variables.dryRunBuffer);
         var lock = new modules.wheels.services.deploy.commands.LockCommands(cfg);
-        $dispatchAny($allHosts(cfg), lock.release(), dryRun);
+        // rm -f is idempotent; surfacing a failure here only obscures the
+        // operator's intent ("clear the lock if it's there"). #2696.
+        $dispatchAny($allHosts(cfg), lock.release(), dryRun, true);
         return $renderResult(arguments.opts, "Released deploy lock for " & cfg.service());
     }
 
@@ -44,7 +46,10 @@ component {
         var dryRun = arguments.opts.dryRun ?: false;
         arrayClear(variables.dryRunBuffer);
         var lock = new modules.wheels.services.deploy.commands.LockCommands(cfg);
-        $dispatchAny($allHosts(cfg), lock.status(), dryRun);
+        // readlink exits nonzero when the lock file is missing — which is
+        // exactly what the operator wants to learn from `status`. Treat that
+        // as advisory output, not a thrown error. #2696.
+        $dispatchAny($allHosts(cfg), lock.status(), dryRun, true);
         return $renderResult(arguments.opts, "Checked deploy lock status for " & cfg.service());
     }
 
@@ -68,16 +73,18 @@ component {
         return out;
     }
 
-    private void function $dispatchAny(required array hosts, required string cmd, required boolean dryRun) {
+    private void function $dispatchAny(required array hosts, required string cmd, required boolean dryRun, boolean allowFail = false) {
         if (arguments.dryRun) {
             if (arrayLen(arguments.hosts)) {
                 arrayAppend(variables.dryRunBuffer, "[" & arguments.hosts[1] & "] " & arguments.cmd);
             }
             return;
         }
-        var c = arguments.cmd;
         // Lock ops target just one host (the lock file lives on one path; any host works).
-        variables.sshPool.onAny(arguments.hosts, function(ssh, host) { ssh.run(c); });
+        // #2696: acquire stays strict (contention should surface); release/status tolerate.
+        var c = arguments.cmd;
+        var doRaise = !arguments.allowFail;
+        variables.sshPool.onAny(arguments.hosts, function(ssh, host) { ssh.run(c, {raise: doRaise}); });
     }
 
     private string function $currentUser() {

--- a/cli/lucli/services/deploy/cli/DeployMainCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployMainCli.cfc
@@ -100,7 +100,11 @@ component {
                     }
                 }
             } finally {
-                $dispatchAny(hosts, lock.release(), dryRun);
+                // Tolerate release failures so they can never shadow the
+                // original deploy exception inside this finally block. rm -f
+                // is idempotent; if it genuinely fails on a remote, the deploy
+                // already has a real error to surface from the try body.
+                $dispatchAny(hosts, lock.release(), dryRun, true);
             }
 
             hookEnv.KAMAL_RUNTIME = int((getTickCount() - deployStart) / 1000);
@@ -270,17 +274,19 @@ component {
                 $dispatch([host], broadRemove, dryRun);
             }
         }
-        // Remove proxy.
-        $dispatch(hosts, proxyCmds.remove(), dryRun);
-        // Remove each accessory.
+        // Remove proxy / accessories / registry-logout are all idempotent
+        // teardowns — a missing container or stale credentials should not
+        // abort the overall remove flow. Strict-by-default still applies
+        // to the broad container teardown above (xargs -r already makes it
+        // exit-0 when nothing matches; daemon-offline is loud on purpose).
+        $dispatch(hosts, proxyCmds.remove(), dryRun, true);
         if (arrayLen(cfg.accessories())) {
             var accCmds = new modules.wheels.services.deploy.commands.AccessoryCommands(cfg);
             for (var acc in cfg.accessories()) {
-                $dispatch(acc.hosts(), accCmds.remove(acc), dryRun);
+                $dispatch(acc.hosts(), accCmds.remove(acc), dryRun, true);
             }
         }
-        // Logout of registry.
-        $dispatch(hosts, regCmds.logout(), dryRun);
+        $dispatch(hosts, regCmds.logout(), dryRun, true);
 
         return $renderResult(
             arguments.opts,
@@ -403,7 +409,8 @@ component {
     private void function $dispatch(
         required array hosts,
         required string cmd,
-        required boolean dryRun
+        required boolean dryRun,
+        boolean allowFail = false
     ) {
         if (arguments.dryRun) {
             for (var h in arguments.hosts) {
@@ -411,11 +418,14 @@ component {
             }
             return;
         }
-        // Capture cmd into a local so the closure sees a stable reference
-        // (Adobe CF argument-scope closures can be flaky otherwise).
+        // Capture cmd + raise flag into locals so the closure sees stable
+        // references (Adobe CF argument-scope closures can be flaky otherwise).
+        // raise=true is the default — see #2696 for why discarding nonzero
+        // remote exit codes was the silent-success bug.
         var c = arguments.cmd;
+        var doRaise = !arguments.allowFail;
         variables.sshPool.onEach(arguments.hosts, function(ssh, host) {
-            ssh.run(c);
+            ssh.run(c, {raise: doRaise});
         });
     }
 
@@ -427,7 +437,8 @@ component {
     private void function $dispatchAny(
         required array hosts,
         required string cmd,
-        required boolean dryRun
+        required boolean dryRun,
+        boolean allowFail = false
     ) {
         if (arguments.dryRun) {
             arrayAppend(variables.dryRunBuffer, "[any] " & arguments.cmd);
@@ -435,15 +446,16 @@ component {
         }
         if (arrayLen(arguments.hosts) == 0) return;
         var c = arguments.cmd;
+        var doRaise = !arguments.allowFail;
         // Prefer onAny when available (both real SshPool and FakeSshPool
         // expose it). Fall back to onEach with a single host otherwise.
         if (structKeyExists(variables.sshPool, "onAny")) {
             variables.sshPool.onAny(arguments.hosts, function(ssh, host) {
-                ssh.run(c);
+                ssh.run(c, {raise: doRaise});
             });
         } else {
             variables.sshPool.onEach([arguments.hosts[1]], function(ssh, host) {
-                ssh.run(c);
+                ssh.run(c, {raise: doRaise});
             });
         }
     }

--- a/cli/lucli/services/deploy/cli/DeployProxyCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployProxyCli.cfc
@@ -25,10 +25,12 @@ component {
     public string function boot(required struct opts)    { return $runOnAllHosts(arguments.opts, "boot",    "Booted kamal-proxy"); }
     public string function reboot(required struct opts)  { return $runOnAllHosts(arguments.opts, "reboot",  "Rebooted kamal-proxy"); }
     public string function start(required struct opts)   { return $runOnAllHosts(arguments.opts, "start",   "Started kamal-proxy"); }
-    public string function stop(required struct opts)    { return $runOnAllHosts(arguments.opts, "stop",    "Stopped kamal-proxy"); }
+    // `stop` and `remove` are idempotent teardowns — a missing kamal-proxy
+    // container should not be a hard error. #2696.
+    public string function stop(required struct opts)    { return $runOnAllHosts(arguments.opts, "stop",    "Stopped kamal-proxy", true); }
     public string function restart(required struct opts) { return $runOnAllHosts(arguments.opts, "restart", "Restarted kamal-proxy"); }
     public string function details(required struct opts) { return $runOnAllHosts(arguments.opts, "details", "Collected kamal-proxy details"); }
-    public string function remove(required struct opts)  { return $runOnAllHosts(arguments.opts, "remove",  "Removed kamal-proxy"); }
+    public string function remove(required struct opts)  { return $runOnAllHosts(arguments.opts, "remove",  "Removed kamal-proxy",  true); }
 
     public string function logs(required struct opts) {
         var tail = arguments.opts.tail ?: 100;
@@ -38,12 +40,12 @@ component {
 
     // ── Private plumbing ───────────────────────────────────────
 
-    private string function $runOnAllHosts(required struct opts, required string method, required string verbLabel) {
-        var n = $runOnAllHostsWithArg(arguments.opts, arguments.method, {});
+    private string function $runOnAllHosts(required struct opts, required string method, required string verbLabel, boolean allowFail = false) {
+        var n = $runOnAllHostsWithArg(arguments.opts, arguments.method, {}, arguments.allowFail);
         return $renderResult(arguments.opts, arguments.verbLabel & " on " & n & " host(s)");
     }
 
-    private numeric function $runOnAllHostsWithArg(required struct opts, required string method, required struct methodOpts) {
+    private numeric function $runOnAllHostsWithArg(required struct opts, required string method, required struct methodOpts, boolean allowFail = false) {
         arrayClear(variables.dryRunBuffer);
         var cfg = variables.loader.load(
             arguments.opts.configPath,
@@ -55,11 +57,7 @@ component {
         var cmdStr = structIsEmpty(arguments.methodOpts)
             ? invoke(proxyCmds, arguments.method)
             : invoke(proxyCmds, arguments.method, [arguments.methodOpts]);
-        // `remove` and `stop` are idempotent teardown verbs — a missing
-        // kamal-proxy container should not be a hard error. Everything else
-        // (boot, start, restart, details, logs, reboot) is strict by default.
-        var idempotentTeardown = (arguments.method == "remove" || arguments.method == "stop");
-        $dispatch(hosts, cmdStr, dryRun, idempotentTeardown);
+        $dispatch(hosts, cmdStr, dryRun, arguments.allowFail);
         return arrayLen(hosts);
     }
 

--- a/cli/lucli/services/deploy/cli/DeployProxyCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployProxyCli.cfc
@@ -55,7 +55,11 @@ component {
         var cmdStr = structIsEmpty(arguments.methodOpts)
             ? invoke(proxyCmds, arguments.method)
             : invoke(proxyCmds, arguments.method, [arguments.methodOpts]);
-        $dispatch(hosts, cmdStr, dryRun);
+        // `remove` and `stop` are idempotent teardown verbs — a missing
+        // kamal-proxy container should not be a hard error. Everything else
+        // (boot, start, restart, details, logs, reboot) is strict by default.
+        var idempotentTeardown = (arguments.method == "remove" || arguments.method == "stop");
+        $dispatch(hosts, cmdStr, dryRun, idempotentTeardown);
         return arrayLen(hosts);
     }
 
@@ -74,12 +78,15 @@ component {
         return out;
     }
 
-    private void function $dispatch(required array hosts, required string cmd, required boolean dryRun) {
+    private void function $dispatch(required array hosts, required string cmd, required boolean dryRun, boolean allowFail = false) {
         if (arguments.dryRun) {
             for (var h in arguments.hosts) arrayAppend(variables.dryRunBuffer, "[" & h & "] " & arguments.cmd);
             return;
         }
+        // #2696: raise defaults to true; only the explicit idempotent teardowns
+        // (remove, stop) tolerate a nonzero exit.
         var c = arguments.cmd;
-        variables.sshPool.onEach(arguments.hosts, function(ssh, host) { ssh.run(c); });
+        var doRaise = !arguments.allowFail;
+        variables.sshPool.onEach(arguments.hosts, function(ssh, host) { ssh.run(c, {raise: doRaise}); });
     }
 }

--- a/cli/lucli/services/deploy/cli/DeployPruneCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployPruneCli.cfc
@@ -55,12 +55,15 @@ component {
         return out;
     }
 
-    private void function $dispatch(required array hosts, required string cmd, required boolean dryRun) {
+    private void function $dispatch(required array hosts, required string cmd, required boolean dryRun, boolean allowFail = false) {
         if (arguments.dryRun) {
             for (var h in arguments.hosts) arrayAppend(variables.dryRunBuffer, "[" & h & "] " & arguments.cmd);
             return;
         }
+        // #2696: raise defaults to true. Prune itself is destructive; failures
+        // (out-of-disk, permission denied) should surface, not pass silently.
         var c = arguments.cmd;
-        variables.sshPool.onEach(arguments.hosts, function(ssh, host) { ssh.run(c); });
+        var doRaise = !arguments.allowFail;
+        variables.sshPool.onEach(arguments.hosts, function(ssh, host) { ssh.run(c, {raise: doRaise}); });
     }
 }

--- a/cli/lucli/services/deploy/cli/DeployRegistryCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployRegistryCli.cfc
@@ -38,7 +38,8 @@ component {
         var cmd = arguments.isLogin
             ? regCmds.login({password: arguments.opts.password ?: $resolvePassword(cfg)})
             : regCmds.logout();
-        $dispatch(hosts, cmd, dryRun);
+        // #2696: login is strict (auth failure must surface); logout tolerates.
+        $dispatch(hosts, cmd, dryRun, !arguments.isLogin);
         var action = arguments.isLogin ? "Logged into" : "Logged out of";
         return $renderResult(
             arguments.opts,
@@ -73,12 +74,14 @@ component {
         return out;
     }
 
-    private void function $dispatch(required array hosts, required string cmd, required boolean dryRun) {
+    private void function $dispatch(required array hosts, required string cmd, required boolean dryRun, boolean allowFail = false) {
         if (arguments.dryRun) {
             for (var h in arguments.hosts) arrayAppend(variables.dryRunBuffer, "[" & h & "] " & arguments.cmd);
             return;
         }
+        // #2696: registry login is strict; logout is tolerant.
         var c = arguments.cmd;
-        variables.sshPool.onEach(arguments.hosts, function(ssh, host) { ssh.run(c); });
+        var doRaise = !arguments.allowFail;
+        variables.sshPool.onEach(arguments.hosts, function(ssh, host) { ssh.run(c, {raise: doRaise}); });
     }
 }

--- a/cli/lucli/services/deploy/cli/DeployServerCli.cfc
+++ b/cli/lucli/services/deploy/cli/DeployServerCli.cfc
@@ -78,12 +78,15 @@ component {
         return filtered;
     }
 
-    private void function $dispatch(required array hosts, required string cmd, required boolean dryRun) {
+    private void function $dispatch(required array hosts, required string cmd, required boolean dryRun, boolean allowFail = false) {
         if (arguments.dryRun) {
             for (var h in arguments.hosts) arrayAppend(variables.dryRunBuffer, "[" & h & "] " & arguments.cmd);
             return;
         }
+        // #2696: server-level `exec` and `bootstrap` are strict — a nonzero
+        // exit on either is a real failure that CI should see.
         var c = arguments.cmd;
-        variables.sshPool.onEach(arguments.hosts, function(ssh, host) { ssh.run(c); });
+        var doRaise = !arguments.allowFail;
+        variables.sshPool.onEach(arguments.hosts, function(ssh, host) { ssh.run(c, {raise: doRaise}); });
     }
 }

--- a/cli/lucli/services/deploy/lib/FakeSshPool.cfc
+++ b/cli/lucli/services/deploy/lib/FakeSshPool.cfc
@@ -46,20 +46,55 @@ component {
 	public struct function $accessExpectations() { return variables.expectations; }
 	public boolean function $accessStrict() { return variables.strict; }
 
+	/**
+	 * Mirror SshClient.$raiseRemoteFailure — same throw type / message shape /
+	 * detail-trim behavior so tests can assert one contract regardless of
+	 * which pool the deploy layer is talking to. Regression #2696.
+	 */
+	public void function $raiseRemoteFailure(
+		required string host,
+		required string cmd,
+		required struct result
+	) {
+		var stderr = arguments.result.stderr ?: "";
+		if (len(stderr) > 500) {
+			stderr = left(stderr, 500) & "…";
+		}
+		var cmdSummary = arguments.cmd;
+		if (len(cmdSummary) > 200) {
+			cmdSummary = left(cmdSummary, 200) & "…";
+		}
+		throw(
+			type = "Wheels.Deploy.RemoteExecutionFailed",
+			message = "Remote command failed on " & arguments.host
+				& " (exit " & arguments.result.exitCode & "): " & cmdSummary,
+			detail = stderr
+		);
+	}
+
 	private any function $makeFakeSsh(required string host) {
 		var pool = this;
 		return {
 			run: function(cmd, opts = {}) {
 				arrayAppend(pool.$accessCalls(), {host: host, cmd: cmd, opts: opts, kind: "run"});
 				var key = "#host#|#cmd#";
-				if (structKeyExists(pool.$accessExpectations(), key)) {
-					return pool.$accessExpectations()[key];
-				}
-				if (pool.$accessStrict()) {
+				var expectations = pool.$accessExpectations();
+				var result = "";
+				if (structKeyExists(expectations, key)) {
+					result = expectations[key];
+				} else if (pool.$accessStrict()) {
 					throw(type="FakeSshPool.Unexpected",
 						message="Unexpected command on #host#: #cmd#");
+				} else {
+					result = {exitCode: 0, stdout: "", stderr: "", durationMs: 0};
 				}
-				return {exitCode: 0, stdout: "", stderr: "", durationMs: 0};
+				// Mirror SshClient.run's opts.raise contract — #2696. Tests
+				// assert that the deploy dispatch layer surfaces nonzero exit
+				// codes by opting into raise=true at the call site.
+				if ((arguments.opts.raise ?: false) && (result.exitCode ?: 0) != 0) {
+					pool.$raiseRemoteFailure(host, cmd, result);
+				}
+				return result;
 			},
 			upload: function(local, remote, opts = {}) {
 				arrayAppend(pool.$accessCalls(), {host: host, kind: "upload",

--- a/cli/lucli/services/deploy/lib/FakeSshPool.cfc
+++ b/cli/lucli/services/deploy/lib/FakeSshPool.cfc
@@ -50,6 +50,11 @@ component {
 	 * Mirror SshClient.$raiseRemoteFailure — same throw type / message shape /
 	 * detail-trim behavior so tests can assert one contract regardless of
 	 * which pool the deploy layer is talking to. Regression #2696.
+	 *
+	 * MIRROR: SshClient.$raiseRemoteFailure is the source of truth. If you
+	 * change the trim limits, throw type, or message template there, update
+	 * this method in lockstep. We don't share the helper because FakeSshPool
+	 * is a test double that should not import the real SSH client.
 	 */
 	public void function $raiseRemoteFailure(
 		required string host,

--- a/cli/lucli/services/deploy/lib/SshClient.cfc
+++ b/cli/lucli/services/deploy/lib/SshClient.cfc
@@ -161,6 +161,11 @@ component {
 	 * Trims the command summary to 200 chars and stderr to 500 chars so log
 	 * output stays scannable when long shell pipelines or noisy stderr would
 	 * otherwise dominate the surfaced error.
+	 *
+	 * MIRROR: FakeSshPool.$raiseRemoteFailure must stay byte-identical to this
+	 * method. If you change the trim limits, throw type, or message template
+	 * here, update the test double in lockstep — tests assert against this
+	 * exact shape regardless of which pool the deploy layer is talking to.
 	 */
 	public void function $raiseRemoteFailure(
 		required string host,

--- a/cli/lucli/services/deploy/lib/SshClient.cfc
+++ b/cli/lucli/services/deploy/lib/SshClient.cfc
@@ -90,15 +90,24 @@ component {
 	 *       - sudo   boolean, default false. If true AND user != "root", prefixes
 	 *                the command with `sudo -n `. Throws SshClient.SudoNoPassword
 	 *                if NOPASSWD isn't configured on the remote host.
+	 *       - raise  boolean, default false. If true and the remote exit code is
+	 *                nonzero, throws Wheels.Deploy.RemoteExecutionFailed with the
+	 *                host, exitCode, and a command summary in the message and the
+	 *                trimmed stderr in the detail. Mirrors the existing sudo-no-
+	 *                password throw shape, just for arbitrary remote failures.
+	 *                Regression #2696 — deploy verbs used to discard the result
+	 *                struct and silently treat any nonzero exit as success.
 	 *
 	 * @return struct {exitCode, stdout, stderr, durationMs}
 	 */
 	public struct function run(required string cmd, struct opts = {}) {
 		var useSudo = (arguments.opts.sudo ?: false) && variables.$opts.user != "root";
+		var raise = arguments.opts.raise ?: false;
 		var effectiveCmd = useSudo ? "sudo -n " & arguments.cmd : arguments.cmd;
 		var loader = variables.$loader;
 		var hostRef = variables.$host;
 		var sshjRef = variables.$sshj;
+		var origCmd = arguments.cmd;
 		var start = getTickCount();
 
 		return loader.withIsolatedTCCL(() => {
@@ -134,11 +143,44 @@ component {
 						message = "Passwordless sudo not configured on #hostRef#"
 					);
 				}
+				if (raise && exitCode != 0) {
+					$raiseRemoteFailure(hostRef, origCmd, result);
+				}
 				return result;
 			} finally {
 				sess.close();
 			}
 		});
+	}
+
+	/**
+	 * Throw Wheels.Deploy.RemoteExecutionFailed with structured detail. Public
+	 * so FakeSshPool can share the exact same throw shape; tests assert against
+	 * this contract. Regression #2696.
+	 *
+	 * Trims the command summary to 200 chars and stderr to 500 chars so log
+	 * output stays scannable when long shell pipelines or noisy stderr would
+	 * otherwise dominate the surfaced error.
+	 */
+	public void function $raiseRemoteFailure(
+		required string host,
+		required string cmd,
+		required struct result
+	) {
+		var stderr = arguments.result.stderr ?: "";
+		if (len(stderr) > 500) {
+			stderr = left(stderr, 500) & "…";
+		}
+		var cmdSummary = arguments.cmd;
+		if (len(cmdSummary) > 200) {
+			cmdSummary = left(cmdSummary, 200) & "…";
+		}
+		throw(
+			type = "Wheels.Deploy.RemoteExecutionFailed",
+			message = "Remote command failed on " & arguments.host
+				& " (exit " & arguments.result.exitCode & "): " & cmdSummary,
+			detail = stderr
+		);
 	}
 
 	/**

--- a/cli/lucli/tests/specs/deploy/cli/DeployMainCliSpec.cfc
+++ b/cli/lucli/tests/specs/deploy/cli/DeployMainCliSpec.cfc
@@ -428,7 +428,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
             // raise Wheels.Deploy.RemoteExecutionFailed on nonzero exits, and the
             // deploy dispatchers opt-in to that strict mode for every non-teardown verb.
 
-            it("deploy throws Wheels.Deploy.RemoteExecutionFailed when docker pull fails on the remote (#2696)", () => {
+            it("deploy throws Wheels.Deploy.RemoteExecutionFailed when docker pull fails on the remote (##2696)", () => {
                 var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
                 // Use the same component the production deploy uses to compute the exact pull command.
                 var cfg = new cli.lucli.services.deploy.config.ConfigLoader().load(variables.fixture);
@@ -443,7 +443,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                     .toThrow(type="Wheels.Deploy.RemoteExecutionFailed", regex="exit 1");
             });
 
-            it("setup throws Wheels.Deploy.RemoteExecutionFailed when docker pull fails (alias for deploy) (#2696)", () => {
+            it("setup throws Wheels.Deploy.RemoteExecutionFailed when docker pull fails (alias for deploy) (##2696)", () => {
                 var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
                 var cfg = new cli.lucli.services.deploy.config.ConfigLoader().load(variables.fixture);
                 var builder = new cli.lucli.services.deploy.commands.BuilderCommands(cfg);
@@ -455,7 +455,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                     .toThrow(type="Wheels.Deploy.RemoteExecutionFailed");
             });
 
-            it("the thrown Wheels.Deploy.RemoteExecutionFailed names the host, exit code, and a command summary (#2696)", () => {
+            it("the thrown Wheels.Deploy.RemoteExecutionFailed names the host, exit code, and a command summary (##2696)", () => {
                 var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
                 var cfg = new cli.lucli.services.deploy.config.ConfigLoader().load(variables.fixture);
                 var builder = new cli.lucli.services.deploy.commands.BuilderCommands(cfg);
@@ -476,7 +476,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                 }
             });
 
-            it("rollback throws on a failing docker start (#2696)", () => {
+            it("rollback throws on a failing docker start (##2696)", () => {
                 var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
                 var cfg = new cli.lucli.services.deploy.config.ConfigLoader().load(variables.fixture);
                 var app = new cli.lucli.services.deploy.commands.AppCommands(cfg);
@@ -489,7 +489,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                     .toThrow(type="Wheels.Deploy.RemoteExecutionFailed");
             });
 
-            it("remove --confirm tolerates a missing kamal-proxy and still dispatches the remaining teardown steps (#2696)", () => {
+            it("remove --confirm tolerates a missing kamal-proxy and still dispatches the remaining teardown steps (##2696)", () => {
                 var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
                 var cfg = new cli.lucli.services.deploy.config.ConfigLoader().load(variables.fixture);
                 var proxyCmds = new cli.lucli.services.deploy.commands.ProxyCommands(cfg);
@@ -507,7 +507,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                 expect(sawLogout).toBeTrue();
             });
 
-            it("deploy still propagates lock-release exceptions in the finally block as no-ops when release fails (#2696)", () => {
+            it("deploy still propagates lock-release exceptions in the finally block as no-ops when release fails (##2696)", () => {
                 // lock.release() runs in the deploy() finally block and must never
                 // shadow the original deploy exception. Inject a release failure
                 // alongside a pull failure and assert the surfaced exception is the

--- a/cli/lucli/tests/specs/deploy/cli/DeployMainCliSpec.cfc
+++ b/cli/lucli/tests/specs/deploy/cli/DeployMainCliSpec.cfc
@@ -423,6 +423,116 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                 expect(out).toInclude("demo");
             });
 
+            // Regression suite for #2696 — deploy verbs reported success even when the
+            // underlying SSH command on the remote exited nonzero. The fix has SshClient
+            // raise Wheels.Deploy.RemoteExecutionFailed on nonzero exits, and the
+            // deploy dispatchers opt-in to that strict mode for every non-teardown verb.
+
+            it("deploy throws Wheels.Deploy.RemoteExecutionFailed when docker pull fails on the remote (#2696)", () => {
+                var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
+                // Use the same component the production deploy uses to compute the exact pull command.
+                var cfg = new cli.lucli.services.deploy.config.ConfigLoader().load(variables.fixture);
+                var builder = new cli.lucli.services.deploy.commands.BuilderCommands(cfg);
+                var pullCmd = builder.pull("v1");
+                fake.expect("1.2.3.4", pullCmd, {
+                    exitCode: 1, stdout: "",
+                    stderr: "Error response from daemon: manifest unknown"
+                });
+                var dc = new cli.lucli.services.deploy.cli.DeployMainCli(fake);
+                expect(() => dc.deploy({configPath: variables.fixture, version: "v1"}))
+                    .toThrow(type="Wheels.Deploy.RemoteExecutionFailed", regex="exit 1");
+            });
+
+            it("setup throws Wheels.Deploy.RemoteExecutionFailed when docker pull fails (alias for deploy) (#2696)", () => {
+                var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
+                var cfg = new cli.lucli.services.deploy.config.ConfigLoader().load(variables.fixture);
+                var builder = new cli.lucli.services.deploy.commands.BuilderCommands(cfg);
+                fake.expect("1.2.3.4", builder.pull("v1"), {
+                    exitCode: 1, stdout: "", stderr: "manifest unknown"
+                });
+                var dc = new cli.lucli.services.deploy.cli.DeployMainCli(fake);
+                expect(() => dc.setup({configPath: variables.fixture, version: "v1"}))
+                    .toThrow(type="Wheels.Deploy.RemoteExecutionFailed");
+            });
+
+            it("the thrown Wheels.Deploy.RemoteExecutionFailed names the host, exit code, and a command summary (#2696)", () => {
+                var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
+                var cfg = new cli.lucli.services.deploy.config.ConfigLoader().load(variables.fixture);
+                var builder = new cli.lucli.services.deploy.commands.BuilderCommands(cfg);
+                fake.expect("1.2.3.4", builder.pull("v1"), {
+                    exitCode: 125, stdout: "",
+                    stderr: "denied: requested access to the resource is denied"
+                });
+                var dc = new cli.lucli.services.deploy.cli.DeployMainCli(fake);
+                try {
+                    dc.deploy({configPath: variables.fixture, version: "v1"});
+                    fail("expected deploy to throw");
+                } catch (any e) {
+                    expect(e.type).toBe("Wheels.Deploy.RemoteExecutionFailed");
+                    expect(e.message).toInclude("1.2.3.4");
+                    expect(e.message).toInclude("125");
+                    expect(e.message).toInclude("docker pull");
+                    expect(e.detail).toInclude("denied");
+                }
+            });
+
+            it("rollback throws on a failing docker start (#2696)", () => {
+                var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
+                var cfg = new cli.lucli.services.deploy.config.ConfigLoader().load(variables.fixture);
+                var app = new cli.lucli.services.deploy.commands.AppCommands(cfg);
+                var startCmd = app.start(cfg.roles()[1], "v-old");
+                fake.expect("1.2.3.4", startCmd, {
+                    exitCode: 1, stdout: "", stderr: "No such container: demo-web-v-old"
+                });
+                var dc = new cli.lucli.services.deploy.cli.DeployMainCli(fake);
+                expect(() => dc.rollback({configPath: variables.fixture, version: "v-old"}))
+                    .toThrow(type="Wheels.Deploy.RemoteExecutionFailed");
+            });
+
+            it("remove --confirm tolerates a missing kamal-proxy and still dispatches the remaining teardown steps (#2696)", () => {
+                var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
+                var cfg = new cli.lucli.services.deploy.config.ConfigLoader().load(variables.fixture);
+                var proxyCmds = new cli.lucli.services.deploy.commands.ProxyCommands(cfg);
+                fake.expect("1.2.3.4", proxyCmds.remove(), {
+                    exitCode: 1, stdout: "", stderr: "Error: No such container: kamal-proxy"
+                });
+                var dc = new cli.lucli.services.deploy.cli.DeployMainCli(fake);
+                var out = dc.remove({configPath: variables.fixture, confirm: true});
+                expect(out).toInclude("Removed");
+                // After the tolerated proxy step, registry logout must still have been issued.
+                var cmds = [];
+                for (var c in fake.calls()) arrayAppend(cmds, c.cmd ?: "");
+                var sawLogout = false;
+                for (var s in cmds) if (findNoCase("docker logout", s)) sawLogout = true;
+                expect(sawLogout).toBeTrue();
+            });
+
+            it("deploy still propagates lock-release exceptions in the finally block as no-ops when release fails (#2696)", () => {
+                // lock.release() runs in the deploy() finally block and must never
+                // shadow the original deploy exception. Inject a release failure
+                // alongside a pull failure and assert the surfaced exception is the
+                // pull one (the original cause), not the release one.
+                var fake = new cli.lucli.services.deploy.lib.FakeSshPool();
+                var cfg = new cli.lucli.services.deploy.config.ConfigLoader().load(variables.fixture);
+                var builder = new cli.lucli.services.deploy.commands.BuilderCommands(cfg);
+                var lockCmds = new cli.lucli.services.deploy.commands.LockCommands(cfg);
+                fake.expect("1.2.3.4", builder.pull("v1"), {
+                    exitCode: 1, stdout: "", stderr: "manifest unknown"
+                });
+                fake.expect("1.2.3.4", lockCmds.release(), {
+                    exitCode: 1, stdout: "", stderr: "rm: cannot remove"
+                });
+                var dc = new cli.lucli.services.deploy.cli.DeployMainCli(fake);
+                try {
+                    dc.deploy({configPath: variables.fixture, version: "v1"});
+                    fail("expected deploy to throw");
+                } catch (any e) {
+                    // The surfaced error must be the pull failure, NOT the lock release failure.
+                    expect(e.type).toBe("Wheels.Deploy.RemoteExecutionFailed");
+                    expect(e.message).toInclude("docker pull");
+                }
+            });
+
             // Regression for #2671 — git's stderr ("fatal: not a git repository...") used to leak through as the version string.
             it("$gitShortSha() returns 'unknown' when run outside a git repo", () => {
                 var nonGitDir = getTempDirectory() & "/wheels-2671-main-" & createUUID();

--- a/cli/lucli/tests/specs/deploy/cli/DeployMainCliSpec.cfc
+++ b/cli/lucli/tests/specs/deploy/cli/DeployMainCliSpec.cfc
@@ -507,7 +507,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                 expect(sawLogout).toBeTrue();
             });
 
-            it("deploy still propagates lock-release exceptions in the finally block as no-ops when release fails (##2696)", () => {
+            it("a failing lock-release in the finally block does not mask the original deploy exception (##2696)", () => {
                 // lock.release() runs in the deploy() finally block and must never
                 // shadow the original deploy exception. Inject a release failure
                 // alongside a pull failure and assert the surfaced exception is the

--- a/cli/lucli/tests/specs/deploy/lib/FakeSshPoolSpec.cfc
+++ b/cli/lucli/tests/specs/deploy/lib/FakeSshPoolSpec.cfc
@@ -57,6 +57,92 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                 p.onAny(["h1", "h2", "h3"], function(ssh, host) { hits++; ssh.run("x"); });
                 expect(hits).toBe(1);
             });
+
+            // Regression for #2696 — deploy verbs used to swallow nonzero remote
+            // exit codes because the SSH callback discarded ssh.run()'s result.
+            // The fix adds opts.raise so the caller can opt into a strict throw.
+            // FakeSshPool's inline run must mirror that contract.
+
+            it("inline run with opts.raise=true throws Wheels.Deploy.RemoteExecutionFailed on nonzero exit", () => {
+                var p = new cli.lucli.services.deploy.lib.FakeSshPool();
+                p.expect("h1", "boom", {exitCode: 1, stdout: "", stderr: "kaboom"});
+                expect(() => p.onEach(["h1"], function(ssh, host) {
+                    ssh.run("boom", {raise: true});
+                })).toThrow(type="Wheels.Deploy.RemoteExecutionFailed", regex="exit 1");
+            });
+
+            it("inline run with opts.raise=true names the host, exit code, and command summary", () => {
+                var p = new cli.lucli.services.deploy.lib.FakeSshPool();
+                p.expect("host-a.example.com", "docker pull acme/demo:v1", {
+                    exitCode: 125, stdout: "", stderr: "denied: requested access is denied"
+                });
+                try {
+                    p.onEach(["host-a.example.com"], function(ssh, host) {
+                        ssh.run("docker pull acme/demo:v1", {raise: true});
+                    });
+                    fail("expected onEach to throw");
+                } catch (any e) {
+                    expect(e.type).toBe("Wheels.Deploy.RemoteExecutionFailed");
+                    expect(e.message).toInclude("host-a.example.com");
+                    expect(e.message).toInclude("125");
+                    expect(e.message).toInclude("docker pull");
+                    expect(e.detail).toInclude("denied");
+                }
+            });
+
+            it("inline run with opts.raise=true returns the result on exitCode 0", () => {
+                var p = new cli.lucli.services.deploy.lib.FakeSshPool();
+                p.expect("h1", "echo ok", {exitCode: 0, stdout: "ok", stderr: ""});
+                p.onEach(["h1"], function(ssh, host) {
+                    var r = ssh.run("echo ok", {raise: true});
+                    expect(r.exitCode).toBe(0);
+                    expect(r.stdout).toBe("ok");
+                });
+            });
+
+            it("inline run without opts.raise stays tolerant of nonzero exit (no throw)", () => {
+                var p = new cli.lucli.services.deploy.lib.FakeSshPool();
+                p.expect("h1", "boom", {exitCode: 1, stdout: "", stderr: "kaboom"});
+                var threw = false;
+                try {
+                    p.onEach(["h1"], function(ssh, host) {
+                        ssh.run("boom");
+                    });
+                } catch (any e) {
+                    threw = true;
+                }
+                expect(threw).toBeFalse();
+            });
+
+            it("inline run with opts.raise=false stays tolerant of nonzero exit (explicit opt-out)", () => {
+                var p = new cli.lucli.services.deploy.lib.FakeSshPool();
+                p.expect("h1", "boom", {exitCode: 1, stdout: "", stderr: "kaboom"});
+                var threw = false;
+                try {
+                    p.onEach(["h1"], function(ssh, host) {
+                        ssh.run("boom", {raise: false});
+                    });
+                } catch (any e) {
+                    threw = true;
+                }
+                expect(threw).toBeFalse();
+            });
+
+            it("inline run trims very long stderr in the thrown error detail", () => {
+                var p = new cli.lucli.services.deploy.lib.FakeSshPool();
+                var longErr = repeatString("x", 800);
+                p.expect("h1", "boom", {exitCode: 1, stdout: "", stderr: longErr});
+                try {
+                    p.onEach(["h1"], function(ssh, host) {
+                        ssh.run("boom", {raise: true});
+                    });
+                    fail("expected throw");
+                } catch (any e) {
+                    // Trimmed to 500 chars plus an ellipsis marker.
+                    expect(len(e.detail)).toBeLT(len(longErr));
+                    expect(e.detail).toInclude("xxxx");
+                }
+            });
         });
     }
 }


### PR DESCRIPTION
## Summary

Closes #2696.

Deploy CLI commands reported success even when the underlying SSH command on the remote exited nonzero. Root cause: `$dispatch()`'s callback in every `cli/lucli/services/deploy/cli/Deploy*Cli.cfc` discarded the result struct from `ssh.run()`. `SshPool.onEach` only rethrows Java-level exceptions (auth/connect failures), so a failed `docker pull`, daemon outage, or lock contention propagated as silent success.

## How the fix works

1. **`SshClient.run()` honors a new `opts.raise`.** When `raise=true` and `exitCode != 0`, it throws `Wheels.Deploy.RemoteExecutionFailed` with `host` + exit code + trimmed command summary in the message, and trimmed stderr in the detail. Mirrors the existing `SshClient.SudoNoPassword` throw pattern.
2. **`FakeSshPool` mirrors the same contract** so tests inject failures via `fake.expect(host, cmd, {exitCode: 1, stderr: \"...\"})` and assert the throw.
3. **Every `Deploy*Cli.cfc` dispatcher (9 files)** now passes `{raise: true}` by default through a new optional `allowFail` parameter on `$dispatch` / `$dispatchAny`.
4. **Known-idempotent teardown call sites opt into `allowFail=true`:**
   - `DeployMainCli.remove()` — `proxyCmds.remove()`, accessory removes, `regCmds.logout()`
   - `DeployMainCli.deploy()` — `lock.release()` inside the `finally` block (so a release failure can never shadow the original deploy exception)
   - `DeployAccessoryCli.remove` / `stop`
   - `DeployProxyCli.remove` / `stop`
   - `DeployLockCli.release` / `status` (`readlink` on a missing lock file is the operator's question, not an error)
   - `DeployRegistryCli.logout`
5. **Everything else stays strict-by-default:** `setup`, `deploy`, `rollback`, app boot/start, proxy boot/restart, accessory boot/start, `server bootstrap`/`server exec`, builder pull/push, registry login, prune.

## Why this design

The strict-by-default policy lives at the SSH boundary (`SshClient.run`), exactly where `SshClient.SudoNoPassword` already raises for a known failure shape. Dispatch closures stay one-liners, the failure semantics are auditable in one place, and `grep allowFail=true` enumerates every tolerant call site.

Considered but rejected: per-host result aggregation with partial-success reporting. Out of scope; fail-fast matches CI/CD intent that \"wheels deploy\" returns nonzero when the deployment didn't happen. Multi-host fanout deduplication is already what `SshPool.onEach` does (rethrow first failed Future's cause).

## Test plan

Regression tests in `cli/lucli/tests/specs/deploy/`:

- [ ] `FakeSshPoolSpec.cfc` — inline `run` raises on nonzero exit when `opts.raise=true`; names host, exit code, command in the message; stderr lands in detail; trimmed when long; stays tolerant when raise omitted/false.
- [ ] `DeployMainCliSpec.cfc` — `deploy()` throws on docker pull failure; `setup()` throws (alias for deploy); the error names host + exit code + \"docker pull\"; `rollback()` throws on `docker start` failure; `remove --confirm` tolerates a missing kamal-proxy and still issues `docker logout`; a failing lock-release inside `finally` never masks the original deploy exception.
- [ ] CI matrix verifies the full deploy spec suite against every engine × database in `compat-matrix.yml`.

## Out of scope

- Changing the success-line wording of `remove` when nothing was actually removed (idempotent-no-op polish; failure detection is the primary value).
- Rewriting `commands/*.cfc` to make every teardown unconditionally idempotent (e.g., `docker stop X 2>/dev/null || true`). The `allowFail=true` opt-in covers it without touching the commands layer.

## Sensitive-area note

Per `cli/lucli/services/deploy/**` being on the wheels-bot sensitive-area list, the triage step for #2696 correctly held this for human review. The fix is bounded to the SSH dispatch layer + 9 small dispatcher edits + an explicit list of allowFail opt-ins; no changes to the command-string builders or the on-server Kamal parity contract.