### PR TITLE
docs: drop scoop bucket add java step after scoop-wheels#4

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/installation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/installation.mdx
@@ -118,7 +118,6 @@ Until the native repos are live, download integrity relies on GitHub's HTTPS tra
 Wheels ships on Windows through [Scoop](https://scoop.sh) — a portable, sandboxed package manager that fits the project's release cadence (hourly autoupdate for both stable and bleeding-edge channels). The legacy Chocolatey path is no longer supported; the old v1.x `wheels` package at `community.chocolatey.org/packages/wheels` is the CommandBox-based release and won't drive a v4 tutorial.
 
 ```powershell
-scoop bucket add java
 scoop bucket add wheels https://github.com/wheels-dev/scoop-wheels
 
 # Pick a channel:
@@ -128,7 +127,7 @@ scoop install wheels-be     # bleeding-edge - tracks every develop merge
 wheels --version
 ```
 
-Both packages declare `java/openjdk21` as a dependency. Scoop pulls the JDK in automatically *once the `java` bucket has been added* — it doesn't add the bucket on your behalf, so the `scoop bucket add java` step is required before the install. Both packages expose the same `wheels` PATH shim — Scoop refuses to install both at once. To switch channels:
+Both packages bundle OpenJDK 21 inline — no separate `java` bucket, no `JAVA_HOME` setup. Both expose the same `wheels` PATH shim, so Scoop refuses to install both at once. To switch channels:
 
 ```powershell
 scoop uninstall wheels && scoop install wheels-be
@@ -137,7 +136,7 @@ scoop uninstall wheels-be && scoop install wheels
 
 See [Release Channels](/v4-0-0/start-here/release-channels/) for the full channel comparison.
 
-The Scoop bucket lives at [`wheels-dev/scoop-wheels`](https://github.com/wheels-dev/scoop-wheels). The bucket's `checkver`/`autoupdate` blocks pull new versions from GitHub Releases hourly via the community [Excavator](https://github.com/ScoopInstaller/Excavator) bot — no manual maintenance per release.
+The Scoop bucket lives at [`wheels-dev/scoop-wheels`](https://github.com/wheels-dev/scoop-wheels). New versions land in the bucket via [`autoupdate.yml`](https://github.com/wheels-dev/scoop-wheels/blob/main/.github/workflows/autoupdate.yml), a self-hosted workflow that listens for a `repository_dispatch` event from this repo's `release.yml`. End-to-end latency from upstream tag to user-installable manifest: ~5-7 min. A daily cron tick at 08:30 UTC catches any dispatch the workflow missed.
 
 WinGet support (`winget install Wheels.Wheels`) is planned for post-v4.0.0 GA once a proper installer artifact is built. Until then, use Scoop.
 

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/installing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/installing.mdx
@@ -126,17 +126,16 @@ The legacy `wheels` package on chocolatey.org is the CommandBox-based v1.x relea
    Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
    ```
 
-2. Add the `java` and `wheels` buckets, then install a channel:
+2. Add the Wheels bucket and install a channel:
 
    ```powershell title="PowerShell"
-   scoop bucket add java
    scoop bucket add wheels https://github.com/wheels-dev/scoop-wheels
    scoop install wheels        # stable - tracks v4.0.0 GA tags
    # OR:
    scoop install wheels-be     # bleeding-edge - tracks every develop merge
    ```
 
-   The `java` bucket is needed because the Wheels manifest declares `java/openjdk21` as a dependency — Scoop will pull JDK 21 in automatically once the bucket is added, but it does not auto-add the bucket on your behalf. Both `wheels` packages expose the same `wheels` shim on PATH — Scoop refuses to install both at once. See [Release Channels](/v4-0-0/start-here/release-channels/) for the comparison.
+   Both packages inline OpenJDK 21 — no separate `java` bucket or `JAVA_HOME` setup required. Both expose the same `wheels` shim on PATH, so Scoop refuses to install both at once. See [Release Channels](/v4-0-0/start-here/release-channels/) for the comparison.
 
 3. Verify:
 

--- a/web/sites/guides/src/content/docs/v4-0-1-snapshot/command-line-tools/installation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-1-snapshot/command-line-tools/installation.mdx
@@ -118,7 +118,6 @@ Until the native repos are live, download integrity relies on GitHub's HTTPS tra
 Wheels ships on Windows through [Scoop](https://scoop.sh) — a portable, sandboxed package manager that fits the project's release cadence (hourly autoupdate for both stable and bleeding-edge channels). The legacy Chocolatey path is no longer supported; the old v1.x `wheels` package at `community.chocolatey.org/packages/wheels` is the CommandBox-based release and won't drive a v4 tutorial.
 
 ```powershell
-scoop bucket add java
 scoop bucket add wheels https://github.com/wheels-dev/scoop-wheels
 
 # Pick a channel:
@@ -128,7 +127,7 @@ scoop install wheels-be     # bleeding-edge - tracks every develop merge
 wheels --version
 ```
 
-Both packages declare `java/openjdk21` as a dependency. Scoop pulls the JDK in automatically *once the `java` bucket has been added* — it doesn't add the bucket on your behalf, so the `scoop bucket add java` step is required before the install. Both packages expose the same `wheels` PATH shim — Scoop refuses to install both at once. To switch channels:
+Both packages bundle OpenJDK 21 inline — no separate `java` bucket, no `JAVA_HOME` setup. Both expose the same `wheels` PATH shim, so Scoop refuses to install both at once. To switch channels:
 
 ```powershell
 scoop uninstall wheels && scoop install wheels-be
@@ -137,7 +136,7 @@ scoop uninstall wheels-be && scoop install wheels
 
 See [Release Channels](/v4-0-1-snapshot/start-here/release-channels/) for the full channel comparison.
 
-The Scoop bucket lives at [`wheels-dev/scoop-wheels`](https://github.com/wheels-dev/scoop-wheels). The bucket's `checkver`/`autoupdate` blocks pull new versions from GitHub Releases hourly via the community [Excavator](https://github.com/ScoopInstaller/Excavator) bot — no manual maintenance per release.
+The Scoop bucket lives at [`wheels-dev/scoop-wheels`](https://github.com/wheels-dev/scoop-wheels). New versions land in the bucket via [`autoupdate.yml`](https://github.com/wheels-dev/scoop-wheels/blob/main/.github/workflows/autoupdate.yml), a self-hosted workflow that listens for a `repository_dispatch` event from this repo's `release.yml`. End-to-end latency from upstream tag to user-installable manifest: ~5-7 min. A daily cron tick at 08:30 UTC catches any dispatch the workflow missed.
 
 WinGet support (`winget install Wheels.Wheels`) is planned for post-v4.0.0 GA once a proper installer artifact is built. Until then, use Scoop.
 

--- a/web/sites/guides/src/content/docs/v4-0-1-snapshot/start-here/installing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-1-snapshot/start-here/installing.mdx
@@ -126,17 +126,16 @@ The legacy `wheels` package on chocolatey.org is the CommandBox-based v1.x relea
    Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
    ```
 
-2. Add the `java` and `wheels` buckets, then install a channel:
+2. Add the Wheels bucket and install a channel:
 
    ```powershell title="PowerShell"
-   scoop bucket add java
    scoop bucket add wheels https://github.com/wheels-dev/scoop-wheels
    scoop install wheels        # stable - tracks v4.0.0 GA tags
    # OR:
    scoop install wheels-be     # bleeding-edge - tracks every develop merge
    ```
 
-   The `java` bucket is needed because the Wheels manifest declares `java/openjdk21` as a dependency — Scoop will pull JDK 21 in automatically once the bucket is added, but it does not auto-add the bucket on your behalf. Both `wheels` packages expose the same `wheels` shim on PATH — Scoop refuses to install both at once. See [Release Channels](/v4-0-1-snapshot/start-here/release-channels/) for the comparison.
+   Both packages inline OpenJDK 21 — no separate `java` bucket or `JAVA_HOME` setup required. Both expose the same `wheels` shim on PATH, so Scoop refuses to install both at once. See [Release Channels](/v4-0-1-snapshot/start-here/release-channels/) for the comparison.
 
 3. Verify:
 


### PR DESCRIPTION
## Summary
Follow-up to [#2761](https://github.com/wheels-dev/wheels/pull/2761) and [scoop-wheels#4](https://github.com/wheels-dev/scoop-wheels/pull/4).

#4 inlined OpenJDK 21 in `wheels.json` and `wheels-be.json`, so the `scoop bucket add java` step #2761 added is no longer required — `scoop install wheels` and `scoop install wheels-be` now work from a truly fresh shell. This PR rolls those step additions back.

While there: dropped the stale claim that scoop-wheels autoupdate runs via the community Excavator bot. The bucket now uses its own [`.github/workflows/autoupdate.yml`](https://github.com/wheels-dev/scoop-wheels/blob/main/.github/workflows/autoupdate.yml) that listens for `repository_dispatch` events from this repo's `release.yml`, with a daily cron at 08:30 UTC as fallback.

## Files
Both `start-here/installing.mdx` and `command-line-tools/installation.mdx` in:
- `v4-0-0/` (already-released docs)
- `v4-0-1-snapshot/` (in-progress docs)

## Test plan
- [ ] Astro guides build is green (`pnpm --dir web/sites/guides build`).
- [ ] Live preview shows the updated install steps on both versions.
- [ ] On a fresh Windows shell: `scoop bucket add wheels …; scoop install wheels-be` succeeds without the bucket-add step (works today — autoupdate has had wheels-be#4 in main since 19:29 UTC).

## Out of scope
- `scoop-wheels#5` (the hub-install fix) is pending. Once that lands, the autoupdate workflow described in these docs will actually be operational end-to-end. This PR's wording is accurate either way — the workflow exists and the dispatch chain is wired up; #5 is about the runtime tool prerequisite, not the architecture.