### PR TITLE
fix(controller): reject backslash and schemeless open-redirect bypass in $isSafeRedirectUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 
 ----
 
+## [Unreleased]
+
+### Security
+
+- `$isSafeRedirectUrl()` rejects backslash-containing URLs (`/\evil.com`, `\/evil.com`, `\\evil.com`) and schemeless-authority URLs (`https:/evil.com`, `javascript:alert(1)`) instead of returning them as safe. Browsers normalize backslashes to forward slashes and single-slash schemes to authority form, so any of those vectors smuggled past the previous check would navigate off-site after `redirectTo()`. Scheme detection now uses the RFC 3986 grammar (`ReFindNoCase("^[a-z][a-z0-9+.-]*:")`) and runs before the relative-URL fast path; backslashes are rejected up front, so the same-domain `ListFirst` no longer needs to treat `\` as a delimiter. Same-origin absolute URLs and genuine relative paths remain allowed (#2898)
+
+----
+
 # [4.0.3](https://github.com/wheels-dev/wheels/releases/tag/v4.0.3) => 2026-06-09
 
 > **Wheels 4.0.3** — third patch on the 4.0 line. Completes the CLI argument-parsing overhaul (`ArgSpec` consumes LuCLI's structured arguments in every command — `--no-*` negations and named-only flags now reach their parsers, and user-error paths exit non-zero) and lands the fixes from a full 24-command CLI audit; write-side commands (`migrate`, `seed`, `reload`, `generate admin`) now refuse to attach to a sibling project's server instead of running against the wrong database; PostgreSQL/CockroachDB foreign-key migrations and pre-23c Oracle `DROP TABLE`/`DROP VIEW` work again; framework helpers can no longer be invoked as controller actions from a URL; auto-derived model properties preserve database column casing; and scaffolded apps keep their reload password out of source control (`WHEELS_RELOAD_PASSWORD` in `.env`). ~45 PRs since the 4.0.2 GA (2026-05-27).

--- a/vendor/wheels/controller/redirection.cfc
+++ b/vendor/wheels/controller/redirection.cfc
@@ -173,27 +173,44 @@ component {
 	 * [category: Miscellaneous Functions]
 	 */
 	public boolean function $isSafeRedirectUrl(required string url, required string serverName) {
-		// Relative URLs (starting with "/" but not "//") are always safe.
-		if (Left(arguments.url, 1) == "/" && (Len(arguments.url) == 1 || Left(arguments.url, 2) != "//")) {
+		// Reject any URL containing a backslash outright. Browsers normalize backslashes to forward
+		// slashes ("/\evil.com", "\/evil.com" and "\\evil.com" all navigate to evil.com), so a
+		// backslash anywhere makes the URL unsafe. Literal backslashes in legitimate URLs should be
+		// percent-encoded (matches the $generateIncludeTemplatePath precedent).
+		if (Find(Chr(92), arguments.url)) {
+			return false;
+		}
+
+		// Protocol-relative URL (//hostname/path): only safe when the hostname matches the current
+		// server name exactly.
+		if (Left(arguments.url, 2) == "//") {
+			local.afterScheme = Mid(arguments.url, 3, Len(arguments.url) - 2);
+			local.refererHost = ListFirst(local.afterScheme, ":/?##");
+			return CompareNoCase(local.refererHost, arguments.serverName) == 0;
+		}
+
+		// Relative URLs (starting with a single "/") are always safe.
+		if (Left(arguments.url, 1) == "/") {
 			return true;
 		}
 
-		// Extract the hostname from the URL for exact comparison.
-		if (Left(arguments.url, 2) == "//") {
-			// Protocol-relative URL: //hostname/path
-			local.afterScheme = Mid(arguments.url, 3, Len(arguments.url) - 2);
-		} else {
-			local.schemeEnd = Find("://", arguments.url);
-			if (local.schemeEnd == 0) {
-				// No scheme and doesn't start with "/" — treat as relative path (e.g. "page", "dir/page").
-				return true;
-			}
-			// Absolute URL: scheme://hostname/path
-			local.afterScheme = Mid(arguments.url, local.schemeEnd + 3, Len(arguments.url) - local.schemeEnd - 2);
+		// No scheme (RFC 3986: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) followed by ":") and not
+		// "/"-rooted: a genuine relative path (e.g. "page", "dir/page").
+		if (ReFindNoCase("^[a-z][a-z0-9+.-]*:", arguments.url) == 0) {
+			return true;
 		}
 
+		// The URL has a scheme: it is only safe when it is a same-domain scheme://hostname/... URL.
+		// Schemes without a "//" authority (javascript:, mailto:, data:, "https:/evil.com") are
+		// rejected because browsers normalize or execute them in ways that escape the current domain.
+		local.schemeEnd = Find("://", arguments.url);
+		if (local.schemeEnd == 0) {
+			return false;
+		}
+		local.afterScheme = Mid(arguments.url, local.schemeEnd + 3, Len(arguments.url) - local.schemeEnd - 2);
+
 		// Extract hostname before any port, path, query, or fragment delimiter.
-		local.refererHost = ListFirst(local.afterScheme, ":/?\##");
+		local.refererHost = ListFirst(local.afterScheme, ":/?##");
 
 		return CompareNoCase(local.refererHost, arguments.serverName) == 0;
 	}

--- a/vendor/wheels/tests/specs/controller/redirectionSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/redirectionSpec.cfc
@@ -285,6 +285,38 @@ component extends="wheels.WheelsTest" {
 				expect(r.url).toBe("//" & request.cgi.server_name & "/page")
 			})
 
+			it("throws on redirectTo url with slash-backslash external domain", () => {
+				// Browsers normalize "/\" to "//" and navigate off-site.
+				expect(function(){
+					_controller.redirectTo(url = "/\evil.com")
+				}).toThrow("Wheels.UnsafeRedirect")
+			})
+
+			it("throws on redirectTo url with backslash-slash external domain", () => {
+				expect(function(){
+					_controller.redirectTo(url = "\/evil.com")
+				}).toThrow("Wheels.UnsafeRedirect")
+			})
+
+			it("throws on redirectTo url with double-backslash external domain", () => {
+				expect(function(){
+					_controller.redirectTo(url = "\\evil.com")
+				}).toThrow("Wheels.UnsafeRedirect")
+			})
+
+			it("throws on redirectTo url with single-slash scheme external domain", () => {
+				// Browsers normalize "https:/evil.com" to "https://evil.com".
+				expect(function(){
+					_controller.redirectTo(url = "https:/evil.com")
+				}).toThrow("Wheels.UnsafeRedirect")
+			})
+
+			it("throws on redirectTo url with javascript scheme", () => {
+				expect(function(){
+					_controller.redirectTo(url = "javascript:alert(1)")
+				}).toThrow("Wheels.UnsafeRedirect")
+			})
+
 			it("allows external redirect when allowExternalRedirects is true", () => {
 				application.wheels.allowExternalRedirects = true;
 				try {


### PR DESCRIPTION
## Summary

`$isSafeRedirectUrl()` (`vendor/wheels/controller/redirection.cfc:175`) — the guard behind `redirectTo()`'s default `allowExternalRedirects=false` policy — accepted five attack vectors as "safe":

- `/\evil.com`, `\/evil.com`, `\\evil.com` — browsers normalize backslashes to forward slashes, so all three navigate to `evil.com` despite passing the old single-slash/`//` checks.
- `https:/evil.com` — single-slash scheme; the old check required a literal `://`, so this fell through to the "no scheme → relative path" branch. Browsers normalize it to `https://evil.com`.
- `javascript:alert(1)` — same `://` blind spot; treated as a relative path.

