### PR TITLE
fix(dispatch): block /wheels/* dev UI unless environment is development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 
 ----
 
+## [Unreleased]
+
+### Security
+
+- `$shouldBlockInProduction()` is now a fail-closed allowlist: the `/wheels/*` dev-UI handlers (routes, env info, CFML REPL, test runner, migrator UI, MCP) 404 unless `application.wheels.environment == "development"` — case-insensitive, matching the gates in `consoleeval.cfm` and `mcp.cfm` — and also when `application.wheels` or its `environment` key is missing. Previously the predicate matched only the literal `"production"`, so any other environment name (`staging`, `qa`, `testing`, `maintenance`, `design`, ...) bypassed the gate when `enablePublicComponent=true` was set, exposing RCE-grade surfaces. `index()` stays ungated per #2233 and `$loadRegistryPackages()` inherits the stricter gate. **Behavioral change:** operators who set `enablePublicComponent=true` in a non-development environment for ad-hoc debugging will now receive 404s on the Tools links — set `environment="development"` (and `enablePublicComponent=true`) to reach them (#2903)
+
+----
+
 # [4.0.3](https://github.com/wheels-dev/wheels/releases/tag/v4.0.3) => 2026-06-09
 
 > **Wheels 4.0.3** — third patch on the 4.0 line. Completes the CLI argument-parsing overhaul (`ArgSpec` consumes LuCLI's structured arguments in every command — `--no-*` negations and named-only flags now reach their parsers, and user-error paths exit non-zero) and lands the fixes from a full 24-command CLI audit; write-side commands (`migrate`, `seed`, `reload`, `generate admin`) now refuse to attach to a sibling project's server instead of running against the wrong database; PostgreSQL/CockroachDB foreign-key migrations and pre-23c Oracle `DROP TABLE`/`DROP VIEW` work again; framework helpers can no longer be invoked as controller actions from a URL; auto-derived model properties preserve database column casing; and scaffolded apps keep their reload password out of source control (`WHEELS_RELOAD_PASSWORD` in `.env`). ~45 PRs since the 4.0.2 GA (2026-05-27).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,6 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 
 ----
 
-## [Unreleased]
-
-### Security
-
-- `$shouldBlockInProduction()` is now a fail-closed allowlist: the `/wheels/*` dev-UI handlers (routes, env info, CFML REPL, test runner, migrator UI, MCP) 404 unless `application.wheels.environment == "development"` — case-insensitive, matching the gates in `consoleeval.cfm` and `mcp.cfm` — and also when `application.wheels` or its `environment` key is missing. Previously the predicate matched only the literal `"production"`, so any other environment name (`staging`, `qa`, `testing`, `maintenance`, `design`, ...) bypassed the gate when `enablePublicComponent=true` was set, exposing RCE-grade surfaces. `index()` stays ungated per #2233 and `$loadRegistryPackages()` inherits the stricter gate. **Behavioral change:** operators who set `enablePublicComponent=true` in a non-development environment for ad-hoc debugging will now receive 404s on the Tools links — set `environment="development"` (and `enablePublicComponent=true`) to reach them (#2903)
-
-----
-
 # [4.0.3](https://github.com/wheels-dev/wheels/releases/tag/v4.0.3) => 2026-06-09
 
 > **Wheels 4.0.3** — third patch on the 4.0 line. Completes the CLI argument-parsing overhaul (`ArgSpec` consumes LuCLI's structured arguments in every command — `--no-*` negations and named-only flags now reach their parsers, and user-error paths exit non-zero) and lands the fixes from a full 24-command CLI audit; write-side commands (`migrate`, `seed`, `reload`, `generate admin`) now refuse to attach to a sibling project's server instead of running against the wrong database; PostgreSQL/CockroachDB foreign-key migrations and pre-23c Oracle `DROP TABLE`/`DROP VIEW` work again; framework helpers can no longer be invoked as controller actions from a URL; auto-derived model properties preserve database column casing; and scaffolded apps keep their reload password out of source control (`WHEELS_RELOAD_PASSWORD` in `.env`). ~45 PRs since the 4.0.2 GA (2026-05-27).

--- a/vendor/wheels/Public.cfc
+++ b/vendor/wheels/Public.cfc
@@ -9,23 +9,29 @@ component output="false" displayName="Internal GUI" extends="wheels.Global" {
 	}
 
 	/**
-	 * Returns true when the current application environment is `production`.
+	 * Returns true unless the current application environment is `development`
+	 * (fail closed: a missing `application.wheels` struct or `environment` key
+	 * also blocks). This is an allowlist matching the environment checks in
+	 * consoleeval.cfm and mcp.cfm; the name is historical from issue #2233,
+	 * when the gate only matched `production`.
 	 *
 	 * The public GUI exposes routes, env info, a CFML REPL, test runners, and
 	 * a migration UI. Even if a developer overrides `enablePublicComponent` to
-	 * true in production (documented historical behavior for ad-hoc
-	 * debugging), these surfaces must stay gated. See issue #2233.
+	 * true outside development (documented historical behavior for ad-hoc
+	 * debugging), these surfaces must stay gated.
 	 */
 	public boolean function $shouldBlockInProduction() {
-		return StructKeyExists(application, "wheels")
-		&& StructKeyExists(application.wheels, "environment")
-		&& application.wheels.environment == "production";
+		if (!StructKeyExists(application, "wheels") || !StructKeyExists(application.wheels, "environment")) {
+			return true;
+		}
+		return application.wheels.environment != "development";
 	}
 
 	/**
-	 * Defense-in-depth: if the current environment is production, short-circuit
-	 * the handler with a 404 response before any view is included. Called as
-	 * the first statement of every non-`index` handler in this component.
+	 * Defense-in-depth: unless the current environment is `development`,
+	 * short-circuit the handler with a 404 response before any view is
+	 * included. Called as the first statement of every non-`index` handler in
+	 * this component.
 	 */
 	public void function $blockInProduction() {
 		if ($shouldBlockInProduction()) {

--- a/vendor/wheels/tests/specs/packages/LoadRegistryPackagesSpec.cfc
+++ b/vendor/wheels/tests/specs/packages/LoadRegistryPackagesSpec.cfc
@@ -35,6 +35,18 @@ component extends="wheels.WheelsTest" {
 				});
 			});
 
