### PR TITLE
fix(cli): warn when wheels start's pinned port is already taken

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -717,6 +717,26 @@ component extends="modules.BaseModule" {
 			registry.clean(serverName);
 		}
 
+		// Defense in depth for the IPv4-blind port check. LuCLI's own
+		// LuceeServerConfig.isPortAvailable() probes with a wildcard ServerSocket
+		// that binds IPv6 on a dual-stack JVM, so it never sees a port held by an
+		// IPv4-only listener (python http.server, Django runserver on 8000,
+		// 127.0.0.1-bound databases) and `wheels start` would boot on top of it.
+		// That is fixed upstream, but older LuCLI binaries still ship the bug, so
+		// when lucee.json pins a port we connect-probe it (both address families)
+		// and warn before delegating. We only reach here when our own server is
+		// NOT already running (the reg.alive early-return above), so an in-use
+		// pinned port is a genuine foreign collision.
+		var pinnedPort = $readPinnedPort(variables.projectRoot);
+		if (pinnedPort > 0 && getService("portProbe").portInUse(pinnedPort)) {
+			out("");
+			out("Warning: port " & pinnedPort & " (configured in lucee.json) is already in use", "yellow");
+			out("by another process. The server may fail to start, or silently share the port", "yellow");
+			out("(IPv4 clients reaching the other process while localhost reaches Wheels).", "yellow");
+			out("Fix: stop the other process, or change the 'port' in lucee.json.", "yellow");
+			out("");
+		}
+
 		out("Starting Wheels server...", "cyan");
 
 		// Stage required JDBC drivers into the Lucee Express lib/ext/ before
@@ -5152,6 +5172,26 @@ component extends="modules.BaseModule" {
 	}
 
 	/**
+	 * Read the HTTP port pinned in the project's lucee.json, or 0 if there is no
+	 * lucee.json, no "port" key, or the file can't be parsed. LuCLI writes this
+	 * file on first start and honours its port on subsequent starts, so it is the
+	 * deterministic port to pre-check for a collision before delegating.
+	 */
+	private numeric function $readPinnedPort(required string projectRoot) {
+		var configFile = arguments.projectRoot & "/lucee.json";
+		if (!fileExists(configFile)) return 0;
+		try {
+			var config = deserializeJSON(fileRead(configFile));
+			if (isStruct(config) && structKeyExists(config, "port") && isNumeric(config.port)) {
+				return config.port;
+			}
+		} catch (any e) {
+			// Malformed lucee.json — let LuCLI surface its own parse error.
+		}
+		return 0;
+	}
+
+	/**
 	 * Wipe the per-server Lucee compiled-class cache so the next request
 	 * recompiles every CFC from source. Called from `wheels reload` because
 	 * Lucee's default `inspectTemplate=once` setting prevents source-edit
@@ -6026,6 +6066,9 @@ component extends="modules.BaseModule" {
 					variables.services.serverRegistry = new services.ServerRegistry(
 						lucliHome = $resolveLucliHome()
 					);
+					break;
+				case "portProbe":
+					variables.services.portProbe = new services.PortProbe();
 					break;
 				default:
 					throw("Unknown service: #name#");

--- a/cli/lucli/services/PortProbe.cfc
+++ b/cli/lucli/services/PortProbe.cfc
@@ -1,0 +1,61 @@
+/**
+ * Reliable, cross-address-family "is this port already taken?" probe for
+ * `wheels start`.
+ *
+ * Why this exists: LuCLI's own port check (LuceeServerConfig.isPortAvailable)
+ * was IPv4-blind on a dual-stack JVM. `new ServerSocket(port)` binds the IPv6
+ * wildcard, which does NOT conflict with a listener bound to the IPv4 family —
+ * so a port already held by an IPv4-only process (python http.server, Django
+ * runserver on 8000, Postgres/Redis on 127.0.0.1, ...) was reported "available"
+ * and `wheels start` booted on top of it, producing a split-stack collision
+ * (IPv4-loopback clients hit the other process, `localhost`->::1 hits Lucee).
+ *
+ * That root cause is fixed upstream in LuCLI, but `wheels start` also probes
+ * here so the collision is caught even on LuCLI binaries that predate the fix
+ * (defense in depth). We detect a listener by CONNECTing to both loopback
+ * families (127.0.0.1 and ::1): a successful connect means something is actively
+ * accepting on that port, and connect — unlike a bind probe — is not fooled by
+ * sockets in TIME_WAIT, so it does not flag a port a server just released.
+ *
+ * Dependency-free leaf service (like Helpers): instantiated directly so it is
+ * trivially unit-testable. See ServerRegistry for the sibling pattern.
+ */
+component {
+
+	/**
+	 * True if a process is actively LISTENing on `port` on either loopback
+	 * address family (IPv4 127.0.0.1 or IPv6 ::1).
+	 */
+	public boolean function portInUse(required numeric port) {
+		return $isListening("127.0.0.1", arguments.port)
+			|| $isListening("::1", arguments.port);
+	}
+
+	/**
+	 * True if a TCP connection to host:port succeeds within timeoutMs — i.e.
+	 * something is accepting connections there. Connection refused, timeout, or
+	 * an unresolvable/unreachable host all mean "nothing listening here" and
+	 * return false. Loopback connects resolve essentially instantly (immediate
+	 * accept or RST), so the timeout only bounds pathological cases.
+	 */
+	private boolean function $isListening(
+		required string host,
+		required numeric port,
+		numeric timeoutMs = 200
+	) {
+		var socket = createObject("java", "java.net.Socket").init();
+		try {
+			var address = createObject("java", "java.net.InetSocketAddress").init(
+				createObject("java", "java.net.InetAddress").getByName(arguments.host),
+				javaCast("int", arguments.port)
+			);
+			socket.connect(address, javaCast("int", arguments.timeoutMs));
+			return true;
+		} catch (any e) {
+			return false;
+		} finally {
+			try { socket.close(); } catch (any e) {}
+		}
+	}
+
+}

