### PR TITLE
ci(release): guard CHANGELOG separator + fix release playbook

### DIFF
--- a/.github/RELEASE_PLAYBOOK.md
+++ b/.github/RELEASE_PLAYBOOK.md
@@ -29,24 +29,44 @@ on them is green. ~5 minutes/day max.
 
 1. **Cherry-pick or merge stabilization commits to `release/X.Y.Z`** if using a
    release-branch workflow. Skip this if cutting directly from develop.
-2. **Update `CHANGELOG.md`** with the release date (replace `=> TBD` for the
-   target version). `release.yml` will refuse to publish if it sees TBD on the
-   target version.
-3. **Verify `box.json` version** matches what you want to release. After the
-   last GA, the `bump-develop-version.yml` workflow set it to next-patch; if
-   you're shipping a bigger bump, update it manually.
+2. **Update `CHANGELOG.md`**: rename `# [Unreleased]` to
+   `# [X.Y.Z](...) => YYYY-MM-DD` with the real release date (replace any
+   `=> TBD`). Then confirm the separator line directly below the renamed
+   section is exactly `---` (three dashes), NOT `----`. `release.yml` refuses
+   to publish if it sees TBD on the target version, and also fails if a `----`
+   separator would make the release-notes awk bleed into the previous version's
+   notes (recurring footgun — see #2606, #2768; now guarded in `release.yml`).
+3. **Verify `wheels.json` version** matches what you want to release.
+   `wheels.json` is the canonical version source since the 4.0 rebrand (the
+   workflows read it; `box.json` is legacy and may be absent or empty). After
+   the last GA, the `bump-develop-version.yml` workflow set it to next-patch;
+   if you're shipping a bigger bump, update it manually.
 
 ### Release day
 
-```bash
-# 1. On main, fast-forward from the release branch.
-git checkout main
-git merge --ff-only release/X.Y.Z   # (or develop, if no release branch)
+`main` has a **"PRs only" ruleset** — `git push origin main` is rejected with
+`GH013`. You also never tag manually: `release.yml` auto-creates the tag via
+`softprops/action-gh-release` once the merge lands on main.
 
-# 2. Tag and push. release.yml fires automatically.
-git tag -a vX.Y.Z -m "Release X.Y.Z"
-git push origin main --tags
+```bash
+# 1. Open a PR into main from a release branch. (Cutting from develop directly
+#    is fine — just branch off develop so the PR has a head ref to merge.)
+git checkout develop && git pull
+git checkout -b release/X.Y.Z-to-main
+git push -u origin release/X.Y.Z-to-main
+gh pr create --base main --head release/X.Y.Z-to-main \
+  --title "Release X.Y.Z" --body "Cut X.Y.Z. See CHANGELOG."
+
+# 2. Merge with "Create a merge commit" (NOT squash — preserves develop
+#    history on main).
+gh pr merge --merge --delete-branch
 ```
+
+The push-to-main from that merge triggers `release.yml`, which builds the
+artifacts and calls `softprops/action-gh-release` with `tag_name: vX.Y.Z`,
+creating the tag at main HEAD automatically. Do **not** run `git tag` /
+`git push --tags` — the legacy `git push origin main --tags` flow is rejected
+by the ruleset anyway.
 
 The tag push triggers:
 - `release.yml` builds artifacts, publishes to `wheels-dev/wheels/releases`
@@ -149,7 +169,8 @@ If any pin to `<X.Y.Z`, open issues on those repos to widen the constraint.
 | Symptom | Cause | Fix |
 |---|---|---|
 | `release.yml` fails: "CHANGELOG contains TBD" | Forgot to update changelog | Add release date to `# [X.Y.Z]` line, push, re-run workflow |
-| `release.yml` fails: "version contains -SNAPSHOT" | `box.json` has `-SNAPSHOT` suffix on main | Strip suffix, push (release.yml asserts clean main versions) |
+| `release.yml` fails: "release-notes range … bleeds into a later version section" | Separator below the target version is `----` (4 dashes), not `---` — the awk extraction overruns into the previous version | Change that separator line to exactly `---`, push, re-run |
+| `release.yml` fails: "version contains -SNAPSHOT" | `wheels.json` has a `-snapshot` suffix on main | Strip the suffix in `wheels.json`, push (release.yml asserts clean main versions) |
 | brew tap PR doesn't open after release | `DOWNSTREAM_DISPATCH_TOKEN` expired or unset | Rotate token in repo secrets; re-run `release.yml` workflow_dispatch |
 | develop-bump PR doesn't open after GA | `DOWNSTREAM_DISPATCH_TOKEN` expired/unset, OR the `bump-develop` dispatch step warned and exited 0 | Fire it manually: Actions → "Bump Develop Version" → "Run workflow" → enter the just-released version (e.g. `4.0.0`). The workflow has a `workflow_dispatch` fallback for exactly this case. |
 | `brew install wheels` post-release fails | Formula sha256 mismatch | Re-run the tap bump workflow with `workflow_dispatch` to recompute |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,23 @@ jobs:
             exit 1
           fi
 
+          # Check that the CHANGELOG separator below this version is exactly
+          # '---' (3 dashes). The release-notes extraction step below uses the
+          # awk range /^# \[VERSION\]/,/^---$/, which terminates ONLY on a line
+          # of exactly three dashes; a '----' (4-dash) separator silently
+          # extends the range into the PREVIOUS version's notes. We mirror that
+          # exact awk here and fail if the extracted range pulls in another
+          # version heading. (Recurring footgun — see #2606, #2768.)
+          VERSION_PATTERN=$(echo "${WHEELS_VERSION%+*}" | sed 's/\./\\./g')
+          BLED=$(awk '/^# \['"${VERSION_PATTERN}"'\]/,/^---$/ {print}' CHANGELOG.md \
+            | tail -n +2 | grep -cE '^# \[' || true)
+          if [ "${BLED}" -ne 0 ]; then
+            echo "ERROR: CHANGELOG release-notes range for [${WHEELS_VERSION%+*}] bleeds into a later version section."
+            echo "The separator directly below the [${WHEELS_VERSION%+*}] block must be exactly '---' (3 dashes), not '----'."
+            echo "This check mirrors the awk extraction used to build the GitHub Release notes."
+            exit 1
+          fi
+
           # Check that source version in wheels.json is clean (no -snapshot suffix).
           # The workflow injects -snapshot.N for develop builds automatically.
           BASE_VERSION=$(jq -r '.version' wheels.json)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 - The documented Linux bleeding-edge install commands in the guides 404'd after #2759 renamed the snapshot artifacts from `wheels_*` to `wheels-be_*` (deb) / `wheels-be-*` (rpm) to differentiate the channel by package name. All six affected pages — three unique (`start-here/installing`, `start-here/release-channels`, `command-line-tools/installation`) mirrored across the v4-0-0 and v4-0-1-snapshot doc versions — now point at the correct `wheels-be_*` assets, and the "switching channels" snippets reflect the real `Conflicts: wheels` package metadata instead of assuming same-package-name `--allow-downgrades` / `dnf downgrade` transitions (#2777)
 - Stale `schema_migrations` table-name references in the v4 migration and seeding guides (`v4-0-0/basics/seeding`, `v4-0-1-snapshot/basics/migrations`, `v4-0-1-snapshot/basics/seeding`) now read `wheels_migrator_versions`, matching the on-disk table name since the `c_o_r_e_*` → `wheels_*` rename — no `schema_migrations` table exists anywhere in `vendor/wheels/`, `cli/`, or `app/`. Carryover from #2799 (#2801)
 
-----
+---
 
 # [4.0.1](https://github.com/wheels-dev/wheels/releases/tag/v4.0.1) => 2026-05-20
 


### PR DESCRIPTION
## Summary

Release-prep hardening ahead of the 4.0.2 cut. **This does not bump the version or cut the release** — that's a separate, maintainer-triggered step.

- **CHANGELOG.md** — the separator below `[Unreleased]` was `----` (4 dashes). `release.yml` extracts release notes via the awk range `/^# \[VERSION\]/,/^---$/`, which terminates only on *exactly* three dashes — so a 4-dash separator would have swallowed all of 4.0.1's notes into the 4.0.2 GitHub Release. Flipped to `---`. (Same regression fixed at #2606 and #2768.)
- **release.yml** — added a `main`-gated guard in the release-checklist step that mirrors the extraction awk and fails the release if the range bleeds into a later version heading. Stops this from recurring silently.
- **RELEASE_PLAYBOOK.md** — corrected two stale points: the version source is `wheels.json` (not `box.json`) since the 4.0 rebrand, and the release-day flow is PR-into-main + `softprops` auto-tag (main's PRs-only ruleset rejects `git push origin main --tags`). Documented the new guard and its failure mode.

Also removed a stray empty untracked `box.json` from the working tree (not in this diff — it was never tracked).

**Deliberately not included:** a changelog entry for #2815. It's an intra-cycle fix to the *unreleased* #2807 advisory feature, so GA 4.0.2 users never experience the break — per the changelog convention we skip internal fix-ups of unreleased work.

## Test plan

- [x] `release.yml` parses as valid YAML (ruby YAML.load_file)
- [x] Guard **passes** (BLED=0) against the fixed `---` separator
- [x] Guard **fires** (BLED=1) against HEAD's `----` separator — regression is caught
- [x] Simulated release-notes extraction stops cleanly at the 4.0.1 boundary (no version-heading bleed)
- [ ] CI green (commitlint + fast-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)