### PR TITLE
fix(migrator): skip transaction commit after rollback in migrateIndividual() (#2811)

### DIFF
--- a/vendor/wheels/Migrator.cfc
+++ b/vendor/wheels/Migrator.cfc
@@ -242,6 +242,10 @@ component output="false" extends="wheels.Global"{
 				local.rv = local.rv & "Error migrating #local.migration.version#.#Chr(13) & Chr(10)##e.message##Chr(13) & Chr(10)##e.detail##Chr(13) & Chr(10)#";
 				transaction action="rollback";
 				StructDelete(request, "$wheelsTransactionWrapper");
+				// Issue #2811: skip the commit below — rollback already closed
+				// the transaction. Mirrors the `break` in migrateTo()'s catch
+				// (no enclosing loop here, so we return instead).
+				return local.rv;
 			}
 			StructDelete(request, "$wheelsTransactionWrapper");
 			transaction action="commit";

--- a/vendor/wheels/Migrator.cfc
+++ b/vendor/wheels/Migrator.cfc
@@ -242,9 +242,9 @@ component output="false" extends="wheels.Global"{
 				local.rv = local.rv & "Error migrating #local.migration.version#.#Chr(13) & Chr(10)##e.message##Chr(13) & Chr(10)##e.detail##Chr(13) & Chr(10)#";
 				transaction action="rollback";
 				StructDelete(request, "$wheelsTransactionWrapper");
-				// Issue #2811: skip the commit below — rollback already closed
-				// the transaction. Mirrors the `break` in migrateTo()'s catch
-				// (no enclosing loop here, so we return instead).
+				// Skip the commit below — rollback already closed the transaction.
+				// Mirrors the `break` in migrateTo()'s catch (no enclosing loop
+				// here, so we return instead).
 				return local.rv;
 			}
 			StructDelete(request, "$wheelsTransactionWrapper");

--- a/vendor/wheels/tests/_assets/migrator-error-path/migrations/004_synthetic_failing_migration.cfc
+++ b/vendor/wheels/tests/_assets/migrator-error-path/migrations/004_synthetic_failing_migration.cfc
@@ -1,0 +1,14 @@
+component extends="wheels.migrator.Migration" hint="Synthetic migration whose up() throws — exercises the migrateIndividual() rollback path. Issue ##2811." {
+
+	function up() {
+		throw(
+			type    = "Wheels.Test.SyntheticFailure",
+			message = "synthetic failure",
+			detail  = "intentional failure to exercise the rollback path in migrateIndividual()"
+		);
+	}
+
+	function down() {
+	}
+
+}

--- a/vendor/wheels/tests/_assets/migrator-error-path/migrations/004_synthetic_failing_migration.cfc
+++ b/vendor/wheels/tests/_assets/migrator-error-path/migrations/004_synthetic_failing_migration.cfc
@@ -1,4 +1,4 @@
-component extends="wheels.migrator.Migration" hint="Synthetic migration whose up() throws — exercises the migrateIndividual() rollback path. Issue ##2811." {
+component extends="wheels.migrator.Migration" hint="Synthetic migration whose up() throws — exercises the migrateIndividual() rollback path." {
 
 	function up() {
 		throw(

--- a/vendor/wheels/tests/specs/migrator/MigrateIndividualErrorPathSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/MigrateIndividualErrorPathSpec.cfc
@@ -1,0 +1,87 @@
+component extends="wheels.WheelsTest" {
+
+	include "helperFunctions.cfm";
+
+	function beforeAll() {
+		migration = CreateObject("component", "wheels.migrator.Migration").init();
+		migrator = CreateObject("component", "wheels.Migrator").init(
+			migratePath = "/wheels/tests/_assets/migrator-error-path/migrations/",
+			sqlPath = "/wheels/tests/_assets/migrator-error-path/sql/"
+		);
+	}
+
+	function run() {
+
+		var _isCockroachDB = CreateObject("component", "wheels.migrator.Migration").init().adapter.adapterName() == "CockroachDB";
+
+		// Issue #2811: when migrateIndividual()'s up() throws, the catch block must
+		// not fall through to `transaction action="commit"` after the rollback.
+		// On Lucee the spurious commit is a silent no-op; on Adobe CF 2023/2025
+		// (and potentially BoxLang) it can throw a JDBC "transaction not active"
+		// error that masks the real migration failure. This spec asserts the
+		// post-fix contract on every engine.
+		describe("migrateIndividual() error path (issue ##2811)", () => {
+
+			beforeEach(() => {
+				deleteMigratorVersions(2);
+				try {
+					queryExecute(
+						"DELETE FROM #application.wheels.migratorTableName# WHERE version = '004'",
+						{},
+						{ datasource = application.wheels.dataSourceName }
+					);
+				} catch (any e) {}
+				$cleanSqlDirectory();
+			});
+
+			afterEach(() => {
+				deleteMigratorVersions(2);
+				try {
+					queryExecute(
+						"DELETE FROM #application.wheels.migratorTableName# WHERE version = '004'",
+						{},
+						{ datasource = application.wheels.dataSourceName }
+					);
+				} catch (any e) {}
+				$cleanSqlDirectory();
+			});
+
+			it("returns normally when the migration's up() throws", () => {
+				if (_isCockroachDB) return;
+				var rv = "";
+				var threw = false;
+				var thrownMessage = "";
+				try {
+					rv = migrator.migrateIndividual("004");
+				} catch (any e) {
+					threw = true;
+					thrownMessage = e.message;
+				}
+				expect(threw).toBeFalse(
+					"migrateIndividual() should catch the migration error and return its message, "
+					& "not propagate an exception. Got: " & thrownMessage
+				);
+				expect(rv).toInclude("Error migrating 004");
+				expect(rv).toInclude("synthetic failure");
+			});
+
+			it("does not record a tracking row when the migration throws", () => {
+				if (_isCockroachDB) return;
+				migrator.migrateIndividual("004");
+				var versions = queryExecute(
+					"SELECT version FROM #application.wheels.migratorTableName# WHERE version = '004'",
+					{},
+					{ datasource = application.wheels.dataSourceName }
+				);
+				expect(versions.recordCount).toBe(
+					0,
+					"The migration's up() threw, so the catch should have rolled back "
+					& "and returned early. No tracking row should exist for version 004."
+				);
+			});
+
+		});
+
+	}
+
+}

--- a/vendor/wheels/tests/specs/migrator/MigrateIndividualErrorPathSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/MigrateIndividualErrorPathSpec.cfc
@@ -14,27 +14,15 @@ component extends="wheels.WheelsTest" {
 
 		var _isCockroachDB = CreateObject("component", "wheels.migrator.Migration").init().adapter.adapterName() == "CockroachDB";
 
-		// Issue #2811: when migrateIndividual()'s up() throws, the catch block must
-		// not fall through to `transaction action="commit"` after the rollback.
-		// On Lucee the spurious commit is a silent no-op; on Adobe CF 2023/2025
-		// (and potentially BoxLang) it can throw a JDBC "transaction not active"
+		// When migrateIndividual()'s up() throws, the catch block must not fall
+		// through to `transaction action="commit"` after the rollback. On Lucee
+		// the spurious commit is a silent no-op; on Adobe CF 2023/2025 (and
+		// potentially BoxLang) it can throw a JDBC "transaction not active"
 		// error that masks the real migration failure. This spec asserts the
 		// post-fix contract on every engine.
-		describe("migrateIndividual() error path (issue ##2811)", () => {
+		describe("migrateIndividual() error path", () => {
 
 			beforeEach(() => {
-				deleteMigratorVersions(2);
-				try {
-					queryExecute(
-						"DELETE FROM #application.wheels.migratorTableName# WHERE version = '004'",
-						{},
-						{ datasource = application.wheels.dataSourceName }
-					);
-				} catch (any e) {}
-				$cleanSqlDirectory();
-			});
-
-			afterEach(() => {
 				deleteMigratorVersions(2);
 				try {
 					queryExecute(


### PR DESCRIPTION
## Summary

`Migrator.migrateIndividual()` issued `transaction action="commit"` unconditionally after its try/catch — including on the error path, where the catch had already issued `transaction action="rollback"`. Unlike the loops in `migrateTo()`, there is no enclosing `for` to `break` out of, so control always fell through to the spurious commit.

On Lucee, the second action against a closed transaction is a silent no-op. On Adobe CF 2023/2025 (and potentially BoxLang) the JDBC driver may throw a "transaction not active" error that masks the real migration failure, making the underlying problem harder to diagnose.

Closes #2811.

## Fix

Return `local.rv` from inside the catch after the rollback. Mirrors the early-exit pattern in `migrateTo()` (which uses `break` to exit its `for` loop and skip the commit); here we use `return` because the `transaction { }` block is not enclosed in a loop.

```diff
 } catch (any e) {
     local.rv = local.rv & "Error migrating #local.migration.version#...";
     transaction action="rollback";
     StructDelete(request, "$wheelsTransactionWrapper");
+    // Issue #2811: skip the commit below — rollback already closed
+    // the transaction. Mirrors the `break` in migrateTo()'s catch
+    // (no enclosing loop here, so we return instead).
+    return local.rv;
 }
 StructDelete(request, "$wheelsTransactionWrapper");
 transaction action="commit";
```

## Regression Spec

New `MigrateIndividualErrorPathSpec.cfc` asserts the post-fix contract:

1. `migrateIndividual()` returns normally when the migration's `up()` throws (no exception escapes).
2. The returned `rv` string contains the original error message.
3. No row is recorded in `wheels_migrator_versions` for the failed version (the rollback held).

The synthetic always-throw migration lives in an isolated fixture directory (`_assets/migrator-error-path/`) so it does not pollute the shared `001/002/003` fixtures that every other migrator spec hard-codes against.

On Lucee the spec passes both with and without the fix (because Lucee silently no-ops the commit-after-rollback). On Adobe CF 2023/2025/BoxLang it serves as the actual bug-catching path. Either way it is a regression guard against future modifications that re-introduce the fall-through.

## Provenance

Diagnosed by both round-1 reviewers on #2810 (the nested-cftransaction fix that lands the surrounding `StructDelete` plumbing) and explicitly recommended as a follow-up rather than expanding that PR's scope. Full diagnosis and pattern comparison against `migrateTo()` in issue #2811.

## Test plan

- [x] `bash tools/test-local.sh migrator` — 240 passed (was 238; +2 for the new spec)
- [x] `bash tools/test-local.sh` — 3782 passed (was 3780; +2 for the new spec); 0 failures, 0 errors
- [ ] CI cross-engine matrix (Lucee 6/7, Adobe 2018/2021/2023/2025, BoxLang × SQLite/H2/MySQL/Postgres/MSSQL/CockroachDB/Oracle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)