### PR TITLE
chore: rename Phase 2 bucket repos to apt-wheels / yum-wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ on:
       DOWNSTREAM_DISPATCH_TOKEN:
         required: false
       # Optional — when present, the build job's "Dispatch Linux repo buckets"
-      # step fires repository_dispatch on apt-wheels-dev / yum-wheels-dev so
+      # step fires repository_dispatch on apt-wheels / yum-wheels so
       # their metadata regen workflows pick up the new .deb/.rpm and republish
       # apt.wheels.dev / yum.wheels.dev within minutes. When absent, the step
       # skips silently — the bucket repos can be populated manually via each
@@ -306,7 +306,7 @@ jobs:
         # CHANNEL derives from the version so develop snapshots produce the
         # `wheels-be` package (which the Phase 2 bleeding-edge receiver
         # downloads) instead of `wheels`. Without this, the snapshot release
-        # ships `wheels_<v>_amd64.deb` and the apt-wheels-dev / yum-wheels-dev
+        # ships `wheels_<v>_amd64.deb` and the apt-wheels / yum-wheels
         # receiver workflow 404s on its `wheels-be_<v>_amd64.deb` fetch.
         # RC builds keep CHANNEL=stable — RCs aren't fanned out to apt/yum
         # (see release.yml § "Dispatch Linux repo buckets").
@@ -588,8 +588,8 @@ jobs:
       #############################################
       # Dispatch Linux repo buckets (apt.wheels.dev / yum.wheels.dev)
       #
-      # Fires repository_dispatch on wheels-dev/apt-wheels-dev and
-      # wheels-dev/yum-wheels-dev so their metadata-regen workflows pick up
+      # Fires repository_dispatch on wheels-dev/apt-wheels and
+      # wheels-dev/yum-wheels so their metadata-regen workflows pick up
       # the new .deb / .rpm asset and republish apt.wheels.dev /
       # yum.wheels.dev within minutes. See issue #2605.
       #
@@ -616,7 +616,7 @@ jobs:
           fi
 
           # Same channel derivation as the homebrew/scoop dispatch.
-          # apt-wheels-dev / yum-wheels-dev route on `channel` in the payload
+          # apt-wheels / yum-wheels route on `channel` in the payload
           # to slot the .deb/.rpm into the right pool (stable vs bleeding-edge).
           # RC releases aren't currently published to apt/yum, so we skip them.
           if echo "${WHEELS_RELEASE_VERSION}" | grep -qiE '\-snapshot[\.\+]'; then
@@ -632,7 +632,7 @@ jobs:
           # Static event type, fixed repo list — no untrusted input flows into
           # the curl arguments. WHEELS_RELEASE_VERSION is generated earlier in
           # the same workflow from wheels.json + run number.
-          for repo in apt-wheels-dev yum-wheels-dev; do
+          for repo in apt-wheels yum-wheels; do
             echo "Dispatching wheels-released to wheels-dev/${repo}..."
             http_status=$(curl -sS -o /tmp/linux-dispatch-resp.txt -w "%{http_code}" \
               -X POST \

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -215,7 +215,7 @@ jobs:
       FORGEBOX_PASS: ${{ secrets.FORGEBOX_PASS }}
       DOWNSTREAM_DISPATCH_TOKEN: ${{ secrets.DOWNSTREAM_DISPATCH_TOKEN }}
       # Optional: when present, the build job's "Dispatch Linux repo buckets"
-      # step fires repository_dispatch on apt-wheels-dev / yum-wheels-dev so
+      # step fires repository_dispatch on apt-wheels / yum-wheels so
       # the bleeding-edge channel of apt.wheels.dev / yum.wheels.dev tracks
       # every develop push. When absent, the step skips silently. See #2605.
       LINUX_REPO_DISPATCH_TOKEN: ${{ secrets.LINUX_REPO_DISPATCH_TOKEN }}

--- a/tools/distribution-drafts/apt-repo/README.md
+++ b/tools/distribution-drafts/apt-repo/README.md
@@ -1,6 +1,6 @@
-# `apt-wheels-dev` bucket repo template
+# `apt-wheels` bucket repo template
 
-This directory is the **template** for the standalone `wheels-dev/apt-wheels-dev`
+This directory is the **template** for the standalone `wheels-dev/apt-wheels`
 repository that backs `https://apt.wheels.dev`. The bucket repo holds the static
 apt metadata tree plus the pooled `.deb` artifacts, and is auto-deployed to
 Cloudflare Pages on every push.
@@ -105,7 +105,7 @@ Before this bucket repo will function:
    the apex domain `apt.wheels.dev`. The build command is empty (the repo
    *is* the static site); the output dir is `./`.
 3. **CI secrets** (set on the bucket repo at
-   `https://github.com/wheels-dev/apt-wheels-dev/settings/secrets/actions`):
+   `https://github.com/wheels-dev/apt-wheels/settings/secrets/actions`):
    - `WHEELS_REPO_GPG_PRIVATE_KEY` — ASCII-armored private key
    - `WHEELS_REPO_GPG_PASSPHRASE` — passphrase
 4. **Upstream dispatch** — the release workflow in `wheels-dev/wheels`

