### PR TITLE
feat(migrator): doctor/forget/pretend reconciliation commands (#2780)

### DIFF
--- a/.ai/wheels/troubleshooting/shared-dev-databases.md
+++ b/.ai/wheels/troubleshooting/shared-dev-databases.md
@@ -37,14 +37,40 @@ If SOME DB versions > target are orphans and SOME have local files, the
 down branch runs as usual but emits a warning naming the orphans (they
 get skipped by the existing loop because it iterates files only).
 
+## Reconciliation commands
+
+Three CLI subcommands for manual reconciliation against the tracking
+table (Flyway `validate` / `repair` / `SkipExecutingMigrations`
+analogues):
+
+- `wheels migrate doctor` — comprehensive health report. Reads
+  `Migrator.doctor()`. Pure read; no mutation. Reports orphans,
+  pending, and applied counts with a human-readable summary.
+- `wheels migrate forget <version> --yes` — removes a single row
+  from `wheels_migrator_versions`. Requires `--yes`. Refuses if the
+  version has a matching local file (use `migrate down` instead) or
+  if it's not in the tracking table.
+- `wheels migrate pretend <version> --yes` — inserts a row without
+  running `up()`. Requires `--yes`. Refuses if already applied or
+  if no local file matches.
+
+Implementation:
+- `Migrator.cfc::doctor()`, `forgetVersion()`, `pretendVersion()`
+- `cli.cfm` cases: `doctor`, `forgetVersion`, `pretendVersion`
+- `Module.cfc::runForgetOrPretend()` handles `--yes` gating
+- Tests: `vendor/wheels/tests/specs/migrator/MigratorReconciliationSpec.cfc`
+
 ## Related
 
 - Issue #2780 (the original report)
-- PR #2798 (the fix)
+- PR #2798 (orphan detection + info display + docs, merged 2026-05-22)
 - `vendor/wheels/Migrator.cfc::$getOrphanVersions()`
 - `vendor/wheels/Migrator.cfc::$buildInfoOutput()`
+- `vendor/wheels/Migrator.cfc::doctor()`
+- `vendor/wheels/Migrator.cfc::forgetVersion()`
+- `vendor/wheels/Migrator.cfc::pretendVersion()`
 - `vendor/wheels/tests/specs/migrator/OrphanDetectionSpec.cfc`
 - `vendor/wheels/tests/specs/migrator/MigratorInfoSpec.cfc`
-- Follow-up work (separate PRs):
-  - `wheels migrate doctor` / `forget` / `pretend` for manual reconciliation
+- `vendor/wheels/tests/specs/migrator/MigratorReconciliationSpec.cfc`
+- Follow-up work (separate PR):
   - Schema enrichment of `wheels_migrator_versions` (add `name` and `applied_at` columns)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 
 # [Unreleased]
 
+### Added
+
+- Three new `wheels migrate` subcommands for manual reconciliation against the tracking table — Flyway `validate` / `repair` / `SkipExecutingMigrations` analogues. `wheels migrate doctor` prints a single-command health report covering applied/pending/orphan versions plus a human-readable summary; pure read, never mutates. `wheels migrate forget <version> --yes` removes a single orphan row from `wheels_migrator_versions` (refuses if a matching local file exists — use `migrate down` for legitimate rollbacks — and refuses if the version isn't in the table). `wheels migrate pretend <version> --yes` records a version as applied without running its `up()` (refuses if already applied or if no local file matches, so future `down()` calls still work). Both `forget` and `pretend` require explicit `--yes` to mutate; without it they print what would happen and exit. Implementation lives in `Migrator.cfc::doctor()`, `forgetVersion()`, `pretendVersion()`. Covers the shared-dev-DB pattern surfaced in #2780 beyond what the orphan auto-detection in #2798 could resolve automatically.
+
 ### Fixed
 
 - `wheels migrate latest` no longer takes a misleading "down" branch and silently no-ops when `wheels_migrator_versions` records a version whose migration file isn't in the current checkout (shared dev DB / peer migration not yet pulled). `Migrator.migrateTo()` now diffs the tracking table against `app/migrator/migrations/` via the new `$getOrphanVersions()` helper and branches on orphan-at-top before the existing direction check — applying pending local migrations with a clear warning when all DB versions above target are orphans, emitting "Nothing to do" naming target vs current when none are pending, and warning + letting the existing down loop continue in mixed cases (orphan rows skip naturally because the loop iterates files). `wheels migrate info` also now shows orphan rows with `[?] <version> ********** NO FILE **********` (Rails-style) and a footer explaining the cause (#2780)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -540,6 +540,18 @@ Specs extend `wheels.wheelstest.BrowserTest`. Install Playwright once: `wheels b
 
 ## Migrations & Seeding
 
+### Shared Dev DB Reconciliation
+
+`wheels_migrator_versions` can drift from on-disk files when several developers share a single dev database (peer applied a migration whose file isn't yet in your branch). Detected and surfaced automatically; reconciliation is explicit:
+
+- `wheels migrate latest` — when a peer's tracked version sits above your latest local file, it now applies pending local migrations with a warning instead of silently no-op'ing on a "down" branch.
+- `wheels migrate info` — orphan rows render as `[?] <version> ********** NO FILE **********` (Rails-style) with a footer explaining the cause.
+- `wheels migrate doctor` — single-command health report. Lists orphans + pending; pure read.
+- `wheels migrate forget <version> --yes` — delete a stale tracking row (refuses if a matching local file exists, refuses if version not in table).
+- `wheels migrate pretend <version> --yes` — record a version as applied without running `up()` (refuses if already applied or no matching file).
+
+Both `forget` and `pretend` are dry-run by default; `--yes` is required to mutate. Helpers live on `Migrator.cfc`: `$getOrphanVersions()`, `doctor()`, `forgetVersion()`, `pretendVersion()`, `$buildInfoOutput()`. Deep reference: [.ai/wheels/troubleshooting/shared-dev-databases.md](.ai/wheels/troubleshooting/shared-dev-databases.md). User-facing guide: `web/sites/guides/src/content/docs/v4-0-0/basics/shared-development-databases.mdx`. Shipped in #2798 + #2799.
+
 ### Auto-Migration
 
 Generate migrations from model/DB schema diffs. Rename detection via explicit hints (authoritative) + heuristic suggestions (normalized-token + Levenshtein).
@@ -688,7 +700,8 @@ Prefer MCP tools when the Wheels MCP server is available. Fall back to CLI other
 | Task | MCP | CLI |
 |------|-----|-----|
 | Generate | `wheels_generate(type, name, attributes)` | `wheels g model/controller/scaffold Name attrs` |
-| Migrate | `wheels_migrate(action="latest\|up\|down\|info")` | `wheels migrate latest\|up\|down\|info` |
+| Migrate | `wheels_migrate(action="latest\|up\|down\|info\|doctor")` | `wheels migrate latest\|up\|down\|info\|doctor` |
+| Migrator reconciliation | — | `wheels migrate forget\|pretend <version> --yes` (shared dev DB orphan cleanup; see #2780) |
 | Test | `wheels_test()` | `wheels test run` |
 | Reload | `wheels_reload()` | `?reload=true&password=...` |
 | Server | `wheels_server(action="status")` | `wheels start\|stop\|status` |
@@ -711,6 +724,7 @@ Search `.ai/` for deeper documentation:
 - [.ai/wheels/channels/channels.md](.ai/wheels/channels/channels.md)
 - [.ai/wheels/snippets/model-snippets.md](.ai/wheels/snippets/model-snippets.md), [controller-snippets.md](.ai/wheels/snippets/controller-snippets.md)
 - [.ai/wheels/troubleshooting/common-errors.md](.ai/wheels/troubleshooting/common-errors.md), [form-helper-errors.md](.ai/wheels/troubleshooting/form-helper-errors.md)
+- [.ai/wheels/troubleshooting/shared-dev-databases.md](.ai/wheels/troubleshooting/shared-dev-databases.md) — Orphan-version handling + `migrate doctor` / `forget` / `pretend` reconciliation commands (#2780)
 - [.ai/cfml/](.ai/cfml/) — CFML language reference (syntax, components, control flow)
 
 **External:** user-facing guides at `web/sites/guides/src/content/docs/v4-0-0/` (deployment, command-line-tools/mcp-integration, etc.) — these ship to guides.wheels.dev. Use when you need the version Wheels users read.

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -347,6 +347,17 @@ component extends="modules.BaseModule" {
 					out("Migration failed: #e.message#", "red");
 					return "";
 				}
+			case "doctor":
+				try {
+					return runMigration("doctor");
+				} catch (MigrationError e) {
+					out("Doctor failed: #e.message#", "red");
+					return "";
+				}
+			case "forget":
+				return runForgetOrPretend("forgetVersion", args);
+			case "pretend":
+				return runForgetOrPretend("pretendVersion", args);
 			case "rename-system-tables":
 				// F15 Phase 2: opt-in one-shot rename of legacy c_o_r_e_*
 				// system tables to wheels_*. Idempotent (no-op when nothing
@@ -363,7 +374,7 @@ component extends="modules.BaseModule" {
 				}
 			default:
 				out("Unknown migration action: #action#", "red");
-				out("Usage: wheels migrate [latest|up|down|info|rename-system-tables]");
+				out("Usage: wheels migrate [latest|up|down|info|doctor|forget|pretend|rename-system-tables]");
 				return "";
 		}
 	}
@@ -3336,6 +3347,7 @@ component extends="modules.BaseModule" {
 			case "up":     command = "migrateUp"; break;
 			case "down":   command = "migrateDown"; break;
 			case "info":   command = "info"; break;
+			case "doctor": command = "doctor"; break;
 		}
 
 		var migrateUrl = "http://localhost:#serverPort#/wheels/cli?command=#command#&format=json";
@@ -3361,6 +3373,69 @@ component extends="modules.BaseModule" {
 			out("Migration #action# completed.", "green");
 		}
 
+		return "";
+	}
+
+	private string function runForgetOrPretend(required string command, required array args) {
+		// `forget` and `pretend` require an explicit <version> arg plus
+		// `--yes` to confirm. Default behavior is to print what would
+		// happen and refuse without the flag. See issue #2780.
+		var version = "";
+		var yes = false;
+		for (var i = 2; i <= arrayLen(arguments.args); i++) {
+			var a = arguments.args[i];
+			if (a == "--yes" || a == "-y") {
+				yes = true;
+			} else if (!a.startsWith("--")) {
+				version = a;
+			}
+		}
+
+		var verb = arguments.command == "forgetVersion" ? "forget" : "pretend";
+
+		if (!Len(version)) {
+			out("Missing required argument: <version>", "red");
+			out("Usage:");
+			out("  wheels migrate #verb# <version> --yes");
+			return "";
+		}
+
+		if (!yes) {
+			out("This will modify wheels_migrator_versions.", "yellow");
+			out("Re-run with --yes to confirm:", "yellow");
+			out("  wheels migrate #verb# #version# --yes");
+			return "";
+		}
+
+		var serverPort = $requireRunningServer([
+			"Migration reconciliation requires a running server.",
+			"Start one with: wheels start"
+		]);
+
+		out("Running #verb# for version #version#...", "cyan");
+
+		var reconcileUrl = "http://localhost:#serverPort#/wheels/cli?command=#arguments.command#&version=#version#&format=json";
+
+		var httpResult = "";
+		try {
+			httpResult = makeHttpRequest(reconcileUrl);
+		} catch (any httpErr) {
+			throw(
+				type    = "MigrationError",
+				message = "#verb# failed (connection error): #httpErr.message#",
+				detail  = httpErr.detail ?: ""
+			);
+		}
+
+		var parsed = isJSON(httpResult) ? deserializeJSON(httpResult) : {success: false, message: "Invalid response"};
+		var success = parsed.success ?: false;
+		var msg = parsed.message ?: "";
+
+		if (success) {
+			out(msg, "green");
+		} else {
+			out(msg, "red");
+		}
 		return "";
 	}
 

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -3414,7 +3414,11 @@ component extends="modules.BaseModule" {
 
 		out("Running #verb# for version #version#...", "cyan");
 
-		var reconcileUrl = "http://localhost:#serverPort#/wheels/cli?command=#arguments.command#&version=#version#&format=json";
+		// URL-encode version: $sanitiseVersion() on the server side strips
+		// non-digits before SQL use (no injection path), but raw URL-special
+		// characters (&, =, %) in the CLI argument could still inject
+		// spurious query parameters before reaching that point.
+		var reconcileUrl = "http://localhost:#serverPort#/wheels/cli?command=#arguments.command#&version=#URLEncodedFormat(version)#&format=json";
 
 		var httpResult = "";
 		try {

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -3367,10 +3367,19 @@ component extends="modules.BaseModule" {
 		// the previous code silently treated it as success. See issue #2315.
 		var result = parseCliResponse(httpResult, "Migration #action#");
 
+		// For `doctor`, switch the output color to yellow when the report
+		// signals unhealthy state (orphans or pending migrations). Green
+		// on an unhealthy result reads as "everything's fine" when it
+		// isn't. Other actions stay green on success.
+		var color = "green";
+		if (arguments.action == "doctor" && structKeyExists(result, "healthy") && !result.healthy) {
+			color = "yellow";
+		}
+
 		if (structKeyExists(result, "message") && len(result.message)) {
-			out(result.message, "green");
+			out(result.message, color);
 		} else {
-			out("Migration #action# completed.", "green");
+			out("Migration #action# completed.", color);
 		}
 
 		return "";

--- a/vendor/wheels/Migrator.cfc
+++ b/vendor/wheels/Migrator.cfc
@@ -782,11 +782,10 @@ component output="false" extends="wheels.Global"{
 				return local.rv;
 			}
 		}
-		local.appKey = $appKey();
-		$query(
-			datasource = application[local.appKey].dataSourceName,
-			sql = "DELETE FROM #application[local.appKey].migratorTableName# WHERE version = '#local.cleanVersion#'"
-		);
+		// Delegate the actual delete to the existing private helper so
+		// the request.$wheelsDebugSQL guard fires uniformly — matches
+		// what pretendVersion() does via $setVersionAsMigrated().
+		$removeVersionAsMigrated(local.cleanVersion);
 		local.rv.success = true;
 		local.rv.removed = local.cleanVersion;
 		local.rv.message = "Removed version " & local.cleanVersion & " from the tracking table.";

--- a/vendor/wheels/Migrator.cfc
+++ b/vendor/wheels/Migrator.cfc
@@ -688,6 +688,159 @@ component output="false" extends="wheels.Global"{
 	}
 
 	/**
+	 * Returns a comprehensive health report on the migrator state. Pure
+	 * read — no mutation. Used by `wheels migrate doctor` to surface
+	 * orphans, gaps, and pending migrations in one pass.
+	 *
+	 * Result struct:
+	 *   - healthy: boolean — true iff no orphans AND no pending
+	 *   - currentVersion: string — highest applied version (may be orphan)
+	 *   - orphans: array — DB versions with no matching file
+	 *   - pending: array — local files not yet applied
+	 *   - summary: struct with .total, .applied, .pending, .orphan counts
+	 *   - message: human-readable one-paragraph summary
+	 *
+	 * See issue #2780 / PR #2798 for the orphan detection foundation.
+	 *
+	 * [section: Migrator]
+	 * [category: General Functions]
+	 */
+	public struct function doctor() {
+		local.migrations = getAvailableMigrations();
+		local.orphans = $getOrphanVersions();
+		local.currentVersion = getCurrentMigrationVersion();
+		local.pending = [];
+		local.applied = 0;
+		for (local.m in local.migrations) {
+			if (local.m.status == "migrated") {
+				local.applied++;
+			} else {
+				ArrayAppend(local.pending, local.m.version);
+			}
+		}
+		local.healthy = ArrayLen(local.orphans) == 0 && ArrayLen(local.pending) == 0;
+		local.rv = {
+			healthy: local.healthy,
+			currentVersion: local.currentVersion,
+			orphans: local.orphans,
+			pending: local.pending,
+			summary: {
+				total: ArrayLen(local.migrations),
+				applied: local.applied,
+				pending: ArrayLen(local.pending),
+				orphan: ArrayLen(local.orphans)
+			}
+		};
+		if (local.healthy) {
+			local.rv.message = "Migrator is healthy. " & local.applied & " migration(s) applied, none pending.";
+		} else {
+			local.parts = [];
+			if (ArrayLen(local.pending)) {
+				ArrayAppend(local.parts, ArrayLen(local.pending) & " pending");
+			}
+			if (ArrayLen(local.orphans)) {
+				ArrayAppend(local.parts, ArrayLen(local.orphans) & " orphan");
+			}
+			local.rv.message = "Migrator needs attention: " & ArrayToList(local.parts, ", ") & ".";
+		}
+		return local.rv;
+	}
+
+	/**
+	 * Removes a row from `wheels_migrator_versions` without running
+	 * down(). Only orphan versions (those with no matching local file)
+	 * can be forgotten — for legitimate rollbacks, use `migrate down`.
+	 *
+	 * Returns: {success, removed, message}
+	 *
+	 * @version The version string to forget (digits only after sanitisation).
+	 *
+	 * [section: Migrator]
+	 * [category: General Functions]
+	 */
+	public struct function forgetVersion(required string version) {
+		local.rv = {success: false, removed: "", message: ""};
+		local.cleanVersion = $sanitiseVersion(arguments.version);
+		if (!Len(local.cleanVersion)) {
+			local.rv.message = "Invalid version: must contain at least one digit.";
+			return local.rv;
+		}
+		local.appliedList = ListToArray($getVersionsPreviouslyMigrated());
+		if (!ArrayFind(local.appliedList, local.cleanVersion)) {
+			local.rv.message = "Version " & local.cleanVersion & " was not found in the tracking table.";
+			return local.rv;
+		}
+		// Refuse to forget a version that has a matching local file. The
+		// user almost certainly wants `migrate down` instead; forgetting
+		// would leave the schema mutated but the row gone, hiding state.
+		for (local.m in getAvailableMigrations()) {
+			if (local.m.version == local.cleanVersion) {
+				local.rv.message = "Refusing to forget version " & local.cleanVersion
+					& " because a matching local file exists "
+					& "(app/migrator/migrations/" & local.m.cfcfile & ".cfc). "
+					& "Use `wheels migrate down` to roll it back properly.";
+				return local.rv;
+			}
+		}
+		local.appKey = $appKey();
+		$query(
+			datasource = application[local.appKey].dataSourceName,
+			sql = "DELETE FROM #application[local.appKey].migratorTableName# WHERE version = '#local.cleanVersion#'"
+		);
+		local.rv.success = true;
+		local.rv.removed = local.cleanVersion;
+		local.rv.message = "Removed version " & local.cleanVersion & " from the tracking table.";
+		return local.rv;
+	}
+
+	/**
+	 * Records a version as applied in `wheels_migrator_versions` without
+	 * running its up() method. Useful when a peer applied the migration
+	 * via direct SQL or a different tool and you need the tracking
+	 * table to reflect that. Refuses if the version is already applied,
+	 * or if no local file matches (only known versions can be pretended).
+	 *
+	 * Returns: {success, recorded, message}
+	 *
+	 * @version The version string to record (digits only after sanitisation).
+	 *
+	 * [section: Migrator]
+	 * [category: General Functions]
+	 */
+	public struct function pretendVersion(required string version) {
+		local.rv = {success: false, recorded: "", message: ""};
+		local.cleanVersion = $sanitiseVersion(arguments.version);
+		if (!Len(local.cleanVersion)) {
+			local.rv.message = "Invalid version: must contain at least one digit.";
+			return local.rv;
+		}
+		local.appliedList = ListToArray($getVersionsPreviouslyMigrated());
+		if (ArrayFind(local.appliedList, local.cleanVersion)) {
+			local.rv.message = "Version " & local.cleanVersion & " is already applied. "
+				& "Use `wheels migrate forget` if you need to remove the tracking row.";
+			return local.rv;
+		}
+		local.fileExists = false;
+		for (local.m in getAvailableMigrations()) {
+			if (local.m.version == local.cleanVersion) {
+				local.fileExists = true;
+				break;
+			}
+		}
+		if (!local.fileExists) {
+			local.rv.message = "Refusing to pretend version " & local.cleanVersion
+				& " — no matching file in app/migrator/migrations/. "
+				& "Create the migration file first, then pretend if it has already been applied externally.";
+			return local.rv;
+		}
+		$setVersionAsMigrated(local.cleanVersion);
+		local.rv.success = true;
+		local.rv.recorded = local.cleanVersion;
+		local.rv.message = "Recorded version " & local.cleanVersion & " as applied (up() was not run).";
+		return local.rv;
+	}
+
+	/**
 	 * F15 Phase 1: detect which system-table naming family this app's database
 	 * already uses, and flip the configured names if needed.
 	 *

--- a/vendor/wheels/public/views/cli.cfm
+++ b/vendor/wheels/public/views/cli.cfm
@@ -171,7 +171,75 @@ try {
 				}
 				data.message = ArrayToList(local.lines, Chr(10));
 				break;
-			
+			case "doctor":
+				// Comprehensive migrator health diagnostic. Returns a struct
+				// describing orphans, pending, and applied counts. See #2780.
+				local.report = migrator.doctor();
+				data.healthy = local.report.healthy;
+				data.currentVersion = local.report.currentVersion;
+				data.orphans = local.report.orphans;
+				data.pending = local.report.pending;
+				data.summary = local.report.summary;
+				local.docLines = [];
+				ArrayAppend(local.docLines, local.report.message);
+				ArrayAppend(local.docLines, "");
+				ArrayAppend(local.docLines, "  Datasource: " & data.datasource);
+				ArrayAppend(local.docLines, "  Database type: " & data.databaseType);
+				ArrayAppend(local.docLines, "  Current version: " & (Len(local.report.currentVersion) ? local.report.currentVersion : "0"));
+				ArrayAppend(local.docLines, "  Total migrations: " & local.report.summary.total);
+				ArrayAppend(local.docLines, "    applied: " & local.report.summary.applied);
+				ArrayAppend(local.docLines, "    pending: " & local.report.summary.pending);
+				if (local.report.summary.orphan > 0) {
+					ArrayAppend(local.docLines, "    orphan:  " & local.report.summary.orphan & " (" & ArrayToList(local.report.orphans, ", ") & ")");
+				}
+				if (ArrayLen(local.report.pending) > 0) {
+					ArrayAppend(local.docLines, "");
+					ArrayAppend(local.docLines, "Pending local migrations:");
+					for (local.v in local.report.pending) {
+						ArrayAppend(local.docLines, "  [ ] " & local.v);
+					}
+				}
+				if (ArrayLen(local.report.orphans) > 0) {
+					ArrayAppend(local.docLines, "");
+					ArrayAppend(local.docLines, "Orphan versions (no matching file):");
+					for (local.v in local.report.orphans) {
+						ArrayAppend(local.docLines, "  [?] " & local.v);
+					}
+					ArrayAppend(local.docLines, "");
+					ArrayAppend(local.docLines, "Resolve: `wheels migrate forget <version> --yes` to remove an orphan row,");
+					ArrayAppend(local.docLines, "         or pull the peer's migration file via git.");
+				}
+				data.message = ArrayToList(local.docLines, Chr(10));
+				break;
+			case "forgetVersion":
+				// Remove a row from wheels_migrator_versions without running
+				// down(). Refuses if the version has a matching local file.
+				local.versionArg = request.wheels.params.version ?: "";
+				if (!Len(local.versionArg)) {
+					data.success = false;
+					data.message = "Missing required argument: version. Usage: wheels migrate forget <version>";
+					break;
+				}
+				local.forgetResult = migrator.forgetVersion(local.versionArg);
+				data.success = local.forgetResult.success;
+				data.removed = local.forgetResult.removed;
+				data.message = local.forgetResult.message;
+				break;
+			case "pretendVersion":
+				// Record a version as applied without running up(). Refuses
+				// if already applied or if no local file matches.
+				local.pretendArg = request.wheels.params.version ?: "";
+				if (!Len(local.pretendArg)) {
+					data.success = false;
+					data.message = "Missing required argument: version. Usage: wheels migrate pretend <version>";
+					break;
+				}
+				local.pretendResult = migrator.pretendVersion(local.pretendArg);
+				data.success = local.pretendResult.success;
+				data.recorded = local.pretendResult.recorded;
+				data.message = local.pretendResult.message;
+				break;
+
 			// Database commands
 			case "dbStatus":
 				// Return migration status

--- a/vendor/wheels/tests/specs/migrator/MigratorReconciliationSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/MigratorReconciliationSpec.cfc
@@ -1,0 +1,195 @@
+component extends="wheels.WheelsTest" {
+
+	include "helperFunctions.cfm";
+
+	function beforeAll() {
+		migration = CreateObject("component", "wheels.migrator.Migration").init();
+		migrator = CreateObject("component", "wheels.Migrator").init(
+			migratePath = "/wheels/tests/_assets/migrator/migrations/",
+			sqlPath = "/wheels/tests/_assets/migrator/sql/"
+		);
+	}
+
+	function run() {
+
+		var _isCockroachDB = CreateObject("component", "wheels.migrator.Migration").init().adapter.adapterName() == "CockroachDB";
+
+		var insertOrphan = function(required string version) {
+			queryExecute(
+				"INSERT INTO #application.wheels.migratorTableName# (version, core_level) VALUES ('#arguments.version#', #application.wheels.migrationLevel#)",
+				{},
+				{ datasource = application.wheels.dataSourceName }
+			);
+		};
+
+		describe("doctor()", () => {
+
+			beforeEach(() => {
+				for (local.table in ["c_o_r_e_bunyips", "c_o_r_e_dropbears", "c_o_r_e_hoopsnakes"]) {
+					try { migration.dropTable(local.table); } catch (any e) {}
+				}
+				deleteMigratorVersions(2);
+				$cleanSqlDirectory();
+			});
+
+			afterEach(() => {
+				for (local.table in ["c_o_r_e_bunyips", "c_o_r_e_dropbears", "c_o_r_e_hoopsnakes"]) {
+					try { migration.dropTable(local.table); } catch (any e) {}
+				}
+				deleteMigratorVersions(2);
+				$cleanSqlDirectory();
+			});
+
+			it("returns a clean health struct when DB and files match", () => {
+				if (_isCockroachDB) return;
+				migrator.migrateTo("003");
+				var report = migrator.doctor();
+				expect(report).toBeStruct();
+				expect(report.healthy).toBeTrue();
+				expect(ArrayLen(report.orphans)).toBe(0);
+				expect(ArrayLen(report.pending)).toBe(0);
+				expect(report.summary.applied).toBe(3);
+				expect(report.summary.total).toBe(3);
+			});
+
+			it("flags orphans as unhealthy", () => {
+				if (_isCockroachDB) return;
+				migrator.migrateTo("001");
+				insertOrphan("999");
+				var report = migrator.doctor();
+				expect(report.healthy).toBeFalse();
+				expect(ArrayLen(report.orphans)).toBe(1);
+				expect(report.orphans[1]).toBe("999");
+			});
+
+			it("flags pending local migrations", () => {
+				if (_isCockroachDB) return;
+				migrator.migrateTo("001");
+				var report = migrator.doctor();
+				expect(report.healthy).toBeFalse();
+				expect(ArrayLen(report.pending)).toBe(2);
+			});
+
+			it("includes a human-readable summary message", () => {
+				if (_isCockroachDB) return;
+				migrator.migrateTo("001");
+				insertOrphan("999");
+				var report = migrator.doctor();
+				expect(report.message).toBeString();
+				expect(report.message).toInclude("orphan");
+			});
+
+		});
+
+		describe("forgetVersion()", () => {
+
+			beforeEach(() => {
+				for (local.table in ["c_o_r_e_bunyips", "c_o_r_e_dropbears", "c_o_r_e_hoopsnakes"]) {
+					try { migration.dropTable(local.table); } catch (any e) {}
+				}
+				deleteMigratorVersions(2);
+				$cleanSqlDirectory();
+			});
+
+			afterEach(() => {
+				for (local.table in ["c_o_r_e_bunyips", "c_o_r_e_dropbears", "c_o_r_e_hoopsnakes"]) {
+					try { migration.dropTable(local.table); } catch (any e) {}
+				}
+				deleteMigratorVersions(2);
+				$cleanSqlDirectory();
+			});
+
+			it("removes an orphan version from the tracking table", () => {
+				if (_isCockroachDB) return;
+				migrator.migrateTo("001");
+				insertOrphan("999");
+				var result = migrator.forgetVersion("999");
+				expect(result.success).toBeTrue();
+				expect(result.removed).toBe("999");
+				expect(ArrayLen(migrator.$getOrphanVersions())).toBe(0);
+			});
+
+			it("refuses to forget a version that has a local file", () => {
+				if (_isCockroachDB) return;
+				migrator.migrateTo("002");
+				var result = migrator.forgetVersion("002");
+				expect(result.success).toBeFalse();
+				expect(result.message).toInclude("local file");
+			});
+
+			it("refuses to forget a version that is not in the tracking table", () => {
+				if (_isCockroachDB) return;
+				var result = migrator.forgetVersion("999");
+				expect(result.success).toBeFalse();
+				expect(result.message).toInclude("not found");
+			});
+
+			it("returns a failure for invalid version input", () => {
+				if (_isCockroachDB) return;
+				var result = migrator.forgetVersion("abc");
+				expect(result.success).toBeFalse();
+				expect(result.message).toInclude("Invalid version");
+			});
+
+		});
+
+		describe("pretendVersion()", () => {
+
+			beforeEach(() => {
+				for (local.table in ["c_o_r_e_bunyips", "c_o_r_e_dropbears", "c_o_r_e_hoopsnakes"]) {
+					try { migration.dropTable(local.table); } catch (any e) {}
+				}
+				deleteMigratorVersions(2);
+				$cleanSqlDirectory();
+			});
+
+			afterEach(() => {
+				for (local.table in ["c_o_r_e_bunyips", "c_o_r_e_dropbears", "c_o_r_e_hoopsnakes"]) {
+					try { migration.dropTable(local.table); } catch (any e) {}
+				}
+				deleteMigratorVersions(2);
+				$cleanSqlDirectory();
+			});
+
+			it("records a version as applied without running its up()", () => {
+				if (_isCockroachDB) return;
+				var result = migrator.pretendVersion("001");
+				expect(result.success).toBeTrue();
+				expect(result.recorded).toBe("001");
+				var versions = queryExecute(
+					"SELECT version FROM #application.wheels.migratorTableName# WHERE version = '001'",
+					{},
+					{datasource = application.wheels.dataSourceName}
+				);
+				expect(versions.recordCount).toBe(1);
+				var info = application.wo.$dbinfo(datasource = application.wheels.dataSourceName, type = "tables", pattern = "c_o_r_e_bunyips");
+				expect(ListFindNoCase(ValueList(info.table_name), "c_o_r_e_bunyips")).toBeFalse();
+			});
+
+			it("refuses to pretend a version that is already applied", () => {
+				if (_isCockroachDB) return;
+				migrator.migrateTo("001");
+				var result = migrator.pretendVersion("001");
+				expect(result.success).toBeFalse();
+				expect(result.message).toInclude("already applied");
+			});
+
+			it("refuses to pretend a version that has no local file", () => {
+				if (_isCockroachDB) return;
+				var result = migrator.pretendVersion("999");
+				expect(result.success).toBeFalse();
+				expect(result.message).toInclude("no matching file");
+			});
+
+			it("returns a failure for invalid version input", () => {
+				if (_isCockroachDB) return;
+				var result = migrator.pretendVersion("abc");
+				expect(result.success).toBeFalse();
+				expect(result.message).toInclude("Invalid version");
+			});
+
+		});
+
+	}
+
+}

--- a/web/sites/guides/src/content/docs/v4-0-0/basics/migrations.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/basics/migrations.mdx
@@ -12,7 +12,7 @@ Migrations are versioned CFCs that carry your schema forward and back. Each one 
 
 **You'll learn:**
 
-- The four `wheels migrate` commands and when to reach for each
+- The seven `wheels migrate` subcommands — four for the day-to-day workflow, three for reconciliation when something's off
 - How to generate a migration file and what the timestamped filename means
 - The column builder methods on `createTable` — `string`, `integer`, `datetime`, `references`, `timestamps`
 - How to add and remove indexes and foreign keys without dropping a table
@@ -34,9 +34,19 @@ wheels --version
 - `wheels migrate latest` — apply every pending migration in order. The most common command; you'll run it after pulling someone else's changes.
 - `wheels migrate up` — apply exactly one pending migration. Useful when you want to watch the effect of a single file.
 - `wheels migrate down` — roll back the most recently applied migration. Runs the `down()` method of the newest row in `schema_migrations`.
-- `wheels migrate info` — show which migrations have run and which are still pending. Read-only; safe any time.
+- `wheels migrate info` — show which migrations have run and which are still pending. Read-only; safe any time. Orphan versions (rows in the tracking table with no matching file in `app/migrator/migrations/`) are flagged with `[?] <version> ********** NO FILE **********` so you can spot when a peer's migration has been applied to a shared DB before the file lands in your branch.
 
 The runner wraps each migration in a transaction so a failing `up()` or `down()` rolls back cleanly — the schema either moves fully or not at all.
+
+## Reconciliation subcommands
+
+Three additional subcommands cover the cases where the tracking table and the on-disk files have drifted — most commonly when several developers share a single dev database. Read more in [Shared development databases](/v4-0-0/basics/shared-development-databases/).
+
+- `wheels migrate doctor` — single-command health report. Lists orphans, pending local migrations, and the applied count with a human-readable summary. Read-only; never mutates.
+- `wheels migrate forget <version> --yes` — removes a single row from `wheels_migrator_versions` without running `down()`. Use this only when a peer rolled back their migration but the tracking row stayed. Refuses if the version has a matching local file (use `migrate down` instead) or if the version isn't in the table.
+- `wheels migrate pretend <version> --yes` — records a version as applied without running `up()`. Use this when a peer applied the migration via direct SQL or a different tool and you need the tracking table to reflect that. Refuses if the version is already applied or if no local file matches.
+
+Both `forget` and `pretend` print what they would do and exit if `--yes` is omitted; the flag is required to mutate the tracking table.
 
 ## Generating a migration
 

--- a/web/sites/guides/src/content/docs/v4-0-0/basics/migrations.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/basics/migrations.mdx
@@ -25,7 +25,7 @@ Migrations are versioned CFCs that carry your schema forward and back. Each one 
 
 ## Running migrations
 
-Four subcommands cover the day-to-day workflow. Each one connects to your app's datasource and reads the migration history out of `schema_migrations`, so the app has to be running (or at least reachable) for them to work — see [Installing Wheels](/v4-0-0/start-here/installing/) for the server setup.
+Four subcommands cover the day-to-day workflow. Each one connects to your app's datasource and reads the migration history out of `wheels_migrator_versions`, so the app has to be running (or at least reachable) for them to work — see [Installing Wheels](/v4-0-0/start-here/installing/) for the server setup.
 
 ```bash {test:cli cmd="wheels --version" asserts-stdout="Wheels"}
 wheels --version
@@ -33,7 +33,7 @@ wheels --version
 
 - `wheels migrate latest` — apply every pending migration in order. The most common command; you'll run it after pulling someone else's changes.
 - `wheels migrate up` — apply exactly one pending migration. Useful when you want to watch the effect of a single file.
-- `wheels migrate down` — roll back the most recently applied migration. Runs the `down()` method of the newest row in `schema_migrations`.
+- `wheels migrate down` — roll back the most recently applied migration. Runs the `down()` method of the newest row in `wheels_migrator_versions`.
 - `wheels migrate info` — show which migrations have run and which are still pending. Read-only; safe any time. Orphan versions (rows in the tracking table with no matching file in `app/migrator/migrations/`) are flagged with `[?] <version> ********** NO FILE **********` so you can spot when a peer's migration has been applied to a shared DB before the file lands in your branch.
 
 The runner wraps each migration in a transaction so a failing `up()` or `down()` rolls back cleanly — the schema either moves fully or not at all.
@@ -56,7 +56,7 @@ The generator scaffolds a CFC with `up()` and `down()` stubs and drops it in `ap
 wheels generate migration CreatePosts
 ```
 
-That produces a file named like `20260420143000_create_posts_table.cfc`. The prefix is `YYYYMMDDHHMMSS` — generated from the clock at creation time — and the runner applies migrations in filename order, so the timestamp is what puts your change after everyone else's. Never rename or reorder migration files after they've been committed: the history in `schema_migrations` keys on the filename, and a renamed file looks like a brand-new migration to the runner.
+That produces a file named like `20260420143000_create_posts_table.cfc`. The prefix is `YYYYMMDDHHMMSS` — generated from the clock at creation time — and the runner applies migrations in filename order, so the timestamp is what puts your change after everyone else's. Never rename or reorder migration files after they've been committed: the history in `wheels_migrator_versions` keys on the timestamp prefix, and a renamed file looks like a brand-new migration to the runner.
 
 ## Writing a migration — full example
 

--- a/web/sites/guides/src/content/docs/v4-0-0/basics/shared-development-databases.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/basics/shared-development-databases.mdx
@@ -14,7 +14,8 @@ When several developers share a single development database, the migration track
 
 - What an orphan version is and how to spot it
 - What `wheels migrate latest` does when one is present
-- Three resolution paths and when to use each
+- Four resolution paths and when to use each
+- How `wheels migrate doctor` gives a one-command health view
 - Why we recommend per-developer schemas instead
 
 <Aside type="caution">
@@ -79,15 +80,26 @@ The `[?]` row becomes `[x]` once the file lands. No DB change needed.
 
 ### Option 2: The peer rolled back their migration
 
-If the peer reverted their work but the tracking row stayed (e.g., their `wheels migrate down` failed mid-flight, or they reverted via `git reset --hard` without running `down()`), you need to remove the stale row manually:
+If the peer reverted their work but the tracking row stayed (e.g., their `wheels migrate down` failed mid-flight, or they reverted via `git reset --hard` without running `down()`), use `wheels migrate forget` to remove the stale row:
 
-```sql
-DELETE FROM wheels_migrator_versions WHERE version = '20260521120100';
+```bash
+wheels migrate forget 20260521120100         # prints what would happen
+wheels migrate forget 20260521120100 --yes   # actually removes the row
 ```
 
-<Aside type="note">
-  A future Wheels release will ship `wheels migrate forget &lt;version&gt;` for this workflow. Track [#2780](https://github.com/wheels-dev/wheels/issues/2780) for progress.
-</Aside>
+The command refuses to forget a version that has a matching local file — for legitimate rollbacks, use `wheels migrate down` instead. It also refuses if the version isn't in the tracking table (idempotent).
+
+### Option 2b: The migration was applied via direct SQL
+
+If a teammate applied the migration outside of Wheels (e.g., via a SQL client during incident response), the schema is changed but `wheels_migrator_versions` doesn't know. Use `wheels migrate pretend` once the file lands in your branch:
+
+```bash
+git pull                                       # pull the peer's migration file
+wheels migrate pretend 20260521120100          # prints what would happen
+wheels migrate pretend 20260521120100 --yes    # records the version
+```
+
+The command refuses if the version is already applied (idempotent) or if no local file matches — the file must exist so future operations can roll the version back via `down()`.
 
 ### Option 3: You need to add a new migration
 
@@ -98,6 +110,45 @@ wheels generate migration AddPhoneToUsers
 ```
 
 If for some reason you've manually picked an older timestamp, rename the file to use a current timestamp before running `wheels migrate latest`.
+
+## Comprehensive diagnostic
+
+For a single-command view of migrator health, run:
+
+```bash
+wheels migrate doctor
+```
+
+Sample output when something needs attention:
+
+```
+Migrator needs attention: 1 pending, 1 orphan.
+
+  Datasource: wheels
+  Database type: MySQL
+  Current version: 20260521120100
+  Total migrations: 3
+    applied: 2
+    pending: 1
+    orphan:  1 (20260521120100)
+
+Pending local migrations:
+  [ ] 20260521131000
+
+Orphan versions (no matching file):
+  [?] 20260521120100
+
+Resolve: `wheels migrate forget <version> --yes` to remove an orphan row,
+         or pull the peer's migration file via git.
+```
+
+Healthy output is a single line:
+
+```
+Migrator is healthy. 3 migration(s) applied, none pending.
+```
+
+`doctor` is read-only — it never mutates the tracking table or runs migrations.
 
 ## Alternative: avoid shared dev databases
 


### PR DESCRIPTION
## Summary

Follow-up to #2798. Adds three new `wheels migrate` subcommands for
manual reconciliation against the tracking table — the Flyway
`validate` / `repair` / `SkipExecutingMigrations` analogues for
Wheels.

## What's new

- **`wheels migrate doctor`** — single-command health report. Lists
  orphans, pending local migrations, and applied count. Pure read;
  never mutates. Built on Plan 1's `$getOrphanVersions()`.
- **`wheels migrate forget <version> --yes`** — removes a single
  row from `wheels_migrator_versions` without running `down()`.
  Refuses if the version has a matching local file (use `migrate
  down` instead) or if the version isn't in the table.
- **`wheels migrate pretend <version> --yes`** — inserts a row
  into `wheels_migrator_versions` without running `up()`. Refuses
  if already applied or if no local file matches.

Both `forget` and `pretend` require explicit `--yes` to mutate.
Without it they print what would happen and exit.

## Behavior summary

| Scenario | Before | After |
|---|---|---|
| One-command health check | none | `wheels migrate doctor` (read-only) |
| Peer rolled back, stale row in tracking table | manual `DELETE` SQL | `wheels migrate forget <ver> --yes` (refuses if local file exists) |
| Peer applied via direct SQL, tracking table out of sync | manual `INSERT` SQL | `wheels migrate pretend <ver> --yes` (refuses if already applied or no file) |
| Accidental command without `--yes` | n/a | prints the would-be action; exits without mutation |

## Test plan

- [ ] CI: `compat-matrix.yml` runs the new `MigratorReconciliationSpec`
      across Lucee 5/6/7, Adobe CF 2018/2021/2023/2025, BoxLang ×
      SQLite/H2/MySQL/Postgres/MSSQL/Oracle/CockroachDB. ~12 new
      specs across `doctor()`, `forgetVersion()`, `pretendVersion()`.
- [ ] CI: existing `migratorSpec`, `OrphanDetectionSpec`,
      `MigratorInfoSpec` continue passing.
- [ ] Manual: `wheels migrate doctor` against an app with an orphan
      row produces the expected report with `[?]` row and resolve hint.
- [ ] Manual: `wheels migrate forget 999` (no `--yes`) prints what
      would happen and exits; with `--yes` removes the row.
- [ ] Manual: `wheels migrate pretend 001` (no `--yes`) prints what
      would happen and exits; with `--yes` records the version.

**Note on local verification**: the leaked JVM from another worktree
that blocked Plan 1's local TDD is still holding Tomcat's shutdown
port (8081). Re-runs happen on the CI compat-matrix.

## Follow-up

Plan 3 (separate PR): schema enrichment of `wheels_migrator_versions`
to add `name` and `applied_at` columns. Plan 3 will let `doctor` and
the `[?]` info row show the peer's migration name instead of just
the version timestamp, and let `forget`/`pretend` output reference
the human-readable name.

Refs #2780, #2798