### PR TITLE
fix(events): validate url.format to prevent error-template path traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 
 ----
 
+## [Unreleased]
+
+### Security
+
+- `$getRequestFormat` now rejects non-alphanumeric `url.format` values, preventing path traversal / local file inclusion via the error-template include path in `$runOnError` (#2900)
+
+----
+
 # [4.0.3](https://github.com/wheels-dev/wheels/releases/tag/v4.0.3) => 2026-06-09
 
 > **Wheels 4.0.3** — third patch on the 4.0 line. Completes the CLI argument-parsing overhaul (`ArgSpec` consumes LuCLI's structured arguments in every command — `--no-*` negations and named-only flags now reach their parsers, and user-error paths exit non-zero) and lands the fixes from a full 24-command CLI audit; write-side commands (`migrate`, `seed`, `reload`, `generate admin`) now refuse to attach to a sibling project's server instead of running against the wrong database; PostgreSQL/CockroachDB foreign-key migrations and pre-23c Oracle `DROP TABLE`/`DROP VIEW` work again; framework helpers can no longer be invoked as controller actions from a URL; auto-derived model properties preserve database column casing; and scaffolded apps keep their reload password out of source control (`WHEELS_RELOAD_PASSWORD` in `.env`). ~45 PRs since the 4.0.2 GA (2026-05-27).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,6 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 
 ----
 
-## [Unreleased]
-
-### Security
-
-- `$getRequestFormat` now rejects non-alphanumeric `url.format` values, preventing path traversal / local file inclusion via the error-template include path in `$runOnError` (#2900)
-
-----
-
 # [4.0.3](https://github.com/wheels-dev/wheels/releases/tag/v4.0.3) => 2026-06-09
 
 > **Wheels 4.0.3** — third patch on the 4.0 line. Completes the CLI argument-parsing overhaul (`ArgSpec` consumes LuCLI's structured arguments in every command — `--no-*` negations and named-only flags now reach their parsers, and user-error paths exit non-zero) and lands the fixes from a full 24-command CLI audit; write-side commands (`migrate`, `seed`, `reload`, `generate admin`) now refuse to attach to a sibling project's server instead of running against the wrong database; PostgreSQL/CockroachDB foreign-key migrations and pre-23c Oracle `DROP TABLE`/`DROP VIEW` work again; framework helpers can no longer be invoked as controller actions from a URL; auto-derived model properties preserve database column casing; and scaffolded apps keep their reload password out of source control (`WHEELS_RELOAD_PASSWORD` in `.env`). ~45 PRs since the 4.0.2 GA (2026-05-27).

--- a/vendor/wheels/events/EventMethods.cfc
+++ b/vendor/wheels/events/EventMethods.cfc
@@ -327,7 +327,17 @@ component extends="wheels.Global" implements="wheels.interfaces.events.EventHand
 	public string function $getRequestFormat() {
 		local.rv = "html";
 		if (StructKeyExists(url, "format")) {
-			local.rv = url.format;
+			// Security (review finding T4): url.format is later interpolated into
+			// the on-disk error-template include path in $runOnError
+			// ("#eventPath#/onerror.#format#.cfm"), guarded only by FileExists. An
+			// unvalidated value such as "../../somefile" enables path traversal /
+			// local file inclusion of any .cfm on disk during error rendering.
+			// Only accept a plain alphanumeric token, which covers every configured
+			// format key (html, xml, json, csv, pdf, xls) and any addFormat()
+			// extension; anything else falls back to html.
+			if (ReFind("^[A-Za-z0-9]+$", url.format)) {
+				local.rv = url.format;
+			}
 		} else if ((StructKeyExists(request, "cgi") && StructKeyExists(request.cgi, "http_accept"))){
 			local.httpAccept = request.cgi.http_accept;
 			local.formats = $get("formats");

--- a/vendor/wheels/events/EventMethods.cfc
+++ b/vendor/wheels/events/EventMethods.cfc
@@ -327,14 +327,7 @@ component extends="wheels.Global" implements="wheels.interfaces.events.EventHand
 	public string function $getRequestFormat() {
 		local.rv = "html";
 		if (StructKeyExists(url, "format")) {
-			// Security (review finding T4): url.format is later interpolated into
-			// the on-disk error-template include path in $runOnError
-			// ("#eventPath#/onerror.#format#.cfm"), guarded only by FileExists. An
-			// unvalidated value such as "../../somefile" enables path traversal /
-			// local file inclusion of any .cfm on disk during error rendering.
-			// Only accept a plain alphanumeric token, which covers every configured
-			// format key (html, xml, json, csv, pdf, xls) and any addFormat()
-			// extension; anything else falls back to html.
+			// Security: reject non-alphanumeric url.format to prevent LFI via the error-template include path in $runOnError.
 			if (ReFind("^[A-Za-z0-9]+$", url.format)) {
 				local.rv = url.format;
 			}

--- a/vendor/wheels/tests/specs/events/onerrorSpec.cfc
+++ b/vendor/wheels/tests/specs/events/onerrorSpec.cfc
@@ -63,16 +63,7 @@ component extends="wheels.WheelsTest" {
 			})
 		})
 
-		// Security regression coverage (review finding T4): $runOnError
-		// interpolates $getRequestFormat() into the on-disk error-template
-		// include path (eventPath & "/onerror." & format & ".cfm"), guarded
-		// only by FileExists. Before the fix, url.format flowed through
-		// verbatim, so a traversal token such as "../../somefile" could pull
-		// any .cfm on disk into error rendering (local file inclusion).
-		// $getRequestFormat must only accept plain alphanumeric tokens and
-		// fall back to "html" for everything else. Tested via a helper that
-		// saves/restores url.format so the test harness's own ?format=json
-		// output detection is not disturbed.
+		// Security regression: $getRequestFormat must reject non-alphanumeric url.format (LFI via $runOnError's error-template include path).
 		describe("$getRequestFormat rejects unsafe format tokens (T4 LFI)", () => {
 
 			it("coerces ../ traversal tokens to html", () => {
@@ -97,12 +88,6 @@ component extends="wheels.WheelsTest" {
 		})
 	}
 
-	/**
-	 * Calls EventMethods.$getRequestFormat() with url.format set to the given
-	 * value, saving and restoring the pre-existing url.format around the call.
-	 * The url.format branch never touches $get("formats"), so a bare
-	 * CreateObject instance suffices (same pattern as EventInterfaceSpec).
-	 */
 	private string function $requestFormatFor(required string formatValue) {
 		var em = CreateObject("component", "wheels.events.EventMethods")
 		var hadFormat = StructKeyExists(url, "format")

--- a/vendor/wheels/tests/specs/events/onerrorSpec.cfc
+++ b/vendor/wheels/tests/specs/events/onerrorSpec.cfc
@@ -62,6 +62,63 @@ component extends="wheels.WheelsTest" {
 				expect($expectedStatusFor("Wheels.ActionParameterMissing")).toBe(500)
 			})
 		})
+
+		// Security regression coverage (review finding T4): $runOnError
+		// interpolates $getRequestFormat() into the on-disk error-template
+		// include path (eventPath & "/onerror." & format & ".cfm"), guarded
+		// only by FileExists. Before the fix, url.format flowed through
+		// verbatim, so a traversal token such as "../../somefile" could pull
+		// any .cfm on disk into error rendering (local file inclusion).
+		// $getRequestFormat must only accept plain alphanumeric tokens and
+		// fall back to "html" for everything else. Tested via a helper that
+		// saves/restores url.format so the test harness's own ?format=json
+		// output detection is not disturbed.
+		describe("$getRequestFormat rejects unsafe format tokens (T4 LFI)", () => {
+
+			it("coerces ../ traversal tokens to html", () => {
+				expect($requestFormatFor("../../../wheels/public/layout/_header_simple")).toBe("html")
+			})
+
+			it("coerces tokens containing a slash or dot to html", () => {
+				expect($requestFormatFor("onerror.cfm/../x")).toBe("html")
+			})
+
+			it("preserves a valid alphanumeric format", () => {
+				expect($requestFormatFor("json")).toBe("json")
+			})
+
+			it("preserves another valid format", () => {
+				expect($requestFormatFor("xml")).toBe("xml")
+			})
+
+			it("falls back to html for an empty format", () => {
+				expect($requestFormatFor("")).toBe("html")
+			})
+		})
+	}
+
+	/**
+	 * Calls EventMethods.$getRequestFormat() with url.format set to the given
+	 * value, saving and restoring the pre-existing url.format around the call.
+	 * The url.format branch never touches $get("formats"), so a bare
+	 * CreateObject instance suffices (same pattern as EventInterfaceSpec).
+	 */
+	private string function $requestFormatFor(required string formatValue) {
+		var em = CreateObject("component", "wheels.events.EventMethods")
+		var hadFormat = StructKeyExists(url, "format")
+		var prior = hadFormat ? url.format : ""
+		var result = ""
+		try {
+			url.format = arguments.formatValue
+			result = em.$getRequestFormat()
+		} finally {
+			if (hadFormat) {
+				url.format = prior
+			} else {
+				StructDelete(url, "format")
+			}
+		}
+		return result
 	}
 
 	private numeric function $expectedStatusFor(required string wheelsType) {


### PR DESCRIPTION
## Summary

`$getRequestFormat()` (`vendor/wheels/events/EventMethods.cfc:327`) returned `url.format` verbatim, and `$runOnError` interpolates that value into the on-disk error-template include path — `"#application.wheels.eventPath#/onerror.#local.format#.cfm"` (`vendor/wheels/events/EventMethods.cfc:129`) — guarded only by `FileExists`. An attacker-supplied value such as `?format=../../somefile` therefore enabled path traversal / local file inclusion of any `.cfm` on disk during error rendering. Both call sites are affected via the same helper: the development `showErrorInformation` branch (`EventMethods.cfc:47`) and the production template-include branch (`EventMethods.cfc:128-134`).

## Source

Internal multi-agent framework review, 2026-06-09, finding T4 (format-lfi).

## Fix

Gate the `url.format` branch in `$getRequestFormat()` behind `ReFind("^[A-Za-z0-9]+$", url.format)`, falling through to the existing `"html"` default for anything else. Applied at the source so both consumers are covered with one change. A plain-alnum token covers every configured format key (`html`, `xml`, `json`, `csv`, `pdf`, `xls`) and any `addFormat()` extension, while rejecting traversal sequences, dots, slashes, backslashes, null bytes, encoded variants, and duplicate-param comma-joins.

Deliberately out of scope:
- The `http_accept` else-branch only emits `$get("formats")` keys (developer-controlled config), so it was left alone.
- `$requestContentType` (`vendor/wheels/controller/rendering.cfc:738`) passes `params.format` through verbatim, but both consumers validate against `$acceptableFormats` before building any template path — not vulnerable, no change.
- `vendor/wheels/public/docs/core.cfm:77` does an unvalidated `include "layouts/#request.wheels.params.format#.cfm"`, but that surface is production-blocked by `Public.cfc` `$blockInProduction()` (#2233) — dev-mode-only exposure, recommended as a separate low-severity follow-up finding rather than folding into this diff.

## Tests

Added five regression cases to `vendor/wheels/tests/specs/events/onerrorSpec.cfc` (`$getRequestFormat rejects unsafe format tokens (T4 LFI)`): `../` traversal, slash/dot tokens, two valid alphanumeric formats preserved, and empty-string fallback. A private `$requestFormatFor` helper (mirroring the existing `$expectedStatusFor` pattern in the same spec) saves/restores `url.format` with try/finally so the harness's own `?format=json` output detection is undisturbed.

Local verification on Lucee 7 + SQLite: red pre-fix (3 of the 5 cases fail — the pre-fix code returns `url.format` verbatim, so the traversal/empty cases come back unchanged), green post-fix (13 pass / 0 fail for the bundle). Per-PR CI runs the full engine × DB matrix.

## Cross-engine notes

- No closures, no catch-body `local` assignments (the `finally` only mutates the shared `url` struct), no `attributeCollection`, no `Left(str, 0)`, no reserved-scope parameter names (`formatValue`).
- `$getRequestFormat` keeps `public` access with the `$` prefix (mixin invariant — `$integrateComponents` only copies public methods) and its `EventHandlerInterface` signature is unchanged.
- Regex nano-quirk noted during review: both ORO and `java.util.regex` allow `$` to match before a single trailing newline, so `"json\n"` passes the gate — but the accepted value is then alnum + one `\n` (no slash/dot/backslash possible), `FileExists` misses, and execution lands on the safe `onerror.cfm` fallback. Harmless, not a bypass; tightening to `\A…\z` is an optional cosmetic follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)