### PR TITLE
docs: note Homebrew 5.1 tap-trust step wherever brew install is documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ brew install wheels
 wheels new myapp
 ```
 
+Homebrew 5.1+ asks you to trust third-party taps on first use — run `brew trust wheels-dev/wheels` once if prompted.
+
 The CLI is powered by [LuCLI](https://github.com/cybersonic/LuCLI) — it ships with Lucee and depends only on Java 21, so no CommandBox install is required.
 
 ### Learning Wheels

--- a/cli/README.md
+++ b/cli/README.md
@@ -11,6 +11,8 @@ brew tap wheels-dev/wheels
 brew install wheels
 ```
 
+Homebrew 5.1+ asks you to trust third-party taps on first use — run `brew trust wheels-dev/wheels` once if prompted.
+
 **Windows (Chocolatey):**
 
 ```powershell

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/installation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/installation.mdx
@@ -37,6 +37,8 @@ brew tap wheels-dev/wheels
 brew install wheels
 ```
 
+Homebrew 5.1+ asks you to trust third-party taps on first use — run `brew trust wheels-dev/wheels` once if prompted.
+
 The formula (`wheels-dev/wheels`) pins a specific LuCLI release and a matching Wheels Module tarball. At install time, Homebrew downloads both and stages the module under `$(brew --prefix)/opt/wheels/share/wheels/module/`. It does not copy the module into your home directory yet — that happens on first run.
 
 The first time you invoke `wheels`, the wrapper:

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/installing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/installing.mdx
@@ -89,6 +89,8 @@ The two are mutually exclusive — both expose the `wheels` binary. You install 
    brew tap wheels-dev/wheels
    ```
 
+   Homebrew 5.1+ asks you to trust third-party taps on first use — run `brew trust wheels-dev/wheels` once if prompted.
+
 2. Install the CLI:
 
    ```bash title="your shell"
@@ -236,6 +238,8 @@ brew update
 brew upgrade wheels
 ```
 
+If Homebrew 5.1+ refuses with an "untrusted tap" error, run `brew trust wheels-dev/wheels` once, then re-run the upgrade.
+
 </TabItem>
 
 <TabItem label="Windows" icon="seti:windows">
@@ -288,6 +292,10 @@ If you installed from Adoptium directly instead of Homebrew, use whatever `/usr/
 **`brew: cask 'wheels' has no formulae to install from`**
 
 You skipped `brew tap wheels-dev/wheels`. Run the tap command, then re-run the install.
+
+**`Refusing to load formula wheels from untrusted tap wheels-dev/wheels`**
+
+Homebrew 5.1+ requires trusting third-party taps before installing or upgrading from them. Run `brew trust wheels-dev/wheels` once, then re-run the command.
 
 ## Related guides
 

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/release-channels.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/release-channels.mdx
@@ -58,6 +58,8 @@ brew install wheels
 brew install wheels-be
 ```
 
+Homebrew 5.1+ asks you to trust third-party taps on first use — run `brew trust wheels-dev/wheels` once if prompted (one trust covers both formulas).
+
 The two formulas are mutually exclusive — both expose the `wheels` binary, so Homebrew refuses to install both at once. To switch channels, uninstall one and install the other (see [Switching channels](#switching-channels) below).
 
 </TabItem>

--- a/web/sites/guides/src/content/docs/v4-0-0/upgrading/3x-to-4x.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/upgrading/3x-to-4x.mdx
@@ -388,6 +388,8 @@ wheels upgrade check
 brew upgrade wheels
 ```
 
+Homebrew 5.1+ asks you to trust third-party taps on first use — run `brew trust wheels-dev/wheels` once if prompted.
+
 ### Browser-test fixture routes (`/_browser/*`) moved into the framework
 
 **CHANGELOG:** `Fixed: Framework-internal browser-test fixture controllers, views, and /_browser/* routes no longer leak into application-level files.` (#2135, #2138)


### PR DESCRIPTION
## Summary

Homebrew 5.1 (June 2026) refuses to load formulae from untrusted third-party taps: `brew install wheels-dev/wheels/wheels` and `brew upgrade wheels` fail with **"Refusing to load formula wheels from untrusted tap wheels-dev/wheels"** until the user runs `brew trust wheels-dev/wheels` once. Hit live on 2026-06-10 during v4.0.3 release verification.

This adds a brief one-line note next to every documented brew install/upgrade flow:

- `start-here/installing.mdx` — tap step, macOS upgrade tab, plus a troubleshooting entry keyed to the literal error message
- `command-line-tools/installation.mdx` — Homebrew install section
- `start-here/release-channels.mdx` — macOS channel installs (one note covers both `wheels` and `wheels-be` — same tap)
- `upgrading/3x-to-4x.mdx` — CommandBox-migration install block
- `README.md` — quick start

**Deliberately skipped:** the landing-page hero snippet (`web/sites/landing/src/pages/index.astro` — design-sensitive 3-liner; flag if you want it there too), historical release blog posts, and incidental prose mentions (`cfml-engines.mdx`, tutorial upgrade tip — those route readers to the install guide, and the brew error message itself names the fix).

The note is prose rather than adding `brew trust` into the copy-paste code blocks because the command doesn't exist on Homebrew <5.1 and would break installs there.

## Test plan

- [ ] Docs-only prose change (16 insertions, no code blocks or test annotations touched) — guides build validated by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)