### PR TITLE
docs: standardize remaining guides on the bare env() accessor

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/basics/database-and-multiple-datasources.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/basics/database-and-multiple-datasources.mdx
@@ -40,11 +40,11 @@ Development, test, and production usually point at different databases. Keep the
 
 ```cfm {test:compile}
 set(dataSourceName = "myapp_production");
-set(dataSourceUserName = application.wo.env("DB_USER"));
-set(dataSourcePassword = application.wo.env("DB_PASSWORD"));
+set(dataSourceUserName = env("DB_USER"));
+set(dataSourcePassword = env("DB_PASSWORD"));
 ```
 
-Environment-specific settings are loaded after the shared ones, so whatever you set here wins. Read secrets from the environment with `application.wo.env("VAR_NAME")` — never commit credentials into the repo. See [Environments and Configuration](/v4-0-0/core-concepts/environments-and-configuration/) for the full configuration loading order.
+Environment-specific settings are loaded after the shared ones, so whatever you set here wins. Read secrets from the environment with `env("VAR_NAME")` — never commit credentials into the repo. See [Environments and Configuration](/v4-0-0/core-concepts/environments-and-configuration/) for the full configuration loading order.
 
 ## Per-model override
 
@@ -67,7 +67,7 @@ The typical legacy case is all three overrides at once: a non-default datasource
 ```cfm {test:compile}
 component extends="Model" {
     function config() {
-        dataSource(datasource="legacy_reporting", username="report_reader", password=application.wo.env("REPORT_DB_PASSWORD"));
+        dataSource(datasource="legacy_reporting", username="report_reader", password=env("REPORT_DB_PASSWORD"));
     }
 }
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/testing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/testing.mdx
@@ -96,7 +96,7 @@ App tests run against your project's configured datasource. To run the same suit
 
 ```cfm {test:compile} title="config/settings.cfm"
 <cfscript>
