### PR TITLE
feat(distribution): land Phase 2 native apt/yum repos via Cloudflare R2

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -52,6 +52,14 @@ jobs:
 
       - name: Build ${{ matrix.site }}
         working-directory: web
+        env:
+          # `sites/packages` calls the GitHub REST API at build time to
+          # enumerate the package registry. Without auth that's capped at
+          # 60 req/hour per runner IP, and rapid CI activity on a single
+          # branch trips the limit (failure mode: 403 from the contents API,
+          # build aborts mid-prerender). Passing GITHUB_TOKEN raises the cap
+          # to 5000/hour. Other site builds ignore the var.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm --filter @wheels-dev/site-${{ matrix.site }} build
 
       - name: Deploy to Cloudflare Pages

--- a/tools/distribution-drafts/apt-repo/README.md
+++ b/tools/distribution-drafts/apt-repo/README.md
@@ -1,9 +1,15 @@
 # `apt-wheels` bucket repo template
 
 This directory is the **template** for the standalone `wheels-dev/apt-wheels`
-repository that backs `https://apt.wheels.dev`. The bucket repo holds the static
-apt metadata tree plus the pooled `.deb` artifacts, and is auto-deployed to
-Cloudflare Pages on every push.
+repository that backs `https://apt.wheels.dev`. The bucket repo holds the
+**workflow + scripts + landing page + signing key**. The apt metadata tree
+(`dists/`) and the `.deb` pool (`pool/`) live in **Cloudflare R2** (bucket
+`wheels-apt`) and are served via R2's custom-domain feature.
+
+> **Note on Pages vs R2:** The original Phase 2 design called for Cloudflare
+> Pages serving the bucket repo directly. Pages has a hard **25 MiB per-file**
+> limit; the `.deb` is ~80 MB. The architecture pivoted to R2 (no per-object
+> size limit) during initial rollout.
 
 Copy these files into the new repo when it's created — they are designed to
 work out of the box once the Phase 2 operational prerequisites (GPG key,
@@ -101,13 +107,15 @@ Before this bucket repo will function:
    into 1Password under `op://Wheels/wheels-linux-repo-signing/` (Wheels
    project vault on `my.1password.com`).
    Public key (ASCII-armored) overwrites `wheels.gpg` at the bucket-repo root.
-2. **Cloudflare Pages** — create a Pages project pointing at this repo, bind
-   the apex domain `apt.wheels.dev`. The build command is empty (the repo
-   *is* the static site); the output dir is `./`.
+2. **R2 bucket** — create a Cloudflare R2 bucket named `wheels-apt` and
+   attach the `apt.wheels.dev` custom domain. R2 has no per-object size
+   limit (unlike Pages' 25 MiB), which is why binaries are stored here.
 3. **CI secrets** (set on the bucket repo at
    `https://github.com/wheels-dev/apt-wheels/settings/secrets/actions`):
    - `WHEELS_REPO_GPG_PRIVATE_KEY` — ASCII-armored private key
    - `WHEELS_REPO_GPG_PASSPHRASE` — passphrase
+   - `CLOUDFLARE_API_TOKEN` — token with `Workers R2 Storage:Edit` on the
+     account that owns the `wheels-apt` bucket
 4. **Upstream dispatch** — the release workflow in `wheels-dev/wheels`
    fires a `repository_dispatch` (`wheels-released`) at this repo when a
    new `.deb` is published to the GitHub Release. The token used by the

--- a/tools/distribution-drafts/apt-repo/workflows/wheels-released.yml
+++ b/tools/distribution-drafts/apt-repo/workflows/wheels-released.yml
@@ -1,19 +1,23 @@
-# Receiver workflow for `wheels-dev/apt-wheels`.
+# Receiver workflow for `wheels-dev/apt-wheels` (R2-backed architecture).
 #
 # Listens for `repository_dispatch` from `wheels-dev/wheels`'s release workflow,
-# downloads the new `.deb` asset from the upstream GitHub Release, slots it
-# into `pool/<channel>/w/<pkg>/`, regenerates the apt metadata via
-# `apt-ftparchive`, signs `Release` + `InRelease` with GPG, and commits the
-# whole tree back to this repo. Cloudflare Pages auto-deploys on push.
+# downloads the new `.deb` asset from the upstream GitHub Release, syncs the
+# existing apt repo state from R2 (so apt-ftparchive can see prior versions),
+# regenerates `Packages.gz` / `Release` / `InRelease` via `apt-ftparchive`,
+# signs with GPG, and uploads the changed tree to the `wheels-apt` R2 bucket
+# (which is served at https://apt.wheels.dev via R2 custom-domain).
+#
+# This repo no longer commits pool/ or dists/ — those are R2-resident only.
+# The repo's job is to hold the WORKFLOW + REGEN SCRIPT + LANDING + GPG KEY.
 #
 # Trigger payload contract (sender: wheels-dev/wheels release.yml):
 #   event_type:    "wheels-released"
 #   client_payload:
-#     version: "<x.y.z>" or "<x.y.z>-snapshot.<n>"   # full SemVer, no leading v
-#     channel: "stable" | "bleeding-edge"             # routes into the pool
+#     version: "<x.y.z>" or "<x.y.z>-snapshot.<n>"
+#     channel: "stable" | "bleeding-edge"
 #
-# Manual dispatch is also supported via `workflow_dispatch` for backfill /
-# disaster-recovery (re-add a missing version without waiting for a new release).
+# Manual dispatch is supported via `workflow_dispatch` for backfill /
+# disaster-recovery.
 
 name: Publish to apt.wheels.dev
 
@@ -36,13 +40,17 @@ on:
           - bleeding-edge
 
 permissions:
-  contents: write   # the workflow commits the regenerated metadata back to this repo
+  contents: read
 
 concurrency:
-  # Serialize across both channels — apt-ftparchive scans the whole pool, so
-  # parallel runs would race on Packages.gz / Release writes.
+  # Serialize across channels — apt-ftparchive scans the whole pool, so
+  # parallel runs would race on the regenerated Packages.gz / Release uploads.
   group: publish-apt
   cancel-in-progress: false
+
+env:
+  R2_BUCKET: wheels-apt
+  CLOUDFLARE_ACCOUNT_ID: "511d04f367103ec276d875ab41a24dea"
 
 jobs:
   publish:
@@ -52,52 +60,53 @@ jobs:
     steps:
       - name: Resolve inputs
         id: inputs
+        env:
+          CLIENT_VERSION: ${{ github.event.client_payload.version }}
+          CLIENT_CHANNEL: ${{ github.event.client_payload.channel }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_CHANNEL: ${{ inputs.channel }}
         run: |
+          set -euo pipefail
           if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            VERSION="${{ github.event.client_payload.version }}"
-            CHANNEL="${{ github.event.client_payload.channel }}"
+            VERSION="$CLIENT_VERSION"
+            CHANNEL="$CLIENT_CHANNEL"
           else
-            VERSION="${{ inputs.version }}"
-            CHANNEL="${{ inputs.channel }}"
+            VERSION="$INPUT_VERSION"
+            CHANNEL="$INPUT_CHANNEL"
           fi
           if [ -z "$VERSION" ] || [ -z "$CHANNEL" ]; then
             echo "::error::Both version and channel are required."
             exit 1
           fi
-          # Reject "release-candidate" and other channels we don't yet plumb.
           case "$CHANNEL" in
             stable|bleeding-edge) ;;
             *) echo "::error::Unsupported channel: $CHANNEL"; exit 1 ;;
           esac
-          # Map channel → package name (mirrors nfpm-wheels.yaml / nfpm-wheels-be.yaml).
           case "$CHANNEL" in
-            stable)        PKG="wheels" ;;
-            bleeding-edge) PKG="wheels-be" ;;
+            stable)        PKG="wheels"; UPSTREAM_REPO="wheels-dev/wheels" ;;
+            bleeding-edge) PKG="wheels-be"; UPSTREAM_REPO="wheels-dev/wheels-snapshots" ;;
           esac
-          # Map channel → upstream releases repo. Stable releases live in
-          # wheels-dev/wheels; snapshot/BE releases live in wheels-dev/wheels-snapshots.
-          case "$CHANNEL" in
-            stable)        UPSTREAM_REPO="wheels-dev/wheels" ;;
-            bleeding-edge) UPSTREAM_REPO="wheels-dev/wheels-snapshots" ;;
-          esac
-          echo "version=$VERSION"           >> "$GITHUB_OUTPUT"
-          echo "channel=$CHANNEL"           >> "$GITHUB_OUTPUT"
-          echo "pkg=$PKG"                   >> "$GITHUB_OUTPUT"
-          echo "upstream_repo=$UPSTREAM_REPO" >> "$GITHUB_OUTPUT"
+          {
+            echo "version=$VERSION"
+            echo "channel=$CHANNEL"
+            echo "pkg=$PKG"
+            echo "upstream_repo=$UPSTREAM_REPO"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Checkout bucket repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          # Persist the workflow token so the trailing `git push` works.
-          persist-credentials: true
 
-      - name: Install apt-ftparchive + gpg
+      - name: Install apt-ftparchive + gpg + wrangler
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends apt-utils gnupg
+          sudo apt-get install -y --no-install-recommends apt-utils gnupg jq
           apt-ftparchive --version
           gpg --version | head -1
+          # wrangler ships with Node — runner has it. Pin to a known-good version.
+          sudo npm install -g wrangler@4.95.0
+          wrangler --version
 
       - name: Import GPG signing key
         env:
@@ -110,11 +119,9 @@ jobs:
             exit 1
           fi
           echo "$GPG_PRIVATE_KEY" | gpg --batch --yes --import
-          # Trust the imported key ultimately so subsequent sign operations don't prompt.
-          # `import-ownertrust` expects the 40-char fingerprint (`fpr:` line, field 10),
-          # NOT the 16-char key_id (`sec:` line, field 5). Using the key_id form emits
-          # a "gpg: error in '[stdin]': invalid fingerprint" warning that's non-fatal
-          # but noisy in CI logs.
+          # import-ownertrust needs the 40-char fingerprint (fpr: field 10),
+          # NOT the 16-char key_id (sec: field 5). Using key_id emits a
+          # non-fatal "invalid fingerprint" warning that's noisy in CI logs.
           FINGERPRINT=$(gpg --list-secret-keys --with-colons \
             | awk -F: '/^fpr:/ { print $10; exit }')
           KEY_ID=$(gpg --list-secret-keys --keyid-format=long --with-colons \
@@ -123,19 +130,46 @@ jobs:
           echo "$FINGERPRINT:6:" | gpg --batch --yes --import-ownertrust
           echo "GPG_KEY_ID=$KEY_ID" >> "$GITHUB_ENV"
 
-      - name: Download .deb from upstream Release
+      - name: Sync existing pool from R2
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CHANNEL: ${{ steps.inputs.outputs.channel }}
+        run: |
+          set -euo pipefail
+          # List all R2 objects under pool/<channel>/ and download each.
+          # apt-ftparchive needs the actual .deb files locally so it can compute
+          # size + sha256 + read package metadata for the Packages index.
+          mkdir -p pool/${CHANNEL}
+          PREFIX="pool/${CHANNEL}/"
+          CURSOR=""
+          while :; do
+            URL="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/r2/buckets/${R2_BUCKET}/objects?prefix=${PREFIX}&per_page=1000"
+            [ -n "$CURSOR" ] && URL="${URL}&cursor=${CURSOR}"
+            RESP=$(curl -sS "$URL" -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}")
+            echo "$RESP" | jq -r '.result[].key' | while IFS= read -r key; do
+              [ -z "$key" ] && continue
+              mkdir -p "$(dirname "$key")"
+              echo "  pulling $key"
+              wrangler r2 object get "${R2_BUCKET}/${key}" --file="$key" --remote >/dev/null 2>&1
+            done
+            CURSOR=$(echo "$RESP" | jq -r '.result_info.cursor // empty')
+            [ -z "$CURSOR" ] && break
+          done
+          echo "Local pool/${CHANNEL}/ contents after sync:"
+          find pool/${CHANNEL}/ -type f | head -20
+
+      - name: Download new .deb from upstream Release
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.inputs.outputs.version }}
-          CHANNEL: ${{ steps.inputs.outputs.channel }}
           PKG: ${{ steps.inputs.outputs.pkg }}
           UPSTREAM_REPO: ${{ steps.inputs.outputs.upstream_repo }}
         run: |
           set -euo pipefail
           mkdir -p incoming
           # GitHub Release URLs rewrite `~` to `.` at upload time. The version
-          # passed in `client_payload.version` uses `-snapshot.N` (SemVer), but
-          # the on-URL filename uses `.snapshot.N`. Translate.
+          # in client_payload uses SemVer hyphen (-snapshot.N); the on-URL form
+          # uses dot (.snapshot.N). Translate before fetch.
           URL_VERSION="${VERSION/-snapshot./.snapshot.}"
           ASSET="${PKG}_${URL_VERSION}_amd64.deb"
           TAG="v${VERSION}"
@@ -144,25 +178,22 @@ jobs:
             --repo "$UPSTREAM_REPO" \
             --pattern "$ASSET" \
             --dir incoming/
-          ls -l incoming/
+          ls -lh incoming/
 
-      - name: Slot .deb into pool/
+      - name: Slot new .deb into local pool
         env:
           VERSION: ${{ steps.inputs.outputs.version }}
           CHANNEL: ${{ steps.inputs.outputs.channel }}
           PKG: ${{ steps.inputs.outputs.pkg }}
         run: |
           set -euo pipefail
-          # Canonical pool form uses `~` (SemVer pre-release separator).
+          # Canonical pool path uses ~-form (SemVer pre-release separator).
           POOL_DIR="pool/${CHANNEL}/${PKG:0:1}/${PKG}"
           POOL_FILE="${POOL_DIR}/${PKG}_${VERSION}_amd64.deb"
           mkdir -p "$POOL_DIR"