--- a/tools/distribution-drafts/apt-repo/templates/index.html
+++ b/tools/distribution-drafts/apt-repo/templates/index.html
@@ -79,7 +79,7 @@ sudo apt update &amp;&amp; sudo apt install wheels-be</code></pre>
   <pre><code>sudo apt update &amp;&amp; sudo apt upgrade wheels        # or wheels-be</code></pre>
 
   <h2>Signing key</h2>
-  <p>The repository is signed with the Wheels project key. The public half is published at <a href="/wheels.gpg"><code>/wheels.gpg</code></a>. The fingerprint is committed to the <a href="https://github.com/wheels-dev/apt-wheels-dev">source repo</a> in <code>FINGERPRINT</code> for offline verification.</p>
+  <p>The repository is signed with the Wheels project key. The public half is published at <a href="/wheels.gpg"><code>/wheels.gpg</code></a>. The fingerprint is committed to the <a href="https://github.com/wheels-dev/apt-wheels">source repo</a> in <code>FINGERPRINT</code> for offline verification.</p>
 
   <h2>Other platforms</h2>
   <ul>
@@ -89,7 +89,7 @@ sudo apt update &amp;&amp; sudo apt install wheels-be</code></pre>
   </ul>
 
   <footer>
-    <p>Hosted on Cloudflare Pages. Repository contents at <a href="https://github.com/wheels-dev/apt-wheels-dev">wheels-dev/apt-wheels-dev</a>.</p>
+    <p>Hosted on Cloudflare Pages. Repository contents at <a href="https://github.com/wheels-dev/apt-wheels">wheels-dev/apt-wheels</a>.</p>
   </footer>
 </main>
 </body>

--- a/tools/distribution-drafts/apt-repo/workflows/wheels-released.yml
+++ b/tools/distribution-drafts/apt-repo/workflows/wheels-released.yml
@@ -1,4 +1,4 @@
-# Receiver workflow for `wheels-dev/apt-wheels-dev`.
+# Receiver workflow for `wheels-dev/apt-wheels`.
 #
 # Listens for `repository_dispatch` from `wheels-dev/wheels`'s release workflow,
 # downloads the new `.deb` asset from the upstream GitHub Release, slots it

--- a/tools/distribution-drafts/linux-packages/README.md
+++ b/tools/distribution-drafts/linux-packages/README.md
@@ -65,8 +65,8 @@ Practical impact for this directory:
 Two new repos (separate from the source monorepo, mirroring the snapshots-repo
 pattern):
 
-- `wheels-dev/apt-wheels-dev` — Cloudflare Pages site at `apt.wheels.dev`
-- `wheels-dev/yum-wheels-dev` — Cloudflare Pages site at `yum.wheels.dev`
+- `wheels-dev/apt-wheels` — Cloudflare Pages site at `apt.wheels.dev`
+- `wheels-dev/yum-wheels` — Cloudflare Pages site at `yum.wheels.dev`
 
 Each repo holds the static metadata tree (Packages.gz, repodata/, etc.) plus
 the `.deb` / `.rpm` files in a `pool/` directory. A CI workflow listens for
@@ -129,12 +129,12 @@ The remaining work is operational:
    `wheels.gpg` (template placeholders live at
    `<bucket>/templates/wheels.gpg.placeholder`).
 2. **Create the two bucket repos** under `wheels-dev`:
-   - `wheels-dev/apt-wheels-dev` — copy contents of `apt-repo/` template
-   - `wheels-dev/yum-wheels-dev` — copy contents of `yum-repo/` template
+   - `wheels-dev/apt-wheels` — copy contents of `apt-repo/` template
+   - `wheels-dev/yum-wheels` — copy contents of `yum-repo/` template
 3. **Create two CF Pages projects** pointing at the new repos, binding the
    apex domains:
-   - `wheels-dev/apt-wheels-dev` → `apt.wheels.dev`
-   - `wheels-dev/yum-wheels-dev` → `yum.wheels.dev`
+   - `wheels-dev/apt-wheels` → `apt.wheels.dev`
+   - `wheels-dev/yum-wheels` → `yum.wheels.dev`
 4. **Add CI secrets** to `wheels-dev/wheels` (for the dispatch sender) and to
    each bucket repo (for the signing receiver):
    - On `wheels-dev/wheels`:
