### PR TITLE
chore: bump develop snapshot target to 4.0.2

### DIFF
--- a/wheels.json
+++ b/wheels.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://wheels.dev/schema/wheels.json/v1.json",
     "name": "Wheels.fw",
-    "version": "4.0.1",
+    "version": "4.0.2",
     "description": "Wheels — CFML MVC framework",
     "homepage": "https://wheels.dev",
     "documentation": "https://wheels.dev/guides/",


### PR DESCRIPTION
## Summary

Manual bump after the v4.0.1 GA. Mirrors [#2608](https://github.com/wheels-dev/wheels/pull/2608) (the v4.0.0 analog).

The fix for [#2609](https://github.com/wheels-dev/wheels/issues/2609) worked — `release.yml` did fire `repository_dispatch: [bump-develop]` after v4.0.1 published, and `bump-develop-version.yml` woke up. But the workflow then **failed in 12 seconds** on a different bug: `peter-evans/create-pull-request@v6` hit `remote: Duplicate header: \"Authorization\"` because the `actions/checkout` step left credentials persisted that conflict with the action's own token.

See run [26173817714](https://github.com/wheels-dev/wheels/actions/runs/26173817714) for the failed log. Follow-up issue tracks the workflow fix.

## What changed

- `wheels.json` version: `4.0.1` → `4.0.2`

Subsequent develop snapshots will now be tagged `4.0.2-snapshot.<run>`. Per the workflow's docstring: "This is a baseline, not a commitment." If the next GA is a minor or major bump, the snapshot version strings still sort strictly lower than any of those, so brew/scoop upgrades continue to work correctly.

## Test plan

- [ ] commitlint passes
- [ ] After merge, next push to develop triggers `snapshot.yml` and tags the artifact `4.0.2-snapshot.<run-number>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)