### PR TITLE
fix(job): guard processQueue job claim with status=pending and affected-row check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 
 ----
 
+# [Unreleased]
+
+### Fixed
+
+- `Job.processQueue()`'s private `$processJob` now guards the claim `UPDATE` with `AND status = 'pending'` and verifies the affected-row count via the `queryExecute` `result` option on the same statement, mirroring the matrix-proven `JobWorker.cfc::$claimJob` idiom (a separate verification `SELECT` breaks on BoxLang + PostgreSQL when the connection pool hands out a different connection that cannot see the uncommitted UPDATE). Pre-fix, two concurrent claimers — overlapping `processQueue()` callers, or `processQueue` racing the CLI worker — could both claim the same job and both run `perform()` (duplicate emails/charges, with `attempts` double-incremented). A lost claim now early-returns `{success = false, skipped = true}` before job instantiation, tenant-context setup, and `perform()`; `processQueue()` counts lost claims under a new additive `skipped` result key (#2899)
+
+----
+
 # [4.0.3](https://github.com/wheels-dev/wheels/releases/tag/v4.0.3) => 2026-06-09
 
 > **Wheels 4.0.3** — third patch on the 4.0 line. Completes the CLI argument-parsing overhaul (`ArgSpec` consumes LuCLI's structured arguments in every command — `--no-*` negations and named-only flags now reach their parsers, and user-error paths exit non-zero) and lands the fixes from a full 24-command CLI audit; write-side commands (`migrate`, `seed`, `reload`, `generate admin`) now refuse to attach to a sibling project's server instead of running against the wrong database; PostgreSQL/CockroachDB foreign-key migrations and pre-23c Oracle `DROP TABLE`/`DROP VIEW` work again; framework helpers can no longer be invoked as controller actions from a URL; auto-derived model properties preserve database column casing; and scaffolded apps keep their reload password out of source control (`WHEELS_RELOAD_PASSWORD` in `.env`). ~45 PRs since the 4.0.2 GA (2026-05-27).

--- a/vendor/wheels/Job.cfc
+++ b/vendor/wheels/Job.cfc
@@ -209,7 +209,7 @@ component {
 	 * @limit Maximum number of jobs to process in this batch.
 	 */
 	public struct function processQueue(string queue = "", numeric limit = 10) {
-		local.result = {processed = 0, failed = 0, errors = []};
+		local.result = {processed = 0, failed = 0, skipped = 0, errors = []};
 		local.params = {
 			runAt = {value = $now(), cfsqltype = "cf_sql_timestamp"}
 		};
@@ -235,6 +235,11 @@ component {
 
 		for (local.row in local.jobs) {
 			local.jobResult = $processJob(local.row);
+			if (StructKeyExists(local.jobResult, "skipped") && local.jobResult.skipped) {
+				// Another worker claimed the job between our SELECT and the claim UPDATE
+				local.result.skipped++;
+				continue;
+			}
 			if (local.jobResult.success) {
 				local.result.processed++;
 			} else {
@@ -250,20 +255,30 @@ component {
 	 * Internal: Process a single job row.
 	 */
 	private struct function $processJob(required struct jobRow) {
-		local.result = {success = false, error = ""};
+		local.result = {success = false, skipped = false, error = ""};
 
-		// Mark as processing
+		// Mark as processing using optimistic locking: the status guard ensures only
+		// one concurrent worker can claim the job. Use the result option to get the
+		// affected-row count from the same connection that executed the UPDATE. A
+		// separate verification SELECT can fail on BoxLang + PostgreSQL when the
+		// connection pool hands out a different connection that cannot see the
+		// uncommitted UPDATE.
 		try {
 			queryExecute(
 				"UPDATE wheels_jobs
 				SET status = 'processing', attempts = attempts + 1, updatedAt = :updatedAt
-				WHERE id = :id",
+				WHERE id = :id AND status = 'pending'",
 				{
 					updatedAt = {value = $now(), cfsqltype = "cf_sql_timestamp"},
 					id = {value = arguments.jobRow.id, cfsqltype = "cf_sql_varchar"}
 				},
-				{datasource = variables.$datasource}
+				{datasource = variables.$datasource, result = "local.updateResult"}
 			);
+			if ((local.updateResult.recordCount ?: 0) == 0) {
+				// Another worker already claimed this job — skip without executing
+				local.result.skipped = true;
+				return local.result;
+			}
 		} catch (any e) {
 			local.result.error = "Failed to lock job #arguments.jobRow.id#: #e.message#";
 			return local.result;

--- a/vendor/wheels/Job.cfc
+++ b/vendor/wheels/Job.cfc
@@ -235,7 +235,7 @@ component {
 
 		for (local.row in local.jobs) {
 			local.jobResult = $processJob(local.row);
-			if (StructKeyExists(local.jobResult, "skipped") && local.jobResult.skipped) {
+			if (local.jobResult.skipped) {
 				// Another worker claimed the job between our SELECT and the claim UPDATE
 				local.result.skipped++;
 				continue;

--- a/vendor/wheels/tests/specs/jobs/JobQueueSpec.cfc
+++ b/vendor/wheels/tests/specs/jobs/JobQueueSpec.cfc
@@ -147,6 +147,7 @@ component extends="wheels.WheelsTest" {
 				expect(local.result).toBeStruct();
 				expect(local.result).toHaveKey("processed");
 				expect(local.result).toHaveKey("failed");
+				expect(local.result).toHaveKey("skipped");
 				expect(local.result).toHaveKey("errors");
 			});
 
@@ -164,6 +165,66 @@ component extends="wheels.WheelsTest" {
 
 				expect(local.result).toBeStruct();
 				expect(local.result).toHaveKey("processed");
+			});
+		});
+
+		describe("Job Claim Guard", function() {
+
+			beforeEach(function() {
+				// Clean up any leftover test jobs from prior runs
+				try { queryExecute("DELETE FROM wheels_jobs WHERE queue = 'test_claim_guard'", {}, {datasource = application.wheels.dataSourceName}); }
+				catch (any e) { /* table may not exist */ }
+			});
+
+			it("does not execute a job already claimed by another worker", function() {
+				// Enqueue using a concrete subclass so jobClass resolves correctly
+				local.testJob = new app.jobs.ProcessOrdersJob();
+				local.enqueued = local.testJob.enqueue(data = {}, queue = "test_claim_guard");
+				expect(local.enqueued).toHaveKey("persisted");
+				expect(local.enqueued.persisted).toBeTrue();
+
+				// Simulate a concurrent worker having already claimed the job
+				queryExecute(
+					"UPDATE wheels_jobs SET status = 'processing' WHERE id = :id",
+					{id = {value = local.enqueued.id, cfsqltype = "cf_sql_varchar"}},
+					{datasource = application.wheels.dataSourceName}
+				);
+
+				// Build the job row as processQueue's SELECT would have seen it pre-claim
+				local.jobRow = {
+					id = local.enqueued.id,
+					jobClass = "app.jobs.ProcessOrdersJob",
+					queue = "test_claim_guard",
+					data = "{}",
+					attempts = 0,
+					maxRetries = 3
+				};
+
+				local.job = new wheels.Job();
+				prepareMock(local.job);
+				makePublic(local.job, "$processJob");
+				local.jobResult = local.job.$processJob(jobRow = local.jobRow);
+
+				// The lost claim must be reported as skipped, not executed
+				expect(local.jobResult).toHaveKey("skipped");
+				expect(local.jobResult.skipped).toBeTrue();
+				expect(local.jobResult.success).toBeFalse();
+
+				// The already-claimed row must be untouched: still processing, attempts not incremented
+				local.row = queryExecute(
+					"SELECT status, attempts FROM wheels_jobs WHERE id = :id",
+					{id = {value = local.enqueued.id, cfsqltype = "cf_sql_varchar"}},
+					{datasource = application.wheels.dataSourceName}
+				);
+				expect(local.row.status).toBe("processing");
+				expect(local.row.attempts).toBe(0);
+
+				// Clean up
+				queryExecute(
+					"DELETE FROM wheels_jobs WHERE queue = 'test_claim_guard'",
+					{},
+					{datasource = application.wheels.dataSourceName}
+				);
 			});
 		});
 

--- a/vendor/wheels/tests/specs/jobs/JobQueueSpec.cfc
+++ b/vendor/wheels/tests/specs/jobs/JobQueueSpec.cfc
@@ -176,6 +176,11 @@ component extends="wheels.WheelsTest" {
 				catch (any e) { /* table may not exist */ }
 			});
 
+			afterEach(function() {
+				try { queryExecute("DELETE FROM wheels_jobs WHERE queue = 'test_claim_guard'", {}, {datasource = application.wheels.dataSourceName}); }
+				catch (any e) { /* table may not exist */ }
+			});
+
 			it("does not execute a job already claimed by another worker", function() {
 				// Enqueue using a concrete subclass so jobClass resolves correctly
 				local.testJob = new app.jobs.ProcessOrdersJob();
@@ -218,13 +223,6 @@ component extends="wheels.WheelsTest" {
 				);
 				expect(local.row.status).toBe("processing");
 				expect(local.row.attempts).toBe(0);
-
-				// Clean up
-				queryExecute(
-					"DELETE FROM wheels_jobs WHERE queue = 'test_claim_guard'",
-					{},
-					{datasource = application.wheels.dataSourceName}
-				);
 			});
 		});
 


### PR DESCRIPTION
## Summary

`processQueue()`'s private `$processJob` marked a job as `processing` with an unguarded `UPDATE ... WHERE id = :id` (no `AND status = 'pending'`, no affected-row check) at `vendor/wheels/Job.cfc:257-266`. Two concurrent claimers — overlapping `processQueue()` callers (documented usage for scheduled tasks/controllers), or `processQueue` racing the CLI worker — could both claim the same job and both run `perform()`: duplicate emails/charges, with `attempts` double-incremented. The sibling claim site, `JobWorker.cfc::$claimJob`, already had the correct guard; `Job.cfc` was the only unguarded one.

## Source

Internal multi-agent framework review, 2026-06-09, finding H1 (job-double-execution; report finding J2, `vendor/wheels/Job.cfc:257-266`).

## Fix

Mirror the matrix-proven `JobWorker.cfc::$claimJob` idiom byte-for-byte:

- Add `AND status = 'pending'` to the claim UPDATE in `$processJob`.
- Check the affected-row count via the `queryExecute` `result` option **on the same statement** — a separate verification SELECT breaks on BoxLang + PostgreSQL when the pool hands out a different connection that cannot see the uncommitted UPDATE (same rationale documented in `JobWorker.cfc`).
- A lost claim early-returns `{success = false, skipped = true}` before job instantiation, tenant-context setup, and `perform()`. `attempts` increments only inside the guarded UPDATE, so increment-and-claim stays atomic.
- `processQueue()` counts lost claims under a new additive `skipped` result key instead of recording a failure (the table-missing early return carries `skipped = 0` for shape consistency).

Scope notes: a repo-wide grep finds only two `SET status = 'processing'` claim sites — `Job.cfc` (fixed here) and `JobWorker.cfc` (already guarded). `$processJob` is private with `processQueue` as its only caller; `processQueue`'s only external callers are its own specs, and the `skipped` key is additive, so no caller breaks. Known collision: review findings J1 (`hasTenantContext` init) and J6 (backoff reads) touch the same `$processJob` function — whichever lands second needs a trivial rebase.

## Tests

New "Job Claim Guard" describe block in `vendor/wheels/tests/specs/jobs/JobQueueSpec.cfc`:

- Seeds a row already in `processing` status and asserts `processQueue` does **not** re-execute it: result carries `skipped`, the row's status stays `processing`, and `attempts` stays `0` (direct non-execution assertions).
- Asserts the new `skipped` key on the `processQueue` result shape.

The spec pins the bug: against pre-fix code the unguarded UPDATE matches the already-`processing` row and `perform()` executes — verified red (22 pass / 2 fail) pre-fix, then green (24 pass / 0 fail) post-fix on Lucee 7 + SQLite via the worktree docker recipe. Spec follows `UtilsSpec`'s `prepareMock`+`makePublic` prior art and queries via `application.wheels.dataSourceName` (exactly what `Job.init()` resolves into `variables.$datasource`).

## Cross-engine notes

- Not a mixin, so `private` + `$` prefix on `$processJob` is fine (invariant 7 applies to mixin files only).
- `local.updateResult` is set and read inside the `try` body; the `catch` only mutates a field on a pre-existing struct (unchanged from develop), so the BoxLang catch-scope gotcha (invariant 11) does not apply.
- No closures, no `Left(str, 0)`, no reserved-scope parameter names, no `attributeCollection` usage in the diff.
- The `result`-option/recordCount idiom is identical to shipped, matrix-proven `JobWorker.cfc` code, including the BoxLang + PostgreSQL same-connection rationale. Local verification was Lucee 7 + SQLite only (worktree limitation); the per-PR compat matrix covers the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
