### PR TITLE
ci(release): fix bump-develop-version.yml duplicate Authorization header

### DIFF
--- a/.github/workflows/bump-develop-version.yml
+++ b/.github/workflows/bump-develop-version.yml
@@ -61,6 +61,11 @@ jobs:
         with:
           ref: develop
           fetch-depth: 1
+          # Don't persist GITHUB_TOKEN as a git extraheader — peter-evans/create-pull-request
+          # below sets its own Authorization, and two simultaneous extraheaders make GitHub
+          # reject git operations with "Duplicate header: Authorization" → HTTP 400.
+          # First hit on the v4.0.1 GA (run 26173817714); manual workaround was #2770.
+          persist-credentials: false
 
       - name: Compute next snapshot target
         run: |


### PR DESCRIPTION
## Summary

Fix the auth-collision bug that prevented `bump-develop-version.yml` from succeeding on the v4.0.1 GA. The trigger ([#2609](https://github.com/wheels-dev/wheels/issues/2609)) is now working — the dispatch fires — but the workflow itself dies in 12 seconds with `remote: Duplicate header: \"Authorization\"`. Manual workaround on v4.0.1 was [#2770](https://github.com/wheels-dev/wheels/pull/2770).

## Root cause

`actions/checkout@v6` defaults to `persist-credentials: true`, which writes:

```
http.https://github.com/.extraheader = AUTHORIZATION: basic <GITHUB_TOKEN>
```

to `.git/config`. `peter-evans/create-pull-request@v6` then sets its **own** `extraheader` using the action's input token. The next git operation (`git remote prune origin`, then the eventual push) sends both Authorization headers, and GitHub returns HTTP 400:

```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/wheels-dev/wheels/': The requested URL returned error: 400
##[error]The process '/usr/bin/git' failed with exit code 128
```

This is a [documented peter-evans/create-pull-request gotcha](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs) when the caller uses a non-default token. Failed run on v4.0.1: [26173817714](https://github.com/wheels-dev/wheels/actions/runs/26173817714).

## Fix

Add `persist-credentials: false` to the `actions/checkout@v6` step. With that flag, checkout never writes `extraheader`, and `peter-evans/create-pull-request@v6` is the sole Authorization authority.

```diff
       - name: Checkout develop
         uses: actions/checkout@v6
         with:
           ref: develop
           fetch-depth: 1
+          persist-credentials: false
```

Five lines (one config line + a four-line explanatory comment).

## Test plan

- [ ] commitlint passes
- [ ] Next GA cut: `bump-develop-version.yml` runs end-to-end on the `repository_dispatch: bump-develop` event and opens the bump PR within ~30s of release publish.

## Related

- v4.0.1 GA tag: [v4.0.1](https://github.com/wheels-dev/wheels/releases/tag/v4.0.1)
- Failed bump run: [26173817714](https://github.com/wheels-dev/wheels/actions/runs/26173817714)
- Manual workaround: [#2770](https://github.com/wheels-dev/wheels/pull/2770)
- Earlier dispatch-trigger fix: [#2609](https://github.com/wheels-dev/wheels/issues/2609)

🤖 Generated with [Claude Code](https://claude.com/claude-code)