### PR TITLE
fix(bot): keep conflict-resolver escalation loop-safe when git commit fails

### DIFF
--- a/.github/workflows/bot-resolve-conflicts.yml
+++ b/.github/workflows/bot-resolve-conflicts.yml
@@ -142,12 +142,31 @@ jobs:
           BASE_SHA: ${{ steps.merge.outputs.base }}
         run: |
           set -euo pipefail
-          # Success = a clean, committed merge to push. Failure = conflict markers
-          # still present, OR the command's safety gate aborted the merge with no
-          # new commit. On failure the PR stays DIRTY, so we MUST post the
-          # conflict-attempted marker and escalate — otherwise the freshen sweep
-          # re-dispatches this resolver every cycle (runaway loop), since the
-          # skip-check only matches that marker.
+          # Success = a clean, committed merge pushed to the PR branch. ANY other
+          # outcome must escalate and post the conflict-attempted marker, or the PR
+          # stays DIRTY with no marker and the freshen sweep re-dispatches this
+          # resolver every cycle (runaway loop) — the skip-check only matches that
+          # marker. A bare merge-commit (or push) that exits non-zero under
+          # "set -e" would abort this step BEFORE a linear escalation block could
+          # run, so we arm an EXIT trap that posts the marker on ANY non-zero exit
+          # — including failures of commands added to this step later. See issue
+          # #2849 (a #2847 follow-up).
+          pushed=0
+          escalate() {
+            # Runs from the EXIT trap. The success path sets pushed=1 first, so a
+            # clean push is a no-op here; every other exit lands the marker + label.
+            if [ "$pushed" = "1" ]; then return 0; fi
+            echo "::error::resolve path produced no pushed merge; escalating to human"
+            gh label create conflict:needs-human --repo "$REPO" --color B60205 \
+              --description "Merge conflict needs manual resolution" 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label conflict:needs-human || true
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$(printf '%s\n' \
+              "⚠️ **Automated content-conflict resolution did not complete** — leaving this for a human." \
+              "" \
+              "<!-- wheels-bot:conflict-attempted:$PR_NUMBER -->")" || true
+          }
+          trap escalate EXIT
+
           if git diff --name-only --diff-filter=U | grep -q .; then
             git merge --abort 2>/dev/null || true       # unresolved markers -> not resolved
           elif [ -f .git/MERGE_HEAD ]; then
@@ -155,16 +174,8 @@ jobs:
           fi
           if [ "$(git rev-parse HEAD)" != "$BASE_SHA" ]; then
             git push origin HEAD                          # resolved cleanly; PR checks re-validate
+            pushed=1
             exit 0
           fi
-          # No new commit -> resolution did not complete. Escalate to a human and
-          # post the marker so freshen does not re-dispatch this resolver.
-          gh label create conflict:needs-human --repo "$REPO" --color B60205 \
-            --description "Merge conflict needs manual resolution" 2>/dev/null || true
-          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label conflict:needs-human
-          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$(printf '%s\n' \
-            "⚠️ **Automated content-conflict resolution did not complete** — leaving this for a human." \
-            "" \
-            "<!-- wheels-bot:conflict-attempted:$PR_NUMBER -->")"
-          echo "::error::resolve path produced no committed merge; escalated to human"
+          # No new commit -> resolution did not complete; the EXIT trap escalates.
           exit 1