Both call sites route through this function: the referer-back path (`redirection.cfc:107`) and the explicit `url=` path (`redirection.cfc:129`), so a referer header or user-supplied URL containing any of these shapes produced an open redirect (or script-scheme navigation).

## Source

Internal multi-agent framework review, 2026-06-09, finding T7 (open-redirect-backslash).

## Fix

- Reject any URL containing a backslash (`Find(Chr(92), arguments.url)`) before the relative-URL checks — matches the `$generateIncludeTemplatePath` precedent; legitimate backslashes in URLs must be percent-encoded.
- Detect schemes case-insensitively with the RFC 3986 scheme grammar (`ReFindNoCase("^[a-z][a-z0-9+.-]*:")`) instead of requiring a literal `://`. URLs with a scheme but no `//` authority (`javascript:`, `mailto:`, `data:`, `https:/single-slash`) are now rejected instead of being treated as relative.
- Behavior preserved for legitimate inputs: single-slash relative paths, bare relative paths (`page`, `dir/page`), and same-domain `scheme://host` / protocol-relative `//host` URLs (exact host match) still pass.

Deliberately deferred (pre-existing, out of T7 scope, flagged for a separate finding): leading-whitespace and embedded tab/CR/LF vectors such as `/<TAB>/evil.com`, which WHATWG URL parsing strips before navigation. The old code had the same gap; this change neither introduces nor worsens it.

## Tests

Added 5 specs to `vendor/wheels/tests/specs/controller/redirectionSpec.cfc`, one per attack vector, each asserting `redirectTo(url=...)` throws `Wheels.UnsafeRedirect`. Each vector hit a `return true` in the pre-fix code path, confirmed RED then GREEN locally on Lucee 7 + SQLite via the worktree docker recipe:

- Pre-fix: 33 pass / 5 fail (the five new vectors)
- Post-fix: 38 pass / 0 fail / 0 error (`wheels.tests.specs.controller.redirectionSpec`)

Full engine x DB matrix runs in per-PR CI.

## Cross-engine notes

- Public `$`-prefixed mixin (invariant #7); no closures, no catch-local writes, no `attributeCollection`.
- `Left()` is never called with a count of 0 (Lucee 7 invariant #8).
- Reserved-scope parameter names `url` / `serverName` are pre-existing and only accessed via `arguments.*`.
- `ReFindNoCase` with a plain character class is portable across Lucee 5/6/7, Adobe 2018-2025, and BoxLang; `##` is correctly escaped in the `ListFirst` delimiter string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
