### PR TITLE
fix(cli): CLI audit follow-ups (test exit codes, deploy flags, release channel, guide fixes)

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -4364,6 +4364,8 @@ component extends="modules.BaseModule" {
 			out("Scope: #filter#", "cyan");
 		}
 
+		var testsFailed = false;
+
 		try {
 			var testUrl = "http://localhost:#serverPort##testPath#?format=#format#&db=#db#";
 			// App tests default to running against the <appname>_test
@@ -4401,6 +4403,11 @@ component extends="modules.BaseModule" {
 					default:
 						displayTestResults(result, verboseOutput, resolvedDir);
 				}
+
+				// Record failure so the command can exit non-zero AFTER the output
+				// is flushed. Throwing here would be swallowed by the catch below.
+				// testing.mdx documents a non-zero exit on failure. CLI audit H6.
+				testsFailed = ((result.totalFail ?: 0) + (result.totalError ?: 0)) > 0;
 			} else {
 				// Could be an HTML error page
 				if (reFindNoCase("<html", httpResult)) {
@@ -4413,6 +4420,13 @@ component extends="modules.BaseModule" {
 			}
 		} catch (any e) {
 			out("Test execution failed: #e.message#", "red");
+		}
+
+		// Exit non-zero when specs failed/errored so CI and shells can detect it.
+		// Previously runTests always returned "" → `wheels test` exited 0 even when
+		// tests failed, silently green-lighting broken builds. CLI audit H6.
+		if (testsFailed) {
+			throw(type = "Wheels.TestsFailed", message = "Tests failed — see the report above.");
 		}
 
 		return "";
@@ -4445,7 +4459,11 @@ component extends="modules.BaseModule" {
 					name: sp.name ?: "(unnamed)",
 					status: sp.status ?: "Failed",
 					failMessage: sp.failMessage ?: "",
-					failOrigin: sp.failOrigin ?: "",
+					// failOrigin can be an array of stack-frame structs, not a
+					// string. Coerce to a string here so the YAML emitter below
+					// (tapEscapeYaml) never receives an array and crashes the
+					// whole TAP run on the first failing spec. See CLI audit H6.
+					failOrigin: $tapOriginString(sp.failOrigin ?: ""),
 					skipped: (sp.status ?: "") == "Skipped"
 				});
 			}
