### PR TITLE
ci(release): pin softprops target_commitish to the release commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -454,8 +454,13 @@ jobs:
           action: softprops/action-gh-release@v2.6.2
           attempt_limit: 3
           attempt_delay: 30000
+          # target_commitish pins the tag to the exact release commit. softprops
+          # otherwise defaults it to the repo default branch (develop), so a
+          # stable tag lands off-main whenever main has diverged from develop at
+          # release time (what happened to v4.0.2). See #2819.
           with: |
             tag_name: v${{ env.WHEELS_VERSION }}
+            target_commitish: ${{ github.sha }}
             name: Wheels ${{ env.WHEELS_VERSION }}
             body_path: release-notes.md
             draft: false


### PR DESCRIPTION
## Summary

Prevents the off-main stable tag from recurring every cut where main has diverged from develop.

`softprops/action-gh-release` defaults `target_commitish` to the repo **default branch (`develop`)** when unset — so the v4.0.2 stable tag was created on develop's HEAD (`59ff240e3`, off-main) instead of the released commit, and had to be force-moved manually post-release (#2819). This pins `target_commitish: ${{ github.sha }}` on the stable **Create GitHub Release** step so the tag always lands on the exact commit that was built.

**Stable step only** — the snapshot step (`Create Snapshot Pre-Release`) publishes to `wheels-dev/wheels-snapshots` via `repository:`, where a `wheels`-repo SHA wouldn't resolve, so it's intentionally left untouched.

## Test plan
- [x] `release.yml` valid YAML; `target_commitish` present once (stable step only)
- [ ] Verified on the next stable cut: `v4.0.3` tag lands on main HEAD with no manual move

🤖 Generated with [Claude Code](https://claude.com/claude-code)