--- a/vendor/wheels/tests/specs/cli/BotResolveConflictsLoopSafeSpec.cfc
+++ b/vendor/wheels/tests/specs/cli/BotResolveConflictsLoopSafeSpec.cfc
@@ -1,0 +1,104 @@
+component extends="wheels.WheelsTest" {
+
+	// Regression for issue ##2849 (a follow-up to ##2847).
+	//
+	// The "Verify resolution, push, or escalate (loop-safe)" step in
+	// .github/workflows/bot-resolve-conflicts.yml runs under `set -euo pipefail`.
+	// It finishes a resolved-but-uncommitted merge with `git commit --no-edit`,
+	// then — if no new commit landed — escalates by applying the
+	// `conflict:needs-human` label and posting a comment carrying the
+	// `wheels-bot:conflict-attempted` marker. The freshen sweep's skip-check
+	// keys off that marker, so the marker is what stops the resolver from being
+	// re-dispatched on every cycle.
+	//
+	// The bug: a *bare* `git commit --no-edit` is fatal under `set -e`. If the
+	// commit itself exits non-zero (e.g. a pre-commit hook rejects it), the step
+	// aborts at that line, BEFORE the escalation block runs. No marker is posted,
+	// the PR stays DIRTY, and the freshen sweep re-dispatches this resolver every
+	// cycle (runaway loop). The author's original comment anticipated the
+	// "merge aborted -> no new commit" path (which correctly falls through to
+	// escalation) but not the "the commit command itself failed" path.
+	//
+	// The fix arms an exit-time trap that posts the marker on ANY non-zero exit
+	// of the step (a hook-rejected commit, a failed push, or any command added
+	// later) — satisfying the acceptance criterion that "any failure on the
+	// resolve path leaves a conflict-attempted marker". This spec pins that
+	// invariant with a static check of the workflow, since the step's behaviour
+	// (gh / git side effects against a real checkout) cannot be exercised in a
+	// unit test.
+
+	function run() {
+
+		describe("bot-resolve-conflicts.yml loop-safe escalation (issue ##2849)", () => {
+
+			// expandPath("/wheels") resolves to vendor/wheels via the configured
+			// Lucee mapping; the repo root is two levels above.
+			var repoRoot = expandPath("/wheels/../..");
+			var workflow = repoRoot & "/.github/workflows/bot-resolve-conflicts.yml";
+
+			// Scope assertions to the finalize step (the last step in the file)
+			// so we test the loop-safe escalation path specifically, not the
+			// separate code-conflict escalation step that shares the same marker.
+			var stepAnchor = "Verify resolution, push, or escalate (loop-safe)";
+
+			it("protects the merge commit so a failed commit cannot bypass escalation", () => {
+				expect(fileExists(workflow)).toBeTrue("Missing file: " & workflow);
+				var src = fileRead(workflow);
+
+				var anchorPos = find(stepAnchor, src);
+				expect(anchorPos > 0).toBeTrue("Could not find the '" & stepAnchor & "' step in " & workflow);
+				var block = mid(src, anchorPos, len(src) - anchorPos + 1);
+
+				// The step should still finish a resolved merge with a commit.
+				var commitPos = reFindNoCase("git[[:space:]]+commit[[:space:]]+--no-edit", block);
+				expect(commitPos > 0).toBeTrue(
+					"The finalize step should still finish a resolved-but-uncommitted merge with "
+					& "`git commit --no-edit`. See issue ##2849."
+				);
+
+				// Protection takes one of the two shapes blessed by the acceptance
+				// criteria: an exit-time trap armed BEFORE the commit, or the commit
+				// itself guarded so its failure falls through to escalation.
+				var trapPos = reFindNoCase("trap[[:space:]]+[^\n]*EXIT", block);
+				var trapArmedBeforeCommit = trapPos > 0 && trapPos < commitPos;
+				var commitIsGuarded =
+					   reFindNoCase("if[[:space:]]+![^\n]*git[[:space:]]+commit[[:space:]]+--no-edit", block) > 0
+					|| reFindNoCase("git[[:space:]]+commit[[:space:]]+--no-edit[^\n]*\|\|", block) > 0;
+
+				expect(trapArmedBeforeCommit || commitIsGuarded).toBeTrue(
+					"issue ##2849: under `set -euo pipefail` a bare `git commit --no-edit` that exits "
+					& "non-zero (e.g. a pre-commit hook rejects it) aborts the step BEFORE the "
+					& "escalation block runs, so no `conflict-attempted` marker is posted and the "
+					& "freshen sweep re-dispatches the resolver forever. The finalize step MUST "
+					& "either arm an exit-time trap before the commit (`trap ... EXIT`) or guard the "
+					& "commit itself (`if ! git commit ...` / `git commit ... ||`) so the failure "
+					& "falls through to the escalation path."
+				);
+			});
+
+			it("always posts the conflict-attempted marker and needs-human label on the escalation path", () => {
+				var src = fileRead(workflow);
+
+				var anchorPos = find(stepAnchor, src);
+				expect(anchorPos > 0).toBeTrue("Could not find the '" & stepAnchor & "' step in " & workflow);
+				var block = mid(src, anchorPos, len(src) - anchorPos + 1);
+
+				expect(reFindNoCase("wheels-bot:conflict-attempted:", block) > 0).toBeTrue(
+					"The finalize step must post the `wheels-bot:conflict-attempted` marker when "
+					& "resolution does not complete — the freshen skip-check keys off it to stop "
+					& "re-dispatching the resolver. See issue ##2849."
+				);
+				expect(reFindNoCase("conflict:needs-human", block) > 0).toBeTrue(
+					"The finalize step must apply the `conflict:needs-human` label on escalation. "
+					& "See issue ##2849."
+				);
+				expect(reFindNoCase("gh[[:space:]]+pr[[:space:]]+comment", block) > 0).toBeTrue(
+					"The finalize step must publish the marker via `gh pr comment`. See issue ##2849."
+				);
+			});
+
+		});
+
+	}
+
+}