@@ -4505,6 +4523,35 @@ component extends="modules.BaseModule" {
 		v = replace(v, chr(13), " ", "all");
 		v = replace(v, "'", "''", "all");
 		return "'" & v & "'";
+	}
+
+	/**
+	 * Coerce a TestBox failOrigin into a single string for the TAP YAML block.
+	 * TestBox reports failOrigin as an array of stack-frame structs (Raw_Trace /
+	 * template+line), but the TAP emitter needs a scalar — passing the array to
+	 * tapEscapeYaml() throws "Cannot cast Array to string" and aborts the run.
+	 * See CLI audit H6.
+	 */
+	private string function $tapOriginString(required any origin) {
+		if (isSimpleValue(arguments.origin)) {
+			return arguments.origin;
+		}
+		if (isArray(arguments.origin) && arrayLen(arguments.origin)) {
+			var first = arguments.origin[1];
+			if (isSimpleValue(first)) {
+				return first;
+			}
+			if (isStruct(first)) {
+				if (structKeyExists(first, "Raw_Trace") && len(first.Raw_Trace)) {
+					return first.Raw_Trace;
+				}
+				var tmpl = first.template ?: "";
+				if (len(tmpl)) {
+					return tmpl & (structKeyExists(first, "line") ? ":" & first.line : "");
+				}
+			}
+		}
+		return "";
 	}
 
 	private void function displayTestResults(

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -2951,15 +2951,20 @@ component extends="modules.BaseModule" {
 	}
 
 	private string function generateTest(required array args) {
-		if (arrayLen(args) < 2) {
-			out("Usage: wheels generate test <type> <Name>", "yellow");
+		// Pull --force out of the positional args so it can appear anywhere.
+		var force = false;
+		var pos = [];
+		for (var a in args) { if (a == "--force") { force = true; } else { arrayAppend(pos, a); } }
+
+		if (arrayLen(pos) < 2) {
+			out("Usage: wheels generate test <type> <Name> [--force]", "yellow");
 			out("  Types: model, controller");
 			out("  Example: wheels generate test model User");
 			return "";
 		}
 
-		var testType = lCase(args[1]);
-		var testName = capitalize(args[2]);
+		var testType = lCase(pos[1]);
+		var testName = capitalize(pos[2]);
 
 		if (!listFindNoCase("model,controller", testType)) {
 			out("Unknown test type: #testType#. Use 'model' or 'controller'.", "red");
@@ -2967,7 +2972,7 @@ component extends="modules.BaseModule" {
 		}
 
 		var codegen = getService("codegen");
-		var result = codegen.generateTest(type = testType, name = testName);
+		var result = codegen.generateTest(type = testType, name = testName, force = force);
 
 		if (result.success) {
 			var relPath = listLast(result.path, "/\");

--- a/cli/lucli/services/CodeGen.cfc
+++ b/cli/lucli/services/CodeGen.cfc
@@ -213,7 +213,8 @@ component {
 	 */
 	public struct function generateTest(
 		required string type,
-		required string name
+		required string name,
+		boolean force = false
 	) {
 		var testName = arguments.name;
 		var testDir = "tests/specs/";
@@ -238,6 +239,12 @@ component {
 		testName &= suffix;
 
 		var fileName = testName & ".cfc";
+		// Refuse to clobber an existing spec unless --force (mirrors generateHelper).
+		// Previously generateTest silently overwrote and still printed "create".
+		var existingPath = variables.projectRoot & "/" & testDir & fileName;
+		if (fileExists(existingPath) && !arguments.force) {
+			return {success: false, error: "Test already exists: #testDir##fileName# (pass --force to overwrite)", path: existingPath};
+		}
 		var destDir = variables.projectRoot & "/" & testDir;
 		if (!directoryExists(destDir)) {
 			directoryCreate(destDir, true);

--- a/cli/lucli/services/ReleaseChannel.cfc
+++ b/cli/lucli/services/ReleaseChannel.cfc
@@ -42,10 +42,17 @@ component {
 	public string function classify(required string moduleVersion) {
 		var v = trim(arguments.moduleVersion);
 
+		// Assemble the build-token sentinel at runtime so the release build's
+		// `@build.version@` -> <version> token replacer can't clobber this string
+		// literal. If written literally, the replacer turns `v == "@build.version@"`
+		// into `v == "4.0.2"`, so a stable build matches its own version here and
+		// misclassifies itself as a dev checkout. See CLI audit H10.
+		var devToken = "@" & "build.version" & "@";
+
 		// Empty / placeholder / dev-checkout sentinels.
 		if (
 			!len(v)
-			|| v == "@build.version@"
+			|| v == devToken
 			|| v == "Version not specified"
 			|| reFindNoCase("\-dev$", v)
 			|| reFindNoCase("^0\.0\.0", v)

--- a/cli/lucli/services/Stats.cfc
+++ b/cli/lucli/services/Stats.cfc
@@ -232,14 +232,30 @@ component {
 
 		for (var lineNum = 1; lineNum <= arrayLen(lines); lineNum++) {
 			var line = lines[lineNum];
+
+			// Only scan the COMMENT portion of the line. Without this, annotations
+			// inside string literals (x = "TODO: ...") and identifiers (methodTODO)
+			// were reported as real notes. Find the earliest line/tag/block comment
+			// marker, or treat a doc-comment continuation line (leading *) as comment.
+			// (Multi-line /* ... */ blocks whose opener is on an earlier line are not
+			// tracked — a known limitation; most annotations sit on //, <!---, or * lines.)
+			var commentStart = 0;
+			for (var marker in ["//", "<!---", "/*"]) {
+				var p = find(marker, line);
+				if (p > 0 && (commentStart == 0 || p < commentStart)) commentStart = p;
+			}
+			if (commentStart == 0 && reFind("^\s*\*", line) > 0) commentStart = 1;
+			if (commentStart == 0) continue;
+			var scanText = mid(line, commentStart, len(line) - commentStart + 1);
+
 			for (var aType in arguments.annotationTypes) {
-				// Match annotation in comment context: // TODO: ..., <!--- FIXME: ... --->, /* OPTIMIZE: ... */
-				var pattern = aType & "[\s:]+(.*)";
-				var match = reFindNoCase(pattern, line, 1, true);
+				// \b so a token isn't matched as the suffix of an identifier (methodTODO).
+				var pattern = "\b" & aType & "[\s:]+(.*)";
+				var match = reFindNoCase(pattern, scanText, 1, true);
 				if (match.pos[1] > 0) {
 					var text = "";
 					if (arrayLen(match.pos) > 1 && match.pos[2] > 0) {
-						text = trim(mid(line, match.pos[2], match.len[2]));
+						text = trim(mid(scanText, match.pos[2], match.len[2]));
 						// Strip trailing comment delimiters
 						text = reReplaceNoCase(text, "\s*--->.*$", "");
 						text = reReplaceNoCase(text, "\s*\*/.*$", "");

--- a/cli/lucli/services/deploy/cli/DeployArgsParser.cfc
+++ b/cli/lucli/services/deploy/cli/DeployArgsParser.cfc
@@ -47,6 +47,12 @@ component {
             } else if (a == "--configPath" && i < n) {
                 opts.configPath = arguments.args[i+1];
                 i++;
+            } else if (left(a, 9) == "--config=") {
+                // Alias for --configPath — the deploy guides document --config. CLI audit H9.
+                opts.configPath = mid(a, 10, 99999);
+            } else if (a == "--config" && i < n) {
+                opts.configPath = arguments.args[i+1];
+                i++;
             } else if (a == "--force") {
                 opts.force = true;
             } else if (left(a, 10) == "--service=") {
@@ -101,6 +107,19 @@ component {
             } else if (a == "--tail" && i < n) {
                 opts.tail = arguments.args[i+1];
                 i++;
+            } else if (left(a, 7) == "--role=") {
+                // `deploy app <verb>` role filter; DeployAppCli reads opts.role. CLI audit H9.
+                opts.role = mid(a, 8, 99999);
+            } else if (a == "--role" && i < n) {
+                opts.role = arguments.args[i+1];
+                i++;
+            } else if (left(a, 12) == "--container=") {
+                opts.container = mid(a, 13, 99999);
+            } else if (a == "--container" && i < n) {
+                opts.container = arguments.args[i+1];
+                i++;
+            } else if (a == "--follow") {
+                opts.follow = true;
             }
             i++;
         }

--- a/cli/lucli/tests/specs/deploy/DeployArgsParserSpec.cfc
+++ b/cli/lucli/tests/specs/deploy/DeployArgsParserSpec.cfc
@@ -67,6 +67,35 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                 var opts = parser.parse(["--version"]);
                 expect(structKeyExists(opts, "version")).toBeFalse();
             });
+
+            // CLI audit H9: --config aliases --configPath; the deploy guides
+            // document --config but only --configPath was parsed.
+            it("parses --config=value as an alias for configPath", () => {
+                var opts = parser.parse(["--config=config/deploy.yml"]);
+                expect(opts.configPath).toBe("config/deploy.yml");
+            });
+
+            it("parses '--config value' as an alias for configPath", () => {
+                var opts = parser.parse(["--config", "deploy.prod.yml"]);
+                expect(opts.configPath).toBe("deploy.prod.yml");
+            });
+
+            // CLI audit H9: app-filter flags DeployAppCli reads but the parser
+            // never populated, so `deploy app boot --role=web` booted all roles.
+            it("parses --role into opts.role", () => {
+                var opts = parser.parse(["--role=web"]);
+                expect(opts.role).toBe("web");
+            });
+
+            it("parses --container into opts.container", () => {
+                var opts = parser.parse(["--container=app-web-v1"]);
+                expect(opts.container).toBe("app-web-v1");
+            });
+
+            it("parses --follow as a boolean flag", () => {
+                var opts = parser.parse(["--follow"]);
+                expect(opts.follow).toBeTrue();
+            });
         });
     }
 }

--- a/cli/lucli/tests/specs/services/CodeGenSpec.cfc
+++ b/cli/lucli/tests/specs/services/CodeGenSpec.cfc
@@ -25,6 +25,34 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 
 		describe("CodeGen Service", () => {
 
+			describe("generateTest()", () => {
+
+				it("creates a model spec file", () => {
+					var result = codegen.generateTest(type = "model", name = "Gizmo");
+					expect(result.success).toBeTrue();
+					expect(fileExists(tempRoot & "/tests/specs/models/GizmoSpec.cfc")).toBeTrue();
+				});
+
+				it("refuses to overwrite an existing spec without force (##M4)", () => {
+					codegen.generateTest(type = "model", name = "Widget", force = true);
+					var path = tempRoot & "/tests/specs/models/WidgetSpec.cfc";
+					fileWrite(path, "// SENTINEL");
+					var result = codegen.generateTest(type = "model", name = "Widget");
+					expect(result.success).toBeFalse();
+					expect(fileRead(path)).toInclude("SENTINEL");
+				});
+
+				it("overwrites an existing spec when force=true", () => {
+					codegen.generateTest(type = "model", name = "Doodad");
+					var path = tempRoot & "/tests/specs/models/DoodadSpec.cfc";
+					fileWrite(path, "// SENTINEL");
+					var result = codegen.generateTest(type = "model", name = "Doodad", force = true);
+					expect(result.success).toBeTrue();
+					expect(find("SENTINEL", fileRead(path))).toBe(0);
+				});
+
+			});
+
 			describe("generateModel()", () => {
 
 				it("creates a model CFC with PascalCase name", () => {

--- a/cli/lucli/tests/specs/services/ReleaseChannelSpec.cfc
+++ b/cli/lucli/tests/specs/services/ReleaseChannelSpec.cfc
@@ -38,7 +38,10 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 				});
 
 				it("classifies dev-checkout sentinels as development", () => {
-					expect(rc.classify("@build.version@")).toBe("development");
+					// Assemble the token at runtime so the build's @build.version@
+					// replacer can't clobber this literal (it would become a real
+					// version and classify as stable). Mirrors the production fix. CLI audit H10.
+					expect(rc.classify("@" & "build.version" & "@")).toBe("development");
 					expect(rc.classify("Version not specified")).toBe("development");
 					expect(rc.classify("0.0.0-dev")).toBe("development");
 					expect(rc.classify("")).toBe("development");

--- a/cli/lucli/tests/specs/services/StatsSpec.cfc
+++ b/cli/lucli/tests/specs/services/StatsSpec.cfc
@@ -137,6 +137,25 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					expect(data.annotations["XYZNONEXISTENT"]).toBeEmpty();
 				});
 
+				it("ignores annotations in string literals and identifier suffixes — only comments count (##M11)", () => {
+					var testFile = tempRoot & "/app/models/NotesFalsePositive.cfc";
+					directoryCreate(getDirectoryFromPath(testFile), true, true);
+					fileWrite(testFile,
+						'component {' & chr(10)
+						& '	// QUIRK: this is a real annotation' & chr(10)
+						& '	var note = "QUIRK: fake one inside a string literal";' & chr(10)
+						& '	var methodQUIRK = 1;' & chr(10)
+						& '}'
+					);
+
+					// Scan only QUIRK so other fixture files don't interfere. Only the
+					// real `// QUIRK` comment must count — not the string literal, not
+					// the `methodQUIRK` identifier suffix.
+					var data = stats.getNotes(annotations = "QUIRK");
+					expect(arrayLen(data.annotations["QUIRK"])).toBe(1);
+					expect(data.annotations["QUIRK"][1].text).toInclude("real");
+				});
+
 			});
 
 		});

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/deploy.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/deploy.mdx
@@ -12,17 +12,17 @@ The everyday deploy verb. Runs the full rolling flow: lock, build, push, pull, b
 ## Synopsis
 
 ``` title="synopsis"
-wheels deploy [--version=<v>] [--destination=<name>] [--dry-run]
+wheels deploy [--release=<v>] [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--version=<v>` | Version label for the new containers. Defaults to `git rev-parse --short HEAD`. |
+| `--release=<v>` | Version label for the new containers. Defaults to `git rev-parse --short HEAD`. |
 | `--destination=<name>` | Overlay `deploy.<name>.yml` and `.kamal/secrets.<name>`. |
 | `--dry-run` | Print the commands that would run, prefixed by host. No network. |
-| `--config=<path>` | Override `config/deploy.yml`. |
+| `--config=<path>` | Override `config/deploy.yml`. `--configPath=<path>` is an accepted alias. |
 
 ## Behavior
 
@@ -38,6 +38,6 @@ wheels deploy [--version=<v>] [--destination=<name>] [--dry-run]
 
 ```bash title="illustrative — requires live infrastructure"
 wheels deploy
-wheels deploy --version=v1.2.3
+wheels deploy --release=v1.2.3
 wheels deploy --destination=staging --dry-run
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/index.mdx
@@ -59,7 +59,7 @@ For the end-to-end walk, start at [Your First Deploy](/v4-0-0/deployment/first-d
   <LinkCard
     title="wheels deploy server"
     href="/v4-0-0/command-line-tools/commands/deploy/server/"
-    description="Host-level operations: exec, bootstrap."
+    description="Host-level operations. Nested verbs are picocli-shadowed — use the flat aliases: wheels deploy bootstrap and wheels deploy exec."
   />
   <LinkCard
     title="wheels deploy prune"
@@ -74,7 +74,7 @@ For the end-to-end walk, start at [Your First Deploy](/v4-0-0/deployment/first-d
   <LinkCard
     title="wheels deploy secrets"
     href="/v4-0-0/command-line-tools/commands/deploy/secrets/"
-    description="Secret-store integration: fetch, extract, print."
+    description="Secret-store integration. Nested verbs are picocli-shadowed — use the flat aliases: wheels deploy fetch-secrets, extract-secrets, print-secrets."
   />
 </CardGrid>
 
@@ -84,7 +84,7 @@ Every `wheels deploy` verb accepts these:
 
 | Flag | Description |
 |------|-------------|
-| `--config=<path>` | Path to `deploy.yml`. Default `config/deploy.yml`. |
+| `--config=<path>` | Path to `deploy.yml`. Default `config/deploy.yml`. `--configPath=<path>` is an accepted alias. |
 | `--destination=<name>` | Overlay `deploy.<name>.yml` and `.kamal/secrets.<name>`. |
 | `--dry-run` | Print the commands that would run, prefixed by host. No network. |
-| `--version=<v>` | Version label (default: `git rev-parse --short HEAD`). |
+| `--release=<v>` | Version label (default: `git rev-parse --short HEAD`). |

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/redeploy.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/redeploy.mdx
@@ -12,14 +12,14 @@ Re-run the deploy flow. Equivalent to `wheels deploy` — boots, ships, cuts tra
 ## Synopsis
 
 ``` title="synopsis"
-wheels deploy redeploy [--version=<v>] [--destination=<name>] [--dry-run]
+wheels deploy redeploy [--release=<v>] [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--version=<v>` | Version to redeploy. Defaults to current git short sha. |
+| `--release=<v>` | Version to redeploy. Defaults to current git short sha. |
 | `--destination=<name>` | Overlay `deploy.<name>.yml` and `.kamal/secrets.<name>`. |
 | `--dry-run` | Print commands without executing. |
 
@@ -33,5 +33,5 @@ wheels deploy redeploy [--version=<v>] [--destination=<name>] [--dry-run]
 
 ```bash title="illustrative — requires deploy infrastructure"
 wheels deploy redeploy
-wheels deploy redeploy --version=abc1234
+wheels deploy redeploy --release=abc1234
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/rollback.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/rollback.mdx
@@ -7,23 +7,23 @@ sidebar:
   order: 3
 ---
 
-Revert traffic to a previously-deployed version. Finds the containers tagged with `--version` on every host, starts them, and asks `kamal-proxy` to switch traffic back.
+Revert traffic to a previously-deployed version. Finds the containers tagged with the given version on every host, starts them, and asks `kamal-proxy` to switch traffic back.
 
 ## Synopsis
 
 ``` title="Synopsis"
-wheels deploy rollback --version=<v> [--destination=<name>] [--dry-run]
+wheels deploy rollback <version> [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--version=<v>` | **Required.** The version to roll back to. |
+| `<version>` | **Required positional.** The version to roll back to. |
 | `--destination=<name>` | Overlay `deploy.<name>.yml`. |
 | `--dry-run` | Print the commands without executing. |
 
-Omitting `--version` throws `DeployMainCli.MissingVersion`.
+Omitting the version throws `DeployMainCli.MissingVersion`.
 
 ## Behavior
 
@@ -34,6 +34,6 @@ Success requires the target containers to still exist on each host. `retain_cont
 ## Examples
 
 ```bash title="Examples"
-wheels deploy rollback --version=abc1234
-wheels deploy rollback --version=v1.2.3 --destination=production
+wheels deploy rollback abc1234
+wheels deploy rollback v1.2.3 --destination=production
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/setup.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/setup.mdx
@@ -12,7 +12,7 @@ The first-time deploy verb. Runs the full `wheels deploy` flow and also boots `k
 ## Synopsis
 
 ``` title="synopsis"
-wheels deploy setup [--version=<v>] [--destination=<name>] [--dry-run]
+wheels deploy setup [--release=<v>] [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
@@ -25,7 +25,7 @@ In Phase 2 the `setup` implementation reduces to the same flow as `wheels deploy
 
 Expected preconditions:
 
-- Docker is installed on every host. Run [`wheels deploy server bootstrap`](/v4-0-0/command-line-tools/commands/deploy/server/bootstrap/) first if not.
+- Docker is installed on every host. Run [`wheels deploy bootstrap`](/v4-0-0/command-line-tools/commands/deploy/server/bootstrap/) first if not (the flat alias — the nested `wheels deploy server bootstrap` form is picocli-shadowed).
 - Registry credentials resolve in `.kamal/secrets`.
 - `ssh.user` has passwordless `sudo` (or is `root`).
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/packages/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/packages/index.mdx
@@ -34,8 +34,8 @@ wheels packages registry info
 | [`add`](./install) | Download, verify, extract into `vendor/<name>/`. |
 | [`update`](./update) | Re-install the latest compatible version. Explicit: requires `--yes`. |
 | [`remove`](./remove) | Delete `vendor/<name>/`. Refuses dirs without a `package.json`. |
-| [`registry refresh`](./registry-refresh) | Bust the 24h cache. |
-| [`registry info`](./registry-info) | Print registry URL, branch, cache state. |
+| [`registry refresh`](./registry/refresh) | Bust the 24h cache. |
+| [`registry info`](./registry/info) | Print registry URL, branch, cache state. |
 
 ## Design principles
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/packages/install.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/packages/install.mdx
@@ -7,7 +7,7 @@ sidebar:
   order: 4
 ---
 
-Adds a package into `vendor/<name>/` from the registry. On the next `wheels reload`, `PackageLoader` auto-discovers the new `vendor/<name>/package.json` and activates the package.
+Adds a package into `vendor/<name>/` from the registry. To activate it, do a cold restart (`wheels stop && wheels start`) — `PackageLoader` discovers the new `vendor/<name>/package.json` at startup. A `wheels reload` is not enough to pick up a newly-installed package.
 
 :::note[Why `add`, not `install`?]
 LuCLI's built-in extension installer intercepts the literal subcommand `install` across every module. Typing `wheels packages install <name>` runs LuCLI's own dependency resolver — it prints `No git or extension dependencies to install` and exits without touching `vendor/`. Use `add` instead. (The same rename happened to `wheels browser setup`, which was previously `wheels browser install`.)
@@ -51,9 +51,9 @@ The same `SemVer` matcher that `PackageLoader` uses at runtime.
 ```sh title="illustrative — terminal session"
 $ wheels packages add wheels-sentry
 Installed wheels-sentry@1.0.0 → /Users/me/app/vendor/wheels-sentry
-Run `wheels reload` to activate it.
+Restart the server (`wheels stop && wheels start`) to activate it.
 
 $ wheels packages add wheels-sentry@1.0.0 --force
 Installed wheels-sentry@1.0.0 → /Users/me/app/vendor/wheels-sentry
-Run `wheels reload` to activate it.
+Restart the server (`wheels stop && wheels start`) to activate it.
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/packages/update.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/packages/update.mdx
@@ -7,7 +7,7 @@ sidebar:
   order: 5
 ---
 
-Updates are always explicit. There is no auto-update on reload and no implicit upgrade when running `install` on an already-installed package. This is the registry's defense against malicious version-bump attacks — every version change is the user's conscious choice.
+Updates are always explicit. There is no auto-update on reload and no implicit upgrade when running `add` on an already-installed package. This is the registry's defense against malicious version-bump attacks — every version change is the user's conscious choice.
 
 ## Synopsis
 
@@ -32,7 +32,7 @@ wheels packages update --all --yes
 ```sh title="example output"
 $ wheels packages update wheels-sentry --yes
 Installed wheels-sentry@1.1.0 → /Users/me/app/vendor/wheels-sentry
-Run `wheels reload` to activate it.
+Restart the server (`wheels stop && wheels start`) to activate it.
 
 $ wheels packages update --all --yes
 Update report:

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/installation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/installation.mdx
@@ -213,7 +213,7 @@ Java 21.0.8
 
 The three-line format tells you the Wheels Module version, the underlying LuCLI version, and the JVM the wrapper picked up. If any of those lines is missing or reports an unexpected value, jump to troubleshooting below.
 
-Running `wheels` with no arguments is also a quick sanity check — it prints the same help banner as `wheels --help` and `wheels help`. If you see a `Component [modules.wheels.Module] has no function with name [main]` error instead, you are running a build that predates this fix — upgrade to the latest 4.0.x release to restore the expected behavior.
+Running `wheels` with no arguments is also a quick sanity check — it prints the same Wheels help banner as `wheels --help`. (`wheels help` falls through to LuCLI's own generic help rather than the Wheels banner, so prefer `wheels --help`.) If you see a `Component [modules.wheels.Module] has no function with name [main]` error instead, you are running a build that predates this fix — upgrade to the latest 4.0.x release to restore the expected behavior.
 
 Once the version check passes, `wheels info` inside a Wheels project gives you a deeper sanity check against a real app — datasource connection, environment, route count. See [App Inspection](../wheels-commands/app-inspection/) for the full output and how to read it.
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/quick-start.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/quick-start.mdx
@@ -28,18 +28,18 @@ wheels new myblog --no-open-browser
 
 ## 2. Start the server
 
-```bash title="illustrative — server runs in foreground"
+```bash title="example"
 cd myblog
 wheels start
 ```
 
-The dev server binds to port `8080` by default and runs in the foreground — it keeps the terminal attached until you stop it with `Ctrl+C` or `wheels stop` from another shell. On first boot the wrapper resolves dependencies and compiles the application; subsequent starts are quick.
+The dev server binds to port `8080` by default and runs in the background — the command returns once the server is up, leaving your terminal free. Stop it later with `wheels stop`. On first boot the wrapper resolves dependencies and compiles the application; subsequent starts are quick.
 
 Override the port with `--port=3000` if `8080` is busy.
 
 ## 3. Generate a scaffold
 
-Open a **second terminal** in the same project directory (the server keeps running in the first), then:
+Back in the same terminal (the server is already running in the background), generate the resource:
 
 ```bash {test:cli cmd="wheels generate scaffold Post title:string body:text" step=2}
 wheels generate scaffold Post title:string body:text
@@ -67,13 +67,13 @@ If you changed the port in step 2, substitute that port instead.
 
 ## 6. Run the scaffold's tests
 
-Still in the second terminal:
+With the server still running in the background:
 
 ```bash title="illustrative — requires running server"
-wheels test --filter=posts
+wheels test posts
 ```
 
-`--filter` scopes the test run to specs whose path matches the filter string. The scaffold generated a `PostsSpec.cfc` under `tests/specs/`, so the filter narrows the run to just that file's specs. Omit the flag to run everything.
+The trailing positional scopes the test run to specs whose path matches the filter string. The scaffold generated a `PostsSpec.cfc` under `tests/specs/`, so the filter narrows the run to just that file's specs. Omit it to run everything. A run with failing or erroring specs exits non-zero; a fully-passing run exits `0`.
 
 ## 7. What's next
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/app-inspection.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/app-inspection.mdx
@@ -81,7 +81,7 @@ None. `wheels info` takes no flags — ignore any reference to `--json` or `--qu
 
 #### Output stream
 
-Output is written to **stderr**, not stdout. If you're piping `wheels info` into another tool, redirect with `2>&1` or capture stderr directly. The process exits successfully either way; no non-zero exit is raised when the summary is empty.
+Output is written to **stdout**. If you're piping `wheels info` into another tool, it reads from stdout directly — no `2>` redirection needed. The process exits successfully either way; no non-zero exit is raised when the summary is empty.
 
 #### Example
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-generation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-generation.mdx
@@ -64,7 +64,7 @@ The other generators (`controller`, `view`, `migration`, `route`, `test`, `helpe
 | `publishedOn:date` | `date` | |
 | `startsAt:time` | `time` | |
 | `payload:binary` | `binary` | |
-| `--belongsTo=author` | — | Adds `belongsTo(name="author")` and an `authorId` FK column. |
+| `--belongsTo=author` | — | Adds `belongsTo("author")` and an `authorId` FK column. |
 | `--hasMany=comments` | — | Adds `hasMany(name="comments")`. Pass multiple names comma-separated. |
 | `--hasOne=profile` | — | Adds `hasOne(name="profile")`. |
 
@@ -186,7 +186,7 @@ wheels generate scaffold Post title body:text publishedAt:datetime --belongsTo=a
 
 Writes:
 
-- `app/models/Post.cfc` with `belongsTo(name="author")`
+- `app/models/Post.cfc` with `belongsTo("author")`
 - `app/migrator/migrations/<timestamp>_create_posts_table.cfc` with `title`, `body`, `publishedAt`, `authorId`, and the `timestamps()` trio
 - `app/controllers/Posts.cfc` with the seven CRUD actions
 - `app/views/posts/index.cfm`, `show.cfm`, `new.cfm`, `edit.cfm`, `_form.cfm`
@@ -395,7 +395,7 @@ Generates the model, migration, controller, views, tests, and route; migrates th
 wheels generate model Comment body:text --belongsTo=post
 ```
 
-Creates `Comment.cfc` with `belongsTo(name="post")`, plus a migration that includes a `postId` foreign-key column. Useful when you want the association wired up but don't need a controller or views yet.
+Creates `Comment.cfc` with `belongsTo("post")`, plus a migration that includes a `postId` foreign-key column. Useful when you want the association wired up but don't need a controller or views yet.
 
 ### A blank migration for a hand-written schema change
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/console-and-repl.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/console-and-repl.mdx
@@ -59,7 +59,7 @@ Commands at the prompt start with `/`. They're short-circuits for things you'd o
 | Command | Description |
 |---|---|
 | `/help`, `/h` | Print the console help text (commands + example expressions). |
-| `/env` | Print the current environment (development, production, etc.). |
+| `/env` | Print the current environment as a struct (`{environment, dataSourceName, ...}`). |
 | `/models` | List every registered model, sorted alphabetically. |
 | `/routes` | List all routes as `pattern -> controller#action`. |
 | `/version` | Print the Wheels version from `application.wheels.version`. |

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/creating-a-project.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/creating-a-project.mdx
@@ -42,7 +42,7 @@ Creates a new application in `<name>/` under the current working directory. SQLi
 
 | Name | Required | Description |
 |---|---|---|
-| `<name>` | yes | Directory and app name. Used as the default datasource name (lowercased) and as the reload password unless overridden. |
+| `<name>` | yes | Directory and app name. Used as the default datasource name (lowercased). The reload password is randomly generated unless you pass `--reload-password`. |
 
 #### Flags
 
@@ -113,7 +113,6 @@ myblog/
     migrator/migrations/
     events/
     global/
-    helpers/
     jobs/
     lib/
     mailers/

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/database.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/database.mdx
@@ -28,7 +28,7 @@ Apply or roll back migration files in `app/migrator/migrations/`.
 #### Synopsis
 
 ``` title="synopsis"
-wheels migrate [latest|up|down|info]
+wheels migrate [latest|up|down|info|doctor|forget|pretend|rename-system-tables]
 ```
 
 Running `wheels migrate` with no subcommand defaults to `latest`. Unknown subcommands print `Unknown migration action: <name>` and exit without touching the schema.
@@ -50,6 +50,22 @@ Rolls back the most recently applied migration by calling its `down()` method. U
 ##### `info`
 
 Prints a summary of applied and pending migrations without changing the schema. For the full tabular breakdown — version, description, status, applied-at timestamp — use [`wheels db status`](#wheels-db) instead.
+
+##### `doctor`
+
+Single-command health report for the migration tracking table. Lists orphan tracking rows (versions recorded as applied with no matching file on disk) and pending local migrations. Pure read — it changes nothing.
+
+##### `forget`
+
+Deletes a stale tracking row: `wheels migrate forget <version> --yes`. Dry-run by default; `--yes` is required to mutate. Refuses if a matching local migration file exists, or if the version isn't in the tracking table.
+
+##### `pretend`
+
+Records a version as applied without running its `up()`: `wheels migrate pretend <version> --yes`. Dry-run by default; `--yes` is required to mutate. Refuses if the version is already applied or has no matching file.
+
+##### `rename-system-tables`
+
+Migrates legacy framework bookkeeping tables to their current `wheels_`-prefixed names. Run once when upgrading a project whose system tables predate the current naming.
 
 #### Example
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/dev-server.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/dev-server.mdx
@@ -45,20 +45,21 @@ Any flags you pass are forwarded verbatim to `wheels server start`. The common o
 | `-v, --version=<version>` | Lucee version to use (e.g., `6.2.2.91`). |
 | `--env, --environment=<env>` | Environment to use (e.g., `dev`, `staging`, `prod`). |
 | `-c, --config=<file>` | Configuration file to use (defaults to `lucee.json`). |
+| `-f, --force` | Force a restart, replacing any server already running for this project. |
 | `--disable-open-browser` | Don't open a browser after the server starts. |
 | `--dry-run` | Show the resolved configuration without starting the server. |
 | `--sandbox` | Start a transient background server without writing `lucee.json`. |
 
 #### Example
 
-```bash title="illustrative — foreground process, not runnable in CI"
+```bash title="example"
 wheels start
 ```
 
-Prints `Starting Wheels server...` in cyan and hands control off to `wheels server start` in the current project directory. The server runs in the foreground and occupies the terminal until it exits.
+Prints `Starting Wheels server...` in cyan and hands control off to `wheels server start` in the current project directory. The server runs in the background and the command returns once the server is up, leaving your terminal free.
 
-<Aside type="caution" title="Foreground process">
-`wheels start` blocks the terminal. To stop the server, run `wheels stop` from another terminal or press `Ctrl+C` in the terminal that owns the process.
+<Aside type="note" title="Background process">
+`wheels start` returns control to your shell once the server is up — it does not block the terminal. Stop the server with `wheels stop`, and force a restart over an already-running instance with `wheels start -f` (or `--force`).
 </Aside>
 
 ### `wheels stop`
@@ -79,7 +80,7 @@ Resolves the server instance from the project directory and asks LuCLI to stop i
 wheels stop
 ```
 
-Prints `Stopping Wheels server...` in cyan and delegates to `wheels server stop`. Useful from a second terminal when `wheels start` is blocking the first one.
+Prints `Stopping Wheels server...` in cyan and delegates to `wheels server stop`. Run it from the project root to take down the background server that `wheels start` brought up.
 
 <Aside type="tip" title="Stopping by name or all at once">
 To stop a server by explicit name or to stop every running Lucee server on the machine, drop down to the core command: `wheels server stop --name=<name>` or `wheels server stop --all`. See the [`server`](../../core-commands/server/) reference.
@@ -122,10 +123,10 @@ Most CFML source changes are picked up on the next request without a reload. In 
 The three commands compose into a typical inner loop:
 
 ```bash title="illustrative — dev loop example"
-# Terminal 1 — bring the server up and leave it running
+# Bring the server up — it runs in the background and returns control
 wheels start
 
-# Terminal 2 — iterate on your app
+# Iterate on your app
 # For most CFML edits: just save the file and hit refresh.
 # For config/routes/services changes, force a reload:
 wheels reload

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/testing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/testing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Testing"
-description: wheels test and wheels browser install — run the test suite from the command line, filter to specific directories, and install Playwright so browser specs can run.
+description: wheels test and wheels browser setup — run the test suite from the command line, filter to specific directories, and install Playwright so browser specs can run.
 type: reference
 sidebar:
   order: 5
@@ -8,7 +8,7 @@ sidebar:
 
 import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-Two commands cover the testing surface at the CLI level. `wheels test` runs the BDD suite against your chosen engine and database, and `wheels browser install` downloads the Playwright JARs and Chromium needed for browser specs.
+Two commands cover the testing surface at the CLI level. `wheels test` runs the BDD suite against your chosen engine and database, and `wheels browser setup` downloads the Playwright JARs and Chromium needed for browser specs.
 
 **You'll use this for:**
 
@@ -112,35 +112,36 @@ This mirrors how Rails (`DATABASE_URL=...`), Laravel (`DB_CONNECTION=...`), Symf
 
 For full-matrix CI (every engine × every database), see [`tools/test-matrix.sh`](../../../testing/ci-integration/) — it spins up the engine + DB containers and invokes the test endpoint per cell.
 
-### `wheels browser install`
+### `wheels browser setup`
 
 Download the Playwright Java JARs and a Chromium binary into `.wheels/browser/` so browser specs can run. This is a one-time setup per workspace — roughly 370MB on first install.
 
 #### Synopsis
 
 ``` title="synopsis"
-wheels browser install [--force] [--browser=<name>]
+wheels browser setup [--force]
 ```
 
-`wheels browser` is an umbrella that also exposes a `test` subcommand for running only the browser spec directory. Most users only need `install` at the CLI level and then run browser specs through the normal `wheels test` path.
+`wheels browser` is an umbrella that also exposes a `test` subcommand (`wheels browser test`) for running only the browser spec directory. Most users only need `setup` at the CLI level and then run browser specs through the normal `wheels test` path.
 
 #### Flags
 
 | Flag | Description |
 |---|---|
 | `--force` | Re-download every JAR even if the local SHA-256 matches the manifest. Useful after a manifest bump. |
-| `--browser=<name>` | Which browser engine to install. Defaults to `chromium`, which is the only engine wired into the browser DSL today. |
+
+Chromium is the only engine wired into the browser DSL today; `wheels browser test` does not yet support selecting Firefox or WebKit.
 
 #### Example
 
 ```bash title="example"
-wheels browser install
+wheels browser setup
 ```
 
 Reads `vendor/wheels/browser-manifest.json`, downloads each missing or mismatched JAR, verifies SHA-256, and installs a matching Chromium build. Subsequent runs skip files that already match the manifest.
 
-<Aside type="note" title="When install is required">
-Specs that extend `wheels.wheelstest.BrowserTest` short-circuit gracefully when the JARs aren't present — they mark themselves skipped rather than failing. Run `wheels browser install` once per workspace before you expect browser specs to actually exercise the DSL. The [Browser Tests](../../../testing/browser-tests/) guide covers the `WHEELS_BROWSER_CI_ENABLE` gate that controls the same behavior in CI.
+<Aside type="note" title="When setup is required">
+Specs that extend `wheels.wheelstest.BrowserTest` short-circuit gracefully when the JARs aren't present — they mark themselves skipped rather than failing. Run `wheels browser setup` once per workspace before you expect browser specs to actually exercise the DSL. The [Browser Tests](../../../testing/browser-tests/) guide covers the `WHEELS_BROWSER_CI_ENABLE` gate that controls the same behavior in CI.
 </Aside>
 
 ## Common workflows
@@ -156,7 +157,7 @@ wheels test --filter=models
 wheels test --ci --db=sqlite
 
 # First-time browser setup, then exercise the browser specs
-wheels browser install
+wheels browser setup
 wheels test --filter=browser
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/upgrade.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/upgrade.mdx
@@ -30,8 +30,8 @@ Calling `wheels upgrade` with no subcommand (or any subcommand other than `check
 
 1. **Reads the current version** from `vendor/wheels/box.json`. If the file is missing or malformed, the version is reported as `unknown` and the comparison below is skipped.
 2. **Resolves the target version.** If you pass `--to=<version>`, that wins. Otherwise the command hits the GitHub releases API (`api.github.com/repos/wheels-dev/wheels/releases/latest`) and strips the leading `v` from the tag name. If the network call fails, the command prints a yellow notice and exits — it will not invent a target.
-3. **Compares major versions.** If current and target share the same major, the command prints "Same major version — no known breaking changes", reminds you of the upgrade command, and exits. No scan runs.
-4. **Runs breaking-change checks** when the major bumps. Each check is either a directory existence test or a regex grep across a sub-tree of the project. Hits are printed as issues (yellow); absences are printed as passed checks (green).
+3. **Compares major versions.** If current and target share the same major, the command notes "Same major version — no known breaking changes" for the major-transition checks, then still runs its advisory scan for the same-major patterns below.
+4. **Runs breaking-change checks.** Each check is either a directory existence test or a regex grep across a sub-tree of the project. Major-version transitions add their own checks on top of the advisory scan. Hits are printed as issues (yellow); absences are printed as passed checks (green).
 
 Nothing in the project is modified. No files are written. The command does not stage, commit, or touch git state.
 
@@ -78,13 +78,14 @@ All Clear (1 checks):
 Upgrade with: brew upgrade wheels
 ```
 
-When current and target share a major version, output collapses to:
+When current and target share a major version, the major-transition note is shown but the advisory scan still runs:
 
 ```text title="illustrative — same-major output"
 Current version: 4.0.0
 Target version:  4.0.1
 
-Same major version — no known breaking changes.
+Same major version — no known breaking changes between majors.
+(advisory scan still runs against the same-major patterns)
 Upgrade with: brew upgrade wheels
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/packages.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/packages.mdx
@@ -36,7 +36,7 @@ Install a package:
 
 ```bash title="your shell"
 wheels packages add wheels-hotwire
-wheels reload
+wheels stop && wheels start
 ```
 
 Browse, search, inspect, update, or remove:
@@ -57,7 +57,7 @@ Deactivation is a single command — `remove` deletes the `vendor/<name>/` direc
   The registry caches its index for 24 hours. If you want to see a just-published version immediately, `wheels packages registry refresh` busts the cache. `wheels packages registry info` shows the configured registry URL and cache state.
 </Aside>
 
-The reload step re-runs `PackageLoader`, which rediscovers what's in `vendor/` and reconciles the mixin, service, and middleware tables with the new state.
+The restart re-runs `PackageLoader` at startup, which rediscovers what's in `vendor/` and reconciles the mixin, service, and middleware tables with the new state. A plain `wheels reload` is not enough — `PackageLoader` only re-scans `vendor/` on a cold start.
 
 ## First-party packages
 
@@ -156,7 +156,7 @@ component output="false" {
 }
 ```
 
-After installing the package into `vendor/myfeature/` and reloading, every controller has `myHelper()` available. The framework collects public methods from the package instance and merges them into the application mixin tables — the same machinery that runs for plugins, but scoped to the targets you named in the manifest.
+After installing the package into `vendor/myfeature/` and restarting the server (`wheels stop && wheels start`), every controller has `myHelper()` available. The framework collects public methods from the package instance and merges them into the application mixin tables — the same machinery that runs for plugins, but scoped to the targets you named in the manifest.
 
 Lifecycle hook names the loader specifically skips when collecting mixins: `init`, `onPluginLoad`, `onPluginActivate`, `register`, `boot`. If you name a method any of those, it won't be mixed in — the loader treats them as package infrastructure.
 

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/tutorial/07-testing-deploying.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/tutorial/07-testing-deploying.mdx
@@ -223,7 +223,7 @@ Things to notice:
 - The signup form uses plain `<input name="user[email]">` without an id, so the spec targets it by attribute selector instead. Attribute selectors like `input[name='user[email]']` are robust against future form refactors.
 - The fluent DSL chains: `.visitRoute("signup").fill(...).click(...).waitForUrl("**/posts").assertUrlContains("/posts")` is one statement. Each method returns the browser object, so the chain keeps going until you call a terminal like `.assertSee(...)` or let the statement end.
 - `.waitForUrl("**/posts")` and `.waitForText("My first post")` are not optional — they bridge the async gap between `.click()` and the assertion. Submitting a form goes through Turbo Drive's `fetch` + `history.pushState`, which doesn't complete on the same tick as the click. `assertUrlContains` and `assertSee` read state synchronously, so without an explicit wait they'd fire before navigation lands and you'd see `Expected URL to contain '/posts', got 'http://localhost:8080/signup'`. `waitForUrl` accepts Playwright glob patterns; `waitForText` waits for visible text anywhere on the page (handy when a Turbo Stream appends content but the URL doesn't change).
-- `if (this.browserTestSkipped) return;` keeps the spec green on machines without Playwright installed — fresh CI runners before `wheels browser install`, for example. The flag is set by `beforeAll` when the JARs can't be loaded.
+- `if (this.browserTestSkipped) return;` keeps the spec green on machines without Playwright installed — fresh CI runners before `wheels browser setup`, for example. The flag is set by `beforeAll` when the JARs can't be loaded.
 
 ## Run the tests
 

--- a/web/sites/guides/src/content/docs/v4-0-0/testing/browser-tests.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/testing/browser-tests.mdx
@@ -24,7 +24,7 @@ Browser tests drive a real Chromium through Playwright. They click buttons, type
 
 ## Install Playwright
 
-Browser tests require Playwright's Java client plus Chromium. The `wheels browser install` command downloads both (~370MB one-time) and verifies SHA-256 hashes.
+Browser tests require Playwright's Java client plus Chromium. The `wheels browser setup` command downloads both (~370MB one-time) and verifies SHA-256 hashes.
 
 ```bash {test:cli cmd="wheels --version" asserts-stdout="Wheels"}
 wheels --version
@@ -33,10 +33,10 @@ wheels --version
 Then, inside your project:
 
 ```bash title="shell"
-wheels browser install
+wheels browser setup
 ```
 
-The installer resolves seven JARs from Maven Central (Playwright client, driver, driver-bundle, transitive deps) and caches them under a per-project install directory. Subsequent runs skip the download when hashes match. Pass `--force` to re-download, or `--browser=firefox|webkit` to install a different engine (Chromium is the default).
+The installer resolves seven JARs from Maven Central (Playwright client, driver, driver-bundle, transitive deps) and caches them under a per-project install directory. Subsequent runs skip the download when hashes match. Pass `--force` to re-download. Chromium is the only engine the browser DSL wires today — Firefox and WebKit are not yet selectable.
 
 If Playwright isn't installed when a spec runs, `BrowserTest.beforeAll` catches the missing-JAR error, sets `this.browserTestSkipped = true`, and the suite stays green. That's the safety net for CI cold starts and fresh dev machines — but every `it` in a browser spec still needs to check the flag.
 

--- a/web/sites/guides/src/content/docs/v4-0-0/testing/ci-integration.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/testing/ci-integration.mdx
@@ -126,7 +126,7 @@ When you do opt in, cache the Playwright install — it's the slowest single ste
 
 - name: Install Playwright
   if: steps.playwright-cache.outputs.cache-hit != 'true'
-  run: wheels browser install
+  run: wheels browser setup
 ```
 
 The cache key hashes `browser-manifest.json` so a Playwright version bump invalidates the cache automatically.
@@ -246,7 +246,7 @@ Each cell runs independently on its own runner with its own LuCLI server — the
 The handful of failures that eat the most CI minutes, with the one-line diagnosis for each:
 
 - **`JAVA_HOME is not set`** — LuCLI's preflight fires an actionable error. Use `actions/setup-java@v4`; it exports `JAVA_HOME` for you. Never set it by hand in a later step.
-- **Playwright JARs missing, browser specs silently skip** — expected when you haven't installed Playwright. If you want browser specs to run, add a `wheels browser install` step and the `actions/cache@v4` block above.
+- **Playwright JARs missing, browser specs silently skip** — expected when you haven't installed Playwright. If you want browser specs to run, add a `wheels browser setup` step and the `actions/cache@v4` block above.
 - **`docker compose` not found** — the `ubuntu-latest` runner includes Docker, but some self-hosted runners don't. Add `docker/setup-buildx-action@v3` if you hit it.
 - **Lucee starts but the test request times out** — the first hit to `/` pays the full Wheels bootstrap cost. Warm the app with `curl -s "http://localhost:PORT/?reload=true&password=..."` before you curl the test endpoint, and raise `--max-time` on the test curl to 600.
 - **Tests pass locally but fail in CI** — almost always a cross-engine gotcha (Adobe's `application` scope, Lucee's struct member functions, closure `this` capture). Reproduce by running the same engine locally via Docker Compose before you debug CI logs.

--- a/web/sites/guides/src/content/docs/v4-0-0/testing/running-tests-locally.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/testing/running-tests-locally.mdx
@@ -198,7 +198,7 @@ These are the errors you'll actually hit. Fix-ups first, diagnosis second.
 - **`JAVA_HOME` unset** — LuCLI's preflight refuses to start and prints a pointer to Adoptium. Set `JAVA_HOME` in your shell profile and re-source.
 - **Docker daemon not running** — `docker compose up` fails with `Cannot connect to the Docker daemon`. Start Docker Desktop (macOS, Windows) or `systemctl start docker` (Linux).
 - **Port already in use** — `docker compose up` fails with `bind: address already in use` or a local `wheels start` is already on the port. Find the holder with `lsof -i :60007` and stop it.
-- **Playwright JARs missing** — browser specs skip with `this.browserTestSkipped = true` instead of failing, so the suite stays green. Run `wheels browser install` once to install the JARs and Chromium.
+- **Playwright JARs missing** — browser specs skip with `this.browserTestSkipped = true` instead of failing, so the suite stays green. Run `wheels browser setup` once to install the JARs and Chromium.
 - **Populate SQL errors** — read the error. "Table already exists" means a stale table from a previous engine-specific run; add a `DROP TABLE IF EXISTS` first. "Syntax error near CURRENT_TIMESTAMP" means cross-engine SQL drift; use `NOW()` — it works on every supported engine.
 - **Flaky `wheels new` in parallel harness runs** — a known LuCLI race (framework gap tracker #11). Retry once, or serialize the runs until the fix lands.
 - **Server not responding after `compose up`** — engines need 30–90 seconds to cold-start. `curl -I http://localhost:60007/` returns connection-refused until the engine is ready. If it stays down after two minutes, check `docker compose logs <service>`.
@@ -215,8 +215,8 @@ docker compose down
 # Purge SQLite test databases between runs
 rm -f wheelstestdb.db wheelstestdb_tenant_b.db
 
-# Stop any local LuCLI server the script started
-lucli server stop
+# Stop any local server the script started
+wheels stop
 ```
 
 ## Related guides


### PR DESCRIPTION
## What & why

Follow-up to #2882 — the next tier of CLI-audit fixes (the deferred Phase 3 items you asked me to tackle), plus a user-facing guide sweep. Every code fix was reproduced and re-verified against the CLI in an isolated harness; every doc edit was reviewed against verified behavior and for MDX/JSX safety.

## Code fixes (`cli/lucli/**`)

| Fix | Was | Now |
|---|---|---|
| **`wheels test` exit code** | always exited `0`, even with failing specs (CI green-but-failing) | exits **non-zero** when specs fail/error; a fully-passing run still exits 0 (verified both ways) |
| **`--reporter=tap`** | crashed on the first failing spec (`failOrigin` is an array → "Cannot cast Array to string") | `$tapOriginString()` coerces it; emits well-formed TAP (verified) |
| **`deploy --config`** | only `--configPath` parsed; guides document `--config` | `--config` accepted as an alias (verified) |
| **`deploy app --role/--container/--follow`** | parsed nowhere → `app boot --role=web` booted **all** roles | parser populates them; role filtering works (verified: `--role=web` → web only) |
| **ReleaseChannel** | the build's `@build.version@` token-replacer clobbered the dev-sentinel string literal → stable builds reported `(development)` | sentinel assembled at runtime so the replacer can't see a literal token |

## Doc sweep (`web/sites/guides/v4-0-0/**`, 23 files)

Corrected guides that documented commands/flags/verbs that error or behave differently:
- **deploy**: `--version=<v>` → `--release=<v>` (picocli root absorbs `--version`); `--configPath` alias noted; `rollback <version>` positional; nested `deploy server`/`secrets <verb>` → flat aliases (`bootstrap`, `exec`, `*-secrets`).
- **testing/CI**: `wheels browser install` → `wheels browser setup`; `wheels test run` → `wheels test`; non-zero-exit-on-failure noted; chromium-only engine; documented `wheels browser test`.
- **wheels-commands**: `wheels info` → STDOUT (not stderr); `wheels start` runs in the **background** + `-f/--force`; all 8 `migrate` subcommands documented (incl. doctor/forget/pretend/rename-system-tables); reload-password is random; no `app/helpers/` dir; `belongsTo` generator emits positional form; `/env` returns a struct; upgrade same-major still runs the advisory scan.
- **packages**: a newly-installed package needs a cold restart (`wheels stop && wheels start`), not `reload`; fixed broken `registry/` links; `add` (not `install`) wording.
- **installation**: `wheels help` falls through to LuCLI's generic help, not the Wheels banner.

## Verification
- Code fixes reproduced + re-verified in an isolated worktree-source harness (exit codes via direct `$?`, TAP output, `--role` dry-run filtering, `--config` load).
- MDX reviewed for JSX safety — fixed one `LinkCard` description that had a JSX-invalid `\"` escape; all other angle-brackets are inside code fences / inline-code / valid `<Aside>` components.
- The full `tools/test-cli-local.sh` suite can't run from a `.claude/worktrees` worktree (framework demo app won't stay up there); **CI is the backstop** (CLI suite + deploy verb-smoke + docs build).

## Still deferred (upstream / out of this repo)
The remaining systemic items live in the **LuCLI runtime** (`cybersonic/LuCLI`) + the per-launcher wrapper, not in `cli/lucli/`, so they need upstream + Homebrew-formula PRs:
- [ ] Per-command `--help`/`-h`/bare `help` all print the global/LuCLI banner (preprocessModuleHelp interception).
- [ ] `--verbose`/`-v` swallowed by the runtime (breaks `doctor`/`stats`/`test` verbose).
- [ ] `--version` picocli root shadowing (the launcher should rewrite `--version`→`--release` for deploy); `wheels help`/`mcp`/error paths leak the `lucli` brand.
- [ ] Per-command help text is hard-coded in each launcher wrapper and drifts.

(Lower-priority in-repo nits — `generate enum` not emitted, silent view-gen failures, `generate test` overwrite guard, `notes` comment-context scanner — remain as smaller follow-ups.)
