### PR TITLE
fix(migrator): wire TenantMigrator to real Migrator API and hold tenant datasource

### DIFF
--- a/vendor/wheels/migrator/TenantMigrator.cfc
+++ b/vendor/wheels/migrator/TenantMigrator.cfc
@@ -39,13 +39,24 @@ component {
 	 * @tenants Array of tenant structs, each with at minimum a `dataSource` key. Optional: `id`.
 	 * @tenantProvider Closure that returns an array of tenant structs. Used when tenants is empty.
 	 * @stopOnError If true (default), stops on the first tenant that fails. If false, collects errors and continues.
+	 * @migratePath Path to the migration files. Defaults to the standard app location.
+	 * @sqlPath Path the migrator writes generated SQL files to (when `writeMigratorSQLFiles` is enabled).
 	 */
 	public struct function migrateAll(
 		string action = "latest",
 		array tenants = [],
 		any tenantProvider,
-		boolean stopOnError = true
+		boolean stopOnError = true,
+		string migratePath = "/app/migrator/migrations/",
+		string sqlPath = "/app/migrator/sql/"
 	) {
+		if (!ListFindNoCase("latest,up,down,info", arguments.action)) {
+			Throw(
+				type = "Wheels.TenantMigrator.InvalidAction",
+				message = "Invalid migration action `#arguments.action#`. Valid actions are `latest`, `up`, `down` and `info`."
+			);
+		}
+
 		local.results = {
 			success = [],
 			failed = [],
@@ -64,47 +75,64 @@ component {
 
 		local.results.total = ArrayLen(local.tenantList);
 
-		for (local.tenant in local.tenantList) {
-			if (!IsStruct(local.tenant) || !StructKeyExists(local.tenant, "dataSource") || !Len(local.tenant.dataSource)) {
-				ArrayAppend(local.results.failed, {
-					tenant = local.tenant,
-					error = "Tenant struct missing required 'dataSource' key"
-				});
-				if (arguments.stopOnError) break;
-				continue;
-			}
+		// Snapshot any pre-existing tenant context (e.g. set by TenantResolver
+		// middleware) so it can be restored after the run instead of deleted.
+		if (!StructKeyExists(request, "wheels")) {
+			request.wheels = {};
+		}
+		local.hadRequestTenant = StructKeyExists(request.wheels, "tenant");
+		if (local.hadRequestTenant) {
+			local.originalRequestTenant = request.wheels.tenant;
+		}
 
-			local.tenantId = StructKeyExists(local.tenant, "id") ? local.tenant.id : local.tenant.dataSource;
-
-			try {
-				// Set the tenant context so migrations use the correct datasource
-				if (!StructKeyExists(request, "wheels")) {
-					request.wheels = {};
+		try {
+			for (local.tenant in local.tenantList) {
+				if (!IsStruct(local.tenant) || !StructKeyExists(local.tenant, "dataSource") || !Len(local.tenant.dataSource)) {
+					ArrayAppend(local.results.failed, {
+						tenant = local.tenant,
+						error = "Tenant struct missing required 'dataSource' key"
+					});
+					if (arguments.stopOnError) break;
+					continue;
 				}
-				request.wheels.tenant = {
-					id = local.tenantId,
-					dataSource = local.tenant.dataSource,
-					config = StructKeyExists(local.tenant, "config") ? local.tenant.config : {}
-				};
 
-				// Run the standard migrator with the tenant's datasource
-				local.migrator = $createMigrator(local.tenant.dataSource);
-				local.output = local.migrator.migrate(arguments.action);
+				local.tenantId = StructKeyExists(local.tenant, "id") ? local.tenant.id : local.tenant.dataSource;
 
-				ArrayAppend(local.results.success, {
-					tenant = local.tenantId,
-					dataSource = local.tenant.dataSource,
-					output = local.output
-				});
-			} catch (any e) {
-				ArrayAppend(local.results.failed, {
-					tenant = local.tenantId,
-					dataSource = local.tenant.dataSource,
-					error = e.message
-				});
-				if (arguments.stopOnError) break;
-			} finally {
-				// Clean up tenant context
+				try {
+					// Set the tenant context so migrations use the correct datasource
+					request.wheels.tenant = {
+						id = local.tenantId,
+						dataSource = local.tenant.dataSource,
+						config = StructKeyExists(local.tenant, "config") ? local.tenant.config : {}
+					};
+
+					// Run the standard migrator against the tenant's datasource
+					local.output = $runForTenant(
+						action = arguments.action,
+						dataSource = local.tenant.dataSource,
+						migratePath = arguments.migratePath,
+						sqlPath = arguments.sqlPath
+					);
+
+					ArrayAppend(local.results.success, {
+						tenant = local.tenantId,
+						dataSource = local.tenant.dataSource,
+						output = local.output
+					});
+				} catch (any e) {
+					ArrayAppend(local.results.failed, {
+						tenant = local.tenantId,
+						dataSource = local.tenant.dataSource,
+						error = e.message
+					});
+					if (arguments.stopOnError) break;
+				}
+			}
+		} finally {
+			// Restore the pre-existing tenant context (or remove the one we set)
+			if (local.hadRequestTenant) {
+				request.wheels.tenant = local.originalRequestTenant;
+			} else {
 				StructDelete(request.wheels, "tenant");
 			}
 		}
@@ -113,28 +141,89 @@ component {
 	}
 
 	/**
-	 * Create a migrator instance configured for a specific datasource.
-	 * Temporarily overrides the application datasource for the migration run.
-	 * Uses cflock to prevent race conditions when multiple threads migrate concurrently.
+	 * Runs a single migration action against one tenant datasource.
+	 * Holds an exclusive named lock for the FULL run: the migrator reads
+	 * `application.wheels.dataSourceName` lazily at query time, so the
+	 * application-wide datasource is swapped to the tenant's for the whole
+	 * action and only restored once it completes. The lock prevents
+	 * concurrent tenant migrations from interleaving datasource swaps.
 	 */
-	private any function $createMigrator(required string dataSource) {
+	public any function $runForTenant(
+		required string action,
+		required string dataSource,
+		required string migratePath,
+		required string sqlPath
+	) {
 		local.appKey = "wheels";
 
-		lock name="wheels_tenant_migrator" type="exclusive" timeout="30" {
-			local.originalDS = application[local.appKey].dataSourceName;
-
-			// Temporarily set the application datasource to the tenant's
+		lock name="wheels_tenant_migrator" type="exclusive" timeout="300" {
+			local.originalDataSourceName = application[local.appKey].dataSourceName;
 			application[local.appKey].dataSourceName = arguments.dataSource;
-
 			try {
-				local.migrator = new wheels.migrator.Migrator();
+				local.migrator = $newMigrator(migratePath = arguments.migratePath, sqlPath = arguments.sqlPath);
+				return $executeAction(migrator = local.migrator, action = arguments.action);
 			} finally {
-				// Restore original datasource
-				application[local.appKey].dataSourceName = local.originalDS;
+				application[local.appKey].dataSourceName = local.originalDataSourceName;
 			}
 		}
+	}
 
-		return local.migrator;
+	/**
+	 * Creates a `wheels.Migrator` instance configured for the given paths.
+	 */
+	public any function $newMigrator(required string migratePath, required string sqlPath) {
+		return CreateObject("component", "wheels.Migrator").init(
+			migratePath = arguments.migratePath,
+			sqlPath = arguments.sqlPath
+		);
+	}
+
+	/**
+	 * Executes one migration action on a migrator instance. Mirrors the
+	 * command handling in `vendor/wheels/public/views/cli.cfm`.
+	 */
+	public any function $executeAction(required any migrator, required string action) {
+		switch (arguments.action) {
+			case "latest":
+				return arguments.migrator.migrateToLatest();
+			case "up":
+				// Walk the migration list (sorted ascending by version) and
+				// migrate to the first pending version after the current one.
+				local.currentVersion = arguments.migrator.getCurrentMigrationVersion();
+				local.targetVersion = "";
+				for (local.migration in arguments.migrator.getAvailableMigrations()) {
+					if (local.migration.status != "migrated" && local.migration.version > local.currentVersion) {
+						local.targetVersion = local.migration.version;
+						break;
+					}
+				}
+				if (Len(local.targetVersion)) {
+					return arguments.migrator.migrateTo(local.targetVersion);
+				}
+				return "No pending migrations. Database is at version #local.currentVersion#.";
+			case "down":
+				// Walk the list in reverse to find the migration immediately
+				// below the current version, then migrate down to it.
+				local.currentVersion = arguments.migrator.getCurrentMigrationVersion();
+				if (local.currentVersion == "0") {
+					return "Database is at version 0; nothing to roll back.";
+				}
+				local.migrations = arguments.migrator.getAvailableMigrations();
+				local.targetVersion = "0";
+				for (local.i = ArrayLen(local.migrations); local.i >= 1; local.i--) {
+					if (local.migrations[local.i].version < local.currentVersion && local.migrations[local.i].status == "migrated") {
+						local.targetVersion = local.migrations[local.i].version;
+						break;
+					}
+				}
+				return arguments.migrator.migrateTo(local.targetVersion);
+			case "info":
+				return ArrayToList(arguments.migrator.$buildInfoOutput(), Chr(10));
+		}
+		Throw(
+			type = "Wheels.TenantMigrator.InvalidAction",
+			message = "Invalid migration action `#arguments.action#`. Valid actions are `latest`, `up`, `down` and `info`."
+		);
 	}
 
 }

--- a/vendor/wheels/tests/specs/migrator/TenantMigratorSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/TenantMigratorSpec.cfc
@@ -1,0 +1,187 @@
+component extends="wheels.WheelsTest" {
+
+	include "helperFunctions.cfm";
+
+	function beforeAll() {
+		migration = CreateObject("component", "wheels.migrator.Migration").init();
+		migrator = CreateObject("component", "wheels.Migrator").init(
+			migratePath = "/wheels/tests/_assets/migrator/migrations/",
+			sqlPath = "/wheels/tests/_assets/migrator/sql/"
+		);
+		tenantMigrator = CreateObject("component", "wheels.migrator.TenantMigrator").init();
+		fixtureMigratePath = "/wheels/tests/_assets/migrator/migrations/";
+		fixtureSqlPath = "/wheels/tests/_assets/migrator/sql/";
+	}
+
+	function run() {
+
+		var _isCockroachDB = CreateObject("component", "wheels.migrator.Migration").init().adapter.adapterName() == "CockroachDB";
+
+		describe("TenantMigrator migrateAll", () => {
+
+			beforeEach(() => {
+				for (local.table in ["c_o_r_e_bunyips", "c_o_r_e_dropbears", "c_o_r_e_hoopsnakes"]) {
+					try { migration.dropTable(local.table); } catch (any e) {}
+				}
+				deleteMigratorVersions(2);
+			});
+
+			afterEach(() => {
+				for (local.table in ["c_o_r_e_bunyips", "c_o_r_e_dropbears", "c_o_r_e_hoopsnakes"]) {
+					try { migration.dropTable(local.table); } catch (any e) {}
+				}
+				deleteMigratorVersions(2);
+				// The suite shares a request scope across specs — never leak a
+				// tenant context set by one of the tests below.
+				if (StructKeyExists(request, "wheels")) {
+					StructDelete(request.wheels, "tenant");
+				}
+			});
+
+			it("action=latest migrates the tenant datasource to the latest fixture version", () => {
+				if (_isCockroachDB) return;
+				var results = tenantMigrator.migrateAll(
+					action = "latest",
+					tenants = [{id = "t1", dataSource = application.wheels.dataSourceName}],
+					migratePath = fixtureMigratePath,
+					sqlPath = fixtureSqlPath
+				);
+				expect(results.total).toBe(1);
+				expect(ArrayLen(results.failed)).toBe(0);
+				expect(ArrayLen(results.success)).toBe(1);
+				expect(migrator.getCurrentMigrationVersion()).toBe("003");
+			});
+
+			it("action=up applies exactly one pending migration", () => {
+				if (_isCockroachDB) return;
+				var results = tenantMigrator.migrateAll(
+					action = "up",
+					tenants = [{id = "t1", dataSource = application.wheels.dataSourceName}],
+					migratePath = fixtureMigratePath,
+					sqlPath = fixtureSqlPath
+				);
+				expect(ArrayLen(results.failed)).toBe(0);
+				expect(ArrayLen(results.success)).toBe(1);
+				expect(migrator.getCurrentMigrationVersion()).toBe("001");
+			});
+
+			it("action=down rolls back one version", () => {
+				if (_isCockroachDB) return;
+				migrator.migrateTo("002");
+				var results = tenantMigrator.migrateAll(
+					action = "down",
+					tenants = [{id = "t1", dataSource = application.wheels.dataSourceName}],
+					migratePath = fixtureMigratePath,
+					sqlPath = fixtureSqlPath
+				);
+				expect(ArrayLen(results.failed)).toBe(0);
+				expect(ArrayLen(results.success)).toBe(1);
+				expect(migrator.getCurrentMigrationVersion()).toBe("001");
+			});
+
+			it("action=info returns output without mutating the version", () => {
+				if (_isCockroachDB) return;
+				migrator.migrateTo("001");
+				var results = tenantMigrator.migrateAll(
+					action = "info",
+					tenants = [{id = "t1", dataSource = application.wheels.dataSourceName}],
+					migratePath = fixtureMigratePath,
+					sqlPath = fixtureSqlPath
+				);
+				expect(ArrayLen(results.failed)).toBe(0);
+				expect(ArrayLen(results.success)).toBe(1);
+				expect(results.success[1].output).toInclude("Current version:");
+				expect(migrator.getCurrentMigrationVersion()).toBe("001");
+			});
+
+			it("restores the application datasource and a pre-existing request tenant context", () => {
+				if (_isCockroachDB) return;
+				var originalDataSourceName = application.wheels.dataSourceName;
+				if (!StructKeyExists(request, "wheels")) {
+					request.wheels = {};
+				}
+				request.wheels.tenant = {id = "preexisting", dataSource = originalDataSourceName, config = {}};
+				var results = tenantMigrator.migrateAll(
+					action = "info",
+					tenants = [{id = "t1", dataSource = originalDataSourceName}],
+					migratePath = fixtureMigratePath,
+					sqlPath = fixtureSqlPath
+				);
+				expect(ArrayLen(results.success)).toBe(1);
+				expect(application.wheels.dataSourceName).toBe(originalDataSourceName);
+				expect(StructKeyExists(request.wheels, "tenant")).toBeTrue();
+				expect(request.wheels.tenant.id).toBe("preexisting");
+			});
+
+			it("records the failure and continues when stopOnError=false", () => {
+				if (_isCockroachDB) return;
+				var results = tenantMigrator.migrateAll(
+					action = "info",
+					tenants = [
+						{id = "bad", dataSource = "wheels_no_such_ds_xyz"},
+						{id = "good", dataSource = application.wheels.dataSourceName}
+					],
+					stopOnError = false,
+					migratePath = fixtureMigratePath,
+					sqlPath = fixtureSqlPath
+				);
+				expect(results.total).toBe(2);
+				expect(ArrayLen(results.failed)).toBe(1);
+				expect(ArrayLen(results.success)).toBe(1);
+				expect(results.failed[1].tenant).toBe("bad");
+				expect(results.success[1].tenant).toBe("good");
+			});
+
+			it("stops after the first failure when stopOnError=true", () => {
+				if (_isCockroachDB) return;
+				var results = tenantMigrator.migrateAll(
+					action = "info",
+					tenants = [
+						{id = "bad", dataSource = "wheels_no_such_ds_xyz"},
+						{id = "good", dataSource = application.wheels.dataSourceName}
+					],
+					stopOnError = true,
+					migratePath = fixtureMigratePath,
+					sqlPath = fixtureSqlPath
+				);
+				expect(results.total).toBe(2);
+				expect(ArrayLen(results.failed)).toBe(1);
+				expect(ArrayLen(results.success)).toBe(0);
+				expect(results.failed[1].tenant).toBe("bad");
+			});
+
+			it("throws Wheels.TenantMigrator.InvalidAction for an unknown action", () => {
+				expect(() => {
+					tenantMigrator.migrateAll(
+						action = "sideways",
+						tenants = [{id = "t1", dataSource = application.wheels.dataSourceName}],
+						migratePath = fixtureMigratePath,
+						sqlPath = fixtureSqlPath
+					);
+				}).toThrow("Wheels.TenantMigrator.InvalidAction");
+			});
+
+			it("resolves tenants from a tenantProvider closure", () => {
+				if (_isCockroachDB) return;
+				// Hoisted before the named-arg call (Adobe CF chokes on inline
+				// closures passed as named arguments). Reads the application
+				// scope directly rather than capturing an outer local var.
+				var provider = function() {
+					return [{id = "fromProvider", dataSource = application.wheels.dataSourceName}];
+				};
+				var results = tenantMigrator.migrateAll(
+					action = "info",
+					tenantProvider = provider,
+					migratePath = fixtureMigratePath,
+					sqlPath = fixtureSqlPath
+				);
+				expect(results.total).toBe(1);
+				expect(ArrayLen(results.success)).toBe(1);
+				expect(results.success[1].tenant).toBe("fromProvider");
+			});
+
+		});
+
+	}
+
+}


### PR DESCRIPTION
## Summary

`TenantMigrator` (the `migrateAll()` multi-tenant migration runner) was dead on arrival, with two stacked bugs:

1. `$createMigrator()` instantiated `wheels.migrator.Migrator` — a component that does not exist (the real component is `wheels.Migrator` at `vendor/wheels/Migrator.cfc`; there is no `Migrator.cfc` under `vendor/wheels/migrator/`) — and then called a nonexistent `.migrate()` method. Every tenant iteration threw method/component-not-found into `results.failed` (`vendor/wheels/migrator/TenantMigrator.cfc:92`).
2. Even with the names fixed, the exclusive lock restored `application.wheels.dataSourceName` immediately after constructing the migrator (`TenantMigrator.cfc:120-138`) — but `Migrator` reads the datasource **lazily at query time** (`Migrator.cfc:117,444,537,...`), so tenant migrations would have silently run against the ORIGINAL (default) database.

There was zero spec coverage, which is how both bugs shipped.

## Source

Internal multi-agent framework review, 2026-06-09 — finding **H3 (tenantmigrator-doa)**, report finding **MG1 [High]** (`vendor/wheels/migrator/TenantMigrator.cfc:92, 120-138`), also called out in the report's Theme 5 and honorable mentions.

## Fix

- `$runForTenant()` now holds the exclusive named lock for the **full** run and restores the application datasource only after the action completes, in a `finally` inside the lock (timeout bumped 30s → 300s since the lock now spans real migrations). The app-wide datasource swap itself is deliberately retained — shrinking its window is what recreated the wrong-database bug.
- `$newMigrator()` creates `wheels.Migrator` via its real `init(migratePath, sqlPath)` signature, with new optional `migrateAll()` args mirroring `Migrator.init` defaults.
- `$executeAction()` maps `latest` / `up` / `down` / `info` onto the real Migrator API (`migrateToLatest()`, `migrateTo()` driven by pending/applied version walks, `$buildInfoOutput()`), mirroring the proven walk logic in `vendor/wheels/public/views/cli.cfm:48-83` — including the same `== "0"` edge case.
- `migrateAll()` validates the action up front (throws `Wheels.TenantMigrator.InvalidAction`) and snapshots/restores any pre-existing `request.wheels.tenant` context instead of deleting it.
- Helpers are `public` with `$` prefix per framework mixin convention; the removed private `$createMigrator` had no other callers (`TenantMigrator` has zero external callers — only the new spec and an accurate `multi-tenancy.mdx` mention).

Deliberately deferred / known follow-ups (non-blocking reviewer notes):
- `migratePath`/`sqlPath` defaults duplicate `Migrator.init` defaults (minor drift risk).
- The `down` action inherits `cli.cfm`'s `""` vs `"0"` currentVersion ambiguity (pre-existing parity with the CLI path, not a regression).

## Tests

New `vendor/wheels/tests/specs/migrator/TenantMigratorSpec.cfc` (9 cases, WheelsTest BDD, modeled on CI-green `MigratorInfoSpec` — same beforeAll hygiene, `deleteMigratorVersions(2)`, CockroachDB guard). Covers: `latest` / `up` / `down` / `info` against the fixture migrations on the live test datasource, datasource restoration, tenant-context snapshot/restore, `stopOnError` both ways, action validation throw, and the `tenantProvider` closure path.

Red-on-pre-fix is structurally guaranteed: pre-fix, every tenant lands in `results.failed` via component-not-found (so all `failed == 0` assertions fail) and there was no action validation (so the `toThrow` case fails). Empirically verified 8 of 9 red on the pre-fix code, all green post-fix; the one coincidental pre-fix pass was a restoration-only assertion. Full migrator directory passes 265/265 locally on Lucee 7 + SQLite; the per-PR CI matrix covers the remaining engines × DBs.

## Cross-engine notes

Checked against the CLAUDE.md invariants one-by-one:
- No reserved-scope parameter/variable names.
- No `local.X` assignments inside `catch` (BoxLang) — error collection uses `ArrayAppend` mutation only.
- Arrays mutated inside closures via parent-struct refs (Adobe copy-by-value in struct literals).
- The `tenantProvider` closure in the spec is hoisted to a `var` before being passed as a named arg (Adobe `ASTcffunction` crash).
- No `Left(str, 0)`, no `attributeCollection`, helpers public with `$` prefix (mixin integration).
- Local verification was Lucee 7 + SQLite only; all spec patterns used have CI-green prior art in sibling specs (`MigratorInfoSpec`, `renameDetectorSpec`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