### PR DESCRIPTION
## What & why

Fixes #2849. In the loop-safe verify step added in #2847, the resolver finishes a resolved-but-uncommitted merge with a bare `git commit --no-edit`, then escalates (posts the `conflict-attempted` marker + `conflict:needs-human` label) only if no new commit landed.

Because the step runs under `set -euo pipefail`, a **bare** `git commit --no-edit` that exits non-zero (e.g. a pre-commit hook rejects it) aborts the step *before* the escalation block runs. The marker is never posted, the PR stays `DIRTY`, and `bot-freshen.yml` re-dispatches this resolver every cycle — a runaway loop, since the skip-check only matches that marker. The same hazard applied to `git push origin HEAD` (also a bare command, on the success path).

## The fix

Arm an `EXIT` trap that posts the marker + label on **any** non-zero exit of the step — a hook-rejected commit, a failed push, or any command added to the step later. A `pushed` flag makes the clean-push success path a no-op for the trap. This satisfies the issue's acceptance criterion ("any failure on the resolve path leaves a conflict-attempted marker") and is the trap option the issue lists first.

Detail worth calling out: every `gh` call inside the trap is `|| true`-guarded and the marker-bearing `gh pr comment` runs **last**, so a transient `gh` failure can't abort the trap before the loop-stopping marker lands.

## Divergence from the triage sketch

The bot's fix-on-hold comment proposed extracting to `tools/bot/finalize-resolution.sh` + an `if !` guard. I took a different shape, deliberately:

- **Location** — `.github/scripts/` (this workflow's existing convention, e.g. `classify-conflicts.sh`) holds *pure decision* scripts (stdin→stdout, no side effects). The finalize logic is heavily side-effecting (`git push`, `gh pr comment`). Side-effecting steps in this file are kept **inline** (cf. the "Escalate (code conflict)" step), so the fix stays inline — no new indirection, smaller blast radius on bot-critical infra.
- **Mechanism** — a trap (vs. an `if !` guard on the commit alone) closes the *whole class* of failures, including the latent `git push` hazard, matching the acceptance criterion's "any failure" wording.

## Verification

- Added `vendor/wheels/tests/specs/cli/BotResolveConflictsLoopSafeSpec.cfc` (modeled on `LinuxPackageStagingSpec`) pinning the invariant: the exit trap is armed **before** the merge commit, and the marker + `conflict:needs-human` label are posted from the escalation path.
- TDD: **RED** (spec fails against the unfixed step) → **GREEN** (passes after the fix) verified in **Lucee 7 + SQLite** via the Docker matrix container.
- Full `cli` spec area green: **52 pass / 0 fail / 0 error**.
- `bash -n` and `shellcheck -S warning` clean on the step body.
- Cross-engine (Adobe 2023/2025, BoxLang, Lucee 6) is covered by `compat-matrix.yml` on this PR; the spec is a structural clone of one already green on every engine.

## Security note
No new untrusted-input interpolation — the step uses only validated `env:` vars (`PR_NUMBER` is validated `^[0-9]+$` upstream before checkout).

Closes #2849