### PR TITLE
fix(cli): repair broken commands and correct command docs (CLI audit)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -614,7 +614,7 @@ wheels seed --environment=production
 wheels seed --generate                 # legacy: random test data
 ```
 
-To scaffold the seed files themselves, use the snippet generator: `wheels generate snippets seed-data` (writes `app/snippets/seeds*.cfm`). There is no `wheels generate seed` generator.
+To scaffold seed templates, use: `wheels generate snippets seed-data` (writes `app/snippets/seeds*.cfm` — copy or move to `app/db/` to activate them). There is no `wheels generate seed` generator.
 
 `seedOnce()`: idempotent — checks `uniqueProperties` via `findOne()`, creates only if not found. Execution: `seeds.cfm` → `seeds/<environment>.cfm`, wrapped in a transaction. Programmatic: `application.wheels.seeder.runSeeds()`. (Note: `wheels db:seed` is NOT a valid command — it errors. Use `wheels seed`.)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ plugins/                        DEPRECATED — legacy plugin system; modern pack
 | If you touched | Run | Required? |
 |---|---|---|
 | `vendor/wheels/**` | `bash tools/test-local.sh` (full) or `bash tools/test-local.sh <area>` | Always |
-| `app/**` only | Demo-app specs via `wheels test run` | Always |
+| `app/**` only | Demo-app specs via `wheels test` | Always |
 | `cli/lucli/**` | `bash tools/test-cli-local.sh` | Always |
 | Anything cross-engine-risky (closures, `obj.map()`, reserved scopes, struct literals, mixins) | `tools/test-matrix.sh adobe2023 mysql` AND `tools/test-matrix.sh lucee7 mysql` | If touched code matches any anti-pattern below |
 | Added/changed a migration | `wheels migrate latest && wheels migrate down && wheels migrate up` | Always |
@@ -588,13 +588,7 @@ var all = am.diffAll({hints: {"User": {renames: {"full_name": "fullName"}}}, heu
 am.writeMigration(d, "rename_name_field");
 ```
 
-```bash
-wheels dbmigrate diff User
-wheels dbmigrate diff User --rename=full_name:fullName
-wheels dbmigrate diff User --write --name=rename_name
-wheels dbmigrate diff --threshold=0.85
-wheels dbmigrate diff --rename=User.full_name:fullName
-```
+_Auto-migration is currently CFC-only (`wheels.migrator.AutoMigrator`, shown above). There is no `wheels dbmigrate diff` CLI command — invoking it errors._
 
 Result struct: `{modelName, tableName, addColumns, removeColumns, changeColumns, renameColumns, suggestedRenames}`. Limits: PK renames not detected; rename + type change requires separate migrations; calculated properties excluded.
 
@@ -618,11 +612,11 @@ seedOnce(modelName="User", uniqueProperties="email", properties={
 wheels seed                            # auto-detect env (canonical)
 wheels seed --environment=production
 wheels seed --generate                 # legacy: random test data
-wheels generate seed                   # create app/db/seeds.cfm
-wheels generate seed --all             # create seeds.cfm + dev/prod stubs
 ```
 
-`seedOnce()`: idempotent — checks `uniqueProperties` via `findOne()`, creates only if not found. Execution: `seeds.cfm` → `seeds/<environment>.cfm`, wrapped in a transaction. Programmatic: `application.wheels.seeder.runSeeds()`. The legacy `wheels db:seed` is a CommandBox alias — prefer `wheels seed`.
+To scaffold the seed files themselves, use the snippet generator: `wheels generate snippets seed-data` (writes `app/snippets/seeds*.cfm`). There is no `wheels generate seed` generator.
+
+`seedOnce()`: idempotent — checks `uniqueProperties` via `findOne()`, creates only if not found. Execution: `seeds.cfm` → `seeds/<environment>.cfm`, wrapped in a transaction. Programmatic: `application.wheels.seeder.runSeeds()`. (Note: `wheels db:seed` is NOT a valid command — it errors. Use `wheels seed`.)
 
 ## Background Jobs Quick Reference
 
@@ -708,9 +702,9 @@ Notes:
 {"mcpServers":{"wheels":{"command":"wheels","args":["mcp","wheels"]}}}
 ```
 
-Or run `wheels mcp setup` to generate `.mcp.json` + `.opencode.json`.
+There is no `wheels mcp setup` command — copy the JSON above into `.mcp.json` manually (see the MCP integration guide for OpenCode/Cursor variants).
 
-Tools are auto-discovered from `cli/lucli/Module.cfc` public functions, prefixed with the module name (`wheels_generate`, `wheels_migrate`, `wheels_test`, `wheels_reload`, `wheels_seed`, `wheels_analyze`, `wheels_validate`, `wheels_routes`, `wheels_info`, `wheels_destroy`, `wheels_doctor`, `wheels_stats`, `wheels_notes`, `wheels_db`, `wheels_upgrade`, `wheels_create`, `wheels_deploy`). CLI-only tools (`mcp`, `d`, `new`, `console`, `start`, `stop`, `browser`) are hidden via `mcpHiddenTools()`.
+Tools are auto-discovered from `cli/lucli/Module.cfc` public functions, prefixed with the module name (`wheels_generate`, `wheels_migrate`, `wheels_test`, `wheels_reload`, `wheels_seed`, `wheels_analyze`, `wheels_validate`, `wheels_routes`, `wheels_info`, `wheels_destroy`, `wheels_doctor`, `wheels_stats`, `wheels_notes`, `wheels_db`, `wheels_upgrade`, `wheels_create`, `wheels_deploy`). CLI-only tools (`mcp`, `d`, `g`, `new`, `console`, `start`, `stop`, `browser`) are hidden via `mcpHiddenTools()`.
 
 **Deprecated:** the in-dev-server HTTP endpoint at `/wheels/mcp`. Emits a deprecation notice on first request. Migrate to the stdio surface.
 
@@ -725,12 +719,12 @@ Prefer MCP tools when the Wheels MCP server is available. Fall back to CLI other
 | Generate | `wheels_generate(type, name, attributes)` | `wheels g model/controller/scaffold Name attrs` |
 | Migrate | `wheels_migrate(action="latest\|up\|down\|info\|doctor")` | `wheels migrate latest\|up\|down\|info\|doctor` |
 | Migrator reconciliation | — | `wheels migrate forget\|pretend <version> --yes` (shared dev DB orphan cleanup; see #2780) |
-| Test | `wheels_test()` | `wheels test run` |
+| Test | `wheels_test()` | `wheels test` |
 | Reload | `wheels_reload()` | `?reload=true&password=...` |
-| Server | `wheels_server(action="status")` | `wheels start\|stop\|status` |
+| Server | — | `wheels start\|stop` |
 | Analyze | `wheels_analyze(target="all")` | — |
 | Admin | — | `wheels g admin ModelName` |
-| Seed | — | `wheels seed` (legacy alias: `wheels db:seed`) |
+| Seed | — | `wheels seed` |
 
 ## Reference Docs (verified to exist)
 

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -1,68 +1,85 @@
-# CLAUDE.md
+# CLAUDE.md — Wheels CLI (`cli/`)
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file guides Claude Code when working in the Wheels CLI directory.
 
-## Project Overview
-This is the Wheels CLI, a CommandBox module that provides command-line tools for Wheels framework applications.
+## What This Is
 
-## Commands
-- **Test**: `wheels test [type] [servername] [reload] [debug]`
-  - Types: core, app, plugin
-- **Run Application**: Use CommandBox's server start functionality
-- **Initialize**: `wheels init [name] [path] [reload] [version] [createFolders]`
+The Wheels CLI is the **LuCLI runtime rebranded as `wheels`** — it is NOT a CommandBox
+module. There is no separate `lucli` binary on a normal install; `libexec/wheels` IS the
+LuCLI binary, name-routed to the `wheels` module via its `$0` basename (`-Dlucli.binary.name=wheels`).
+Install is via Homebrew / Scoop / apt / yum (see `tools/distribution-drafts/` and the
+sibling distribution repos) — **not** `box install`.
 
-## Code Style Guidelines
-- **Language**: CFML (ColdFusion Markup Language)
-- **Architecture**: Component-based with CFC files inheriting from base.cfc
-- **Naming**: CamelCase for component names, functions, and variables
-- **Organization**:
-  - Commands in /commands directory, grouped by functionality
-  - Templates for code generation in /templates
-- **Error Handling**: Use try/catch blocks with appropriate error messages
-- **Code Generation**: Follow existing template patterns when modifying or creating new templates
+> Anything in older docs mentioning `box`, `CommandBox`, `box install wheels-cli`, `/cli/src/`,
+> `wheels init`, or `wheels g app` predates the LuCLI rebrand and is wrong. Scaffold with
+> `wheels new <name>`.
 
-## Development Notes
-- This is a CommandBox module that integrates with Wheels framework
-- Follow MVC pattern when creating new features
-- Maintain backward compatibility when possible
-- Refer to CLI-IMPROVEMENTS.md for planned enhancements and architectural goals
-- To run the CLI commands we need to launch CommandBox with the `box` command
-- The CLI is installed with `box install wheels-cli` command
-- Then use the `wheels` commands to run a particular CLI command
-- First create an app with the `wheels g app` command.
-- Then start the web server with `server start` commandbox command
+## Code Map
 
-## Monorepo Integration
+```
+cli/lucli/
+  Module.cfc          The CLI itself. Each PUBLIC function is a subcommand
+                      (generate, g, migrate, seed, test, reload, start, stop, new,
+                      create, routes, info, mcp, console, analyze, validate, destroy, d,
+                      doctor, deploy, packages, stats, notes, db, upgrade, browser,
+                      version, showHelp). Private functions are internal helpers.
+  module.json         Module manifest (name=wheels, main=Module.cfc).
+  ARCHITECTURE.md     Deep architectural reference — read this first.
+  services/           Service objects the subcommands delegate to:
+                        ArgSpec.cfc        typed, declarative argument/flag parser
+                        Scaffold.cfc       generate/scaffold/api-resource
+                        CodeGen.cfc        model/controller/view/test generation
+                        Templates.cfc      template rendering
+                        MigrationRunner.cfc, Analysis.cfc, Doctor.cfc, Stats.cfc,
+                        Destroy.cfc, ServerRegistry.cfc, ReleaseChannel.cfc,
+                        UpdateChecker.cfc, Helpers.cfc, SemVer.cfc, …
+                        deploy/            Kamal-compatible deploy port (DeployMainCli +
+                                           App/Proxy/Build/Registry/Lock/Prune/Secrets/Server CLIs,
+                                           config/, secrets/ adapters)
+                        packages/          package registry/install (Installer, Registry, …)
+  templates/          Code-generation templates (app scaffold, codegen, app tests).
+  tests/specs/        CLI test suite (commands/, services/, integration/, deploy/, packages/).
+```
 
-The Wheels CLI is part of a larger monorepo ecosystem:
+## Argument Parsing
 
-### CLI's Role in the Ecosystem
-- **Source**: `/cli/src/` contains CLI source code (commands, models, templates)
-- **Build**: `tools/build/scripts/build-cli.sh` packages CLI for distribution
-- **Distribution**: Published to ForgeBox as `wheels-cli` CommandBox module
-- **Integration**: Works with base templates and generates code following framework patterns
+Subcommands parse args via the **ArgSpec service** (`services/ArgSpec.cfc`) — a typed,
+declarative spec builder (`.option()`, `.flag()`, `.parse()`). Build the command's ArgSpec
+to enumerate its real flags/options/defaults. (Historical note: the legacy `getArgs()`
+argv round-trip was removed in the #2861/#2875 ArgSpec migration.)
 
-### Key Dependencies
-- **ForgeBox Integration**: Downloads `wheels-base-template` package from ForgeBox during `wheels g app`
-- **Template Snippets**: Uses base template snippets from `/app/snippets/`
-- **Core Patterns**: Generates code that follows core framework conventions (`$` prefix, `config()` methods)
-- **Version Sync**: Shares version numbers with other monorepo components
+LuCLI reserves some tokens before the module sees them: `--help`/`-h`, bare `help`,
+`--verbose`/`-v`, `--version`, and verbs like `run`/`install`/`mcp` and nested `server`/`secrets`.
+Be aware these can be intercepted by the runtime/launcher rather than reaching `Module.cfc`.
 
-### Development Workflow
-1. Modify CLI source in `/cli/src/`
-2. Test in monorepo `/workspace/` directory
-3. Reload CommandBox: `box reload` after changes
-4. Build process handles packaging and ForgeBox distribution via GitHub Actions
+## Running & Testing
 
-### Package Structure
-- `ModuleConfig.cfc` - CommandBox module configuration
-- `commands/wheels/` - Hierarchical command structure extending `base.cfc`
-- `models/` - Business logic with WireBox dependency injection
-- `templates/` - Code generation templates using `{{variable}}` syntax
-- `box.json` - Package metadata with `type: "commandbox-modules"`
+- Run a command against a checkout: the CLI loads the module from `$LUCLI_HOME/modules/wheels`.
+- CLI test suite: `bash tools/test-cli-local.sh` (boots a server, hits `/wheels/cli/tests`),
+  or the in-server endpoint `/wheels/cli/tests?format=json`. End-to-end lifecycle smoke:
+  `tools/test-cli-e2e.sh`. Deploy verb smoke (dry-run): `tools/deploy-verb-smoke.sh`.
+- Build/distribution: `tools/build/scripts/build-cli.sh` packages the module; the Homebrew/
+  Scoop/apt launchers stage `libexec/wheels` + the module zip and generate the `wheels` wrapper.
 
-For complete monorepo architecture details, see the main repository's `CLAUDE.md` file.
+## Code Style
+
+- **Language**: CFML. Components, CamelCase names. Internal helpers use a `$` prefix and
+  must be `public` only when they need to be reachable as mixins/specs — otherwise keep them
+  `private` so they don't surface as MCP tools.
+- **Cross-engine**: the CLI runs on the bundled Lucee; still avoid the engine traps in the
+  root `CLAUDE.md` (e.g. `(.+)` matching newlines in `reFind` — use `[^\r\n]+`).
+- **Error handling**: try/catch with actionable messages; throw typed errors for usage
+  failures so the runtime maps them to a non-zero exit.
+- **Code generation**: follow existing template patterns; strip CFML comments before any
+  source-scanning (anti-pattern #14).
+
+## MCP
+
+`wheels mcp wheels` launches the stdio MCP server. Tools are auto-discovered from `Module.cfc`
+public functions; stateful/interactive commands are hidden via `mcpHiddenTools()`. There is
+no `wheels mcp setup` command — write `.mcp.json` manually. See the root `CLAUDE.md`
+"CLI / MCP" section and `web/.../command-line-tools/mcp-integration` for details.
 
 ## Things to remember
-- Don't add the Claude signature to commit messages
-- Don't add the Claude signature to PR reviews
+- Don't add the Claude signature to commit messages.
+- Don't add the Claude signature to PR reviews.

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -161,6 +161,7 @@ component extends="modules.BaseModule" {
 			"main",     // bare `wheels` no-args dispatch target — not an MCP tool
 			"mcp",      // meta command — prints MCP setup instructions
 			"d",        // alias for destroy
+			"g",        // alias for generate
 			"new",      // scaffolds a whole new Wheels project
 			"console",  // interactive CFML REPL — not usable over stdio
 			"start",    // dev server lifecycle (stateful)
@@ -266,7 +267,7 @@ component extends="modules.BaseModule" {
 		help &= "  generate            Generate model, controller, scaffold, migration, etc." & nl;
 		help &= "  destroy (or d)      Remove generated files" & nl & nl;
 		help &= "Database:" & nl;
-		help &= "  migrate             Run database migrations (latest, up, down, info, rename-system-tables)" & nl;
+		help &= "  migrate             Run database migrations (latest, up, down, info, doctor, forget, pretend, rename-system-tables)" & nl;
 		help &= "  seed                Run database seeds" & nl;
 		help &= "  db                  Database management (reset, status, version)" & nl & nl;
 		help &= "Testing & Inspection:" & nl;
@@ -391,7 +392,7 @@ component extends="modules.BaseModule" {
 	// ─────────────────────────────────────────────────
 
 	/**
-	 * hint: Run database migrations (latest, up, down, info)
+	 * hint: Run database migrations (latest, up, down, info, doctor, forget, pretend, rename-system-tables)
 	 */
 	public string function migrate() {
 		var args = new services.ArgSpec().toArgv(structuredArgs(arguments));
@@ -871,7 +872,7 @@ component extends="modules.BaseModule" {
 			out("Options:", "bold");
 			out("  --port=<number>           Server port (default: 8080)");
 			out("  --datasource=<name>       Datasource name (default: app name)");
-			out("  --reload-password=<pw>    Reload password (default: app name)");
+			out("  --reload-password=<pw>    Reload password (default: random)");
 			out("  --no-sqlite               Skip default SQLite database setup");
 			out("  --setup-h2                Use H2 embedded database instead of SQLite");
 			out("  --no-open-browser         Don't open browser on server start");
@@ -1086,7 +1087,10 @@ component extends="modules.BaseModule" {
 			// Count routes
 			var routesFile = variables.projectRoot & "/config/routes.cfm";
 			if (fileExists(routesFile)) {
-				var routeContent = fileRead(routesFile);
+				// Strip comments first so a commented-out .resources(...) isn't
+				// counted (anti-pattern #14 — commented code must not satisfy
+				// substring scans). Mirrors the datasource block above.
+				var routeContent = stripCfmlComments(fileRead(routesFile));
 				var resourceCount = 0;
 				var pos = 1;
 				while (pos > 0) {
@@ -1792,7 +1796,14 @@ component extends="modules.BaseModule" {
 	 * hint: Alias for destroy
 	 */
 	public string function d() {
-		return destroy();
+		return destroy(argumentCollection = arguments);
+	}
+
+	/**
+	 * hint: Alias for generate
+	 */
+	public string function g() {
+		return generate(argumentCollection = arguments);
 	}
 
 	// ─────────────────────────────────────────────────
@@ -2825,19 +2836,14 @@ component extends="modules.BaseModule" {
 
 		ensureDirectory(migrationDir);
 
-		// Use the DBMigrate template if available, otherwise inline
-		var templates = getService("templates");
-		var result = templates.generateFromTemplate(
-			template = "dbmigrate/blank.txt",
-			destination = "app/migrator/migrations/#fileName#",
-			context = {migrationName: migrationName}
-		);
-
-		if (!result.success) {
-			// Fallback to inline empty migration
-			var content = buildEmptyMigration(migrationName);
-			fileWrite(filePath, content);
-		}
+		// Always build the migration inline. The shipped codegen template
+		// dbmigrate/blank.txt carries |DBMigrateExtends|/|DBMigrateDescription|
+		// tokens that Templates.cfc never substitutes, so on packaged installs
+		// (where that template resolves) `generate migration` produced an
+		// uncompilable file (literal extends="|DBMigrateExtends|"). The inline
+		// builder emits a correct extends="wheels.migrator.Migration" body and
+		// was already the path every dev-checkout install used. See CLI audit H4.
+		fileWrite(filePath, buildEmptyMigration(migrationName));
 
 		printCreated("app/migrator/migrations/#fileName#");
 		return "";
@@ -3371,7 +3377,7 @@ component extends="modules.BaseModule" {
 			"seed-data": {
 				name: "Seed Data",
 				description: "Database seeding template with seedOnce() examples",
-				hint: "Run seeds with: wheels db:seed.",
+				hint: "Run seeds with: wheels seed.",
 				generate: function(string projectRoot, boolean force) {
 					var created = [];
 
@@ -3798,7 +3804,7 @@ component extends="modules.BaseModule" {
 			out("Migration Status", "bold");
 			out(repeatString("=", 70));
 
-			var fmt = "%-16s %-30s %-10s %s";
+			var fmt = "%-16s %-30s %-10s %-19s";
 			out(sprintf(fmt, "Version", "Description", "Status", "Applied"));
 			out(repeatString("-", 70));
 
@@ -5755,7 +5761,7 @@ component extends="modules.BaseModule" {
 		var envFile = variables.projectRoot & "/.env";
 		if (fileExists(envFile)) {
 			var envContent = fileRead(envFile);
-			var pwMatch = reFindNoCase("(?:WHEELS_)?RELOAD_PASSWORD\s*=\s*(.+)", envContent, 1, true);
+			var pwMatch = reFindNoCase("(?:WHEELS_)?RELOAD_PASSWORD\s*=\s*([^\r\n]+)", envContent, 1, true);
 			if (arrayLen(pwMatch.match) > 1 && len(trim(pwMatch.match[2]))) {
 				return trim(pwMatch.match[2]);
 			}

--- a/cli/lucli/services/Analysis.cfc
+++ b/cli/lucli/services/Analysis.cfc
@@ -354,8 +354,10 @@ component {
 			});
 		}
 
-		// Check mixed argument styles (uses same pattern as analyze)
-		if (reFindNoCase(variables.MIXED_ARGS_PATTERN, content)) {
+		// Check mixed argument styles (uses same pattern as analyze).
+		// Scan comment-stripped content so a commented-out association with
+		// mixed args doesn't false-positive (anti-pattern #14).
+		if (reFindNoCase(variables.MIXED_ARGS_PATTERN, activeContent)) {
 			arrayAppend(issues, {
 				file: arguments.path,
 				severity: "error",
@@ -393,7 +395,9 @@ component {
 
 	private array function validateRoutes(required string path) {
 		var issues = [];
-		var content = fileRead(arguments.path);
+		// Strip comments first so commented-out mapper()/.end()/.wildcard()/
+		// .resources() lines don't skew the balance/order checks (anti-pattern #14).
+		var content = $stripCfmlComments(fileRead(arguments.path));
 
 		// Check for balanced mapper/end
 		var mapperCount = 0;
@@ -443,10 +447,13 @@ component {
 		// Skip layouts and partials
 		if (fileName == "layout.cfm" || left(fileName, 1) == "_") return issues;
 
-		// Check for variable usage without cfparam
+		// Check for variable usage without cfparam. Scan comment-stripped
+		// content so a view whose only # / cfparam / cfset lives inside a
+		// CFML comment doesn't warn (or falsely appear protected) — #14.
+		var activeContent = $stripCfmlComments(content);
 		var hashChar = chr(35);
 		var cfsetTag = chr(60) & "cfset";
-		if (findNoCase(hashChar, content) && !findNoCase("cfparam", content) && !findNoCase(cfsetTag, content)) {
+		if (findNoCase(hashChar, activeContent) && !findNoCase("cfparam", activeContent) && !findNoCase(cfsetTag, activeContent)) {
 			arrayAppend(issues, {
 				file: arguments.path,
 				severity: "warning",

--- a/cli/lucli/services/Scaffold.cfc
+++ b/cli/lucli/services/Scaffold.cfc
@@ -437,8 +437,12 @@ component {
 				}
 			}
 
-			// 5. Update routes with API namespace
-			updateApiRoutes(arguments.name);
+			// 5. Update routes with API namespace.
+			// Use the PLURAL name so the route matches the plural controller
+			// (api/Products.cfc) and table (products) — mirrors updateRoutes(pluralName)
+			// on the non-api scaffold path. Passing singular arguments.name mapped
+			// /api/product and never reached the plural controller.
+			updateApiRoutes(pluralName);
 
 		} catch (any e) {
 			results.success = false;


### PR DESCRIPTION
## What & why

A full audit of **every Wheels CLI command** — running the worktree's CLI source in an isolated harness and cross-checking each command's real behavior against its source, `--help`, the root `CLAUDE.md`, `cli/CLAUDE.md`, and the v4-0-0 guides. 24 command groups were audited (fan-out + adversarial verification), surfacing **69 unique confirmed issues**. This PR lands the **verified, low-risk subset** that makes broken commands work and corrects the most misleading agent-facing docs. Larger/behavioral and systemic-LuCLI items are listed below for follow-up.

Every fix here was reproduced and re-verified against the worktree CLI before and after the change.

## Code fixes (commands that did not work as documented)

| Fix | Was | Now |
|---|---|---|
| **`g` alias** | `wheels g model X` → raw `has no function with name [g]` | `g()` → `generate()`, hidden from MCP |
| **`console` / `reload` auto-password** | `detectReloadPassword()` `(.+)` captured across newlines → wrong password on every default scaffold | anchored `([^\r\n]+)` (matches the sibling helper) |
| **`generate migration`** | `dbmigrate/blank.txt` template left `\|DBMigrateExtends\|` tokens → uncompilable migration on packaged installs | always build inline via `buildEmptyMigration()` |
| **`generate api-resource`** | wrote singular route `.resources(name="product")` → never reached `api/Products` | writes plural, matching controller/table |
| **`validate`** | mixed-args / routes / view checks scanned raw source (comment-blind, false +/−) | scan comment-stripped content (anti-pattern #14) |
| **`db status`** | rendered a literal `%s` in the Applied column | `%-19s` |
| **`info`** | counted commented-out `.resources()` | strips comments first |
| **`migrate` help/hint** | listed only `latest, up, down, info, rename-system-tables` | lists all 8 real subcommands (adds `doctor/forget/pretend`) |
| **`wheels new` help + snippet hint** | "reload-password default: app name"; `wheels db:seed` | "default: random"; `wheels seed` |

## Doc fixes (agent-facing)

- **Root `CLAUDE.md`** — removed claims for commands that error or don't exist: `wheels dbmigrate diff` (CFC-only), `wheels generate seed`/`--all`, `wheels db:seed`, `wheels mcp setup`, `wheels status` + the `wheels_server` MCP tool; `wheels test run` → `wheels test` (`run` is a reserved LuCLI builtin); added `g` to the hidden-tools list.
- **`cli/CLAUDE.md`** — rewritten wholesale. It described the **defunct CommandBox CLI** (`box install wheels-cli`, `/cli/src/`, `wheels init`, `wheels g app` via ForgeBox); now documents the current LuCLI architecture (`cli/lucli/Module.cfc` subcommands, `services/`, ArgSpec parsing, brew/scoop install, MCP, testing).

## Verification

- Each command fix reproduced + re-verified in an isolated LUCLI_HOME running the worktree source.
- Relevant CLI specs reviewed (`AnalysisSpec`, `ScaffoldSpec`, `GenerateCommandSpec`) — no assertion regressions.
- The full `tools/test-cli-local.sh` suite couldn't be run from the `.claude/worktrees` worktree (the framework demo app won't stay up there — a known worktree limitation), so **CI is the backstop for the full CLI suite** on this PR.

## Deferred (follow-up — larger / behavioral / systemic, not in this PR)

- [ ] **`wheels test` exit codes / `--ci` / `--reporter=tap`** — `--ci` inert, exit always 0 on failure, TAP reporter crashes on a failing spec (`failOrigin` is an array). Needs a failing-spec test.
- [ ] **`deploy` flags** — `--version=<tag>` is shadowed by picocli's root `--version` (use `--release`); `--config` vs `--configPath`; nested `deploy server`/`secrets` verbs are picocli-shadowed (flat aliases work); `app` role/host filters parsed-but-dropped. Mostly docs + a couple of `DeployArgsParser` arms.
- [ ] **`browser install` / `test run`** verb errors across the testing/CI guides (`install` hits LuCLI's extension installer; `run` is reserved) — guide sweep.
- [ ] **Systemic LuCLI dispatch (highest leverage, likely upstream):** per-command `--help`/`-h`/`help` all print the global banner; `--verbose`/`-v` swallowed (breaks `doctor`/`stats`/`test` verbose); `wheels help` + several error paths leak the raw `lucli`/picocli banner; per-command help is hard-coded in the launcher and drifts.
- [ ] **`ReleaseChannel`** — shipped stable 4.0.2 reports `(development)` (build token clobbered the dev sentinel); `wheels version` vs `wheels --version` format mismatch.
- [ ] **Misc:** `generate enum` parsed-but-not-emitted; silent view-gen failures; `generate test` overwrites without `--force`; `notes` scanner matches strings/identifiers not comments; a command rewrote tracked `vendor/wheels/wheels.json` as a side effect (observed during the audit).
- [ ] LOW guide sample-output drift across the v4-0-0 command-line-tools pages.

Full per-command findings + a prioritized fix plan are available (157 confirmed findings; 69 unique after de-dup).
