### PR TITLE
docs(changelog): promote develop [Unreleased] to [4.0.2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 
 ----
 
-# [Unreleased]
+# [4.0.2](https://github.com/wheels-dev/wheels/releases/tag/v4.0.2) => 2026-05-27
+
+> **Wheels 4.0.2** — second patch on the 4.0 line. Adds shared-development-database migrator reconciliation (`wheels migrate doctor` / `forget` / `pretend`, orphan-version auto-detection, and `name` / `applied_at` enrichment of the `wheels_migrator_versions` tracking table) plus `columnNames` aliases across `t.references()`, `t.primaryKey()`, and the `Migration.cfc` command helpers; ships native GPG-signed Linux package repositories at `apt.wheels.dev` and `yum.wheels.dev` (Cloudflare R2); resolves `BrowserTest` base URLs through a layered instance-time lookup; and greens the compatibility matrix across BoxLang and Adobe ColdFusion 2023/2025. ~30 PRs since the 4.0.1 GA (2026-05-20).
 
 ### Added
 


### PR DESCRIPTION
## Summary

The 4.0.2 cut renamed `[Unreleased]` → `[4.0.2]` on the release branch only (#2819 squash-merged to main), so **develop still shows the 4.0.2 entries under `[Unreleased]`**. Left as-is, the 4.0.3 cut would rename those same already-shipped entries to `[4.0.3]` and re-publish them.

This promotes them to `# [4.0.2] => 2026-05-27` (heading + blockquote copied verbatim from main), so develop's CHANGELOG is now **identical to main's**. The next 4.0.3 entry PR re-creates `[Unreleased]` on top, per the existing post-cut convention.

## Test plan
- [x] `git diff origin/main -- CHANGELOG.md` is empty after the rename (develop == main)
- [x] 4.0.2 entries now correctly labelled `[4.0.2]`, not `[Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)