### PR TITLE
docs(web/guides): document Scoop install for Windows in release-channels

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/release-channels.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/release-channels.mdx
@@ -64,12 +64,19 @@ The two formulas are mutually exclusive — both expose the `wheels` binary, so 
 
 <TabItem label="Windows" icon="seti:windows">
 
-A Scoop bucket is in the works. Until it lands, install manually from the corresponding releases page:
+A [Scoop](https://scoop.sh) bucket ships both channels:
 
-- **Stable**: download `wheels-module-<version>.zip` from [github.com/wheels-dev/wheels/releases](https://github.com/wheels-dev/wheels/releases).
-- **Bleeding-edge**: download `wheels-module-<version>.zip` from [github.com/wheels-dev/wheels-snapshots/releases](https://github.com/wheels-dev/wheels-snapshots/releases).
+```powershell title="PowerShell"
+scoop bucket add wheels https://github.com/wheels-dev/scoop-wheels
 
-The rest of the install steps are identical — see [Installing Wheels → Windows](/v4-0-0/start-here/installing/#install-the-cli) for the LuCLI launcher and module-extraction details.
+# Stable
+scoop install wheels
+
+# Bleeding-edge
+scoop install wheels-be
+```
+
+The two packages are mutually exclusive — both expose the `wheels` binary, so Scoop refuses to install both at once. To switch channels, uninstall one and install the other (see [Switching channels](#switching-channels) below). Both inline OpenJDK 21, so no separate Java setup is needed — see [Installing Wheels → Windows](/v4-0-0/start-here/installing/#install-the-cli) for the Scoop + git prerequisites.
 
 </TabItem>
 

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/release-channels.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/release-channels.mdx
@@ -64,7 +64,7 @@ The two formulas are mutually exclusive — both expose the `wheels` binary, so 
 
 <TabItem label="Windows" icon="seti:windows">
 
-A [Scoop](https://scoop.sh) bucket ships both channels:
+Both channels are available via a [Scoop](https://scoop.sh) bucket:
 
 ```powershell title="PowerShell"
 scoop bucket add wheels https://github.com/wheels-dev/scoop-wheels


### PR DESCRIPTION
## Why

The Windows tab of the Release Channels guide still read *"A Scoop bucket is in the works. Until it lands, install manually from the corresponding releases page."* — stale since the `wheels-dev/scoop-wheels` bucket went live. It also **contradicted itself**: the "Switching channels" section further down the same page already used `scoop install wheels-be` / `scoop install wheels`, and the canonical install docs ([`installing.mdx`](https://github.com/wheels-dev/wheels/blob/develop/web/sites/guides/src/content/docs/v4-0-0/start-here/installing.mdx), [`command-line-tools/installation.mdx`](https://github.com/wheels-dev/wheels/blob/develop/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/installation.mdx)) document the bucket.

## What changed

Replaced the manual-download placeholder with the real Scoop install, mirroring the macOS tab's structure:

```powershell
scoop bucket add wheels https://github.com/wheels-dev/scoop-wheels
scoop install wheels        # stable
scoop install wheels-be     # bleeding-edge
```

Single-file docs change (`release-channels.mdx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