-          # The downloaded file uses `.` in the snapshot separator; rename to `~`.
           URL_VERSION="${VERSION/-snapshot./.snapshot.}"
           mv "incoming/${PKG}_${URL_VERSION}_amd64.deb" "$POOL_FILE"
-          echo "Placed: $POOL_FILE"
-          # Idempotency: if the pool already had this version, the mv overwrote
-          # it. Re-runs of the same dispatch are safe (last-writer-wins).
+          echo "Placed: $POOL_FILE ($(du -h "$POOL_FILE" | cut -f1))"
 
       - name: Regenerate apt metadata + sign
         env:
@@ -173,19 +204,35 @@ jobs:
           chmod +x scripts/regenerate-apt-metadata.sh
           ./scripts/regenerate-apt-metadata.sh
 
-      - name: Commit + push
+      - name: Upload pool + dists to R2
         env:
-          VERSION: ${{ steps.inputs.outputs.version }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CHANNEL: ${{ steps.inputs.outputs.channel }}
-          PKG: ${{ steps.inputs.outputs.pkg }}
         run: |
           set -euo pipefail
-          git config user.name  "wheels-release-bot"
-          git config user.email "hello@wheels.dev"
-          git add pool/ dists/
-          if git diff --cached --quiet; then
-            echo "No changes — dispatch must have been a no-op (same version re-published?)."
-            exit 0
-          fi
-          git commit -m "publish: ${PKG} ${VERSION} (${CHANNEL})"
-          git push origin HEAD:main
+          upload_one() {
+            local local_path="$1"
+            local ct="$2"
+            local key="$local_path"
+            echo "  uploading $key (ct=${ct})"
+            wrangler r2 object put "${R2_BUCKET}/${key}" --file="$local_path" --content-type="$ct" --remote >/dev/null 2>&1
+          }
+          # Upload pool files (.deb). Only the one we just added is new, but
+          # uploading all is idempotent (overwrites with same content).
+          find pool/${CHANNEL} -type f -name '*.deb' | while read -r f; do
+            upload_one "$f" "application/vnd.debian.binary-package"
+          done
+          # Upload regenerated dists tree. apt-ftparchive rewrites these on
+          # every run; upload all files in dists/ regardless of channel.
+          find dists -type f | while read -r f; do
+            # Pick a sensible content-type per file
+            case "$f" in
+              *.gz)             ct="application/gzip" ;;
+              *.gpg)            ct="application/pgp-signature" ;;
+              *InRelease|*Release) ct="text/plain" ;;
+              *Packages)        ct="text/plain" ;;
+              *)                ct="application/octet-stream" ;;
+            esac
+            upload_one "$f" "$ct"
+          done
+          echo "R2 upload complete for channel=${CHANNEL}."

--- a/tools/distribution-drafts/apt-repo/workflows/wheels-released.yml
+++ b/tools/distribution-drafts/apt-repo/workflows/wheels-released.yml
@@ -50,7 +50,12 @@ concurrency:
 
 env:
   R2_BUCKET: wheels-apt
-  CLOUDFLARE_ACCOUNT_ID: "511d04f367103ec276d875ab41a24dea"
+  # Cloudflare account ID is not a secret (no auth power on its own), but
+  # keep it as a repo-level Actions variable so the workflow template stays
+  # account-agnostic and so harvesting a public template doesn't hand an
+  # attacker a ready-made API target. Set on the bucket repo:
+  #   gh variable set CLOUDFLARE_ACCOUNT_ID --body '<id>' --repo wheels-dev/apt-wheels
+  CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
 
 jobs:
   publish:
@@ -146,12 +151,29 @@ jobs:
             URL="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/r2/buckets/${R2_BUCKET}/objects?prefix=${PREFIX}&per_page=1000"
             [ -n "$CURSOR" ] && URL="${URL}&cursor=${CURSOR}"
             RESP=$(curl -sS "$URL" -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}")
-            echo "$RESP" | jq -r '.result[].key' | while IFS= read -r key; do
+            # Guard against silent failures: when the token is invalid/expired
+            # or the API rate-limits, success=false comes back with an empty
+            # result array. Without this check, jq emits nothing, the loop
+            # never runs, regen produces a single-package index, and the
+            # upload step overwrites Packages.gz on R2 with that trimmed
+            # index. Every apt update afterward sees the historical packages
+            # vanish from the repo. Fail loud here instead.
+            if ! echo "$RESP" | jq -e '.success == true' >/dev/null; then
+              echo "::error::Cloudflare R2 list API returned success=false (or invalid JSON). Response:"
+              echo "$RESP"
+              exit 1
+            fi
+            # Process substitution (not a pipe) so the while body runs in the
+            # parent shell — pipe-RHS runs in a subshell where set -e in the
+            # parent does not see wrangler's non-zero exit, masking download
+            # failures. Same reasoning: wrangler's stderr is NOT suppressed
+            # so a real failure surfaces in the CI log.
+            while IFS= read -r key; do
               [ -z "$key" ] && continue
               mkdir -p "$(dirname "$key")"
               echo "  pulling $key"
-              wrangler r2 object get "${R2_BUCKET}/${key}" --file="$key" --remote >/dev/null 2>&1
-            done
+              wrangler r2 object get "${R2_BUCKET}/${key}" --file="$key" --remote
+            done < <(echo "$RESP" | jq -r '.result[].key')
             CURSOR=$(echo "$RESP" | jq -r '.result_info.cursor // empty')
             [ -z "$CURSOR" ] && break
           done
@@ -215,16 +237,21 @@ jobs:
             local ct="$2"
             local key="$local_path"
             echo "  uploading $key (ct=${ct})"
-            wrangler r2 object put "${R2_BUCKET}/${key}" --file="$local_path" --content-type="$ct" --remote >/dev/null 2>&1
+            # Do not suppress wrangler output — a silent upload failure would
+            # leave R2 with a stale Packages.gz / Release while the job exits
+            # green.
+            wrangler r2 object put "${R2_BUCKET}/${key}" --file="$local_path" --content-type="$ct" --remote
           }
           # Upload pool files (.deb). Only the one we just added is new, but
           # uploading all is idempotent (overwrites with same content).
-          find pool/${CHANNEL} -type f -name '*.deb' | while read -r f; do
+          # Process substitution (not pipe) so set -e fires on upload_one
+          # failures — pipe-RHS subshell semantics would swallow them.
+          while read -r f; do
             upload_one "$f" "application/vnd.debian.binary-package"
-          done
+          done < <(find pool/${CHANNEL} -type f -name '*.deb')
           # Upload regenerated dists tree. apt-ftparchive rewrites these on
           # every run; upload all files in dists/ regardless of channel.
-          find dists -type f | while read -r f; do
+          while read -r f; do
             # Pick a sensible content-type per file
             case "$f" in
               *.gz)             ct="application/gzip" ;;
@@ -234,5 +261,5 @@ jobs:
               *)                ct="application/octet-stream" ;;
             esac
             upload_one "$f" "$ct"
-          done
+          done < <(find dists -type f)
           echo "R2 upload complete for channel=${CHANNEL}."

--- a/tools/distribution-drafts/linux-packages/README.md
+++ b/tools/distribution-drafts/linux-packages/README.md
@@ -62,17 +62,24 @@ Practical impact for this directory:
 
 ## Phase 2: apt.wheels.dev / yum.wheels.dev (post-Tuesday)
 
-Two new repos (separate from the source monorepo, mirroring the snapshots-repo
-pattern):
+Two-repo pattern (one bucket-control repo per package format):
 
-- `wheels-dev/apt-wheels` — Cloudflare Pages site at `apt.wheels.dev`
-- `wheels-dev/yum-wheels` — Cloudflare Pages site at `yum.wheels.dev`
+- `wheels-dev/apt-wheels` — workflow + scripts + signing key + landing page;
+  the apt metadata + `.deb` pool live in **Cloudflare R2 bucket `wheels-apt`**,
+  served at `apt.wheels.dev` via R2's custom-domain feature.
+- `wheels-dev/yum-wheels` — same pattern; R2 bucket `wheels-yum` serves
+  `yum.wheels.dev`.
 
-Each repo holds the static metadata tree (Packages.gz, repodata/, etc.) plus
-the `.deb` / `.rpm` files in a `pool/` directory. A CI workflow listens for
-`repository_dispatch` from the source repo's release workflows, fetches new
-artifacts, regenerates metadata, signs with GPG, commits and pushes — CF Pages
-auto-deploys on push.
+A CI workflow on each bucket repo listens for `repository_dispatch` from
+the source repo's release workflows, fetches new artifacts, syncs the
+existing pool from R2, regenerates metadata, signs with GPG, and uploads
+the changes back to R2. R2's edge serves the new files within seconds.
+
+> **Why R2 and not Pages:** Cloudflare Pages enforces a hard 25 MiB
+> per-file limit. The Wheels `.deb` and `.rpm` are ~80 MB each. The
+> original Phase 2 sketch used Pages; the architecture pivoted to R2
+> during rollout. End-user URLs are unchanged — both `apt.wheels.dev`
+> and `yum.wheels.dev` still serve at the same paths.
 
 **Filename gotcha for the metadata generator**: when fetching snapshot
 artifacts from the source repo's GitHub Release, the URL filenames have `.`
@@ -131,12 +138,14 @@ The remaining work is operational:
 2. **Create the two bucket repos** under `wheels-dev`:
    - `wheels-dev/apt-wheels` — copy contents of `apt-repo/` template
    - `wheels-dev/yum-wheels` — copy contents of `yum-repo/` template
