### PR TITLE
feat(engine): recognize RustCFML + degrade caching when cfcache is absent

### DIFF
--- a/.ai/wheels/cross-engine-compatibility.md
+++ b/.ai/wheels/cross-engine-compatibility.md
@@ -2,6 +2,8 @@
 
 Wheels runs on multiple CFML engines (Lucee 5/6/7, Adobe CF 2018-2025, BoxLang) and databases (H2, MySQL, PostgreSQL, SQL Server, CockroachDB). Each engine has runtime differences that can cause code to pass on one engine but fail on another. This guide documents the known gotchas.
 
+**RustCFML (best-effort, experimental):** [RustCFML](https://github.com/RustCFML/RustCFML) — a young, JVM-free CFML interpreter written in Rust — is recognized as a first-class engine in the adapter layer (`server.coldfusion.productName == "RustCFML"` → `RustCFMLAdapter`), but it is NOT yet part of the CI matrix and cannot fully boot the framework today. The confirmed divergence handled in-framework is the **missing `cfcache` built-in** (the cfcache-backed cache degrades to a no-op via the adapter's `supportsCfcache()=false`). Remaining blockers are tracked upstream — chiefly an argument-scope-fidelity gap (undeclared/`argumentCollection`-forwarded named args lose their names) and no Query-of-Queries — so treat RustCFML support as in-progress.
+
 ## Engine-Specific Gotchas
 
 ### struct.map() Collision (Lucee + Adobe)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 
 # [Unreleased]
 
+### Added
+
+- RustCFML is now recognized as a first-class engine in the engine-adapter layer. Wheels detects it via `server.coldfusion.productName == "RustCFML"` (it exposes no `server.lucee`/`server.boxlang`), instantiates a `RustCFMLAdapter` (extends `Base`, whose defaults are Lucee-shaped, matching RustCFML's semantics) ordered before the Adobe ColdFusion fallback, and accepts any version in `$checkMinimumVersion` (RustCFML is pre-1.0 and rapidly evolving, so the usual minimum-version guard doesn't apply). Because RustCFML does not yet implement the `cfcache` built-in, the framework's cfcache-backed template/static cache degrades gracefully to a no-op when the adapter reports `supportsCfcache() = false`, so requests still render (cacheless-but-working). The new `supportsCfcache()` capability defaults to `true` on Lucee/Adobe/BoxLang, leaving their behavior unchanged. Support is best-effort: RustCFML is a young, JVM-free CFML interpreter and is not yet part of the CI matrix (#2837)
+
 ### Changed
 
 - Version switcher now labels the 4.0 stable docs "v4.0 (current)" (was "v4.0.0"); the vestigial pre-GA `v4-0-1-snapshot` guides tree is removed and its one unique page, "Reading the Changelog", is salvaged into `v4-0-0/upgrading/`. Both sites deploy from `develop`, so in-progress patch docs already live in the `v4-0-0` tree; a separate `*-snapshot` tree is only warranted when a different minor/major (e.g. `v4-1-snapshot`) is under development. Courtesy redirects cover the high-traffic `/v4-0-1-snapshot/*` paths (#2827)

--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -109,6 +109,13 @@ component output="false" {
 	public any function $cache() {
 		// If cache is found only the function is aborted, not page. --->
 		variables.$instance.reCache = false;
+		// Engines without the `cfcache` built-in (e.g. RustCFML) can't back
+		// the template/static cache. Degrade to a no-op: leaving reCache=true
+		// means the request still renders normally, just without this layer.
+		if ($hasEngineAdapter() && !$engineAdapter().supportsCfcache()) {
+			variables.$instance.reCache = true;
+			return;
+		}
 		local.args = {};
 		for (local.key in arguments) {
 			local.args[local.key] = arguments[local.key];
@@ -3016,6 +3023,12 @@ return local.$wheels;
 			local.minimumMinor = "0";
 			local.minimumPatch = "10";
 			local.minimumBuild = "314028";
+		} else if (arguments.engine == "RustCFML") {
+			// RustCFML is a pre-1.0, rapidly evolving experimental engine that
+			// Wheels supports on a best-effort basis. Accept any version (leave
+			// local.rv = "") rather than enforcing a minimum; per-version
+			// divergences are tracked via the RustCFMLAdapter capabilities.
+			local.rv = "";
 		} else {
 			local.rv = false;
 		}

--- a/vendor/wheels/engineAdapters/Base.cfc
+++ b/vendor/wheels/engineAdapters/Base.cfc
@@ -52,6 +52,24 @@ component output="false" {
 		return false;
 	}
 
+	/**
+	 * Returns true if the current engine is RustCFML.
+	 */
+	public boolean function isRustCFML() {
+		return false;
+	}
+
+	// --- Capabilities ---
+
+	/**
+	 * Returns true if the engine implements the `cfcache` built-in.
+	 * When false, Wheels degrades its cfcache-backed template/static cache
+	 * to a no-op (the framework still runs, just without that cache layer).
+	 */
+	public boolean function supportsCfcache() {
+		return true;
+	}
+
 	// --- Response / PageContext ---
 
 	/**

--- a/vendor/wheels/engineAdapters/RustCFML/RustCFMLAdapter.cfc
+++ b/vendor/wheels/engineAdapters/RustCFML/RustCFMLAdapter.cfc
@@ -1,0 +1,29 @@
+/**
+ * Engine adapter for RustCFML — an experimental, JVM-free CFML runtime
+ * written in Rust (https://github.com/RustCFML/RustCFML).
+ *
+ * RustCFML's CFML semantics track Lucee closely, so Base.cfc's
+ * Lucee-shaped defaults apply unchanged for most behavior. This adapter
+ * records the divergences we've confirmed against RustCFML so far; add an
+ * override here whenever a new divergence is found rather than scattering
+ * `serverName == "RustCFML"` checks through the framework.
+ */
+component extends="wheels.engineAdapters.Base" output="false" {
+
+	variables.engineName = "RustCFML";
+
+	public boolean function isRustCFML() {
+		return true;
+	}
+
+	/**
+	 * RustCFML (as of 0.41.0) does not implement the `cfcache` built-in.
+	 * Returning false makes Wheels skip its cfcache-backed template/static
+	 * cache (see Global.cfc $cache) so the framework boots and serves
+	 * cacheless-but-working instead of erroring on the missing built-in.
+	 */
+	public boolean function supportsCfcache() {
+		return false;
+	}
+
+}

--- a/vendor/wheels/events/onapplicationstart.cfc
+++ b/vendor/wheels/events/onapplicationstart.cfc
@@ -39,6 +39,16 @@ component {
 		} else if (StructKeyExists(server, "lucee")) {
 			application.$wheels.serverName = "Lucee";
 			application.$wheels.serverVersion = server.lucee.version;
+		} else if (
+			StructKeyExists(server, "coldfusion")
+			&& StructKeyExists(server.coldfusion, "productName")
+			&& server.coldfusion.productName == "RustCFML"
+		) {
+			// RustCFML reports itself via server.coldfusion.productName (no
+			// server.lucee / server.boxlang), so it must be detected before
+			// the Adobe fallback below or it gets misclassified as Adobe CF.
+			application.$wheels.serverName = "RustCFML";
+			application.$wheels.serverVersion = server.coldfusion.productVersion;
 		} else {
 			application.$wheels.serverName = "Adobe ColdFusion";
 			application.$wheels.serverVersion = server.coldfusion.productVersion;
@@ -50,6 +60,8 @@ component {
 			application.$wheels.engineAdapter = new wheels.engineAdapters.BoxLang.BoxLangAdapter(application.$wheels.serverVersion);
 		} else if (application.$wheels.serverName == "Lucee") {
 			application.$wheels.engineAdapter = new wheels.engineAdapters.Lucee.LuceeAdapter(application.$wheels.serverVersion);
+		} else if (application.$wheels.serverName == "RustCFML") {
+			application.$wheels.engineAdapter = new wheels.engineAdapters.RustCFML.RustCFMLAdapter(application.$wheels.serverVersion);
 		} else {
 			application.$wheels.engineAdapter = new wheels.engineAdapters.Adobe.AdobeAdapter(application.$wheels.serverVersion);
 		}

--- a/vendor/wheels/tests/specs/engineAdapterSpec.cfc
+++ b/vendor/wheels/tests/specs/engineAdapterSpec.cfc
@@ -10,7 +10,7 @@ component extends="wheels.WheelsTest" {
 
 			it("returns the correct engine name", function() {
 				var name = application.wheels.engineAdapter.getName();
-				expect(ListFind("Lucee,Adobe ColdFusion,BoxLang", name)).toBeGT(0);
+				expect(ListFind("Lucee,Adobe ColdFusion,BoxLang,RustCFML", name)).toBeGT(0);
 			});
 
 			it("returns a non-empty version string", function() {
@@ -18,7 +18,12 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("returns a valid major version", function() {
-				expect(application.wheels.engineAdapter.getMajorVersion()).toBeGT(0);
+				// Pre-1.0 engines (e.g. RustCFML 0.x) legitimately report major version 0.
+				if (application.wheels.engineAdapter.isRustCFML()) {
+					expect(application.wheels.engineAdapter.getMajorVersion()).toBeGTE(0);
+				} else {
+					expect(application.wheels.engineAdapter.getMajorVersion()).toBeGT(0);
+				}
 			});
 
 			it("matches the application serverName", function() {
@@ -79,6 +84,7 @@ component extends="wheels.WheelsTest" {
 				if (adapter.isLucee()) count++;
 				if (adapter.isAdobe()) count++;
 				if (adapter.isBoxLang()) count++;
+				if (adapter.isRustCFML()) count++;
 				expect(count).toBe(1);
 			});
 
@@ -107,6 +113,31 @@ component extends="wheels.WheelsTest" {
 					expect(adapter.isLucee()).toBeFalse();
 					expect(adapter.isAdobe()).toBeFalse();
 				}
+			});
+
+			it("identity matches engine name for RustCFML", function() {
+				var adapter = application.wheels.engineAdapter;
+				if (adapter.getName() == "RustCFML") {
+					expect(adapter.isRustCFML()).toBeTrue();
+					expect(adapter.isLucee()).toBeFalse();
+					expect(adapter.isAdobe()).toBeFalse();
+					expect(adapter.isBoxLang()).toBeFalse();
+				}
+			});
+
+		});
+
+		describe("Engine Adapter - Capabilities", function() {
+
+			it("supportsCfcache returns true on non-RustCFML engines (Base default)", function() {
+				var base = new wheels.engineAdapters.Base("7.0.0");
+				expect(base.supportsCfcache()).toBeTrue();
+			});
+
+			it("RustCFMLAdapter reports supportsCfcache false and isRustCFML true", function() {
+				var rustAdapter = new wheels.engineAdapters.RustCFML.RustCFMLAdapter("0.50.0");
+				expect(rustAdapter.supportsCfcache()).toBeFalse();
+				expect(rustAdapter.isRustCFML()).toBeTrue();
 			});
 
 		});

--- a/vendor/wheels/tests/specs/global/internalSpec.cfc
+++ b/vendor/wheels/tests/specs/global/internalSpec.cfc
@@ -181,6 +181,13 @@ component extends="wheels.WheelsTest" {
 				expect(len(g.$checkMinimumVersion(version="11,0,3,282462", engine="Adobe ColdFusion"))).toBeGT(0)
 				expect(len(g.$checkMinimumVersion(version="11,0,12,302575", engine="Adobe ColdFusion"))).toBeGT(0)
 			})
+
+			it("checks rustcfml accepts any version", () => {
+				// RustCFML is pre-1.0 and rapidly evolving; the guard accepts any version.
+				expect(len(g.$checkMinimumVersion(version="0.41.0", engine="RustCFML"))).toBe(0)
+				expect(len(g.$checkMinimumVersion(version="0.50.0", engine="RustCFML"))).toBe(0)
+				expect(len(g.$checkMinimumVersion(version="1.0.0", engine="RustCFML"))).toBe(0)
+			})
 		})
 
 		describe("Tests that $fullDomainString", () => {


### PR DESCRIPTION
## What

First step toward running Wheels on **RustCFML** (the JVM-free, Rust-based CFML runtime). Two additive, engine-gated changes:

1. **Recognize RustCFML as a first-class engine.** It reports `server.coldfusion.productName = "RustCFML"` and exposes no `server.lucee`/`server.boxlang`, so today Wheels misclassifies it as "Adobe ColdFusion 0.x" and the `$checkMinimumVersion` guard rejects it at `onApplicationStart`. This adds detection + a `RustCFMLAdapter` to the existing engine-adapter layer, and accepts it in the version guard.
2. **Degrade the `cfcache`-backed cache gracefully.** RustCFML doesn't implement the `cfcache` built-in. A new `supportsCfcache()` capability on the engine adapter lets `$cache()` no-op (leaving `reCache=true` so requests still render) instead of erroring at boot. The framework runs cacheless-but-working.

## How

- `events/onapplicationstart.cfc` — detect RustCFML (ordered before the Adobe fallback) + instantiate `RustCFMLAdapter`.
- `engineAdapters/RustCFML/RustCFMLAdapter.cfc` (new) — extends `Base` (whose defaults are Lucee-shaped, matching RustCFML's semantics); `isRustCFML()=true`, `supportsCfcache()=false`.
- `engineAdapters/Base.cfc` — `isRustCFML()` (false) + `supportsCfcache()` (true). The `supportsCfcache()` capability is the seam for tracking per-engine divergences going forward.
- `Global.cfc` — `$checkMinimumVersion` accepts RustCFML; `$cache()` guards on `supportsCfcache()`.

## Why it's safe for existing engines

Every change is additive and engine-gated:
- The new detection/adapter branches only match RustCFML (Lucee/Adobe/BoxLang hit their existing branches first, unchanged).
- `Base.supportsCfcache()` returns `true`, so the `$cache()` guard is **inert** on Lucee/Adobe/BoxLang — the original `cfcache` path runs exactly as before.
- New `Base` methods are purely additive.

## Verification

- **Lucee 7**: clean boot + core **model suite 843/843** via `tools/test-local.sh model`. Because all changes are boot-level, a clean boot exercises every one of them (engine detection, `$checkMinimumVersion`, the `onApplicationStart` `$cache(action="flush")` through the new guard, and adapter instantiation) with `supportsCfcache()=true`.
- Full engine × DB matrix runs in CI.
- On RustCFML 0.41.0 these changes let the boot clear the engine guard + the `cfcache` wall (it previously died at both).

## Scope / follow-ups

This is engine **recognition + cacheless degradation** — not a claim that Wheels fully renders on RustCFML yet. Further runtime divergences exist past this point (e.g. RustCFML's `cfdirectory` function-call form, filed upstream) and are being worked through separately. Companion to the cross-engine test PRs contributed to RustCFML itself.