--- a/cli/lucli/tests/specs/services/PortProbeSpec.cfc
+++ b/cli/lucli/tests/specs/services/PortProbeSpec.cfc
@@ -22,34 +22,38 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 	function run() {
 		describe("PortProbe.portInUse", () => {
 
+			// NOTE: the listener var must NOT be named `server` — that is a CFML
+			// reserved scope (anti-pattern #11) and would shadow our ServerSocket
+			// with the `server` scope struct, so `.bind()`/`.close()` would fail
+			// with "function does not exist in the Struct".
 			it("reports a port held by an IPv4-only (127.0.0.1) listener as in use", () => {
-				var server = createObject("java", "java.net.ServerSocket").init();
+				var listener = createObject("java", "java.net.ServerSocket").init();
 				try {
-					server.setReuseAddress(false);
-					server.bind(
+					listener.setReuseAddress(false);
+					listener.bind(
 						createObject("java", "java.net.InetSocketAddress").init(
 							createObject("java", "java.net.InetAddress").getByName("127.0.0.1"),
 							javaCast("int", 0)
 						)
 					);
-					var port = server.getLocalPort();
+					var port = listener.getLocalPort();
 					expect(probe.portInUse(port)).toBeTrue();
 				} finally {
-					server.close();
+					listener.close();
 				}
 			});
 
 			it("reports a free port (nothing listening) as not in use", () => {
 				// Bind then immediately release to obtain a port we know is free.
-				var server = createObject("java", "java.net.ServerSocket").init();
-				server.bind(
+				var listener = createObject("java", "java.net.ServerSocket").init();
+				listener.bind(
 					createObject("java", "java.net.InetSocketAddress").init(
 						createObject("java", "java.net.InetAddress").getByName("127.0.0.1"),
 						javaCast("int", 0)
 					)
 				);
-				var port = server.getLocalPort();
-				server.close();
+				var port = listener.getLocalPort();
+				listener.close();
 
 				expect(probe.portInUse(port)).toBeFalse();
 			});

--- a/cli/lucli/tests/specs/services/PortProbeSpec.cfc
+++ b/cli/lucli/tests/specs/services/PortProbeSpec.cfc
@@ -1,0 +1,60 @@
+/**
+ * Coverage for cli.lucli.services.PortProbe — the cross-address-family
+ * port-in-use probe `wheels start` uses to warn before booting on top of a
+ * port that is already taken.
+ *
+ * Regression intent: LuCLI's bind-based port check was IPv4-blind on a
+ * dual-stack JVM (a wildcard ServerSocket binds IPv6 and never conflicts with
+ * an IPv4-only listener), so a port held by python http.server / Django
+ * runserver / a 127.0.0.1-bound service was reported "available". PortProbe
+ * uses a connect probe against both loopback families so an IPv4-only listener
+ * is correctly seen as in-use.
+ *
+ * Tests bind real loopback sockets on OS-assigned ephemeral ports, so they are
+ * hermetic and never collide with a developer's running servers.
+ */
+component extends="wheels.wheelstest.system.BaseSpec" {
+
+	function beforeAll() {
+		variables.probe = new cli.lucli.services.PortProbe();
+	}
+
+	function run() {
+		describe("PortProbe.portInUse", () => {
+
+			it("reports a port held by an IPv4-only (127.0.0.1) listener as in use", () => {
+				var server = createObject("java", "java.net.ServerSocket").init();
+				try {
+					server.setReuseAddress(false);
+					server.bind(
+						createObject("java", "java.net.InetSocketAddress").init(
+							createObject("java", "java.net.InetAddress").getByName("127.0.0.1"),
+							javaCast("int", 0)
+						)
+					);
+					var port = server.getLocalPort();
+					expect(probe.portInUse(port)).toBeTrue();
+				} finally {
+					server.close();
+				}
+			});
+
+			it("reports a free port (nothing listening) as not in use", () => {
+				// Bind then immediately release to obtain a port we know is free.
+				var server = createObject("java", "java.net.ServerSocket").init();
+				server.bind(
+					createObject("java", "java.net.InetSocketAddress").init(
+						createObject("java", "java.net.InetAddress").getByName("127.0.0.1"),
+						javaCast("int", 0)
+					)
+				);
+				var port = server.getLocalPort();
+				server.close();
+
+				expect(probe.portInUse(port)).toBeFalse();
+			});
+
+		});
+	}
+
+}


### PR DESCRIPTION
## What & why

`wheels start` delegates port selection to LuCLI, whose `isPortAvailable()` is **IPv4-blind** on a dual-stack JVM: a wildcard `ServerSocket` bind is IPv6 and never conflicts with a listener bound to the IPv4 family. So a port already held by an IPv4-only process — `python -m http.server`, Django `runserver` (default **8000**), Postgres/Redis on `127.0.0.1` — is treated as free, and `wheels start` boots on top of it. The result is a silent split-stack collision: IPv4-loopback clients hit the other process while `localhost` (→`::1`) reaches Wheels, so the printed URL *looks* fine.

The root-cause fix is in LuCLI: **bpamiri/LuCLI#6**. But that only reaches users after a LuCLI release + brew/scoop rebuild, so this PR adds **wheels-side defense in depth** that works on the currently-shipped binary.

## Change

- **`cli/lucli/services/PortProbe.cfc`** — dependency-free service that detects a listener by connect-probing both loopback families (`127.0.0.1` + `::1`). Mirrors the LuCLI fix; sibling pattern to `ServerRegistry`. Connect (not bind) is used so it sees either family and isn't fooled by `TIME_WAIT`.
- **`cli/lucli/tests/specs/services/PortProbeSpec.cfc`** — unit spec (IPv4-only listener → in use; free port → not in use).
- **`Module.cfc`** — registers the `portProbe` service, adds `$readPinnedPort()`, and in `start()` warns before delegating when `lucee.json` pins a port that a foreign process already holds. (Only reached when our own server isn't running — the `reg.alive` early-return guards that — so an in-use pinned port is a genuine collision.)

No behavior change beyond an added warning; the server still starts.

## Verification

- The connect-probe **algorithm** is proven in the LuCLI PR (Java RED→GREEN unit tests) and was reproduced live (an IPv4-only listener that the old wildcard probe reported "available").
- `PortProbeSpec` runs in **CI** (the CLI suite, every engine). It could not be executed locally from a `.claude/worktrees` worktree (the worktree can't host a server — its path canonicalizes to `wheels` and collides with the running server; Docker virtiofs blocks the file-mounts; the core-test image routes `.cfm` through Wheels). Flagging this so reviewers lean on the CI run for `PortProbeSpec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