@@ -142,14 +142,14 @@ The remaining work is operational:
        on both bucket repos. The dispatch step in `release.yml` skips
        silently when this secret is unset, so it's safe to land the wiring
        before the bucket repos exist.
-   - On each bucket repo (`apt-wheels-dev`, `yum-wheels-dev`):
+   - On each bucket repo (`apt-wheels`, `yum-wheels`):
      - `WHEELS_REPO_GPG_PRIVATE_KEY` — ASCII-armored private key
      - `WHEELS_REPO_GPG_PASSPHRASE` — passphrase
 5. **Smoke-test** by running the bucket-repo workflows manually (each
    supports `workflow_dispatch` for backfill). For the apt bucket:
    ```
    gh workflow run wheels-released.yml \
-     --repo wheels-dev/apt-wheels-dev \
+     --repo wheels-dev/apt-wheels \
      -f version=4.0.0 -f channel=stable
    ```
    then verify the published tree on a fresh Debian/Ubuntu host. Do the same

--- a/tools/distribution-drafts/yum-repo/README.md
+++ b/tools/distribution-drafts/yum-repo/README.md
@@ -1,6 +1,6 @@
-# `yum-wheels-dev` bucket repo template
+# `yum-wheels` bucket repo template
 
-This directory is the **template** for the standalone `wheels-dev/yum-wheels-dev`
+This directory is the **template** for the standalone `wheels-dev/yum-wheels`
 repository that backs `https://yum.wheels.dev`. The bucket repo holds the
 static yum metadata tree plus the pooled `.rpm` artifacts, and is auto-deployed
 to Cloudflare Pages on every push.
@@ -79,7 +79,7 @@ so `rpmvercmp` orders snapshot releases below the next GA correctly.
 Same GPG key as the apt repo (one key for both, importable on both clients
 via `https://apt.wheels.dev/wheels.gpg` or `https://yum.wheels.dev/wheels.gpg`).
 
-CI secrets on `https://github.com/wheels-dev/yum-wheels-dev/settings/secrets/actions`:
+CI secrets on `https://github.com/wheels-dev/yum-wheels/settings/secrets/actions`:
 - `WHEELS_REPO_GPG_PRIVATE_KEY` — ASCII-armored private key
 - `WHEELS_REPO_GPG_PASSPHRASE` — passphrase
 

--- a/tools/distribution-drafts/yum-repo/templates/index.html
+++ b/tools/distribution-drafts/yum-repo/templates/index.html
@@ -72,7 +72,7 @@ sudo dnf install wheels-be</code></pre>
   <pre><code>sudo dnf upgrade wheels        # or wheels-be</code></pre>
 
   <h2>Signing key</h2>
-  <p>The repository is signed with the Wheels project key. The public half is published at <a href="/wheels.gpg"><code>/wheels.gpg</code></a>. Both <code>.repo</code> files reference it via <code>gpgkey=</code>, so <code>dnf</code> imports it automatically on first refresh. The fingerprint is committed to the <a href="https://github.com/wheels-dev/yum-wheels-dev">source repo</a> in <code>FINGERPRINT</code> for offline verification.</p>
+  <p>The repository is signed with the Wheels project key. The public half is published at <a href="/wheels.gpg"><code>/wheels.gpg</code></a>. Both <code>.repo</code> files reference it via <code>gpgkey=</code>, so <code>dnf</code> imports it automatically on first refresh. The fingerprint is committed to the <a href="https://github.com/wheels-dev/yum-wheels">source repo</a> in <code>FINGERPRINT</code> for offline verification.</p>
 
   <h2>Other platforms</h2>
   <ul>
@@ -82,7 +82,7 @@ sudo dnf install wheels-be</code></pre>
   </ul>
 
   <footer>
-    <p>Hosted on Cloudflare Pages. Repository contents at <a href="https://github.com/wheels-dev/yum-wheels-dev">wheels-dev/yum-wheels-dev</a>.</p>
+    <p>Hosted on Cloudflare Pages. Repository contents at <a href="https://github.com/wheels-dev/yum-wheels">wheels-dev/yum-wheels</a>.</p>
   </footer>
 </main>
 </body>

