### PR TITLE
ci: keep refresh-visual-baselines commit body under commitlint's 100-char limit

### DIFF
--- a/.github/workflows/refresh-visual-baselines.yml
+++ b/.github/workflows/refresh-visual-baselines.yml
@@ -156,11 +156,16 @@ jobs:
           # readable inside the YAML and the SITES value is never spliced into
           # a shell-expanded string. SITES is constrained to the choice list
           # above, but writing through a file keeps that contract obvious.
+          #
+          # Branch name lives on its own line so long names (e.g. bot-generated
+          # fix/bot-NNNN-<slug>) can't push the body past the 100-char
+          # body-max-line-length enforced by commitlint.
           commit_msg_file="$(mktemp)"
           {
             printf '%s\n\n' "chore(web): refresh visual baseline(s) ($SITES)"
             printf '%s\n' "Manually triggered baseline refresh via"
-            printf '%s\n\n' ".github/workflows/refresh-visual-baselines.yml on branch $BRANCH."
+            printf '%s\n' ".github/workflows/refresh-visual-baselines.yml"
+            printf '%s\n\n' "on branch $BRANCH."
             printf '%s\n' "Run when an intentional content/layout change makes the visual-regression"
             printf '%s\n' "check fail. The new PNG(s) under web/tests/visual-baselines/ are now the"
             printf '%s\n' "expected rendering; re-run the failing visual-regression job to flip the"


### PR DESCRIPTION
## Summary

- The auto-generated commit body in [.github/workflows/refresh-visual-baselines.yml](.github/workflows/refresh-visual-baselines.yml) inlined the workflow path and branch name on a single line, producing lines >100 chars for normal-length branch names and failing commitlint's `body-max-line-length` rule on every auto-baseline-refresh.
- Split `on branch <BRANCH>.` onto its own line so the commit body now stays under 100 chars regardless of branch-name length.
- Concrete instances observed on #2728: commits `0e956bac` and `3123a386` each produced a 121-char body line; both required manual amends. Repro is reliable on any branch with a name longer than ~37 chars.

## Before / after (using branch `fix/bot-2703-wheels-middleware-cors-cannot-short-circuit-option`)

Before: `.github/workflows/refresh-visual-baselines.yml on branch fix/bot-2703-...` → **121 chars** (fails commitlint).

After: workflow path on one line + `on branch <BRANCH>.` on the next → **max 74 chars** in the entire body. Branch names can grow to ~89 chars before tripping the limit, far beyond any realistic branch name in this repo.

## Test plan

- [x] Simulated the heredoc generation locally against the 63-char branch from #2728; max line is 74 chars.
- [x] Ran the resulting commit message through this repo's local `commitlint` (exit 0).
- [ ] Verify the next auto-fired baseline refresh (the workflow is only manually-triggered, so this will be confirmed when someone next runs it from the Actions UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)