### PR TITLE
fix(test): branch addColumnOptionsSpec text-default check for MySQL (#2742)

### DIFF
--- a/vendor/wheels/tests/specs/migrator/addColumnOptionsSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/addColumnOptionsSpec.cfc
@@ -90,7 +90,7 @@ component extends="wheels.WheelsTest" {
 				expect(sql).toInclude("'hello'");
 			});
 
-			it("text with a real default (non-empty) still emits DEFAULT", () => {
+			it("text with a real default: emits DEFAULT except on MySQL (TEXT columns suppressed)", () => {
 				var sql = buildOptions(type = "text", default = "long body");
 				if (variables.isMySQLFamily) {
 					// MySQL adapter suppresses DEFAULT on TEXT columns entirely

--- a/vendor/wheels/tests/specs/migrator/addColumnOptionsSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/addColumnOptionsSpec.cfc
@@ -37,6 +37,10 @@ component extends="wheels.WheelsTest" {
 		// for cross-adapter branching.
 		var name = variables.adapter.adapterName();
 		variables.isPostgresFamily = (name == "PostgreSQL" || name == "CockroachDB");
+		// MySQL's optionsIncludeDefault() returns false for text/mediumtext/longtext/float
+		// because MySQL forbids DEFAULT on TEXT/BLOB columns pre-8.0.13. So text columns
+		// — even with a real non-empty default — emit no DEFAULT clause on MySQL.
+		variables.isMySQLFamily = (name == "MySQL");
 	}
 
 	private string function buildOptions(string type, string default = "", boolean allowNull = true) {
@@ -88,8 +92,14 @@ component extends="wheels.WheelsTest" {
 
 			it("text with a real default (non-empty) still emits DEFAULT", () => {
 				var sql = buildOptions(type = "text", default = "long body");
-				expect(sql).toInclude("DEFAULT");
-				expect(sql).toInclude("'long body'");
+				if (variables.isMySQLFamily) {
+					// MySQL adapter suppresses DEFAULT on TEXT columns entirely
+					// (MySQLMigrator.optionsIncludeDefault returns false for text).
+					expect(sql).notToInclude("DEFAULT");
+				} else {
+					expect(sql).toInclude("DEFAULT");
+					expect(sql).toInclude("'long body'");
+				}
 			});
 
 			it("integer with default='' becomes DEFAULT NULL across adapters", () => {


### PR DESCRIPTION
## Summary

Follow-up to [#2661](https://github.com/wheels-dev/wheels/pull/2661). MySQL's `MySQLMigrator.optionsIncludeDefault()` returns `false` for `text` / `mediumtext` / `longtext` / `float` columns (MySQL forbids `DEFAULT` on TEXT/BLOB pre-8.0.13), so `addColumnOptions` emits no `DEFAULT` clause for `text` even with a non-empty default. The "text with a real default (non-empty) still emits DEFAULT" spec asserted `DEFAULT` unconditionally and failed on Lucee 6, Lucee 7, and BoxLang against MySQL.

This PR mirrors the `isPostgresFamily` carve-out pattern that #2661 already established: adds `variables.isMySQLFamily` in `beforeAll` and splits the failing assertion so MySQL asserts `notToInclude("DEFAULT")` while other Abstract-based adapters still assert `DEFAULT '<value>'`.

Pure test edit — the adapter contract is correct and unchanged.

## Why only `text` (not `string` or `char`)

MySQL's suppression list is `text,mediumtext,longtext,float`. `string` (VARCHAR) and `char` accept `DEFAULT` normally on MySQL, so the existing assertions for those types already pass.

## Test plan

Verified locally with `tools/test-matrix.sh`:

- [x] `lucee7 + mysql` — `addColumnOptionsSpec` 7/7 pass
- [x] `lucee6 + mysql` — full migrator suite passes
- [x] `boxlang + mysql` — failing spec count drops from 2 → 1 (remaining failure is the unrelated transaction-locking issue called out in the original issue)
- [x] `lucee7 + sqlite` — migrator suite 186/186 pass (regression check on the non-MySQL path)

Closes #2742

🤖 Generated with [Claude Code](https://claude.com/claude-code)