--- a/tools/distribution-drafts/yum-repo/workflows/wheels-released.yml
+++ b/tools/distribution-drafts/yum-repo/workflows/wheels-released.yml
@@ -1,4 +1,4 @@
-# Receiver workflow for `wheels-dev/yum-wheels-dev`.
+# Receiver workflow for `wheels-dev/yum-wheels`.
 #
 # Listens for `repository_dispatch` from `wheels-dev/wheels`'s release workflow,
 # downloads the new `.rpm` asset from the upstream GitHub Release, slots it


### PR DESCRIPTION
## Summary

Phase 2 Linux native-repo templates and dispatch wiring referenced `wheels-dev/apt-wheels-dev` and `wheels-dev/yum-wheels-dev`. The `-dev` suffix appeared to mirror the DNS form (`apt.wheels.dev` → `apt-wheels-dev`) but it reads as a redundant org echo inside the `wheels-dev` org and breaks the established `<package-manager>-wheels` convention used by every other sister repo.

Existing sister repos in `wheels-dev`:

| Existing repo | Pattern |
|---|---|
| `homebrew-wheels` | `<pm>-wheels` |
| `scoop-wheels` | `<pm>-wheels` |
| `chocolatey-wheels` | `<pm>-wheels` |

Phase 2 should follow:

| Renamed to | Was |
|---|---|
| `wheels-dev/apt-wheels` | `wheels-dev/apt-wheels-dev` |
| `wheels-dev/yum-wheels` | `wheels-dev/yum-wheels-dev` |

## Why now

@bpamiri created the two bucket repos under the new names earlier today (2026-05-21 ~20:15 UTC). The repos exist and are non-empty. This PR brings every in-tree reference into agreement with the on-GitHub reality so the first end-to-end `repository_dispatch` fires at the correct target.

No live infrastructure references the old names yet — Cloudflare Pages bindings, DNS records, and bucket-side CI secrets are all post-rename work.

## Related Issue

Touches [#2605](https://github.com/wheels-dev/wheels/issues/2605) (Phase 2 standup) — doesn't close it; the operational work (GPG key, CF Pages, secrets, smoke test, docs swap) is still ahead.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Documentation update
- [x] Refactoring (mechanical rename across templates + dispatch wiring)

## Feature Completeness Checklist

- [x] **DCO sign-off** — `Signed-off-by:` trailer present
- [x] **Tests** — N/A; no executable code paths touched, only YAML/Markdown/HTML string substitutions in templates and workflow dispatch targets
- [x] **Framework Docs** — N/A; this is org-level repo naming, not framework behavior
- [x] **AI Reference Docs** — N/A; no `.ai/` references to the old names
- [x] **CLAUDE.md** — N/A
- [x] **CHANGELOG.md** — intentionally skipped; pure repo-naming hygiene with zero user-visible behavior change (the actual Phase 2 user-facing flow doesn't ship until apt/yum bucket repos are live, which is operational work separate from this PR)
- [x] **Verification** — `grep -rn "apt-wheels-dev\|yum-wheels-dev"` across `.github/`, `tools/`, `web/`, `.ai/`, `CLAUDE.md` returns zero matches post-rename. `wheels-dev/apt-wheels` and `wheels-dev/yum-wheels` confirmed to exist via `gh repo view`.

## Test Plan

- [ ] CI green (no functional change, but workflow YAML lints + structural tests should pass cleanly)
- [ ] Once Phase 2 secrets land and the first `release.yml` run fires the Linux dispatch step, confirm it targets the renamed repos (visible in the workflow logs as "Dispatching wheels-released to wheels-dev/apt-wheels...")

## Files touched (9)

| File | Substitutions |
|---|---|
| `.github/workflows/release.yml` | 10 |
| `.github/workflows/snapshot.yml` | 2 |
| `tools/distribution-drafts/linux-packages/README.md` | 9 |
| `tools/distribution-drafts/apt-repo/README.md` | 3 |
| `tools/distribution-drafts/apt-repo/templates/index.html` | 2 |
| `tools/distribution-drafts/apt-repo/workflows/wheels-released.yml` | 1 |
| `tools/distribution-drafts/yum-repo/README.md` | 3 |
| `tools/distribution-drafts/yum-repo/templates/index.html` | 2 |
| `tools/distribution-drafts/yum-repo/workflows/wheels-released.yml` | 1 |

Total: 9 files, 27 substitutions (`27 insertions(+), 27 deletions(-)` — pure 1:1 rename, no other content drift).

## Follow-up (not in this PR)

- [ ] Edit the body of issue [#2605](https://github.com/wheels-dev/wheels/issues/2605) to reference the new names (separate from code, requires repo-owner edit)
- [ ] Operational steps for Phase 2 (GPG key, CF Pages bindings, secrets, smoke test, docs swap to use sources.list / dnf config-manager flow)