### PR TITLE
ci(release): force Node 24 for JS actions + add workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,12 @@ on:
   push:
     branches:
       - main
+  # Manual re-trigger for a stuck or failed release without needing a fresh
+  # push to main. Version + channel are derived from the dispatched ref's
+  # wheels.json (main -> stable, develop -> snapshot), identical to the
+  # push / workflow_call paths since channel selection keys on GITHUB_REF.
+  # See #2819.
+  workflow_dispatch:
   workflow_call:
     secrets:
       SLACK_WEBHOOK_URL:
@@ -41,6 +47,13 @@ on:
 env:
   WHEELS_PRERELEASE: false
   LUCLI_VERSION: "0.3.7"
+  # Route JS actions through Node 24 instead of the deprecated Node 20 runtime.
+  # The lone Node 20 action here — Wandalen/wretry.action@v3, which wraps
+  # softprops/action-gh-release — began failing its pre/post hooks with
+  # "Argument list too long" once GitHub's forced Node 20 -> 24 migration
+  # reached the runners (forced default 2026-06-02). Node 24 is backward
+  # compatible for JS actions. See #2819.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   #############################################


### PR DESCRIPTION
## Summary

Unblocks the stuck **v4.0.2** release. The release push from #2819 failed in ~13–33s, **before any step ran** — the pre-hooks of `Wandalen/wretry.action@v3` (the lone Node 20 action, wrapping `softprops/action-gh-release`) threw `Argument list too long` spawning the `node20` binary.

**Root cause: GitHub's forced Node 20→24 runner migration** (forced default 2026-06-02), not our config:
- Run #2769 (4.0.1) passed 7 days earlier with the identical workflow + action.
- The develop snapshot path (same `wretry@v3`) succeeded 16 min before the failed release, on a pre-migration runner.
- The failure is at job init (pre-hook), so no step-exported env is involved — it's the deprecated node20 launcher.

## Changes
- **`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`** (workflow `env:`) — routes all JS actions, including `wretry@v3`, through Node 24, bypassing the broken node20 path. GitHub's documented remedy.
- **`workflow_dispatch`** trigger — re-fire a stuck/failed release from the Actions tab without a fresh push. Channel/version key on `GITHUB_REF` (main → stable, develop → snapshot), so no logic changes.

## ⚠️ Merging this re-fires the v4.0.2 release
The push to main triggers `release.yml` (now on Node 24): builds artifacts, auto-tags `v4.0.2`, dispatches homebrew/scoop + the develop bump. Prior failed attempts created **no** tag/release, so there's no double-publish risk.

## Follow-up
- [ ] Port the same `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` line to `develop`'s `release.yml` so snapshots don't break as the migration reaches their runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)