### PR TITLE
ci: allow-list APPROVED + CHANGES_REQUESTED in Reviewer A guard

### DIFF
--- a/.github/workflows/bot-review-a.yml
+++ b/.github/workflows/bot-review-a.yml
@@ -143,15 +143,16 @@ jobs:
         run: |
           set -euo pipefail
 
-          # COMMENTED reviews are filtered out: GitHub's dismiss API returns 422
-          # ("Can not dismiss a commented pull request review") for them, which
-          # would fail this step and red-X the check. Only APPROVED and
-          # CHANGES_REQUESTED reviews can be dismissed — and those are also the
-          # only states that gate merging, so COMMENTED placeholders are noise
-          # the guard shouldn't act on. Observed on PR #2795 commit 0db188a5.
+          # Allow-list APPROVED and CHANGES_REQUESTED only: those are the
+          # exclusive set of states that (a) GitHub's dismiss API accepts and
+          # (b) gate merging. Feeding the dismiss API any other state returns
+          # HTTP 422 — e.g. "Can not dismiss a commented pull request review"
+          # for COMMENTED, the same shape for PENDING — which would fail this
+          # step and red-X the check. Originally observed on PR #2795 commit
+          # 0db188a5 when a COMMENTED placeholder leaked through.
           reviews=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" --paginate \
             | jq -c --arg sha "$HEAD_SHA" \
-                '[.[] | select(.user.login == "wheels-bot[bot]") | select(.commit_id == $sha) | select(.state != "DISMISSED") | select(.state != "COMMENTED")]')
+                '[.[] | select(.user.login == "wheels-bot[bot]") | select(.commit_id == $sha) | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED")]')
 
           count=$(echo "$reviews" | jq 'length')
           if [[ "$count" == "0" ]]; then

--- a/.github/workflows/bot-review-a.yml
+++ b/.github/workflows/bot-review-a.yml
@@ -143,9 +143,15 @@ jobs:
         run: |
           set -euo pipefail
 
+          # COMMENTED reviews are filtered out: GitHub's dismiss API returns 422
+          # ("Can not dismiss a commented pull request review") for them, which
+          # would fail this step and red-X the check. Only APPROVED and
+          # CHANGES_REQUESTED reviews can be dismissed — and those are also the
+          # only states that gate merging, so COMMENTED placeholders are noise
+          # the guard shouldn't act on. Observed on PR #2795 commit 0db188a5.
           reviews=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" --paginate \
             | jq -c --arg sha "$HEAD_SHA" \
-                '[.[] | select(.user.login == "wheels-bot[bot]") | select(.commit_id == $sha) | select(.state != "DISMISSED")]')
+                '[.[] | select(.user.login == "wheels-bot[bot]") | select(.commit_id == $sha) | select(.state != "DISMISSED") | select(.state != "COMMENTED")]')
 
           count=$(echo "$reviews" | jq 'length')
           if [[ "$count" == "0" ]]; then


### PR DESCRIPTION
## Summary

- The post-submission guard in [bot-review-a.yml](.github/workflows/bot-review-a.yml) tries to dismiss "bogus" wheels-bot reviews on the head SHA via `gh api -X PUT .../reviews/${id}/dismissals`. GitHub's dismiss API only accepts `APPROVED` or `CHANGES_REQUESTED` — passing a `COMMENTED` review id returns HTTP 422 (`Can not dismiss a commented pull request review`) and crashes the step, red-X'ing the Reviewer A check even when A's actual substantive review landed cleanly seconds earlier.
- wheels-bot itself occasionally posts placeholder `COMMENTED` reviews mid-cycle while it probes `gh pr review` before issuing the real one (observed bodies: `placeholder test - ignore`, `placeholder2 - updating`, `test with dollar sign: see \$reincludeGlobals function`). The guard's job is to clean them up — but it can't dismiss them via this endpoint, so it has to skip them.
- Add `select(.state != "COMMENTED")` to the jq pipeline that selects actionable reviews. `COMMENTED` reviews don't gate merging anyway — only `APPROVED` and `CHANGES_REQUESTED` do — so leaving them in PR history is acceptable noise. The guard now only acts on what it can actually dismiss.

Observed on [#2795](https://github.com/wheels-dev/wheels/pull/2795) commit `0db188a5a5d27cd80b58939df5e0c8dd7464a00b`, [job run 26296842347](https://github.com/wheels-dev/wheels/actions/runs/26296842347/job/77411584235).

## Filter behavior

Tested the new jq filter against representative inputs:

| State | Result |
|---|---|
| `COMMENTED` (placeholder) | filtered out (new) |
| `APPROVED` (still gated by 200-char + marker checks) | kept |
| `CHANGES_REQUESTED` (still gated by 200-char + marker checks) | kept |
| `DISMISSED` (already terminal) | filtered out (existing) |
| `APPROVED` on wrong SHA | filtered out (existing) |
| `APPROVED` from a human reviewer | filtered out (existing) |

## Test plan

- [ ] CI: existing workflows pass on this PR (no test logic touched; the only file changed is `.github/workflows/bot-review-a.yml`).
- [ ] Behavioral: wait for a future PR where wheels-bot's Reviewer A posts a `COMMENTED` placeholder mid-cycle. The guard should now log `No active wheels-bot reviews on <sha> to validate` (if the placeholder was the only one) or proceed to evaluate the APPROVED/CHANGES_REQUESTED review without 422-ing.
- [ ] Negative: confirm an actual bogus APPROVED review on a future PR (one with a stub body < 200 chars) still gets dismissed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)