### PR TITLE
fix(dispatch): stop trusting X-Forwarded-For for debug-access IP allowlisting

### DIFF
--- a/cli/lucli/templates/app/public/Application.cfc
+++ b/cli/lucli/templates/app/public/Application.cfc
@@ -168,7 +168,18 @@ component output="false" {
 			application.wheels.environment != "development" &&
 			(application.wheels.allowIPBasedDebugAccess)
 		) {
-			local.clientIP = CGI.HTTP_X_FORWARDED_FOR ?: CGI.REMOTE_ADDR;
+			// Client IP comes from the socket address. X-Forwarded-For is client-controlled
+			// and trivially spoofed, so it is only consulted when the app explicitly opts in
+			// via set(debugAccessTrustProxy=true) behind a trusted reverse proxy.
+			local.clientIP = Trim(CGI.REMOTE_ADDR);
+			if (
+				StructKeyExists(application.wheels, "debugAccessTrustProxy")
+				&& application.wheels.debugAccessTrustProxy
+				&& Len(Trim(CGI.HTTP_X_FORWARDED_FOR))
+			) {
+				// Rightmost entry is the one appended by the trusted proxy nearest the app.
+				local.clientIP = Trim(ListLast(CGI.HTTP_X_FORWARDED_FOR));
+			}
 			local.allowedIPs = application.wheels.debugAccessIPs;
 
 			if (arrayContains(local.allowedIPs, local.clientIP)) {

--- a/examples/starter-app/public/Application.cfc
+++ b/examples/starter-app/public/Application.cfc
@@ -170,7 +170,18 @@ component output="false" {
 			application.wheels.environment != "development" &&
 			(application.wheels.allowIPBasedDebugAccess)
 		) {
-			local.clientIP = CGI.HTTP_X_FORWARDED_FOR ?: CGI.REMOTE_ADDR;
+			// Client IP comes from the socket address. X-Forwarded-For is client-controlled
+			// and trivially spoofed, so it is only consulted when the app explicitly opts in
+			// via set(debugAccessTrustProxy=true) behind a trusted reverse proxy.
+			local.clientIP = Trim(CGI.REMOTE_ADDR);
+			if (
+				StructKeyExists(application.wheels, "debugAccessTrustProxy")
+				&& application.wheels.debugAccessTrustProxy
+				&& Len(Trim(CGI.HTTP_X_FORWARDED_FOR))
+			) {
+				// Rightmost entry is the one appended by the trusted proxy nearest the app.
+				local.clientIP = Trim(ListLast(CGI.HTTP_X_FORWARDED_FOR));
+			}
 			local.allowedIPs = application.wheels.debugAccessIPs;
 
 			if (arrayContains(local.allowedIPs, local.clientIP)) {

--- a/examples/tweet/public/Application.cfc
+++ b/examples/tweet/public/Application.cfc
@@ -170,7 +170,18 @@ component output="false" {
 			application.wheels.environment != "development" &&
 			(application.wheels.allowIPBasedDebugAccess)
 		) {
-			local.clientIP = CGI.HTTP_X_FORWARDED_FOR ?: CGI.REMOTE_ADDR;
+			// Client IP comes from the socket address. X-Forwarded-For is client-controlled
+			// and trivially spoofed, so it is only consulted when the app explicitly opts in
+			// via set(debugAccessTrustProxy=true) behind a trusted reverse proxy.
+			local.clientIP = Trim(CGI.REMOTE_ADDR);
+			if (
+				StructKeyExists(application.wheels, "debugAccessTrustProxy")
+				&& application.wheels.debugAccessTrustProxy
+				&& Len(Trim(CGI.HTTP_X_FORWARDED_FOR))
+			) {
+				// Rightmost entry is the one appended by the trusted proxy nearest the app.
+				local.clientIP = Trim(ListLast(CGI.HTTP_X_FORWARDED_FOR));
+			}
 			local.allowedIPs = application.wheels.debugAccessIPs;
 
 			if (arrayContains(local.allowedIPs, local.clientIP)) {

--- a/public/Application.cfc
+++ b/public/Application.cfc
@@ -185,7 +185,18 @@ component output="false" {
 			application.wheels.environment != "development" &&
 			(application.wheels.allowIPBasedDebugAccess)
 		) {
-			local.clientIP = CGI.HTTP_X_FORWARDED_FOR ?: CGI.REMOTE_ADDR;
+			// Client IP comes from the socket address. X-Forwarded-For is client-controlled
+			// and trivially spoofed, so it is only consulted when the app explicitly opts in
+			// via set(debugAccessTrustProxy=true) behind a trusted reverse proxy.
+			local.clientIP = Trim(CGI.REMOTE_ADDR);
+			if (
+				StructKeyExists(application.wheels, "debugAccessTrustProxy")
+				&& application.wheels.debugAccessTrustProxy
+				&& Len(Trim(CGI.HTTP_X_FORWARDED_FOR))
+			) {
+				// Rightmost entry is the one appended by the trusted proxy nearest the app.
+				local.clientIP = Trim(ListLast(CGI.HTTP_X_FORWARDED_FOR));
+			}
 			local.allowedIPs = application.wheels.debugAccessIPs;
 
 			if (arrayContains(local.allowedIPs, local.clientIP)) {

--- a/vendor/wheels/events/init/security.cfm
+++ b/vendor/wheels/events/init/security.cfm
@@ -27,4 +27,7 @@
 		// IP based restriction settings
 		application.$wheels.debugAccessIPs = [];
 		application.$wheels.allowIPBasedDebugAccess = false;
+		// Only when true is X-Forwarded-For consulted when resolving the client IP for
+		// debug access. Leave false unless the app sits behind a trusted reverse proxy.
+		application.$wheels.debugAccessTrustProxy = false;
 </cfscript>

--- a/vendor/wheels/tests/specs/environment/ipbasedaccessSpec.cfc
+++ b/vendor/wheels/tests/specs/environment/ipbasedaccessSpec.cfc
@@ -12,6 +12,9 @@ component extends="wheels.WheelsTest" {
 		if (StructKeyExists(application.wheels, "enablePublicComponent")) {
 			variables.originalEnablePublicComponent = application.wheels.enablePublicComponent;
 		}
+		if (StructKeyExists(application.wheels, "debugAccessTrustProxy")) {
+			variables.originalDebugAccessTrustProxy = application.wheels.debugAccessTrustProxy;
+		}
 	}
 
 	function afterAll() {
@@ -25,6 +28,9 @@ component extends="wheels.WheelsTest" {
 		}
 		if (StructKeyExists(variables, "originalEnablePublicComponent")) {
 			application.wheels.enablePublicComponent = variables.originalEnablePublicComponent;
+		}
+		if (StructKeyExists(variables, "originalDebugAccessTrustProxy")) {
+			application.wheels.debugAccessTrustProxy = variables.originalDebugAccessTrustProxy;
 		}
 	}
 

--- a/vendor/wheels/tests/specs/environment/ipbasedaccessSpec.cfc
+++ b/vendor/wheels/tests/specs/environment/ipbasedaccessSpec.cfc
@@ -169,5 +169,112 @@ component extends="wheels.WheelsTest" {
 				expect(application.wheels.enablePublicComponent).toBeTrue();
 			});
 		});
+
+		describe("Debug Access Trust Proxy Default", () => {
+
+			it("debugAccessTrustProxy defaults to false", () => {
+				expect(StructKeyExists(application.wheels, "debugAccessTrustProxy")).toBeTrue(
+					"events/init/security.cfm should set a debugAccessTrustProxy default so apps can opt in to X-Forwarded-For resolution behind a trusted proxy."
+				);
+				expect(application.wheels.debugAccessTrustProxy).toBeFalse(
+					"debugAccessTrustProxy must default to false: X-Forwarded-For is client-controlled and must never be trusted without explicit opt-in."
+				);
+			});
+
+			it("resolves the client IP from REMOTE_ADDR when trust proxy is disabled, ignoring X-Forwarded-For", () => {
+				// Mirrors the gated resolution logic in public/Application.cfc onRequestStart.
+				var remoteAddr = "10.0.0.5";
+				var forwardedFor = "203.0.113.99"; // attacker-controlled header value
+				var trustProxy = false;
+				var clientIP = Trim(remoteAddr);
+				if (trustProxy && Len(Trim(forwardedFor))) {
+					clientIP = Trim(ListLast(forwardedFor));
+				}
+				expect(clientIP).toBe("10.0.0.5");
+			});
+
+			it("resolves the client IP from the rightmost X-Forwarded-For entry when trust proxy is enabled", () => {
+				// Rightmost entry is the one appended by the trusted proxy nearest the app;
+				// earlier entries are client-supplied and spoofable.
+				var remoteAddr = "10.0.0.5";
+				var forwardedFor = "203.0.113.99, 198.51.100.7";
+				var trustProxy = true;
+				var clientIP = Trim(remoteAddr);
+				if (trustProxy && Len(Trim(forwardedFor))) {
+					clientIP = Trim(ListLast(forwardedFor));
+				}
+				expect(clientIP).toBe("198.51.100.7");
+			});
+		});
+
+		describe("Debug Access Client IP Source Regression", () => {
+
+			// Source-scan regression: the debug-access allowlist must not match
+			// attacker-controlled X-Forwarded-For input. CGI keys always exist
+			// (empty string), so `CGI.HTTP_X_FORWARDED_FOR ?: CGI.REMOTE_ADDR`
+			// handed header input straight to the allowlist. Plain find()/
+			// findNoCase() only (no regex) per the Lucee 7 global-regex gotcha.
+			// Repo-root resolution prior art: specs/cli/UpgradeCheckCoverageSpec.cfc.
+
+			it("public/Application.cfc does not trust X-Forwarded-For unconditionally for debug access", () => {
+				var filePath = expandPath("/wheels/../..") & "/public/Application.cfc";
+				expect(fileExists(filePath)).toBeTrue("Missing: " & filePath);
+				var src = fileRead(filePath);
+				expect(find("CGI.HTTP_X_FORWARDED_FOR ?: CGI.REMOTE_ADDR", src)).toBe(
+					0,
+					"Vulnerable elvis pattern present: debug-access client IP must default to CGI.REMOTE_ADDR."
+				);
+				expect(findNoCase("debugAccessTrustProxy", src) > 0).toBeTrue(
+					"X-Forwarded-For use must be gated behind the debugAccessTrustProxy setting."
+				);
+			});
+
+			it("CLI app template Application.cfc does not trust X-Forwarded-For unconditionally for debug access", () => {
+				var filePath = expandPath("/wheels/../..") & "/cli/lucli/templates/app/public/Application.cfc";
+				expect(fileExists(filePath)).toBeTrue("Missing: " & filePath);
+				var src = fileRead(filePath);
+				expect(find("CGI.HTTP_X_FORWARDED_FOR ?: CGI.REMOTE_ADDR", src)).toBe(
+					0,
+					"Vulnerable elvis pattern present: debug-access client IP must default to CGI.REMOTE_ADDR."
+				);
+				expect(findNoCase("debugAccessTrustProxy", src) > 0).toBeTrue(
+					"X-Forwarded-For use must be gated behind the debugAccessTrustProxy setting."
+				);
+			});
+
+			it("starter-app example Application.cfc does not trust X-Forwarded-For unconditionally for debug access", () => {
+				var filePath = expandPath("/wheels/../..") & "/examples/starter-app/public/Application.cfc";
+				// Example trees may be pruned from some distributions; only assert when present.
+				if (fileExists(filePath)) {
+					var src = fileRead(filePath);
+					expect(find("CGI.HTTP_X_FORWARDED_FOR ?: CGI.REMOTE_ADDR", src)).toBe(
+						0,
+						"Vulnerable elvis pattern present: debug-access client IP must default to CGI.REMOTE_ADDR."
+					);
+					expect(findNoCase("debugAccessTrustProxy", src) > 0).toBeTrue(
+						"X-Forwarded-For use must be gated behind the debugAccessTrustProxy setting."
+					);
+				} else {
+					expect(true).toBeTrue();
+				}
+			});
+
+			it("tweet example Application.cfc does not trust X-Forwarded-For unconditionally for debug access", () => {
+				var filePath = expandPath("/wheels/../..") & "/examples/tweet/public/Application.cfc";
+				// Example trees may be pruned from some distributions; only assert when present.
+				if (fileExists(filePath)) {
+					var src = fileRead(filePath);
+					expect(find("CGI.HTTP_X_FORWARDED_FOR ?: CGI.REMOTE_ADDR", src)).toBe(
+						0,
+						"Vulnerable elvis pattern present: debug-access client IP must default to CGI.REMOTE_ADDR."
+					);
+					expect(findNoCase("debugAccessTrustProxy", src) > 0).toBeTrue(
+						"X-Forwarded-For use must be gated behind the debugAccessTrustProxy setting."
+					);
+				} else {
+					expect(true).toBeTrue();
+				}
+			});
+		});
 	}
 }


### PR DESCRIPTION
## Summary

The IP-based debug-access gate (`public/Application.cfc:188` pre-fix, duplicated in `cli/lucli/templates/app/public/Application.cfc`, `examples/starter-app/public/Application.cfc`, and `examples/tweet/public/Application.cfc`) derived the client IP via `CGI.HTTP_X_FORWARDED_FOR ?: CGI.REMOTE_ADDR`. CGI keys always exist (as empty strings), so the elvis fallback never engaged and the `debugAccessIPs` allowlist was matched against attacker-controlled header input: any client could send `X-Forwarded-For: <allowlisted IP>` to switch on the public debug GUI, debug output, and verbose error info in production. The same bug also broke legitimate use — an allowlisted `REMOTE_ADDR` without the header could never match (the comparison ran against the empty XFF string).

## Source

Internal multi-agent framework review, 2026-06-09, finding T1 (xff-debug-access).

## Fix

- Client IP now defaults to `Trim(CGI.REMOTE_ADDR)` (the socket address, non-spoofable).
- `X-Forwarded-For` is only consulted behind the new opt-in framework setting `set(debugAccessTrustProxy=true)` (default `false`, added in `vendor/wheels/events/init/security.cfm`). When trusted, the **rightmost** XFF entry is used — the one appended by the trusted proxy nearest the app — so an attacker sending `X-Forwarded-For: <allowlisted>` through a trusted proxy still resolves to their real IP.
- The block stays inline with a `StructKeyExists` guard (not a Global helper) so the CLI template and example apps degrade to the secure REMOTE_ADDR-only path when run against older vendored frameworks that lack the setting. All four copies fixed identically.
- **Behavioral note:** apps using `allowIPBasedDebugAccess` behind a reverse proxy must now set `debugAccessTrustProxy=true` to keep debug access. Needs a release-notes entry at changelog reconciliation time (CHANGELOG.md deliberately not edited here, per parallel-PR policy).
- Deliberately deferred (out of T1 scope): `vendor/wheels/events/EventMethods.cfc:224-243` maintenance-mode `ipExceptions` trusts `request.cgi.http_x_forwarded_for` unconditionally and lets unauthenticated callers overwrite `application.wheels.ipExceptions` via `?except=` — to be filed as a separate finding. A v4-0-0 guides page covering `allowIPBasedDebugAccess` / `debugAccessIPs` / `debugAccessTrustProxy` is also a follow-up (these settings are currently only documented in the v3 tree).

## Tests

`vendor/wheels/tests/specs/environment/ipbasedaccessSpec.cfc` extended with: a source regression scan over all four Application.cfc copies asserting the vulnerable elvis pattern is absent and the `debugAccessTrustProxy` gate is present (same repoRoot scan idiom as `cli/ApplicationCfcInjectorAssignmentSpec`), the new default (`debugAccessTrustProxy == false`), and the documented resolution semantics. Empirically verified in a one-off Lucee7 + SQLite container: GREEN 13/13 on the fix; reverting the 5 production files to develop while keeping the spec went RED (HTTP 417) with exactly the 4 new source-scan specs failing — the spec genuinely pins the bug. Full engine x DB matrix runs in per-PR CI.

## Cross-engine notes

Surface is `Trim` / `Len` / `ListLast` / `StructKeyExists` / `find` / `findNoCase` / `fileExists` / `fileRead` only — no closures as constructor args, no `attributeCollection`, no `catch`-local writes, no `Left(str, 0)`, no reserved-scope parameter names, no regex (avoids the Lucee 7 global-regex hang), no unescaped `#` in spec strings. Setting propagation via `application.wheels = application.$wheels` is the standard init path; `$set()` accepts arbitrary keys, so the opt-in works on every engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
