### PR TITLE
fix(cli): generate enum() emission, view-gen warnings, route-dup message

### DIFF
--- a/app/snippets/ModelContent.txt
+++ b/app/snippets/ModelContent.txt
@@ -6,6 +6,7 @@
 		{{hasManyRelationships}}
 		{{hasOneRelationships}}
 		{{validations}}
+		{{enums}}
 	}
 
 }

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -2794,6 +2794,10 @@ component extends="modules.BaseModule" {
 				var viewResult = codegen.generateView(name = controllerName, action = action);
 				if (viewResult.success) {
 					printCreated("app/views/#lCase(controllerName)#/#lCase(action)#.cfm");
+				} else {
+					// Warn instead of silently skipping — a controller reporting
+					// success with no views written is misleading. CLI audit M3.
+					out("  skip    app/views/#lCase(controllerName)#/#lCase(action)#.cfm: " & (viewResult.error ?: "generation failed"), "yellow");
 				}
 			}
 		}
@@ -2933,6 +2937,14 @@ component extends="modules.BaseModule" {
 		var resourceRoute = '.resources("' & routeName & '")';
 		if (findNoCase(resourceRoute, content)) {
 			out("Route already exists: #resourceRoute#", "yellow");
+			return "";
+		}
+		// Also detect the named-arg form (e.g. .resources(name="posts", only="...")),
+		// which updateRoutes() treats as a duplicate. Without this, an existing
+		// named-arg route was misreported as "Could not find insertion point". M5.
+		var namedArgPattern = "\.resources\s*\([^)]*name\s*=\s*[""']" & routeName & "[""']";
+		if (reFindNoCase(namedArgPattern, content)) {
+			out("Route already exists: .resources(name=""#routeName#"", ...)", "yellow");
 			return "";
 		}
 

--- a/cli/lucli/services/CodeGen.cfc
+++ b/cli/lucli/services/CodeGen.cfc
@@ -50,6 +50,7 @@ component {
 			hasMany: arguments.hasMany,
 			hasOne: arguments.hasOne,
 			validations: buildModelValidations(arguments.properties),
+			enums: buildModelEnums(arguments.properties),
 			timestamp: dateTimeFormat(now(), "yyyy-mm-dd HH:nn:ss")
 		};
 
@@ -88,6 +89,25 @@ component {
 		// Join with newline + 2 tabs so subsequent lines align with the template's
 		// `\t\t{{validations}}` placeholder indent. The first line gets its indent
 		// from the placeholder's leading whitespace at fill time.
+		return arrayToList(lines, chr(10) & chr(9) & chr(9));
+	}
+
+	/**
+	 * Build enum() declarations for any `name:enum:a,b,c` properties. Emits one
+	 * `enum(property="name", values="a,b,c")` line per enum property so generated
+	 * models carry the auto-checkers/scopes the framework derives from enum().
+	 * Previously the enum type was parsed but never emitted. CLI audit M2.
+	 */
+	private string function buildModelEnums(required array properties) {
+		var lines = [];
+		for (var prop in arguments.properties) {
+			var propType = structKeyExists(prop, "type") ? lCase(prop.type) : "";
+			if (propType == "enum" && structKeyExists(prop, "values") && len(prop.values)) {
+				arrayAppend(lines, 'enum(property="#prop.name#", values="#prop.values#");');
+			}
+		}
+		// Same newline + 2-tab join as buildModelValidations to align with the
+		// template's `\t\t{{enums}}` placeholder indent.
 		return arrayToList(lines, chr(10) & chr(9) & chr(9));
 	}
 

--- a/cli/lucli/services/ReleaseChannel.cfc
+++ b/cli/lucli/services/ReleaseChannel.cfc
@@ -42,11 +42,12 @@ component {
 	public string function classify(required string moduleVersion) {
 		var v = trim(arguments.moduleVersion);
 
-		// Assemble the build-token sentinel at runtime so the release build's
-		// `@build.version@` -> <version> token replacer can't clobber this string
-		// literal. If written literally, the replacer turns `v == "@build.version@"`
-		// into `v == "4.0.2"`, so a stable build matches its own version here and
-		// misclassifies itself as a dev checkout. See CLI audit H10.
+		// Assemble the sentinel at runtime ("@" & "build.version" & "@") so the
+		// release build's version-token replacer can't clobber this string literal.
+		// If the sentinel were written as the bare literal, the replacer would swap
+		// it for the real version at build time — a stable build would then compare
+		// v against its own version here and misclassify itself as a dev checkout.
+		// (The comment itself avoids the bare token for the same reason.) CLI audit H10.
 		var devToken = "@" & "build.version" & "@";
 
 		// Empty / placeholder / dev-checkout sentinels.

--- a/cli/lucli/services/Scaffold.cfc
+++ b/cli/lucli/services/Scaffold.cfc
@@ -127,6 +127,11 @@ component {
 					if (viewResult.success) {
 						arrayAppend(results.generated, {type: "view", path: viewResult.path});
 						arrayAppend(results.rollback, viewResult.path);
+					} else {
+						// Surface the failure instead of silently producing a
+						// "complete" scaffold with no views (e.g. unbundled
+						// templates, #1944). CLI audit M3.
+						arrayAppend(results.skipped, "view " & action & ": " & (viewResult.error ?: "generation failed"));
 					}
 				}
 			}

--- a/cli/lucli/services/Templates.cfc
+++ b/cli/lucli/services/Templates.cfc
@@ -103,6 +103,13 @@ component {
 		}
 		processed = reReplace(processed, "\{\{validations\}\}", validationCode, "all");
 
+		// Process {{enums}} placeholder. Mirrors {{validations}}: CodeGen.generateModel
+		// pre-builds an `enums` code string of enum(property=..., values=...) lines for
+		// any name:enum:a,b,c properties. Explicit (not just the generic {{key}} loop)
+		// so it's substituted even when empty. CLI audit M2.
+		var enumCode = (structKeyExists(arguments.context, "enums") && isSimpleValue(arguments.context.enums)) ? arguments.context.enums : "";
+		processed = reReplace(processed, "\{\{enums\}\}", enumCode, "all");
+
 		// Process actions for controllers
 		if (structKeyExists(arguments.context, "actions") && isArray(arguments.context.actions)) {
 			var actionsCode = generateActionsCode(arguments.context.actions);

--- a/cli/lucli/templates/app/app/snippets/ModelContent.txt
+++ b/cli/lucli/templates/app/app/snippets/ModelContent.txt
@@ -6,6 +6,7 @@
 		{{hasManyRelationships}}
 		{{hasOneRelationships}}
 		{{validations}}
+		{{enums}}
 	}
 
 }

--- a/cli/lucli/tests/specs/deploy/DeployArgsParserSpec.cfc
+++ b/cli/lucli/tests/specs/deploy/DeployArgsParserSpec.cfc
@@ -87,8 +87,18 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                 expect(opts.role).toBe("web");
             });
 