-3. **Create two CF Pages projects** pointing at the new repos, binding the
-   apex domains:
-   - `wheels-dev/apt-wheels` → `apt.wheels.dev`
-   - `wheels-dev/yum-wheels` → `yum.wheels.dev`
+3. **Create two Cloudflare R2 buckets** and attach apex domain bindings:
+   - bucket `wheels-apt` → custom domain `apt.wheels.dev`
+   - bucket `wheels-yum` → custom domain `yum.wheels.dev`
+
+   R2 has no per-object size limit (unlike Pages' 25 MiB) which is why we
+   serve from R2. End-user URLs are identical.
 4. **Add CI secrets** to `wheels-dev/wheels` (for the dispatch sender) and to
-   each bucket repo (for the signing receiver):
+   each bucket repo (for the signing receiver + R2 upload):
    - On `wheels-dev/wheels`:
      - `LINUX_REPO_DISPATCH_TOKEN` — fine-grained PAT with `actions: write`
        on both bucket repos. The dispatch step in `release.yml` skips
@@ -145,6 +154,8 @@ The remaining work is operational:
    - On each bucket repo (`apt-wheels`, `yum-wheels`):
      - `WHEELS_REPO_GPG_PRIVATE_KEY` — ASCII-armored private key
      - `WHEELS_REPO_GPG_PASSPHRASE` — passphrase
+     - `CLOUDFLARE_API_TOKEN` — token with `Workers R2 Storage:Edit` on the
+       account that owns the bucket
 5. **Smoke-test** by running the bucket-repo workflows manually (each
    supports `workflow_dispatch` for backfill). For the apt bucket:
    ```

--- a/tools/distribution-drafts/yum-repo/README.md
+++ b/tools/distribution-drafts/yum-repo/README.md
@@ -2,8 +2,14 @@
 
 This directory is the **template** for the standalone `wheels-dev/yum-wheels`
 repository that backs `https://yum.wheels.dev`. The bucket repo holds the
-static yum metadata tree plus the pooled `.rpm` artifacts, and is auto-deployed
-to Cloudflare Pages on every push.
+**workflow + scripts + landing page + .repo files + signing key**. The yum
+metadata (`<channel>/repodata/`) and `.rpm` pool (`<channel>/packages/`)
+live in **Cloudflare R2** (bucket `wheels-yum`) and are served via R2's
+custom-domain feature.
+
+> **Note on Pages vs R2:** The original Phase 2 design called for Cloudflare
+> Pages. Pages has a hard 25 MiB per-file limit; the `.rpm` is ~81 MB.
+> Architecture pivoted to R2 during initial rollout.
 
 Copy these files into the new repo when it's created — they are designed to
 work out of the box once the Phase 2 operational prerequisites (GPG key,
@@ -79,9 +85,12 @@ so `rpmvercmp` orders snapshot releases below the next GA correctly.
 Same GPG key as the apt repo (one key for both, importable on both clients
 via `https://apt.wheels.dev/wheels.gpg` or `https://yum.wheels.dev/wheels.gpg`).
 
+R2 bucket: create `wheels-yum`, attach `yum.wheels.dev` as a custom domain.
+
 CI secrets on `https://github.com/wheels-dev/yum-wheels/settings/secrets/actions`:
 - `WHEELS_REPO_GPG_PRIVATE_KEY` — ASCII-armored private key
 - `WHEELS_REPO_GPG_PASSPHRASE` — passphrase
+- `CLOUDFLARE_API_TOKEN` — token with `Workers R2 Storage:Edit` on the account
 
 The upstream dispatch token (`LINUX_REPO_DISPATCH_TOKEN` on
 `wheels-dev/wheels`) must have `actions: write` on this repo.

--- a/tools/distribution-drafts/yum-repo/scripts/regenerate-yum-metadata.sh
+++ b/tools/distribution-drafts/yum-repo/scripts/regenerate-yum-metadata.sh
@@ -29,15 +29,29 @@ CHANNELS="stable bleeding-edge"
 # any existing signature).
 #
 # Requires rpm-sign (Fedora/RHEL) for the rpm command itself.
+#
+# Why a custom %__gpg_sign_cmd: in CI there is no TTY, so the default
+# rpm-build sign command (`gpg ... --pinentry-mode loopback --passphrase-fd 3 ...`)
+# either fails to open /dev/tty or has no fd 3 wired up. Override with an
+# explicit `--passphrase-file` pointing at a chmod-600 file we control. The
+# file lives under $RUNNER_TEMP (or /tmp as a fallback), is unreadable by
+# other users, and is wiped at the end of the script.
+PASS_FILE="${RUNNER_TEMP:-/tmp}/wheels-rpm-pass.$$"
+umask 077
+printf '%s' "${GPG_PASSPHRASE:-}" > "$PASS_FILE"
+trap 'rm -f "$PASS_FILE"' EXIT
+
 cat > ~/.rpmmacros <<RPMMACROS
 %_signature gpg
 %_gpg_name ${GPG_KEY_ID}
 %_gpg_path ${GNUPGHOME:-${HOME}/.gnupg}
 %__gpg $(command -v gpg)
+%__gpg_sign_cmd %{__gpg} --batch --no-armor --no-secmem-warning --pinentry-mode loopback --passphrase-file ${PASS_FILE} --local-user "%{_gpg_name}" --sign --detach-sign --output %{__signature_filename} %{__plaintext_filename}
 RPMMACROS
 
-# rpm --addsign drives gpg via the agent; force loopback so the passphrase
-# can come from the env var without a TTY.
+# Also configure gpg-agent to allow loopback (belt-and-braces — the macro
+# above is the load-bearing piece, but other gpg invocations later in the
+# script — repomd.xml signing, public-key export — still rely on the agent).
 mkdir -p "${GNUPGHOME:-${HOME}/.gnupg}"
 cat > "${GNUPGHOME:-${HOME}/.gnupg}/gpg-agent.conf" <<GPGAGENT
 allow-loopback-pinentry

--- a/tools/distribution-drafts/yum-repo/scripts/regenerate-yum-metadata.sh
+++ b/tools/distribution-drafts/yum-repo/scripts/regenerate-yum-metadata.sh
@@ -75,8 +75,12 @@ for CHANNEL in $CHANNELS; do
   echo "── Signing .rpm files in ${PKG_DIR}/ ──"
   for rpm_file in "${PKG_DIR}"/*.rpm; do
     [ -f "$rpm_file" ] || continue
-    # --addsign with the macro setup above. Passphrase via env (rpm reads
-    # $GNUPGHOME/gpg.conf which sets pinentry-mode loopback).
+    # --addsign with the macro setup above. The passphrase comes from the
+    # --passphrase-file we wrote earlier (via %__gpg_sign_cmd in ~/.rpmmacros).
+    # The `>/dev/null` only suppresses rpm's stdout progress chatter; stderr
+    # is intentionally left open so a signing failure (bad passphrase, missing
+    # macro, gpg error) still surfaces in the CI log. Do NOT broaden this to
+    # `>/dev/null 2>&1` — silent signing failures would corrupt the repo.
     rpm --addsign "$rpm_file" >/dev/null
     echo "  ✓ signed $(basename "$rpm_file")"
   done

--- a/tools/distribution-drafts/yum-repo/workflows/wheels-released.yml
+++ b/tools/distribution-drafts/yum-repo/workflows/wheels-released.yml
@@ -44,7 +44,12 @@ concurrency:
 
 env:
   R2_BUCKET: wheels-yum
-  CLOUDFLARE_ACCOUNT_ID: "511d04f367103ec276d875ab41a24dea"
+  # Cloudflare account ID is not a secret (no auth power on its own), but
+  # keep it as a repo-level Actions variable so the workflow template stays
+  # account-agnostic and so harvesting a public template doesn't hand an
+  # attacker a ready-made API target. Set on the bucket repo:
+  #   gh variable set CLOUDFLARE_ACCOUNT_ID --body '<id>' --repo wheels-dev/yum-wheels
+  CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
 
 jobs:
   publish:
@@ -137,12 +142,29 @@ jobs:
             URL="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/r2/buckets/${R2_BUCKET}/objects?prefix=${PREFIX}&per_page=1000"
             [ -n "$CURSOR" ] && URL="${URL}&cursor=${CURSOR}"
             RESP=$(curl -sS "$URL" -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}")
-            echo "$RESP" | jq -r '.result[].key' | while IFS= read -r key; do
+            # Guard against silent failures: when the token is invalid/expired
+            # or the API rate-limits, success=false comes back with an empty
+            # result array. Without this check, jq emits nothing, the loop
+            # never runs, createrepo_c regenerates over a single-package
+            # channel, and the upload step overwrites repomd.xml on R2 with
+            # that trimmed metadata. Every dnf update afterward sees the
+            # historical packages vanish. Fail loud here instead.
+            if ! echo "$RESP" | jq -e '.success == true' >/dev/null; then
+              echo "::error::Cloudflare R2 list API returned success=false (or invalid JSON). Response:"
+              echo "$RESP"
+              exit 1
+            fi
+            # Process substitution (not a pipe) so the while body runs in the
+            # parent shell — pipe-RHS runs in a subshell where set -e in the
+            # parent does not see wrangler's non-zero exit, masking download
+            # failures. Same reasoning: wrangler's stderr is NOT suppressed
+            # so a real failure surfaces in the CI log.
+            while IFS= read -r key; do
               [ -z "$key" ] && continue
               mkdir -p "$(dirname "$key")"
               echo "  pulling $key"
-              wrangler r2 object get "${R2_BUCKET}/${key}" --file="$key" --remote >/dev/null 2>&1
-            done
+              wrangler r2 object get "${R2_BUCKET}/${key}" --file="$key" --remote
+            done < <(echo "$RESP" | jq -r '.result[].key')
             CURSOR=$(echo "$RESP" | jq -r '.result_info.cursor // empty')
             [ -z "$CURSOR" ] && break
           done
@@ -203,13 +225,18 @@ jobs:
             local ct="$2"
             local key="$local_path"
             echo "  uploading $key (ct=${ct})"
-            wrangler r2 object put "${R2_BUCKET}/${key}" --file="$local_path" --content-type="$ct" --remote >/dev/null 2>&1
+            # Do not suppress wrangler output — a silent upload failure would
+            # leave R2 with stale repomd.xml / repodata while the job exits
+            # green.
+            wrangler r2 object put "${R2_BUCKET}/${key}" --file="$local_path" --content-type="$ct" --remote
           }
           # Walk the channel tree and upload every file. createrepo_c is
           # idempotent — files unchanged from prior runs will overwrite
           # with the same bytes. New .rpm + regenerated repodata/ are the
           # only meaningful diffs.
-          find "${CHANNEL}" -type f | while read -r f; do
+          # Process substitution (not pipe) so set -e fires on upload_one
+          # failures — pipe-RHS subshell semantics would swallow them.
+          while read -r f; do
             case "$f" in
               *.rpm)        ct="application/x-rpm" ;;
               *.xml)        ct="application/xml" ;;
@@ -219,5 +246,5 @@ jobs:
               *)            ct="application/octet-stream" ;;
             esac
             upload_one "$f" "$ct"
-          done
+          done < <(find "${CHANNEL}" -type f)
           echo "R2 upload complete for channel=${CHANNEL}."

--- a/tools/distribution-drafts/yum-repo/workflows/wheels-released.yml
+++ b/tools/distribution-drafts/yum-repo/workflows/wheels-released.yml
@@ -1,18 +1,19 @@
-# Receiver workflow for `wheels-dev/yum-wheels`.
+# Receiver workflow for `wheels-dev/yum-wheels` (R2-backed architecture).
 #
 # Listens for `repository_dispatch` from `wheels-dev/wheels`'s release workflow,
-# downloads the new `.rpm` asset from the upstream GitHub Release, slots it
-# into `<channel>/packages/`, regenerates the repodata via `createrepo_c`,
-# signs `repomd.xml` with GPG (detached → repomd.xml.asc), and commits the
-# whole tree back to this repo. Cloudflare Pages auto-deploys on push.
+# downloads the new `.rpm` asset from the upstream GitHub Release, syncs the
+# existing yum tree from R2 (so createrepo_c can re-scan prior versions),
+# signs each .rpm with `rpm --addsign`, regenerates the channel's repodata
+# via `createrepo_c`, gpg-signs `repomd.xml`, and uploads the changes to the
+# `wheels-yum` R2 bucket (served at https://yum.wheels.dev).
+#
+# This repo no longer commits stable/ or bleeding-edge/ — those are R2-only.
 #
 # Trigger payload contract (sender: wheels-dev/wheels release.yml):
 #   event_type:    "wheels-released"
 #   client_payload:
-#     version: "<x.y.z>" or "<x.y.z>-snapshot.<n>"   # full SemVer, no leading v
-#     channel: "stable" | "bleeding-edge"             # routes into the pool
-#
-# Manual dispatch is also supported via `workflow_dispatch`.
+#     version: "<x.y.z>" or "<x.y.z>-snapshot.<n>"
+#     channel: "stable" | "bleeding-edge"
 
 name: Publish to yum.wheels.dev
 
@@ -35,11 +36,15 @@ on:
           - bleeding-edge
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: publish-yum
   cancel-in-progress: false
+
+env:
+  R2_BUCKET: wheels-yum
+  CLOUDFLARE_ACCOUNT_ID: "511d04f367103ec276d875ab41a24dea"
 
 jobs:
   publish:
@@ -49,13 +54,19 @@ jobs:
     steps:
       - name: Resolve inputs
         id: inputs
+        env:
+          CLIENT_VERSION: ${{ github.event.client_payload.version }}
+          CLIENT_CHANNEL: ${{ github.event.client_payload.channel }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_CHANNEL: ${{ inputs.channel }}
         run: |
+          set -euo pipefail
           if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            VERSION="${{ github.event.client_payload.version }}"
-            CHANNEL="${{ github.event.client_payload.channel }}"
+            VERSION="$CLIENT_VERSION"
+            CHANNEL="$CLIENT_CHANNEL"
           else
-            VERSION="${{ inputs.version }}"
-            CHANNEL="${{ inputs.channel }}"
+            VERSION="$INPUT_VERSION"
+            CHANNEL="$INPUT_CHANNEL"
           fi
           if [ -z "$VERSION" ] || [ -z "$CHANNEL" ]; then
             echo "::error::Both version and channel are required."
@@ -66,35 +77,30 @@ jobs:
             *) echo "::error::Unsupported channel: $CHANNEL"; exit 1 ;;
           esac
           case "$CHANNEL" in
-            stable)        PKG="wheels" ;;
-            bleeding-edge) PKG="wheels-be" ;;
+            stable)        PKG="wheels"; UPSTREAM_REPO="wheels-dev/wheels" ;;
+            bleeding-edge) PKG="wheels-be"; UPSTREAM_REPO="wheels-dev/wheels-snapshots" ;;
           esac
-          case "$CHANNEL" in
-            stable)        UPSTREAM_REPO="wheels-dev/wheels" ;;
-            bleeding-edge) UPSTREAM_REPO="wheels-dev/wheels-snapshots" ;;
-          esac
-          echo "version=$VERSION"           >> "$GITHUB_OUTPUT"
-          echo "channel=$CHANNEL"           >> "$GITHUB_OUTPUT"
-          echo "pkg=$PKG"                   >> "$GITHUB_OUTPUT"
-          echo "upstream_repo=$UPSTREAM_REPO" >> "$GITHUB_OUTPUT"
+          {
+            echo "version=$VERSION"
+            echo "channel=$CHANNEL"
+            echo "pkg=$PKG"
+            echo "upstream_repo=$UPSTREAM_REPO"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Checkout bucket repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          persist-credentials: true
 
-      - name: Install createrepo_c + gpg + rpm
-        # `rpm` brings the `rpm --addsign` tool, used by
-        # regenerate-yum-metadata.sh to sign each .rpm before createrepo_c
-        # records the hash chain. Without it, dnf clients refuse to install
-        # because the wheels.repo files set gpgcheck=1.
+      - name: Install createrepo_c + gpg + rpm + wrangler
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends createrepo-c gnupg rpm
+          sudo apt-get install -y --no-install-recommends createrepo-c gnupg rpm jq
           createrepo_c --version
           gpg --version | head -1
           rpm --version
+          sudo npm install -g wrangler@4.95.0
+          wrangler --version
 
       - name: Import GPG signing key
         env:
@@ -107,9 +113,6 @@ jobs:
             exit 1
           fi
           echo "$GPG_PRIVATE_KEY" | gpg --batch --yes --import
-          # See apt-repo/workflows/wheels-released.yml for the fingerprint-vs-key_id
-          # rationale — import-ownertrust needs the 40-char fingerprint, not the
-          # 16-char key_id (otherwise: "gpg: error in '[stdin]': invalid fingerprint").
           FINGERPRINT=$(gpg --list-secret-keys --with-colons \
             | awk -F: '/^fpr:/ { print $10; exit }')
           KEY_ID=$(gpg --list-secret-keys --keyid-format=long --with-colons \
@@ -118,11 +121,38 @@ jobs:
           echo "$FINGERPRINT:6:" | gpg --batch --yes --import-ownertrust
           echo "GPG_KEY_ID=$KEY_ID" >> "$GITHUB_ENV"
 
-      - name: Download .rpm from upstream Release
+      - name: Sync existing channel from R2
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CHANNEL: ${{ steps.inputs.outputs.channel }}
+        run: |
+          set -euo pipefail
+          # createrepo_c rescans <channel>/packages/ on each run, so we need
+          # ALL previously-published .rpm files locally to keep them in the
+          # repodata. Pull the whole channel down before adding the new one.
+          mkdir -p "${CHANNEL}/packages"
+          PREFIX="${CHANNEL}/"
+          CURSOR=""
+          while :; do
+            URL="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/r2/buckets/${R2_BUCKET}/objects?prefix=${PREFIX}&per_page=1000"
+            [ -n "$CURSOR" ] && URL="${URL}&cursor=${CURSOR}"
+            RESP=$(curl -sS "$URL" -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}")
+            echo "$RESP" | jq -r '.result[].key' | while IFS= read -r key; do
+              [ -z "$key" ] && continue
+              mkdir -p "$(dirname "$key")"
+              echo "  pulling $key"
+              wrangler r2 object get "${R2_BUCKET}/${key}" --file="$key" --remote >/dev/null 2>&1
+            done
+            CURSOR=$(echo "$RESP" | jq -r '.result_info.cursor // empty')
+            [ -z "$CURSOR" ] && break
+          done
+          echo "Local ${CHANNEL}/ contents after sync:"
+          find "${CHANNEL}/" -type f | head -20
+
+      - name: Download new .rpm from upstream Release
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.inputs.outputs.version }}
-          CHANNEL: ${{ steps.inputs.outputs.channel }}
           PKG: ${{ steps.inputs.outputs.pkg }}
           UPSTREAM_REPO: ${{ steps.inputs.outputs.upstream_repo }}
         run: |
@@ -136,9 +166,9 @@ jobs:
             --repo "$UPSTREAM_REPO" \
             --pattern "$ASSET" \
             --dir incoming/
-          ls -l incoming/
+          ls -lh incoming/
 
-      - name: Slot .rpm into packages/
+      - name: Slot new .rpm into local channel
         env:
           VERSION: ${{ steps.inputs.outputs.version }}
           CHANNEL: ${{ steps.inputs.outputs.channel }}
@@ -148,7 +178,6 @@ jobs:
           PKG_DIR="${CHANNEL}/packages"
           mkdir -p "$PKG_DIR"
           URL_VERSION="${VERSION/-snapshot./.snapshot.}"
-          # Rename to the canonical `~`-form for pool storage.
           mv "incoming/${PKG}-${URL_VERSION}.x86_64.rpm" \
              "${PKG_DIR}/${PKG}-${VERSION}.x86_64.rpm"
           echo "Placed: ${PKG_DIR}/${PKG}-${VERSION}.x86_64.rpm"
@@ -163,19 +192,32 @@ jobs:
           chmod +x scripts/regenerate-yum-metadata.sh
           ./scripts/regenerate-yum-metadata.sh
 
-      - name: Commit + push
+      - name: Upload channel tree to R2
         env:
-          VERSION: ${{ steps.inputs.outputs.version }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CHANNEL: ${{ steps.inputs.outputs.channel }}
-          PKG: ${{ steps.inputs.outputs.pkg }}
         run: |
           set -euo pipefail
-          git config user.name  "wheels-release-bot"
-          git config user.email "hello@wheels.dev"
-          git add stable/ bleeding-edge/
-          if git diff --cached --quiet; then
-            echo "No changes — dispatch must have been a no-op."
-            exit 0
-          fi
-          git commit -m "publish: ${PKG} ${VERSION} (${CHANNEL})"
-          git push origin HEAD:main
+          upload_one() {
+            local local_path="$1"
+            local ct="$2"
+            local key="$local_path"
+            echo "  uploading $key (ct=${ct})"
+            wrangler r2 object put "${R2_BUCKET}/${key}" --file="$local_path" --content-type="$ct" --remote >/dev/null 2>&1
+          }
+          # Walk the channel tree and upload every file. createrepo_c is
+          # idempotent — files unchanged from prior runs will overwrite
+          # with the same bytes. New .rpm + regenerated repodata/ are the
+          # only meaningful diffs.
+          find "${CHANNEL}" -type f | while read -r f; do
+            case "$f" in
+              *.rpm)        ct="application/x-rpm" ;;
+              *.xml)        ct="application/xml" ;;
+              *.xml.gz)     ct="application/gzip" ;;
+              *.asc)        ct="application/pgp-signature" ;;
+              *.key)        ct="application/pgp-keys" ;;
+              *)            ct="application/octet-stream" ;;
+            esac
+            upload_one "$f" "$ct"
+          done
+          echo "R2 upload complete for channel=${CHANNEL}."

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/installation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/installation.mdx
@@ -49,68 +49,59 @@ The first time you invoke `wheels`, the wrapper:
 
 On upgrades (`brew upgrade wheels`), the staged module version bumps; the next `wheels` invocation notices the mismatch and refreshes `~/.wheels/modules/wheels/` in place.
 
-## Linux (`.deb` / `.rpm`)
+## Linux (apt / yum)
 
-Wheels ships native packages for x86_64 Debian/Ubuntu (`.deb`) and Fedora/RHEL (`.rpm`) hosts on every release. Both are built by `nfpm` on the release workflow and uploaded to the GitHub Release alongside the zip/tar artifacts. The package declares an OpenJDK 21 runtime dependency so `apt`/`dnf` pulls a JDK in automatically when needed.
+Wheels publishes signed native `apt` and `yum` repositories at **<https://apt.wheels.dev>** and **<https://yum.wheels.dev>**. The packages are built by `nfpm` on the release workflow, signed with the Wheels Distribution GPG key, and served from a Cloudflare R2 bucket per format. Add the source once; `apt`/`dnf` watches the repo and upgrades automatically.
 
-Install the latest stable release:
-
-```bash title="illustrative — Debian / Ubuntu"
-WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-  | jq -r '.tag_name | sub("^v"; "")')
-if [ -z "$WHEELS_VERSION" ] || [ "$WHEELS_VERSION" = "null" ]; then
-  echo "Error: could not resolve release tag. Check your network, GitHub API rate limit, or set WHEELS_VERSION manually." >&2
-  exit 1
-fi
-curl -fsSLO "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels_${WHEELS_VERSION}_amd64.deb"
-sudo apt install "./wheels_${WHEELS_VERSION}_amd64.deb"
+```bash title="Debian / Ubuntu — stable"
+curl -fsSL https://apt.wheels.dev/wheels.gpg \
+  | sudo tee /usr/share/keyrings/wheels.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev stable main" \
+  | sudo tee /etc/apt/sources.list.d/wheels.list
+sudo apt update && sudo apt install wheels
 ```
 
-```bash title="illustrative — Fedora / RHEL"
-WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-  | jq -r '.tag_name | sub("^v"; "")')
-if [ -z "$WHEELS_VERSION" ] || [ "$WHEELS_VERSION" = "null" ]; then
-  echo "Error: could not resolve release tag. Check your network, GitHub API rate limit, or set WHEELS_VERSION manually." >&2
-  exit 1
-fi
-sudo dnf install "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels-${WHEELS_VERSION}.x86_64.rpm"
+```bash title="Fedora / RHEL — stable"
+sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels.repo
+sudo dnf install wheels
 ```
 
 The package lays down `/usr/bin/wheels` (a shell wrapper), `/opt/wheels/wheels` (the LuCLI launcher, renamed at stage time so `basename(argv[0])` is `wheels` and module dispatch routes correctly), `/opt/wheels/module/` (the staged Wheels Module), `/opt/wheels/.version` and `/opt/wheels/.channel` (read by the wrapper for `wheels --version`), and `/opt/wheels/sqlite-jdbc.jar` (auto-staged into Lucee Express on first run). The wrapper mirrors the Homebrew flow: probes `/usr/lib/jvm/` for OpenJDK 21, exports `LUCLI_HOME=$HOME/.wheels`, syncs the staged module into `~/.wheels/modules/wheels/` on first run or version mismatch, then execs LuCLI.
 
-The bleeding-edge channel publishes `.deb`/`.rpm` to [`wheels-dev/wheels-snapshots`](https://github.com/wheels-dev/wheels-snapshots/releases) on every merge to `develop`. Every release there is a GitHub *pre-release*, so `api.github.com/.../releases/latest` returns nothing — use `/releases` and take the first entry. The asset filename also differs: snapshot tags use a SemVer hyphen (`v4.0.0-snapshot.1825`) but the on-disk asset name uses a dot (`wheels-be_4.0.0.snapshot.1825_amd64.deb`) because GitHub Releases rewrites the package's internal `~snapshot.N` form to `.` at upload time. The substitution converts the tag's hyphen-form to the URL's dot-form:
+The bleeding-edge channel publishes a new package on every merge to `develop`, with a distinct package name (`wheels-be`) so it can coexist with stable on the same host:
 
-```bash title="illustrative — Debian / Ubuntu (bleeding-edge)"
-SNAP_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
-  | jq -r '.[0].tag_name | sub("^v"; "")')
-if [ -z "$SNAP_TAG" ] || [ "$SNAP_TAG" = "null" ]; then
-  echo "Error: could not resolve snapshot tag. Check your network, GitHub API rate limit, or set SNAP_TAG manually." >&2
-  exit 1
-fi
-SNAP_FILENAME_VER="${SNAP_TAG//-/.}"
-curl -fsSLO "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${SNAP_TAG}/wheels-be_${SNAP_FILENAME_VER}_amd64.deb"
-sudo apt install "./wheels-be_${SNAP_FILENAME_VER}_amd64.deb"
+```bash title="Debian / Ubuntu — bleeding-edge"
+curl -fsSL https://apt.wheels.dev/wheels.gpg \
+  | sudo tee /usr/share/keyrings/wheels.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev bleeding-edge main" \
+  | sudo tee /etc/apt/sources.list.d/wheels-be.list
+sudo apt update && sudo apt install wheels-be
 ```
 
-```bash title="illustrative — Fedora / RHEL (bleeding-edge)"
-SNAP_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
-  | jq -r '.[0].tag_name | sub("^v"; "")')
-if [ -z "$SNAP_TAG" ] || [ "$SNAP_TAG" = "null" ]; then
-  echo "Error: could not resolve snapshot tag. Check your network, GitHub API rate limit, or set SNAP_TAG manually." >&2
-  exit 1
-fi
-SNAP_FILENAME_VER="${SNAP_TAG//-/.}"
-sudo dnf install "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${SNAP_TAG}/wheels-be-${SNAP_FILENAME_VER}.x86_64.rpm"
+```bash title="Fedora / RHEL — bleeding-edge"
+sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels-be.repo
+sudo dnf install wheels-be
 ```
 
-The version metadata *inside* the `.deb`/`.rpm` preserves the canonical `~snapshot.N` form, so `dpkg --compare-versions` and `rpmvercmp` order pre-releases below the next GA correctly.
+Each `.deb`/`.rpm` carries its full SemVer version internally (e.g. `4.0.1~snapshot.1700` for snapshots), so `dpkg --compare-versions` and `rpmvercmp` correctly order pre-releases below the next GA. (GitHub Releases rewrites `~` to `.` in uploaded asset filenames, but the URLs you actually fetch from the apt/yum repos already use the canonical `~`-form.)
 
-<Aside type="note" title="Native apt/yum repositories">
-The download-and-install flow above is the v4.0 GA story. Native `apt`/`yum` repositories at `apt.wheels.dev` and `yum.wheels.dev` are on the v4.0.x roadmap — once they're live, you'll be able to add a sources list once and `sudo apt install wheels` / `sudo dnf install wheels` will pull new versions automatically via `apt update`. The package format on disk doesn't change.
+<Aside type="note" title="GPG signing">
+Both repositories are signed with the Wheels Distribution key — fingerprint `6872 16C9 32B4 9F03 94E0 9AED 5D89 AF8F 9C9B 8CFB`. The public key is published at `https://apt.wheels.dev/wheels.gpg` and `https://yum.wheels.dev/wheels.gpg` (byte-identical files). `apt update` verifies the `InRelease` / `Release.gpg` signature on every refresh; `dnf` verifies `repomd.xml.asc` and each per-package signature. The sources.list / `.repo` snippets above wire all of that in automatically.
+
+For users who want to verify the fingerprint out-of-band before trusting the key, the same fingerprint is committed to <https://github.com/wheels-dev/apt-wheels/blob/main/FINGERPRINT> and <https://github.com/wheels-dev/yum-wheels/blob/main/FINGERPRINT>.
 </Aside>
 
-<Aside type="caution" title="Trust model during Phase 1">
-Until the native repos are live, download integrity relies on GitHub's HTTPS transport — the `.deb`/`.rpm` artifacts ship without detached GPG signatures, so neither `apt-key` nor `rpm --checksig` has anything to verify against. Phase 2 introduces a GPG-signed apt/yum repository (the signing key will live in 1Password and be published at `apt.wheels.dev/wheels.gpg`), which will add cryptographic provenance on top of TLS. For now, treat `wheels-dev/wheels/releases` as the trust root.
+<Aside type="tip" title="Need a one-off download?">
+The raw `.deb`/`.rpm` are still uploaded to each GitHub Release as asset attachments — useful if you need to install on a host that can't reach `apt.wheels.dev` (air-gapped CI runners, etc.). Snippet:
+
+```bash
+WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
+  | jq -r '.tag_name | sub("^v"; "")')
+curl -fsSLO "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels_${WHEELS_VERSION}_amd64.deb"
+sudo apt install "./wheels_${WHEELS_VERSION}_amd64.deb"
+```
+
+The asset-attached `.deb`/`.rpm` ships without a detached GPG signature (only the apt/yum repo metadata is signed), so the trust root for direct downloads is GitHub's HTTPS transport.
 </Aside>
 
 ## Windows (Scoop)

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/installation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/installation.mdx
@@ -51,7 +51,7 @@ On upgrades (`brew upgrade wheels`), the staged module version bumps; the next `
 
 ## Linux (apt / yum)
 
-Wheels publishes signed native `apt` and `yum` repositories at **<https://apt.wheels.dev>** and **<https://yum.wheels.dev>**. The packages are built by `nfpm` on the release workflow, signed with the Wheels Distribution GPG key, and served from a Cloudflare R2 bucket per format. Add the source once; `apt`/`dnf` watches the repo and upgrades automatically.
+Wheels publishes signed native `apt` and `yum` repositories at **[https://apt.wheels.dev](https://apt.wheels.dev)** and **[https://yum.wheels.dev](https://yum.wheels.dev)**. The packages are built by `nfpm` on the release workflow, signed with the Wheels Distribution GPG key, and served from a Cloudflare R2 bucket per format. Add the source once; `apt`/`dnf` watches the repo and upgrades automatically.
 
 ```bash title="Debian / Ubuntu — stable"
 curl -fsSL https://apt.wheels.dev/wheels.gpg \
@@ -88,7 +88,7 @@ Each `.deb`/`.rpm` carries its full SemVer version internally (e.g. `4.0.1~snaps
 <Aside type="note" title="GPG signing">
 Both repositories are signed with the Wheels Distribution key — fingerprint `6872 16C9 32B4 9F03 94E0 9AED 5D89 AF8F 9C9B 8CFB`. The public key is published at `https://apt.wheels.dev/wheels.gpg` and `https://yum.wheels.dev/wheels.gpg` (byte-identical files). `apt update` verifies the `InRelease` / `Release.gpg` signature on every refresh; `dnf` verifies `repomd.xml.asc` and each per-package signature. The sources.list / `.repo` snippets above wire all of that in automatically.
 
-For users who want to verify the fingerprint out-of-band before trusting the key, the same fingerprint is committed to <https://github.com/wheels-dev/apt-wheels/blob/main/FINGERPRINT> and <https://github.com/wheels-dev/yum-wheels/blob/main/FINGERPRINT>.
+For users who want to verify the fingerprint out-of-band before trusting the key, the same fingerprint is committed to [https://github.com/wheels-dev/apt-wheels/blob/main/FINGERPRINT](https://github.com/wheels-dev/apt-wheels/blob/main/FINGERPRINT) and [https://github.com/wheels-dev/yum-wheels/blob/main/FINGERPRINT](https://github.com/wheels-dev/yum-wheels/blob/main/FINGERPRINT).
 </Aside>
 
 <Aside type="tip" title="Need a one-off download?">

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/installing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/installing.mdx
@@ -165,48 +165,46 @@ Pick LuCLI and Wheels Module versions that are known to be paired — see [CLI I
 
 <TabItem label="Linux" icon="linux">
 
-Wheels ships `.deb` and `.rpm` packages for x86_64 hosts. A native apt/yum repository at `apt.wheels.dev` / `yum.wheels.dev` is on the v4.0.x roadmap — until then, install the package directly from a GitHub Release. The package installs `/usr/bin/wheels`, declares OpenJDK 21 as a runtime dependency (so `apt`/`dnf` pulls a JDK in automatically), and on first run syncs the framework module into `~/.wheels/`.
+Wheels publishes signed native apt and yum repositories at **<https://apt.wheels.dev>** and **<https://yum.wheels.dev>**. Add the source once, then `apt upgrade wheels` / `dnf upgrade wheels` picks up new versions automatically. The package installs `/usr/bin/wheels`, declares OpenJDK 21 as a runtime dependency (so `apt`/`dnf` pulls a JDK in automatically), and on first run syncs the framework module into `~/.wheels/`.
 
-<Aside type="caution" title="Trust model during Phase 1">
-During Phase 1 (before `apt.wheels.dev` / `yum.wheels.dev` are live), download integrity relies on GitHub's HTTPS transport — the `.deb`/`.rpm` artifacts ship without detached GPG signatures, so there's nothing for `apt-key` / `rpm --checksig` to verify against. Phase 2 adds GPG-signed apt/yum repositories. For now, `wheels-dev/wheels/releases` is the trust root.
+<Aside type="note" title="GPG signing">
+The apt and yum repos are GPG-signed with the Wheels Distribution key (fingerprint `6872 16C9 32B4 9F03 94E0 9AED 5D89 AF8F 9C9B 8CFB`). `apt`/`dnf` verify the signature on every update, so a network-level attacker can't substitute the package contents. The public half is published at `https://apt.wheels.dev/wheels.gpg` and `https://yum.wheels.dev/wheels.gpg` — both files are byte-identical. The sources.list / `.repo` snippets below wire the signature check in automatically.
 </Aside>
 
 <Steps>
 
-1. Download and install the latest Wheels release:
+1. Add the Wheels apt/yum source:
 
    ```bash title="Debian / Ubuntu — stable"
-   WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-     | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
-   curl -fsSLO "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels_${WHEELS_VERSION}_amd64.deb"
-   sudo apt install "./wheels_${WHEELS_VERSION}_amd64.deb"
+   curl -fsSL https://apt.wheels.dev/wheels.gpg \
+     | sudo tee /usr/share/keyrings/wheels.gpg >/dev/null
+   echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev stable main" \
+     | sudo tee /etc/apt/sources.list.d/wheels.list
+   sudo apt update && sudo apt install wheels
    ```
 
    ```bash title="Fedora / RHEL — stable"
-   WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-     | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
-   sudo dnf install "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels-${WHEELS_VERSION}.x86_64.rpm"
+   sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels.repo
+   sudo dnf install wheels
    ```
 
    <Aside type="note" title="Want bleeding-edge?">
-   The bleeding-edge channel publishes a fresh `.deb`/`.rpm` on every merge to `develop`, in the [`wheels-dev/wheels-snapshots`](https://github.com/wheels-dev/wheels-snapshots/releases) repo. Because every release there is a GitHub *pre-release*, `api.github.com/.../releases/latest` returns nothing — use `/releases` and pick the first entry. Snapshot tags use a SemVer hyphen (`v4.0.0-snapshot.1825`); the on-disk asset filename uses a dot in the same slot (`wheels-be_4.0.0.snapshot.1825_amd64.deb`) because GitHub Releases rewrites the package's internal `~snapshot.N` form to `.` at upload time. Self-contained snippets:
+   The bleeding-edge channel publishes a fresh `.deb`/`.rpm` on every merge to `develop`. It's served from the same apt.wheels.dev / yum.wheels.dev hosts but under a separate `bleeding-edge` distribution name, with a distinct package name (`wheels-be`) so it can coexist with the stable `wheels` install on the same host:
 
    ```bash title="Debian / Ubuntu — bleeding-edge"
-   SNAP_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
-     | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
-   SNAP_FILENAME_VER="${SNAP_TAG//-/.}"
-   curl -fsSLO "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${SNAP_TAG}/wheels-be_${SNAP_FILENAME_VER}_amd64.deb"
-   sudo apt install "./wheels-be_${SNAP_FILENAME_VER}_amd64.deb"
+   curl -fsSL https://apt.wheels.dev/wheels.gpg \
+     | sudo tee /usr/share/keyrings/wheels.gpg >/dev/null
+   echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev bleeding-edge main" \
+     | sudo tee /etc/apt/sources.list.d/wheels-be.list
+   sudo apt update && sudo apt install wheels-be
    ```
 
    ```bash title="Fedora / RHEL — bleeding-edge"
-   SNAP_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
-     | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
-   SNAP_FILENAME_VER="${SNAP_TAG//-/.}"
-   sudo dnf install "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${SNAP_TAG}/wheels-be-${SNAP_FILENAME_VER}.x86_64.rpm"
+   sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels-be.repo
+   sudo dnf install wheels-be
    ```
 
-   The metadata inside the package keeps the canonical `~snapshot.N` form so `apt`/`dnf` order the version correctly relative to GA. See [Release Channels](/v4-0-0/start-here/release-channels/).
+   Snapshot tags use a SemVer hyphen (`v4.0.0-snapshot.1825`) and the package's internal version preserves the `~snapshot.N` form so `apt`/`dnf` order the version correctly relative to GA. See [Release Channels](/v4-0-0/start-here/release-channels/).
    </Aside>
 
 2. Verify:
@@ -254,22 +252,15 @@ scoop update wheels-be
 
 <TabItem label="Linux" icon="linux">
 
-Re-run the install command for your distro — `apt`/`dnf` upgrades the package in place when it sees a newer version:
+Once the apt or yum source from the install step is in place, upgrades are a single command — `apt`/`dnf` watches the repo and pulls the latest signed package on every refresh:
 
 ```bash title="Debian / Ubuntu"
-WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
-curl -fsSLO "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels_${WHEELS_VERSION}_amd64.deb"
-sudo apt install "./wheels_${WHEELS_VERSION}_amd64.deb"
+sudo apt update && sudo apt upgrade wheels        # or `wheels-be` for bleeding-edge
 ```
 
 ```bash title="Fedora / RHEL"
-WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
-sudo dnf upgrade "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels-${WHEELS_VERSION}.x86_64.rpm"
+sudo dnf upgrade wheels                            # or `wheels-be` for bleeding-edge
 ```
-
-For the bleeding-edge channel, run the install snippet from the [bleeding-edge Aside](#install-the-cli) — it points at `wheels-dev/wheels-snapshots` and `apt`/`dnf` will treat each new snapshot as an upgrade.
 
 The first `wheels` invocation after upgrade syncs the new framework module into `~/.wheels/modules/wheels/` automatically.
 

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/installing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/installing.mdx
@@ -165,7 +165,7 @@ Pick LuCLI and Wheels Module versions that are known to be paired — see [CLI I
 
 <TabItem label="Linux" icon="linux">
 
-Wheels publishes signed native apt and yum repositories at **<https://apt.wheels.dev>** and **<https://yum.wheels.dev>**. Add the source once, then `apt upgrade wheels` / `dnf upgrade wheels` picks up new versions automatically. The package installs `/usr/bin/wheels`, declares OpenJDK 21 as a runtime dependency (so `apt`/`dnf` pulls a JDK in automatically), and on first run syncs the framework module into `~/.wheels/`.
+Wheels publishes signed native apt and yum repositories at **[https://apt.wheels.dev](https://apt.wheels.dev)** and **[https://yum.wheels.dev](https://yum.wheels.dev)**. Add the source once, then `apt upgrade wheels` / `dnf upgrade wheels` picks up new versions automatically. The package installs `/usr/bin/wheels`, declares OpenJDK 21 as a runtime dependency (so `apt`/`dnf` pulls a JDK in automatically), and on first run syncs the framework module into `~/.wheels/`.
 
 <Aside type="note" title="GPG signing">
 The apt and yum repos are GPG-signed with the Wheels Distribution key (fingerprint `6872 16C9 32B4 9F03 94E0 9AED 5D89 AF8F 9C9B 8CFB`). `apt`/`dnf` verify the signature on every update, so a network-level attacker can't substitute the package contents. The public half is published at `https://apt.wheels.dev/wheels.gpg` and `https://yum.wheels.dev/wheels.gpg` — both files are byte-identical. The sources.list / `.repo` snippets below wire the signature check in automatically.

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/release-channels.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/release-channels.mdx
@@ -75,44 +75,38 @@ The rest of the install steps are identical — see [Installing Wheels → Windo
 
 <TabItem label="Linux" icon="linux">
 
-Each channel ships `.deb` and `.rpm` packages on its respective releases page:
+Each channel ships from a signed native repository — distinct package names (`wheels` vs `wheels-be`) so both channels can coexist on the same host:
 
-- **Stable**: [github.com/wheels-dev/wheels/releases](https://github.com/wheels-dev/wheels/releases)
-- **Bleeding-edge**: [github.com/wheels-dev/wheels-snapshots/releases](https://github.com/wheels-dev/wheels-snapshots/releases)
+- **Stable**: `https://apt.wheels.dev stable main` / `https://yum.wheels.dev/wheels.repo` → package `wheels`
+- **Bleeding-edge**: `https://apt.wheels.dev bleeding-edge main` / `https://yum.wheels.dev/wheels-be.repo` → package `wheels-be`
 
 ```bash title="Debian / Ubuntu (stable)"
-WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
-curl -fsSLO "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels_${WHEELS_VERSION}_amd64.deb"
-sudo apt install "./wheels_${WHEELS_VERSION}_amd64.deb"
+curl -fsSL https://apt.wheels.dev/wheels.gpg \
+  | sudo tee /usr/share/keyrings/wheels.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev stable main" \
+  | sudo tee /etc/apt/sources.list.d/wheels.list
+sudo apt update && sudo apt install wheels
 ```
 
 ```bash title="Fedora / RHEL (stable)"
-WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
-sudo dnf install "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels-${WHEELS_VERSION}.x86_64.rpm"
+sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels.repo
+sudo dnf install wheels
 ```
 
 ```bash title="Debian / Ubuntu (bleeding-edge)"
-# The bleeding-edge channel publishes only pre-releases, so use /releases (not /releases/latest).
-WHEELS_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
-# Tag uses a SemVer hyphen (4.0.0-snapshot.N). The on-disk asset name uses a dot
-# in the same slot because GitHub Releases rewrites the package's internal
-# ~snapshot.N form to . at upload time. So translate hyphen → dot for the URL.
-WHEELS_FILENAME_VER="${WHEELS_TAG//-/.}"
-curl -fsSLO "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${WHEELS_TAG}/wheels-be_${WHEELS_FILENAME_VER}_amd64.deb"
-sudo apt install "./wheels-be_${WHEELS_FILENAME_VER}_amd64.deb"
+curl -fsSL https://apt.wheels.dev/wheels.gpg \
+  | sudo tee /usr/share/keyrings/wheels.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev bleeding-edge main" \
+  | sudo tee /etc/apt/sources.list.d/wheels-be.list
+sudo apt update && sudo apt install wheels-be
 ```
 
 ```bash title="Fedora / RHEL (bleeding-edge)"
-WHEELS_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
-WHEELS_FILENAME_VER="${WHEELS_TAG//-/.}"
-sudo dnf install "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${WHEELS_TAG}/wheels-be-${WHEELS_FILENAME_VER}.x86_64.rpm"
+sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels-be.repo
+sudo dnf install wheels-be
 ```
 
-Apt and yum repos at `apt.wheels.dev` / `yum.wheels.dev` are coming — they'll let you `apt upgrade wheels` instead of re-downloading.
+Both repos are GPG-signed (fingerprint `6872 16C9 32B4 9F03 94E0 9AED 5D89 AF8F 9C9B 8CFB`); `apt update` / `dnf check-update` verifies the signature on every refresh. The raw `.deb`/`.rpm` are also uploaded to each GitHub Release as a fallback for air-gapped installs (see [CLI Installation](/v4-0-0/command-line-tools/installation/)).
 
 </TabItem>
 
@@ -139,47 +133,41 @@ brew install wheels
 ```
 
 ```bash title="Linux — stable → bleeding-edge (Debian / Ubuntu)"
-# wheels-be .deb declares Replaces: wheels + Conflicts: wheels, so apt
-# removes the stable wheels package and installs wheels-be in its place
-# without a separate `apt remove` step.
-SNAP_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
-SNAP_FILENAME_VER="${SNAP_TAG//-/.}"
-curl -fsSLO "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${SNAP_TAG}/wheels-be_${SNAP_FILENAME_VER}_amd64.deb"
-sudo apt install "./wheels-be_${SNAP_FILENAME_VER}_amd64.deb"
+# Add the bleeding-edge source (uses the same key already imported for stable).
+# wheels-be .deb declares Replaces: wheels + Conflicts: wheels, so apt removes
+# the stable wheels package and installs wheels-be in its place — no separate
+# `apt remove` needed.
+echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev bleeding-edge main" \
+  | sudo tee /etc/apt/sources.list.d/wheels-be.list
+sudo apt update && sudo apt install wheels-be
 ```
 
 ```bash title="Linux — stable → bleeding-edge (Fedora / RHEL)"
 # wheels-be .rpm declares Conflicts: wheels but no Obsoletes, so dnf
 # refuses to install while the stable wheels package is present. Remove
-# it first.
+# it first, then add the bleeding-edge .repo source and install.
 sudo dnf remove wheels
-SNAP_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
-SNAP_FILENAME_VER="${SNAP_TAG//-/.}"
-sudo dnf install "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${SNAP_TAG}/wheels-be-${SNAP_FILENAME_VER}.x86_64.rpm"
+sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels-be.repo
+sudo dnf install wheels-be
 ```
 
 ```bash title="Linux — bleeding-edge → stable (Debian / Ubuntu)"
 # wheels-be declares Conflicts: wheels, so apt refuses to install wheels
-# while wheels-be is present. (Stable wheels .deb also doesn't declare
-# Replaces: wheels-be, so apt wouldn't auto-remove either way.) Remove
-# wheels-be first.
+# while wheels-be is present. Remove wheels-be, then install wheels —
+# both come from the same apt.wheels.dev source list, so no extra setup
+# is needed.
 sudo apt remove wheels-be
-WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
-curl -fsSLO "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels_${WHEELS_VERSION}_amd64.deb"
-sudo apt install "./wheels_${WHEELS_VERSION}_amd64.deb"
+sudo apt install wheels
 ```
 
 ```bash title="Linux — bleeding-edge → stable (Fedora / RHEL)"
 # Same as Debian above — wheels-be declares Conflicts: wheels, so dnf
 # refuses to install wheels while wheels-be is present. Remove wheels-be
-# first.
+# first, then install wheels. Both come from yum.wheels.dev (stable
+# lives at wheels.repo, bleeding-edge at wheels-be.repo); the stable
+# .repo file is left in place from the original install.
 sudo dnf remove wheels-be
-WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
-sudo dnf install "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels-${WHEELS_VERSION}.x86_64.rpm"
+sudo dnf install wheels
 ```
 
 ```powershell title="Windows (Scoop) — stable → bleeding-edge"

--- a/web/sites/guides/src/content/docs/v4-0-1-snapshot/command-line-tools/installation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-1-snapshot/command-line-tools/installation.mdx
@@ -49,68 +49,59 @@ The first time you invoke `wheels`, the wrapper:
 
 On upgrades (`brew upgrade wheels`), the staged module version bumps; the next `wheels` invocation notices the mismatch and refreshes `~/.wheels/modules/wheels/` in place.
 
-## Linux (`.deb` / `.rpm`)
+## Linux (apt / yum)
 
-Wheels ships native packages for x86_64 Debian/Ubuntu (`.deb`) and Fedora/RHEL (`.rpm`) hosts on every release. Both are built by `nfpm` on the release workflow and uploaded to the GitHub Release alongside the zip/tar artifacts. The package declares an OpenJDK 21 runtime dependency so `apt`/`dnf` pulls a JDK in automatically when needed.
+Wheels publishes signed native `apt` and `yum` repositories at **<https://apt.wheels.dev>** and **<https://yum.wheels.dev>**. The packages are built by `nfpm` on the release workflow, signed with the Wheels Distribution GPG key, and served from a Cloudflare R2 bucket per format. Add the source once; `apt`/`dnf` watches the repo and upgrades automatically.
 
-Install the latest stable release:
-
-```bash title="illustrative — Debian / Ubuntu"
-WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-  | jq -r '.tag_name | sub("^v"; "")')
-if [ -z "$WHEELS_VERSION" ] || [ "$WHEELS_VERSION" = "null" ]; then
-  echo "Error: could not resolve release tag. Check your network, GitHub API rate limit, or set WHEELS_VERSION manually." >&2
-  exit 1
-fi
-curl -fsSLO "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels_${WHEELS_VERSION}_amd64.deb"
-sudo apt install "./wheels_${WHEELS_VERSION}_amd64.deb"
+```bash title="Debian / Ubuntu — stable"
+curl -fsSL https://apt.wheels.dev/wheels.gpg \
+  | sudo tee /usr/share/keyrings/wheels.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev stable main" \
+  | sudo tee /etc/apt/sources.list.d/wheels.list
+sudo apt update && sudo apt install wheels
 ```
 
-```bash title="illustrative — Fedora / RHEL"
-WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-  | jq -r '.tag_name | sub("^v"; "")')
-if [ -z "$WHEELS_VERSION" ] || [ "$WHEELS_VERSION" = "null" ]; then
-  echo "Error: could not resolve release tag. Check your network, GitHub API rate limit, or set WHEELS_VERSION manually." >&2
-  exit 1
-fi
-sudo dnf install "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels-${WHEELS_VERSION}.x86_64.rpm"
+```bash title="Fedora / RHEL — stable"
+sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels.repo
+sudo dnf install wheels
 ```
 
 The package lays down `/usr/bin/wheels` (a shell wrapper), `/opt/wheels/wheels` (the LuCLI launcher, renamed at stage time so `basename(argv[0])` is `wheels` and module dispatch routes correctly), `/opt/wheels/module/` (the staged Wheels Module), `/opt/wheels/.version` and `/opt/wheels/.channel` (read by the wrapper for `wheels --version`), and `/opt/wheels/sqlite-jdbc.jar` (auto-staged into Lucee Express on first run). The wrapper mirrors the Homebrew flow: probes `/usr/lib/jvm/` for OpenJDK 21, exports `LUCLI_HOME=$HOME/.wheels`, syncs the staged module into `~/.wheels/modules/wheels/` on first run or version mismatch, then execs LuCLI.
 
-The bleeding-edge channel publishes `.deb`/`.rpm` to [`wheels-dev/wheels-snapshots`](https://github.com/wheels-dev/wheels-snapshots/releases) on every merge to `develop`. Every release there is a GitHub *pre-release*, so `api.github.com/.../releases/latest` returns nothing — use `/releases` and take the first entry. The asset filename also differs: snapshot tags use a SemVer hyphen (`v4.0.0-snapshot.1825`) but the on-disk asset name uses a dot (`wheels-be_4.0.0.snapshot.1825_amd64.deb`) because GitHub Releases rewrites the package's internal `~snapshot.N` form to `.` at upload time. The substitution converts the tag's hyphen-form to the URL's dot-form:
+The bleeding-edge channel publishes a new package on every merge to `develop`, with a distinct package name (`wheels-be`) so it can coexist with stable on the same host:
 
-```bash title="illustrative — Debian / Ubuntu (bleeding-edge)"
-SNAP_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
-  | jq -r '.[0].tag_name | sub("^v"; "")')
-if [ -z "$SNAP_TAG" ] || [ "$SNAP_TAG" = "null" ]; then
-  echo "Error: could not resolve snapshot tag. Check your network, GitHub API rate limit, or set SNAP_TAG manually." >&2
-  exit 1
-fi
-SNAP_FILENAME_VER="${SNAP_TAG//-/.}"
-curl -fsSLO "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${SNAP_TAG}/wheels-be_${SNAP_FILENAME_VER}_amd64.deb"
-sudo apt install "./wheels-be_${SNAP_FILENAME_VER}_amd64.deb"
+```bash title="Debian / Ubuntu — bleeding-edge"
+curl -fsSL https://apt.wheels.dev/wheels.gpg \
+  | sudo tee /usr/share/keyrings/wheels.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev bleeding-edge main" \
+  | sudo tee /etc/apt/sources.list.d/wheels-be.list
+sudo apt update && sudo apt install wheels-be
 ```
 
-```bash title="illustrative — Fedora / RHEL (bleeding-edge)"
-SNAP_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
-  | jq -r '.[0].tag_name | sub("^v"; "")')
-if [ -z "$SNAP_TAG" ] || [ "$SNAP_TAG" = "null" ]; then
-  echo "Error: could not resolve snapshot tag. Check your network, GitHub API rate limit, or set SNAP_TAG manually." >&2
-  exit 1
-fi
-SNAP_FILENAME_VER="${SNAP_TAG//-/.}"
-sudo dnf install "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${SNAP_TAG}/wheels-be-${SNAP_FILENAME_VER}.x86_64.rpm"
+```bash title="Fedora / RHEL — bleeding-edge"
+sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels-be.repo
+sudo dnf install wheels-be
 ```
 
-The version metadata *inside* the `.deb`/`.rpm` preserves the canonical `~snapshot.N` form, so `dpkg --compare-versions` and `rpmvercmp` order pre-releases below the next GA correctly.
+Each `.deb`/`.rpm` carries its full SemVer version internally (e.g. `4.0.1~snapshot.1700` for snapshots), so `dpkg --compare-versions` and `rpmvercmp` correctly order pre-releases below the next GA. (GitHub Releases rewrites `~` to `.` in uploaded asset filenames, but the URLs you actually fetch from the apt/yum repos already use the canonical `~`-form.)
 
-<Aside type="note" title="Native apt/yum repositories">
-The download-and-install flow above is the v4.0 GA story. Native `apt`/`yum` repositories at `apt.wheels.dev` and `yum.wheels.dev` are on the v4.0.x roadmap — once they're live, you'll be able to add a sources list once and `sudo apt install wheels` / `sudo dnf install wheels` will pull new versions automatically via `apt update`. The package format on disk doesn't change.
+<Aside type="note" title="GPG signing">
+Both repositories are signed with the Wheels Distribution key — fingerprint `6872 16C9 32B4 9F03 94E0 9AED 5D89 AF8F 9C9B 8CFB`. The public key is published at `https://apt.wheels.dev/wheels.gpg` and `https://yum.wheels.dev/wheels.gpg` (byte-identical files). `apt update` verifies the `InRelease` / `Release.gpg` signature on every refresh; `dnf` verifies `repomd.xml.asc` and each per-package signature. The sources.list / `.repo` snippets above wire all of that in automatically.
+
+For users who want to verify the fingerprint out-of-band before trusting the key, the same fingerprint is committed to <https://github.com/wheels-dev/apt-wheels/blob/main/FINGERPRINT> and <https://github.com/wheels-dev/yum-wheels/blob/main/FINGERPRINT>.
 </Aside>
 
-<Aside type="caution" title="Trust model during Phase 1">
-Until the native repos are live, download integrity relies on GitHub's HTTPS transport — the `.deb`/`.rpm` artifacts ship without detached GPG signatures, so neither `apt-key` nor `rpm --checksig` has anything to verify against. Phase 2 introduces a GPG-signed apt/yum repository (the signing key will live in 1Password and be published at `apt.wheels.dev/wheels.gpg`), which will add cryptographic provenance on top of TLS. For now, treat `wheels-dev/wheels/releases` as the trust root.
+<Aside type="tip" title="Need a one-off download?">
+The raw `.deb`/`.rpm` are still uploaded to each GitHub Release as asset attachments — useful if you need to install on a host that can't reach `apt.wheels.dev` (air-gapped CI runners, etc.). Snippet:
+
+```bash
+WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
+  | jq -r '.tag_name | sub("^v"; "")')
+curl -fsSLO "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels_${WHEELS_VERSION}_amd64.deb"
+sudo apt install "./wheels_${WHEELS_VERSION}_amd64.deb"
+```
+
+The asset-attached `.deb`/`.rpm` ships without a detached GPG signature (only the apt/yum repo metadata is signed), so the trust root for direct downloads is GitHub's HTTPS transport.
 </Aside>
 
 ## Windows (Scoop)

--- a/web/sites/guides/src/content/docs/v4-0-1-snapshot/command-line-tools/installation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-1-snapshot/command-line-tools/installation.mdx
@@ -51,7 +51,7 @@ On upgrades (`brew upgrade wheels`), the staged module version bumps; the next `
 
 ## Linux (apt / yum)
 
-Wheels publishes signed native `apt` and `yum` repositories at **<https://apt.wheels.dev>** and **<https://yum.wheels.dev>**. The packages are built by `nfpm` on the release workflow, signed with the Wheels Distribution GPG key, and served from a Cloudflare R2 bucket per format. Add the source once; `apt`/`dnf` watches the repo and upgrades automatically.
+Wheels publishes signed native `apt` and `yum` repositories at **[https://apt.wheels.dev](https://apt.wheels.dev)** and **[https://yum.wheels.dev](https://yum.wheels.dev)**. The packages are built by `nfpm` on the release workflow, signed with the Wheels Distribution GPG key, and served from a Cloudflare R2 bucket per format. Add the source once; `apt`/`dnf` watches the repo and upgrades automatically.
 
 ```bash title="Debian / Ubuntu — stable"
 curl -fsSL https://apt.wheels.dev/wheels.gpg \
@@ -88,7 +88,7 @@ Each `.deb`/`.rpm` carries its full SemVer version internally (e.g. `4.0.1~snaps
 <Aside type="note" title="GPG signing">
 Both repositories are signed with the Wheels Distribution key — fingerprint `6872 16C9 32B4 9F03 94E0 9AED 5D89 AF8F 9C9B 8CFB`. The public key is published at `https://apt.wheels.dev/wheels.gpg` and `https://yum.wheels.dev/wheels.gpg` (byte-identical files). `apt update` verifies the `InRelease` / `Release.gpg` signature on every refresh; `dnf` verifies `repomd.xml.asc` and each per-package signature. The sources.list / `.repo` snippets above wire all of that in automatically.
 
-For users who want to verify the fingerprint out-of-band before trusting the key, the same fingerprint is committed to <https://github.com/wheels-dev/apt-wheels/blob/main/FINGERPRINT> and <https://github.com/wheels-dev/yum-wheels/blob/main/FINGERPRINT>.
+For users who want to verify the fingerprint out-of-band before trusting the key, the same fingerprint is committed to [https://github.com/wheels-dev/apt-wheels/blob/main/FINGERPRINT](https://github.com/wheels-dev/apt-wheels/blob/main/FINGERPRINT) and [https://github.com/wheels-dev/yum-wheels/blob/main/FINGERPRINT](https://github.com/wheels-dev/yum-wheels/blob/main/FINGERPRINT).
 </Aside>
 
 <Aside type="tip" title="Need a one-off download?">

--- a/web/sites/guides/src/content/docs/v4-0-1-snapshot/start-here/installing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-1-snapshot/start-here/installing.mdx
@@ -165,48 +165,46 @@ Pick LuCLI and Wheels Module versions that are known to be paired — see [CLI I
 
 <TabItem label="Linux" icon="linux">
 
-Wheels ships `.deb` and `.rpm` packages for x86_64 hosts. A native apt/yum repository at `apt.wheels.dev` / `yum.wheels.dev` is on the v4.0.x roadmap — until then, install the package directly from a GitHub Release. The package installs `/usr/bin/wheels`, declares OpenJDK 21 as a runtime dependency (so `apt`/`dnf` pulls a JDK in automatically), and on first run syncs the framework module into `~/.wheels/`.
+Wheels publishes signed native apt and yum repositories at **<https://apt.wheels.dev>** and **<https://yum.wheels.dev>**. Add the source once, then `apt upgrade wheels` / `dnf upgrade wheels` picks up new versions automatically. The package installs `/usr/bin/wheels`, declares OpenJDK 21 as a runtime dependency (so `apt`/`dnf` pulls a JDK in automatically), and on first run syncs the framework module into `~/.wheels/`.
 
-<Aside type="caution" title="Trust model during Phase 1">
-During Phase 1 (before `apt.wheels.dev` / `yum.wheels.dev` are live), download integrity relies on GitHub's HTTPS transport — the `.deb`/`.rpm` artifacts ship without detached GPG signatures, so there's nothing for `apt-key` / `rpm --checksig` to verify against. Phase 2 adds GPG-signed apt/yum repositories. For now, `wheels-dev/wheels/releases` is the trust root.
+<Aside type="note" title="GPG signing">
+The apt and yum repos are GPG-signed with the Wheels Distribution key (fingerprint `6872 16C9 32B4 9F03 94E0 9AED 5D89 AF8F 9C9B 8CFB`). `apt`/`dnf` verify the signature on every update, so a network-level attacker can't substitute the package contents. The public half is published at `https://apt.wheels.dev/wheels.gpg` and `https://yum.wheels.dev/wheels.gpg` — both files are byte-identical. The sources.list / `.repo` snippets below wire the signature check in automatically.
 </Aside>
 
 <Steps>
 
-1. Download and install the latest Wheels release:
+1. Add the Wheels apt/yum source:
 
    ```bash title="Debian / Ubuntu — stable"
-   WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-     | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
-   curl -fsSLO "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels_${WHEELS_VERSION}_amd64.deb"
-   sudo apt install "./wheels_${WHEELS_VERSION}_amd64.deb"
+   curl -fsSL https://apt.wheels.dev/wheels.gpg \
+     | sudo tee /usr/share/keyrings/wheels.gpg >/dev/null
+   echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev stable main" \
+     | sudo tee /etc/apt/sources.list.d/wheels.list
+   sudo apt update && sudo apt install wheels
    ```
 
    ```bash title="Fedora / RHEL — stable"
-   WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-     | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
-   sudo dnf install "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels-${WHEELS_VERSION}.x86_64.rpm"
+   sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels.repo
+   sudo dnf install wheels
    ```
 
    <Aside type="note" title="Want bleeding-edge?">
-   The bleeding-edge channel publishes a fresh `.deb`/`.rpm` on every merge to `develop`, in the [`wheels-dev/wheels-snapshots`](https://github.com/wheels-dev/wheels-snapshots/releases) repo. Because every release there is a GitHub *pre-release*, `api.github.com/.../releases/latest` returns nothing — use `/releases` and pick the first entry. Snapshot tags use a SemVer hyphen (`v4.0.0-snapshot.1825`); the on-disk asset filename uses a dot in the same slot (`wheels-be_4.0.0.snapshot.1825_amd64.deb`) because GitHub Releases rewrites the package's internal `~snapshot.N` form to `.` at upload time. Self-contained snippets:
+   The bleeding-edge channel publishes a fresh `.deb`/`.rpm` on every merge to `develop`. It's served from the same apt.wheels.dev / yum.wheels.dev hosts but under a separate `bleeding-edge` distribution name, with a distinct package name (`wheels-be`) so it can coexist with the stable `wheels` install on the same host:
 
    ```bash title="Debian / Ubuntu — bleeding-edge"
-   SNAP_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
-     | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
-   SNAP_FILENAME_VER="${SNAP_TAG//-/.}"
-   curl -fsSLO "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${SNAP_TAG}/wheels-be_${SNAP_FILENAME_VER}_amd64.deb"
-   sudo apt install "./wheels-be_${SNAP_FILENAME_VER}_amd64.deb"
+   curl -fsSL https://apt.wheels.dev/wheels.gpg \
+     | sudo tee /usr/share/keyrings/wheels.gpg >/dev/null
+   echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev bleeding-edge main" \
+     | sudo tee /etc/apt/sources.list.d/wheels-be.list
+   sudo apt update && sudo apt install wheels-be
    ```
 
    ```bash title="Fedora / RHEL — bleeding-edge"
-   SNAP_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
-     | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
-   SNAP_FILENAME_VER="${SNAP_TAG//-/.}"
-   sudo dnf install "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${SNAP_TAG}/wheels-be-${SNAP_FILENAME_VER}.x86_64.rpm"
+   sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels-be.repo
+   sudo dnf install wheels-be
    ```
 
-   The metadata inside the package keeps the canonical `~snapshot.N` form so `apt`/`dnf` order the version correctly relative to GA. See [Release Channels](/v4-0-1-snapshot/start-here/release-channels/).
+   Snapshot tags use a SemVer hyphen (`v4.0.0-snapshot.1825`) and the package's internal version preserves the `~snapshot.N` form so `apt`/`dnf` order the version correctly relative to GA. See [Release Channels](/v4-0-1-snapshot/start-here/release-channels/).
    </Aside>
 
 2. Verify:
@@ -254,22 +252,15 @@ scoop update wheels-be
 
 <TabItem label="Linux" icon="linux">
 
-Re-run the install command for your distro — `apt`/`dnf` upgrades the package in place when it sees a newer version:
+Once the apt or yum source from the install step is in place, upgrades are a single command — `apt`/`dnf` watches the repo and pulls the latest signed package on every refresh:
 
 ```bash title="Debian / Ubuntu"
-WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
-curl -fsSLO "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels_${WHEELS_VERSION}_amd64.deb"
-sudo apt install "./wheels_${WHEELS_VERSION}_amd64.deb"
+sudo apt update && sudo apt upgrade wheels        # or `wheels-be` for bleeding-edge
 ```
 
 ```bash title="Fedora / RHEL"
-WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
-sudo dnf upgrade "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels-${WHEELS_VERSION}.x86_64.rpm"
+sudo dnf upgrade wheels                            # or `wheels-be` for bleeding-edge
 ```
-
-For the bleeding-edge channel, run the install snippet from the [bleeding-edge Aside](#install-the-cli) — it points at `wheels-dev/wheels-snapshots` and `apt`/`dnf` will treat each new snapshot as an upgrade.
 
 The first `wheels` invocation after upgrade syncs the new framework module into `~/.wheels/modules/wheels/` automatically.
 

--- a/web/sites/guides/src/content/docs/v4-0-1-snapshot/start-here/installing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-1-snapshot/start-here/installing.mdx
@@ -165,7 +165,7 @@ Pick LuCLI and Wheels Module versions that are known to be paired — see [CLI I
 
 <TabItem label="Linux" icon="linux">
 
-Wheels publishes signed native apt and yum repositories at **<https://apt.wheels.dev>** and **<https://yum.wheels.dev>**. Add the source once, then `apt upgrade wheels` / `dnf upgrade wheels` picks up new versions automatically. The package installs `/usr/bin/wheels`, declares OpenJDK 21 as a runtime dependency (so `apt`/`dnf` pulls a JDK in automatically), and on first run syncs the framework module into `~/.wheels/`.
+Wheels publishes signed native apt and yum repositories at **[https://apt.wheels.dev](https://apt.wheels.dev)** and **[https://yum.wheels.dev](https://yum.wheels.dev)**. Add the source once, then `apt upgrade wheels` / `dnf upgrade wheels` picks up new versions automatically. The package installs `/usr/bin/wheels`, declares OpenJDK 21 as a runtime dependency (so `apt`/`dnf` pulls a JDK in automatically), and on first run syncs the framework module into `~/.wheels/`.
 
 <Aside type="note" title="GPG signing">
 The apt and yum repos are GPG-signed with the Wheels Distribution key (fingerprint `6872 16C9 32B4 9F03 94E0 9AED 5D89 AF8F 9C9B 8CFB`). `apt`/`dnf` verify the signature on every update, so a network-level attacker can't substitute the package contents. The public half is published at `https://apt.wheels.dev/wheels.gpg` and `https://yum.wheels.dev/wheels.gpg` — both files are byte-identical. The sources.list / `.repo` snippets below wire the signature check in automatically.

--- a/web/sites/guides/src/content/docs/v4-0-1-snapshot/start-here/release-channels.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-1-snapshot/start-here/release-channels.mdx
@@ -75,44 +75,38 @@ The rest of the install steps are identical — see [Installing Wheels → Windo
 
 <TabItem label="Linux" icon="linux">
 
-Each channel ships `.deb` and `.rpm` packages on its respective releases page:
+Each channel ships from a signed native repository — distinct package names (`wheels` vs `wheels-be`) so both channels can coexist on the same host:
 
-- **Stable**: [github.com/wheels-dev/wheels/releases](https://github.com/wheels-dev/wheels/releases)
-- **Bleeding-edge**: [github.com/wheels-dev/wheels-snapshots/releases](https://github.com/wheels-dev/wheels-snapshots/releases)
+- **Stable**: `https://apt.wheels.dev stable main` / `https://yum.wheels.dev/wheels.repo` → package `wheels`
+- **Bleeding-edge**: `https://apt.wheels.dev bleeding-edge main` / `https://yum.wheels.dev/wheels-be.repo` → package `wheels-be`
 
 ```bash title="Debian / Ubuntu (stable)"
-WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
-curl -fsSLO "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels_${WHEELS_VERSION}_amd64.deb"
-sudo apt install "./wheels_${WHEELS_VERSION}_amd64.deb"
+curl -fsSL https://apt.wheels.dev/wheels.gpg \
+  | sudo tee /usr/share/keyrings/wheels.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev stable main" \
+  | sudo tee /etc/apt/sources.list.d/wheels.list
+sudo apt update && sudo apt install wheels
 ```
 
 ```bash title="Fedora / RHEL (stable)"
-WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
-sudo dnf install "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels-${WHEELS_VERSION}.x86_64.rpm"
+sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels.repo
+sudo dnf install wheels
 ```
 
 ```bash title="Debian / Ubuntu (bleeding-edge)"
-# The bleeding-edge channel publishes only pre-releases, so use /releases (not /releases/latest).
-WHEELS_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
-# Tag uses a SemVer hyphen (4.0.0-snapshot.N). The on-disk asset name uses a dot
-# in the same slot because GitHub Releases rewrites the package's internal
-# ~snapshot.N form to . at upload time. So translate hyphen → dot for the URL.
-WHEELS_FILENAME_VER="${WHEELS_TAG//-/.}"
-curl -fsSLO "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${WHEELS_TAG}/wheels-be_${WHEELS_FILENAME_VER}_amd64.deb"
-sudo apt install "./wheels-be_${WHEELS_FILENAME_VER}_amd64.deb"
+curl -fsSL https://apt.wheels.dev/wheels.gpg \
+  | sudo tee /usr/share/keyrings/wheels.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev bleeding-edge main" \
+  | sudo tee /etc/apt/sources.list.d/wheels-be.list
+sudo apt update && sudo apt install wheels-be
 ```
 
 ```bash title="Fedora / RHEL (bleeding-edge)"
-WHEELS_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
-WHEELS_FILENAME_VER="${WHEELS_TAG//-/.}"
-sudo dnf install "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${WHEELS_TAG}/wheels-be-${WHEELS_FILENAME_VER}.x86_64.rpm"
+sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels-be.repo
+sudo dnf install wheels-be
 ```
 
-Apt and yum repos at `apt.wheels.dev` / `yum.wheels.dev` are coming — they'll let you `apt upgrade wheels` instead of re-downloading.
+Both repos are GPG-signed (fingerprint `6872 16C9 32B4 9F03 94E0 9AED 5D89 AF8F 9C9B 8CFB`); `apt update` / `dnf check-update` verifies the signature on every refresh. The raw `.deb`/`.rpm` are also uploaded to each GitHub Release as a fallback for air-gapped installs (see [CLI Installation](/v4-0-1-snapshot/command-line-tools/installation/)).
 
 </TabItem>
 
@@ -139,47 +133,41 @@ brew install wheels
 ```
 
 ```bash title="Linux — stable → bleeding-edge (Debian / Ubuntu)"
-# wheels-be .deb declares Replaces: wheels + Conflicts: wheels, so apt
-# removes the stable wheels package and installs wheels-be in its place
-# without a separate `apt remove` step.
-SNAP_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
-SNAP_FILENAME_VER="${SNAP_TAG//-/.}"
-curl -fsSLO "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${SNAP_TAG}/wheels-be_${SNAP_FILENAME_VER}_amd64.deb"
-sudo apt install "./wheels-be_${SNAP_FILENAME_VER}_amd64.deb"
+# Add the bleeding-edge source (uses the same key already imported for stable).
+# wheels-be .deb declares Replaces: wheels + Conflicts: wheels, so apt removes
+# the stable wheels package and installs wheels-be in its place — no separate
+# `apt remove` needed.
+echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev bleeding-edge main" \
+  | sudo tee /etc/apt/sources.list.d/wheels-be.list
+sudo apt update && sudo apt install wheels-be
 ```
 
 ```bash title="Linux — stable → bleeding-edge (Fedora / RHEL)"
 # wheels-be .rpm declares Conflicts: wheels but no Obsoletes, so dnf
 # refuses to install while the stable wheels package is present. Remove
-# it first.
+# it first, then add the bleeding-edge .repo source and install.
 sudo dnf remove wheels
-SNAP_TAG=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels-snapshots/releases \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p' | head -1)
-SNAP_FILENAME_VER="${SNAP_TAG//-/.}"
-sudo dnf install "https://github.com/wheels-dev/wheels-snapshots/releases/download/v${SNAP_TAG}/wheels-be-${SNAP_FILENAME_VER}.x86_64.rpm"
+sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels-be.repo
+sudo dnf install wheels-be
 ```
 
 ```bash title="Linux — bleeding-edge → stable (Debian / Ubuntu)"
 # wheels-be declares Conflicts: wheels, so apt refuses to install wheels
 # while wheels-be is present. (Stable wheels .deb also doesn't declare
-# Replaces: wheels-be, so apt wouldn't auto-remove either way.) Remove
-# wheels-be first.
+# Replaces: wheels-be.) Remove wheels-be, then install wheels — both
+# come from the same apt.wheels.dev source list, so no extra setup needed.
 sudo apt remove wheels-be
-WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
-curl -fsSLO "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels_${WHEELS_VERSION}_amd64.deb"
-sudo apt install "./wheels_${WHEELS_VERSION}_amd64.deb"
+sudo apt install wheels
 ```
 
 ```bash title="Linux — bleeding-edge → stable (Fedora / RHEL)"
 # Same as Debian above — wheels-be declares Conflicts: wheels, so dnf
 # refuses to install wheels while wheels-be is present. Remove wheels-be
-# first.
+# first, then install wheels. Both come from yum.wheels.dev (stable lives
+# at wheels.repo, bleeding-edge at wheels-be.repo); the stable .repo file
+# is left in place from the original install so no extra setup is needed.
 sudo dnf remove wheels-be
-WHEELS_VERSION=$(curl -fsSL https://api.github.com/repos/wheels-dev/wheels/releases/latest \
-  | sed -nE 's/.*"tag_name": *"v([^"]+)".*/\1/p')
-sudo dnf install "https://github.com/wheels-dev/wheels/releases/download/v${WHEELS_VERSION}/wheels-${WHEELS_VERSION}.x86_64.rpm"
+sudo dnf install wheels
 ```
 
 ```powershell title="Windows (Scoop) — stable → bleeding-edge"

--- a/web/sites/packages/src/lib/registry.test.ts
+++ b/web/sites/packages/src/lib/registry.test.ts
@@ -59,6 +59,43 @@ describe('registry', () => {
       const { listPackageNames } = await import('./registry');
       await expect(listPackageNames()).rejects.toThrow(/Registry fetch failed: 403/);
     });
+
+    it('sends an Authorization header when GITHUB_TOKEN is set', async () => {
+      vi.stubEnv('GITHUB_TOKEN', 'ghs_test-token-abc');
+      vi.resetModules();
+
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify([{ name: 'foo', type: 'dir' }]), { status: 200 }),
+      );
+
+      const { listPackageNames } = await import('./registry');
+      await listPackageNames();
+
+      const [, init] = fetchSpy.mock.calls[0];
+      const sentHeaders = (init as RequestInit | undefined)?.headers as
+        | Record<string, string>
+        | undefined;
+      expect(sentHeaders?.Authorization).toBe('Bearer ghs_test-token-abc');
+    });
+
+    it('omits Authorization when no token env var is set', async () => {
+      vi.stubEnv('GITHUB_TOKEN', '');
+      vi.stubEnv('GH_TOKEN', '');
+      vi.resetModules();
+
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify([{ name: 'foo', type: 'dir' }]), { status: 200 }),
+      );
+
+      const { listPackageNames } = await import('./registry');
+      await listPackageNames();
+
+      const [, init] = fetchSpy.mock.calls[0];
+      const sentHeaders = (init as RequestInit | undefined)?.headers as
+        | Record<string, string>
+        | undefined;
+      expect(sentHeaders?.Authorization).toBeUndefined();
+    });
   });
 
   describe('fetchManifest', () => {

--- a/web/sites/packages/src/lib/registry.ts
+++ b/web/sites/packages/src/lib/registry.ts
@@ -28,8 +28,24 @@ const REPO = process.env.WHEELS_PACKAGES_REGISTRY ?? 'wheels-dev/wheels-packages
 const BRANCH = 'main';
 const UA = 'wheels-dev/packages-site (https://packages.wheels.dev)';
 
+// Build the request headers for each registry fetch. When a GitHub token is
+// available (CI: `GITHUB_TOKEN` is auto-provided to every workflow), include
+// an Authorization header. This raises the GitHub REST API rate limit from
+// 60 req/hour (unauthenticated, per-IP) to 5000 req/hour (per-token). The
+// build hit the 60/hour cap during rapid CI activity on PR #2814, failing
+// with a 403 and trashing the deploy. Locally / in offline preview builds
+// the variable is unset and we fall back to unauthenticated requests.
+function headers(): HeadersInit {
+  const h: Record<string, string> = { 'User-Agent': UA };
+  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  if (token) {
+    h.Authorization = `Bearer ${token}`;
+  }
+  return h;
+}
+
 async function getJson(url: string): Promise<unknown> {
-  const res = await fetch(url, { headers: { 'User-Agent': UA } });
+  const res = await fetch(url, { headers: headers() });
   if (!res.ok) {
     throw new Error(`Registry fetch failed: ${res.status} ${res.statusText} — ${url}`);
   }
@@ -37,7 +53,7 @@ async function getJson(url: string): Promise<unknown> {
 }
 
 async function getText(url: string): Promise<string> {
-  const res = await fetch(url, { headers: { 'User-Agent': UA } });
+  const res = await fetch(url, { headers: headers() });
   if (!res.ok) {
     throw new Error(`Registry fetch failed: ${res.status} ${res.statusText} — ${url}`);
   }


### PR DESCRIPTION
## Summary

Closes [#2605](https://github.com/wheels-dev/wheels/issues/2605). `apt.wheels.dev` and `yum.wheels.dev` are now **live, signed, and serving from Cloudflare R2** with custom apex-domain bindings.

End-user UX:
```bash
# Debian / Ubuntu
curl -fsSL https://apt.wheels.dev/wheels.gpg \
  | sudo tee /usr/share/keyrings/wheels.gpg >/dev/null
echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev stable main" \
  | sudo tee /etc/apt/sources.list.d/wheels.list
sudo apt update && sudo apt install wheels

# Fedora / RHEL
sudo dnf config-manager --add-repo https://yum.wheels.dev/wheels.repo
sudo dnf install wheels
```

GPG-signed with key `6872 16C9 32B4 9F03 94E0 9AED 5D89 AF8F 9C9B 8CFB` (`Wheels Distribution <hello@wheels.dev>`, expires 2031-05-25). Both `InRelease` and `repomd.xml.asc` verify locally against the published `wheels.gpg`.

## Architecture deviation: R2, not Pages

The original Phase 2 sketch in [`tools/distribution-drafts/linux-packages/README.md`](tools/distribution-drafts/linux-packages/README.md) used Cloudflare Pages. Pages enforces a **25 MiB per-file limit**; the `.deb` is 80 MB and the `.rpm` is 81 MB. The architecture pivoted to **Cloudflare R2** (no per-object size limit) with custom-domain serving, so the URL UX is unchanged.

| Component | Implementation |
|--|--|
| `apt.wheels.dev` | R2 bucket `wheels-apt` with custom domain attached |
| `yum.wheels.dev` | R2 bucket `wheels-yum` with custom domain attached |
| Receiver workflow | `wheels-dev/{apt,yum}-wheels` repos host the workflow; each run syncs from R2 → regen metadata → uploads changed tree to R2 |
| Sender wiring | unchanged — `release.yml`'s existing dispatch step fires `wheels-released` at both buckets |

## Files in this commit (all in `wheels-dev/wheels`)

- `tools/distribution-drafts/apt-repo/` — receiver workflow rewired for R2 sync + README updated
- `tools/distribution-drafts/yum-repo/` — same, plus the **rpm-sign passphrase fix**: `rpm --addsign` was failing in CI because `pinentry-mode loopback` doesn't tell gpg WHERE to get the passphrase. Override `%__gpg_sign_cmd` with explicit `--passphrase-file` pointing at a chmod-600 temp file
- `tools/distribution-drafts/linux-packages/README.md` — Phase 2 section now documents the R2 architecture + the secrets checklist gains `CLOUDFLARE_API_TOKEN` on each bucket repo
- `web/sites/guides/src/content/docs/v4-0-1-snapshot/start-here/installing.mdx` — Linux install flips to `apt.wheels.dev`/`yum.wheels.dev` sources, replaces the "Phase 1 trust model" caveat with a "GPG signing" Aside naming the fingerprint
- `web/sites/guides/src/content/docs/v4-0-1-snapshot/command-line-tools/installation.mdx` — same flip + retains the GH-Release one-off download as a Tip for air-gapped use
- `web/sites/guides/src/content/docs/v4-0-0/start-here/installing.mdx`, `web/sites/guides/src/content/docs/v4-0-0/start-here/release-channels.mdx`, `web/sites/guides/src/content/docs/v4-0-0/command-line-tools/installation.mdx` — same flip for the v4-0-0 docs so the GA-shipped Linux install instructions point at the canonical native sources rather than the Phase 1 GH-Release `apt install ./<file>.deb` story

## Operational state (parallel, outside this repo)

- ✅ Wheels Distribution GPG key minted, stored in 1Password at `op://Wheels/wheels-linux-repo-signing/` (private key, passphrase, revocation cert, fingerprint, key ID, expiry).
- ✅ Cloudflare API token extended to add `Workers R2 Storage:Edit` permission.
- ✅ R2 buckets `wheels-apt` + `wheels-yum` created on the wheels.dev account.
- ✅ Custom domains `apt.wheels.dev` / `yum.wheels.dev` bound to the buckets; SSL active.
- ✅ Bucket-repo secrets set: `WHEELS_REPO_GPG_PRIVATE_KEY`, `WHEELS_REPO_GPG_PASSPHRASE`, `CLOUDFLARE_API_TOKEN` on both `wheels-dev/apt-wheels` and `wheels-dev/yum-wheels`.
- ✅ Both receivers smoke-tested via `gh workflow run wheels-released.yml -f version=4.0.1 -f channel=stable`. Verified live: GPG-signed metadata + 80MB `.deb` / 81MB `.rpm` serving with correct `content-length`.

## Still outstanding (single user-only step)

**`LINUX_REPO_DISPATCH_TOKEN` on `wheels-dev/wheels`** — needs a fine-grained PAT with `actions: write` on `wheels-dev/apt-wheels` and `wheels-dev/yum-wheels`. Until it's set, the dispatch step in `release.yml` skips silently — the next release ships without auto-publish, but backfill via `gh workflow run wheels-released.yml --repo wheels-dev/<bucket> -f version=<v> -f channel=<c>` works.

Mint at <https://github.com/settings/personal-access-tokens/new> with:
- Resource owner: `wheels-dev`
- Repository access: `apt-wheels` + `yum-wheels` (just those two)
- Permissions: `Actions: Read and write`
- Expiry: pick whatever your org allows (90 days is fine; renew before expiry)

Then: `gh secret set LINUX_REPO_DISPATCH_TOKEN --repo wheels-dev/wheels` (paste the token value).

## Test plan

- [x] GPG verification of `InRelease` and `repomd.xml.asc` against the published `wheels.gpg` passes (matches the minted fingerprint).
- [x] Apt metadata's `Filename:` and reported `Size:` / `SHA256:` agree with the live `.deb` URL.
- [x] HEAD request on the live `.deb` returns 200 with `Content-Length: 80127158`, matching the upstream GH Release asset byte-for-byte.
- [x] HEAD request on the live `.rpm` returns 200 with `Content-Length: 81156159`, matching upstream.
- [ ] End-to-end install on a fresh Debian/Ubuntu host (not run locally — Docker daemon unavailable; cryptographic verification proves the trust chain so this is low-risk).
- [ ] End-to-end install on a fresh Fedora/RHEL host (same).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
