### PR TITLE
ci: skip secret-dependent jobs on Dependabot PRs

### DIFF
--- a/.github/workflows/bot-review-a.yml
+++ b/.github/workflows/bot-review-a.yml
@@ -38,6 +38,7 @@ jobs:
       vars.WHEELS_BOT_ENABLED == 'true'
       && (
         (github.event_name == 'pull_request'
+          && github.event.pull_request.user.login != 'dependabot[bot]'
           && (github.event.pull_request.user.login == 'wheels-bot[bot]'
               || github.event.pull_request.draft == false))
         || (github.event_name == 'issue_comment'

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -63,6 +63,14 @@ jobs:
         run: pnpm --filter @wheels-dev/site-${{ matrix.site }} build
 
       - name: Deploy to Cloudflare Pages
+        # Dependabot-triggered runs can't read repository secrets (they use
+        # the separate Dependabot secrets store), so CLOUDFLARE_API_TOKEN is
+        # empty and wrangler aborts with a non-interactive-auth error — which
+        # red-X'd every Dependabot PR touching web/**. Skip the publish for
+        # Dependabot: the Build step above still runs and validates the bump;
+        # we just don't push a per-PR preview deploy for it. Non-PR events
+        # (push to develop, repository_dispatch) keep deploying as before.
+        if: github.actor != 'dependabot[bot]'
         working-directory: web
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Problem

Every Dependabot PR red-X's six checks — 5× **Deploy *site*** and **Reviewer A** — even when the bump itself is fine. Most recently on [#2836](https://github.com/wheels-dev/wheels/pull/2836) (vitest 2→4), where the bump was verified green locally but CI looked failed.

## Root cause

Workflows **triggered by Dependabot** run against the separate *Dependabot secrets* store and **cannot read normal repository secrets** — they resolve to empty strings. Any job that needs a real secret therefore fails on every Dependabot PR:

| Check | Workflow | Empty secret → failure |
|---|---|---|
| Deploy api/blog/guides/landing/packages | `web-deploy.yml` | `CLOUDFLARE_API_TOKEN` empty → `wrangler` aborts: *"necessary to set a CLOUDFLARE_API_TOKEN…"* |
| Reviewer A | `bot-review-a.yml` | `WHEELS_BOT_APP_ID` empty → `create-github-app-token`: *"appId option is required"* |

These are **false negatives** — they say nothing about the change. Proven by the same jobs passing on normal contributor PRs (e.g. #2845) and on `develop`.

## Fix

- **`web-deploy.yml`** — guard the **`Deploy to Cloudflare Pages` step** (not the job) with `github.actor != 'dependabot[bot]'`. The `Build` step above still runs, so the dependency bump is **still validated**; only the per-PR preview publish is skipped. `push`-to-`develop` and `repository_dispatch` deploys are unchanged.
- **`bot-review-a.yml`** — add `github.event.pull_request.user.login != 'dependabot[bot]'` to the `pull_request` branch of the existing job gate, so Reviewer A is **skipped** (neutral) rather than failed on Dependabot PRs. The `issue_comment` convergence-loop path is untouched.

## Deliberately *not* guarded

Verified by reading each workflow's `on:` triggers — these never auto-fire on PR open, so they never red-X a Dependabot PR:

- `bot-review-b.yml` → `pull_request_review` (only after a review is posted; on a Dependabot PR, Reviewer A is now skipped, so B still never fires)
- `bot-advisor.yml`, `bot-propose-fix.yml`, `bot-address-review.yml` → `issue_comment` / `workflow_dispatch`
- `bot-triage.yml` → `issues`

## Verification

- `actionlint` parses both files and reports **no issues** on the new `if:` expressions (only pre-existing shellcheck *style* warnings in untouched `run:` blocks).
- `git diff` is +9 lines, two files, no logic moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)