-set(dataSourceName=application.wo.env("WHEELS_DATASOURCE", "myapp"));
+set(dataSourceName=env("WHEELS_DATASOURCE", "myapp"));
 </cfscript>
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/authentication-patterns.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/authentication-patterns.mdx
@@ -255,7 +255,7 @@ if (StructKeyExists(application, "wheelsdi") && application.wheelsdi.containsIns
 
     if (!auth.hasStrategy("jwt")) {
         var jwtService = new wheels.auth.JwtService(
-            secretKey=application.wo.env("JWT_SECRET"),
+            secretKey=env("JWT_SECRET"),
             defaultExpiry=3600,
             issuer="myapp"
         );
@@ -265,7 +265,7 @@ if (StructKeyExists(application, "wheelsdi") && application.wheelsdi.containsIns
 }
 ```
 
-The secret lives in the environment (`application.wo.env("JWT_SECRET")`) — never commit it. `defaultExpiry` is seconds; 3600 = one hour. `issuer` is stamped as the `iss` claim and can be used by downstream validators to reject tokens meant for other services.
+The secret lives in the environment (`env("JWT_SECRET")`) — never commit it. `defaultExpiry` is seconds; 3600 = one hour. `issuer` is stamped as the `iss` claim and can be used by downstream validators to reject tokens meant for other services.
 
 ### Issue tokens on login
 
@@ -278,7 +278,7 @@ component extends="Controller" {
     function create() {
         var user = model("User").findOne(where="email = :email", values={email: params.email ?: ""});
         if (IsObject(user) && user.authenticate(params.password ?: "")) {
-            var jwtService = new wheels.auth.JwtService(secretKey=application.wo.env("JWT_SECRET"));
+            var jwtService = new wheels.auth.JwtService(secretKey=env("JWT_SECRET"));
             var token = jwtService.encode({sub: user.id, email: user.email, role: user.role});
             renderWith({token: token, expiresIn: 3600});
         } else {
@@ -322,7 +322,7 @@ if (StructKeyExists(application, "wheelsdi") && application.wheelsdi.containsIns
     var auth = service("authenticator");
 
     if (!auth.hasStrategy("jwt")) {
-        var jwtService = new wheels.auth.JwtService(secretKey=application.wo.env("JWT_SECRET"));
+        var jwtService = new wheels.auth.JwtService(secretKey=env("JWT_SECRET"));
         auth.registerStrategy(name="jwt", strategy=new wheels.auth.JwtStrategy(jwtService=jwtService));
     }
     if (!auth.hasStrategy("session")) {

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/sending-email.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/sending-email.mdx
@@ -57,10 +57,10 @@ set(functionName="sendEmail",
     port=587,
     useTLS=true,
     username="smtp-user",
-    password=application.wo.env("SMTP_PASSWORD"));
+    password=env("SMTP_PASSWORD"));
 ```
 
-Every argument `cfmail` accepts is available here: `server`, `port`, `username`, `password`, `useSSL`, `useTLS`, `from`, `replyto`, `failto`, `subject`, and more. Pulling secrets from `application.wo.env()` keeps credentials out of source control.
+Every argument `cfmail` accepts is available here: `server`, `port`, `username`, `password`, `useSSL`, `useTLS`, `from`, `replyto`, `failto`, `subject`, and more. Pulling secrets from `env()` keeps credentials out of source control.
 
 <Aside type="caution">
   Wheels does not define a `mailerSettings` struct. SMTP connection arguments go through the `sendEmail` function defaults (above) or via your CFML engine's mail service configuration. Anything you can pass to `cfmail`, you can set as a `sendEmail` default.
@@ -241,8 +241,8 @@ set(functionName="sendEmail",
     server="smtp.postmarkapp.com",
     port=587,
     useTLS=true,
-    username=application.wo.env("POSTMARK_TOKEN"),
-    password=application.wo.env("POSTMARK_TOKEN"));
+    username=env("POSTMARK_TOKEN"),
+    password=env("POSTMARK_TOKEN"));
 ```
 
 Set the env var once in your deploy config; the same mailer code now routes mail correctly in every environment. See [Environments and Configuration](/v4-0-0/core-concepts/environments-and-configuration/) for the full per-environment settings pipeline.


### PR DESCRIPTION
## What

Standardizes the env-var accessor in four `v4-0-0` guides on the bare `env(...)` form, replacing the remaining `application.wo.env(...)` calls — in both `{test:compile}` code fences and inline-code prose.

This is the deferred follow-up from #2857, which converted the scaffold plus the `deployment/` and `core-concepts/environments-and-configuration.mdx` env() guides. These four files were the remainder it did not touch:

- `basics/database-and-multiple-datasources.mdx`
- `digging-deeper/sending-email.mdx`
- `digging-deeper/authentication-patterns.mdx`
- `command-line-tools/wheels-commands/testing.mdx`

13 occurrences across the 4 files (13 insertions / 13 deletions).

## Why it's safe

`env()` is the **same public function** as `application.wo.env()` — `vendor/wheels/Global.cfc:597` (`public any function env(required string name, any defaultValue = "")`). The bare form resolves in config files and integrated components, and it is already the canonical, shipping pattern in the migration guide (`upgrading/3x-to-4x.mdx`) under `{test:compile}`.

## Scope guardrail

Accessor-style only — **no env-var names were renamed**. `DB_USER`, `DB_PASSWORD`, `REPORT_DB_PASSWORD`, `SMTP_PASSWORD`, `POSTMARK_TOKEN`, `JWT_SECRET`, and `WHEELS_DATASOURCE` are all preserved. No reload-password reconciliation here — that is #2857's domain.

## Verification

```
$ node scripts/verify-docs/verify-docs.mjs <4 touched files>
verify-docs: found 35 tagged block(s)
35 passed, 0 failed   (exit 0)
```

The migration guide's existing bare `env()` blocks pass the same harness (13/13), confirming this is the established convention.

## Note on the repo-wide grep

`grep -rn "application.wo.env" .../v4-0-0/` is **zero for the four files this PR owns**. The only remaining occurrences live in the four files owned by the still-open #2857 (`core-concepts/environments-and-configuration.mdx`, `deployment/{production-config,security-hardening,vm-deployment}.mdx`). The repo-wide count reaches zero once **both** this PR and #2857 land. The two PRs touch disjoint files — no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)