### PR TITLE
chore(release): prep CHANGELOG for v4.0.1 GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 
 ----
 
-## [Unreleased]
+# [4.0.1](https://github.com/wheels-dev/wheels/releases/tag/v4.0.1) => 2026-05-20
+
+> **Wheels 4.0.1** — first patch on the 4.0 line. Hardens Adobe ColdFusion 2023/2025 compatibility (Adobe-specific `cfheader` attributeCollection rejection, `env()` reserved-word parameter, Vite asset-walk array-by-value), fixes the Windows Scoop install regressions (`wheels.cmd` cmd.exe pre-parser, `.zip.sha512` sidecar layout), and adds `viewStyle` framework presets to `paginationNav()` plus plural `mappings` aliases to `package.json`. ~100 PRs since the 4.0.0 GA (2026-05-12).
 
 ### Added
 
@@ -100,7 +102,7 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 - Document that `reloadPassword` must be wired through `config/settings.cfm` via `set(reloadPassword = env("WHEELS_RELOAD_PASSWORD", ""))` — a value in `.env` alone is not wired into framework settings automatically, and the fail-closed boot warning will fire regardless (#2631)
 - Upgrade guide (v4-0-0 and v4-0-1-snapshot) item 4 now documents the `config/environment.cfm` load-order gap: `application.env.environment` is not reliably populated before that file runs, causing production servers to resolve `environment=""` and emit `environment=development` to Sentry and the debug bar. The canonical fix (`set(environment=env("environment", "production"))`) and its deliberate `"production"` fail-safe default are documented alongside the existing `reloadPassword` guidance. A matching "Common issues" entry is added for discoverability (#2709)
 
-----
+---
 
 # [4.0.0](https://github.com/wheels-dev/wheels/releases/tag/v4.0.0) => 2026-05-12
 


### PR DESCRIPTION
## Summary

Pre-flight prep for the v4.0.1 GA tag. Mirrors [#2606](https://github.com/wheels-dev/wheels/pull/2606) (the v4.0.0 analog). Once this lands, the remaining release-day step is a single `release/v4.0.1-to-main` PR.

## What changed

- **CHANGELOG header** — promoted `## [Unreleased]` to `# [4.0.1](...) => 2026-05-20`. This is the line `release.yml` grep-validates for `=> TBD`. **Bump the date here on develop if the release-to-main PR slides past today.**
- **Section terminator fix** — changed the `----` (4 dashes) separator between the new 4.0.1 block and the 4.0.0 block to `---` (3 dashes). `release.yml`'s release-notes extraction is `awk '/^# \[VERSION\]/,/^---$/'` — that pattern matches only the 3-dash form. Without this fix, the GitHub Release body for 4.0.1 would bleed into the 4.0.0 section. Same issue, same fix as #2606.
- **Short patch tagline** — one-line blockquote summarizing the release theme (Adobe CF 2023/2025 compat hardening, Windows Scoop install fixes, `paginationNav()` framework presets, plural `mappings`).

## Pre-flight checks

- [x] CHANGELOG has no `=> TBD` for 4.0.1 → `release.yml` validation step passes
- [x] `wheels.json` version is clean (`4.0.1`, no `-snapshot` suffix) → already bumped by `bump-develop-version.yml` after the v4.0.0 GA
- [x] Release-notes awk extraction terminates at the correct boundary: ``awk '/^# \[4\.0\.1\]/,/^---$/' CHANGELOG.md | wc -l`` reports 85 lines, ending immediately before `# [4.0.0]`
- [x] develop CI is green (last push, [run 26171463495](https://github.com/wheels-dev/wheels/actions/runs/26171463495), success in 8m31s)

## Scope of v4.0.1

103 commits / ~97 unique PR references since the v4.0.0 tag (8 days). Highlights:

- **Adobe CF 2023/2025 compat hardening** — `cfheader` attributeCollection trap (#2750), `env()` reserved-word parameter (#2756), Vite asset-walk array-by-value (#2756). Documented in [.ai/wheels/cross-engine-compatibility.md](.ai/wheels/cross-engine-compatibility.md) and CLAUDE.md anti-patterns #10/#11.
- **Windows Scoop install** — `wheels.cmd` cmd.exe bat-jar pre-parser (#2766), `.zip.sha512` sidecar layout (#2761), Git prereq doc fix (#2763), `scoop bucket add java` doc fix (#2762).
- **paginationNav presets** — `viewStyle` argument with Bootstrap 4/5 and Tailwind presets (#2731), anchor-mode `auto`/`always`/`never` (#2733), unknown-arg validation (#2726).
- **Package system** — plural `mappings` for legacy CFML aliases (#2705/#2739), auto-registered per-package mapping in PackageLoader (#2712), `wheels packages add` is now the canonical install verb (#2729).
- **CLI deploy** — flat-alias bootstrap/exec/fetch-secrets/extract-secrets/print-secrets to dodge picocli root-token absorption (#2690/#2699), `--release` alias for `--version` (#2691), Dockerfile/`.dockerignore` scaffolding in `wheels deploy init` (#2686).
- **Compat-matrix fixes** — CockroachDB advisory-lock skip (#2746/#2747), Oracle `insertAll` + system-tables transaction skip (#2749/#2753), MySQL `addColumnOptions` text-default carve-out (#2748), BoxLang `lockingSpec` catch-scope discard workaround (#2754).

## Manual steps for me (after this PR merges to develop)

1. Pull develop locally.
2. Verify the date in CHANGELOG still reflects the release day; bump on develop if it slid.
3. Cut archive branches: `archive/develop-pre-v4.0.1`, `archive/main-pre-v4.0.1` (keep for at least one cycle in case rollback is needed).
4. Open `release/v4.0.1-to-main` (merge develop into main, since main's PR-required ruleset blocks direct push — see #2607 for the v4.0.0 pattern).
5. PR to main, merge with "Create a merge commit". `release.yml` fires on the push to main, creates the v4.0.1 tag via `softprops/action-gh-release`, and publishes the GitHub Release.
6. `bump-develop-version.yml` should auto-fire via `repository_dispatch` (the fix for [#2609](https://github.com/wheels-dev/wheels/issues/2609) shipped on develop), opening a follow-up PR to bump `wheels.json` to `4.0.2`.

## Test plan

- [ ] commitlint passes on this PR
- [ ] No-op CI on develop (this is a CHANGELOG-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)