+            it("parses '--role value' (space-separated) into opts.role", () => {
+                var opts = parser.parse(["--role", "workers"]);
+                expect(opts.role).toBe("workers");
+            });
+
             it("parses --container into opts.container", () => {
                 var opts = parser.parse(["--container=app-web-v1"]);
+                expect(opts.container).toBe("app-web-v1");
+            });
+
+            it("parses '--container value' (space-separated) into opts.container", () => {
+                var opts = parser.parse(["--container", "app-web-v1"]);
                 expect(opts.container).toBe("app-web-v1");
             });
 

--- a/cli/lucli/tests/specs/services/CodeGenSpec.cfc
+++ b/cli/lucli/tests/specs/services/CodeGenSpec.cfc
@@ -125,6 +125,23 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					expect(content).notToInclude("validatesFormatOf");
 				});
 
+				it("emits enum() for enum-typed properties (##M2)", () => {
+					codegen.generateModel(
+						name = "Ticket",
+						properties = [{name: "status", type: "enum", values: "open,pending,closed"}],
+						force = true
+					);
+					var content = fileRead(tempRoot & "/app/models/Ticket.cfc");
+					expect(content).toInclude('enum(property="status", values="open,pending,closed")');
+				});
+
+				it("leaves no stray enums placeholder when there are no enum properties (##M2)", () => {
+					codegen.generateModel(name = "NoEnum", properties = [{name: "title", type: "string"}], force = true);
+					var content = fileRead(tempRoot & "/app/models/NoEnum.cfc");
+					expect(content).notToInclude("{" & "{enums}}");
+					expect(content).notToInclude("enum(");
+				});
+
 				it("produces no orphan whitespace-only lines (##2329)", () => {
 					codegen.generateModel(
 						name = "Layout",

--- a/cli/src/templates/ModelContent.txt
+++ b/cli/src/templates/ModelContent.txt
@@ -6,6 +6,7 @@
 		{{hasManyRelationships}}
 		{{hasOneRelationships}}
 		{{validations}}
+		{{enums}}
 	}
 
 }


### PR DESCRIPTION
## What & why

The final tier of CLI-audit follow-ups (after #2882 and #2883) — the remaining in-repo nits plus the wheels-bot's non-blocking review nits from #2883. Every fix reproduced + verified against the CLI in an isolated harness.

## Fixes

| Fix | Was | Now |
|---|---|---|
| **`generate model … status:enum:a,b,c`** | the enum type was parsed but never written to the model | emits `enum(property="status", values="a,b,c")` in `config()` (verified) |
| **`generate controller` / `scaffold` views** | a view that failed to generate was silently skipped — the command reported success with no views | warns (`skip … : <reason>`) so the failure is visible (M3) |
| **`generate route <name>`** | an existing **named-arg** route (`.resources(name="x", …)`) was misreported as "Could not find insertion point" | reports "Route already exists" (M5, verified) |
| **DeployArgsParserSpec** | no space-form coverage for the new `--role`/`--container` flags | added `--role value` / `--container value` cases |
| **ReleaseChannel comment** | the explanatory comment contained a bare `@build.version@` literal the build's token-replacer would garble | rephrased to be clobber-proof (bot nit) |

### `enum` emission detail
`enum` was parsed (`prop.values`) but no `enum()` line was written. This adds `buildModelEnums()` (mirroring `buildModelValidations()`), an `{{enums}}` placeholder to **all** `ModelContent.txt` copies (scaffold source, shared `cli/src/templates`, demo `app/snippets`), and an **explicit** `{{enums}}` substitution in `Templates.cfc` (the generic `{{key}}` loop wasn't applying it). The migration side already mapped `enum` → a string column. + CodeGenSpec coverage (emits for enum props; no stray placeholder otherwise).

## Verification
- enum emission, route-dup message, view-gen warning, and the deploy-flag space-forms all reproduced in the isolated harness (fresh `wheels new` app for the template path; genbase copies for the rest).
- New CodeGenSpec + DeployArgsParserSpec cases mirror the existing specs; **CI's CLI suite is the validator** (the spec runner needs a server that won't stay up from a `.claude/worktrees` worktree).

## Remaining
The systemic LuCLI dispatch work (per-command `--help`/`--verbose`/`--version`/`wheels help` + brand leaks) is scoped for a dedicated upstream `cybersonic/LuCLI` effort — not in this repo's `cli/lucli/`.