+			it("returns empty packages and no error in staging (gate allows development only)", () => {
+				// 2026-06-09 review (S2/SEC-1): the old denylist only matched
+				// "production", so any other non-development environment name
+				// reached the registry. The gate is now an allowlist.
+				$withEnv("staging", () => {
+					var pub = $newPublic();
+					var result = pub.$loadRegistryPackages(registry = $fakeRegistry(packages = [{name = "should-not-appear"}]));
+					expect(result.packages).toBe([]);
+					expect(result.error).toBe("");
+				});
+			});
+
 			it("returns packages from the registry in development", () => {
 				$withEnv("development", () => {
 					var pub = $newPublic();

--- a/vendor/wheels/tests/specs/security/PublicComponentProductionSpec.cfc
+++ b/vendor/wheels/tests/specs/security/PublicComponentProductionSpec.cfc
@@ -1,9 +1,12 @@
 /**
  * Locks down `/wheels/*` dispatch so the internal GUI / migrator / test-runner /
- * consoleeval surface cannot be reached in `production`, even if a developer
- * has explicitly set `enablePublicComponent=true`.
+ * consoleeval surface cannot be reached outside `development`, even if a
+ * developer has explicitly set `enablePublicComponent=true`.
  *
- * See issue #2233 (Bucket A8 in the v4 GA architectural review).
+ * The gate is an allowlist (block unless development, fail closed), matching
+ * the environment checks in consoleeval.cfm and mcp.cfm. See issue #2233
+ * (Bucket A8 in the v4 GA architectural review) and the 2026-06-09 framework
+ * review (finding S2/SEC-1).
  */
 component extends="wheels.WheelsTest" {
 
@@ -35,22 +38,47 @@ component extends="wheels.WheelsTest" {
 					expect(publicCfc.$shouldBlockInProduction()).toBeFalse();
 				});
 
-				it("returns false in testing", () => {
+				it("returns true in testing (allowlist: only development passes)", () => {
 					application.wheels.environment = "testing";
 					var publicCfc = createObject("component", "wheels.Public").$init();
-					expect(publicCfc.$shouldBlockInProduction()).toBeFalse();
+					expect(publicCfc.$shouldBlockInProduction()).toBeTrue();
 				});
 
-				it("returns false in maintenance", () => {
+				it("returns true in maintenance (allowlist: only development passes)", () => {
 					application.wheels.environment = "maintenance";
 					var publicCfc = createObject("component", "wheels.Public").$init();
-					expect(publicCfc.$shouldBlockInProduction()).toBeFalse();
+					expect(publicCfc.$shouldBlockInProduction()).toBeTrue();
 				});
 
-				it("returns false in design", () => {
+				it("returns true in design (allowlist: only development passes)", () => {
 					application.wheels.environment = "design";
 					var publicCfc = createObject("component", "wheels.Public").$init();
-					expect(publicCfc.$shouldBlockInProduction()).toBeFalse();
+					expect(publicCfc.$shouldBlockInProduction()).toBeTrue();
+				});
+
+				// Attack-shaped cases from the 2026-06-09 review (S2/SEC-1): a
+				// denylist matching only the literal "production" let any other
+				// environment name straight through to the REPL/migrator/test
+				// surface. The predicate must be an allowlist instead.
+				var nonDevEnvironments = ["staging", "qa", "uat", "prod", "production-1"];
+				for (var envName in nonDevEnvironments) {
+					(function(blockedEnv) {
+						it("returns true for arbitrary non-development environment '#blockedEnv#'", () => {
+							application.wheels.environment = blockedEnv;
+							var publicCfc = createObject("component", "wheels.Public").$init();
+							expect(publicCfc.$shouldBlockInProduction()).toBeTrue();
+						});
+					})(envName);
+				}
+
+				it("fails closed when application.wheels.environment is missing", () => {
+					// Instantiate before deleting the key so component setup
+					// can't trip over the missing environment; the predicate
+					// itself must treat a missing key as "block".
+					var publicCfc = createObject("component", "wheels.Public").$init();
+					StructDelete(application.wheels, "environment");
+					expect(publicCfc.$shouldBlockInProduction()).toBeTrue();
+					// afterEach restores application.wheels.environment.
 				});
 
 			});


### PR DESCRIPTION
## Summary

`$shouldBlockInProduction()` in `vendor/wheels/Public.cfc` (develop line 19-22) was a denylist that only matched the literal environment name `"production"`. The handlers it guards expose the dev-UI surface — routes browser, env info, a CFML REPL (`consoleeval.cfm`), test runners, the migrator UI, and the MCP endpoint — behind the `enablePublicComponent` gate in `vendor/wheels/Dispatch.cfc:308`. The RCE-grade views (`consoleeval.cfm`, `mcp.cfm`) already required `environment == "development"`, but every *other* gated handler passed for any non-production environment name (`staging`, `qa`, `uat`, `testing`, `maintenance`, `design`, `production-1`, ...) whenever a deployer force-enabled `enablePublicComponent`.

**Intentional behavior change:** setting `enablePublicComponent=true` in testing / maintenance / design / any non-development environment no longer exposes the gated dev-UI handlers — they 404. Only `environment="development"` may reach them. `index()` (the congratulations page) stays ungated per #2233.

## Source

Internal multi-agent framework review, 2026-06-09, finding T2 (devui-allowlist-gate, S2/SEC-1).

## Fix

Rewrite the predicate as a fail-closed allowlist (`vendor/wheels/Public.cfc:23`):

- block when `application.wheels` or `application.wheels.environment` is missing (previously fell open),
- otherwise block unless the environment is `development` (case-insensitive `!=`, the same operator `consoleeval.cfm` uses).

Method names `$shouldBlockInProduction()` / `$blockInProduction()` are kept — 29 handler call sites and the static-coverage spec grep for them. `$loadRegistryPackages()` inherits the stricter gate. The new gate is strictly stronger than the per-view checks in `consoleeval.cfm` / `mcp.cfm`, which fall through when `application.wheels` is missing.

Deliberately deferred (non-blocking follow-ups, not in this minimal diff):
- stale docblock at `vendor/wheels/Public.cfc:47` ("Short-circuits in production" should read "outside development")
- stale comment at `vendor/wheels/tests/specs/dispatch/InvokeMethodSpec.cfc:46` ("non-production... no-op" is now development-only)
- `web/sites/guides/.../digging-deeper/debug-panel.mdx` `enablePublicComponent` override example could note the Tools links 404 outside development

## Tests

`vendor/wheels/tests/specs/security/PublicComponentProductionSpec.cfc`:
- inverted the testing / maintenance / design predicate cases to expect blocking
- added arbitrary non-dev environment names (`staging`, `qa`, `uat`, `prod`, `production-1`)
- added a fail-closed case for a missing `environment` key

`vendor/wheels/tests/specs/packages/LoadRegistryPackagesSpec.cfc`: staging now yields empty packages (would have surfaced `should-not-appear` pre-fix).

All 9 new/inverted assertions fail against develop's predicate — verified RED empirically on Lucee 7 + SQLite: 35 pass / 9 fail pre-fix, 44 / 0 post-fix. Only the `security` + `packages` bundles were run locally (acceptable given the narrow caller surface); **gate the merge on a green per-PR compat-matrix run.**

CI safety: all fixture/demo/template apps set `environment="development"` and nothing flips the env mid-run, so the gated `/wheels/core/tests` endpoint CI hits stays reachable.

## Cross-engine notes

The predicate is `StructKeyExists` + case-insensitive `!=` only — no closures, no reserved-scope names, no `attributeCollection`, no catch-local writes. Specs reuse the file's existing IIFE loop pattern. `$`-prefixed methods stay `public` (mixin invariant #7). Safe `StructDelete`/restore ordering in the missing-key spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
