### PR TITLE
fix(model): fix >=/<= parsing and fail-open swallow in validation condition evaluator

### DIFF
--- a/vendor/wheels/model/validations.cfc
+++ b/vendor/wheels/model/validations.cfc
@@ -578,8 +578,20 @@ component {
 			if (StructKeyExists(arguments, local.item) && Len(arguments[local.item])) {
 				local.key = local.item & "Evaluated";
 				try {
-        	local[local.key] = $evaluateConditionString(arguments[local.item]);
+					local[local.key] = $evaluateConditionString(arguments[local.item]);
 				} catch (any e) {
+					if ($get("showErrorInformation")) {
+						Throw(
+							type = "Wheels.InvalidValidationCondition",
+							message = "The `#local.item#` expression `#arguments[local.item]#` could not be evaluated: #e.message#",
+							extendedInfo = "Supported forms: `this.property`, `this.method()`, bare `method()` (optionally negated with `!`), and binary comparisons using eq/neq/lt/lte/gt/gte or ==/!=/</<=/>/>=."
+						);
+					}
+					cflog(
+						text = "Wheels: validation `#local.item#` expression `#arguments[local.item]#` could not be evaluated (#e.message#); validation skipped.",
+						type = "error",
+						file = "wheels-errors"
+					);
 					return false;
 				}
 			}
@@ -838,23 +850,30 @@ component {
 	 * Normalizes symbolic comparison operators to their CFML string equivalents.
 	 */
 	public string function $normalizeConditionOperators(required string condition) {
-		local.rv = ReplaceList(arguments.condition, "==,!=,<,<=,>,>=", "eq,neq,lt,lte,gt,gte");
-		return Replace(local.rv, "  ", " ", "all");
+		// Replace two-character operators first so the single-character "<" and ">"
+		// replacements cannot mangle "<=" and ">=" into "lt=" and "gt=".
+		local.rv = Replace(arguments.condition, "==", " eq ", "all");
+		local.rv = Replace(local.rv, "!=", " neq ", "all");
+		local.rv = Replace(local.rv, "<=", " lte ", "all");
+		local.rv = Replace(local.rv, ">=", " gte ", "all");
+		local.rv = Replace(local.rv, "<", " lt ", "all");
+		local.rv = Replace(local.rv, ">", " gt ", "all");
+		return Trim(REReplace(local.rv, "\s+", " ", "all"));
 	}
 
 	/**
-	 * Splits a normalized condition on the last matching comparison operator.
+	 * Splits a normalized condition on the first whitespace-delimited comparison operator.
 	 * Returns {expression} always, plus {operator, rightOperand} when an operator is found.
 	 */
 	public struct function $splitConditionOnOperator(required string condition) {
 		local.rv = {expression: arguments.condition};
-		for (local.op in ListToArray("eq,neq,lt,lte,gt,gte")) {
-			local.position = FindNoCase(local.op, arguments.condition);
-			if (local.position) {
-				local.rv.expression = Trim(Mid(arguments.condition, 1, local.position - 1));
-				local.rv.operator = local.op;
-				local.rv.rightOperand = Trim(Mid(arguments.condition, local.position + Len(local.op), Len(arguments.condition)));
-			}
+		local.padded = " " & arguments.condition & " ";
+		local.match = REFindNoCase("\s(neq|lte|gte|eq|lt|gt)\s", local.padded, 1, true);
+		if (local.match.pos[1] > 0) {
+			local.rv.expression = Trim(Mid(local.padded, 1, local.match.pos[2] - 1));
+			// LCase keeps the operator compatible with the case-sensitive switch in $resolveOperator on Adobe CF.
+			local.rv.operator = LCase(Mid(local.padded, local.match.pos[2], local.match.len[2]));
+			local.rv.rightOperand = Trim(Mid(local.padded, local.match.pos[2] + local.match.len[2], Len(local.padded)));
 		}
 		return local.rv;
 	}

--- a/vendor/wheels/tests/specs/model/validationsSpec.cfc
+++ b/vendor/wheels/tests/specs/model/validationsSpec.cfc
@@ -226,6 +226,62 @@ component extends="wheels.WheelsTest" {
 				user.validatesLengthOf(argumentCollection = args)
 				assert_test(user, true)
 			})
+
+			it("normalizes compound symbolic operators without mangling them", () => {
+				expect(user.$normalizeConditionOperators("a >= b")).toBe("a gte b")
+				expect(user.$normalizeConditionOperators("a <= b")).toBe("a lte b")
+				expect(user.$normalizeConditionOperators("a>=b")).toBe("a gte b")
+			})
+
+			it("evaluates symbolic comparison operators in condition strings", () => {
+				expect(user.$evaluateConditionString("5 >= 3")).toBeTrue()
+				expect(user.$evaluateConditionString("3 <= 5")).toBeTrue()
+				expect(user.$evaluateConditionString("3 >= 5")).toBeFalse()
+				expect(user.$evaluateConditionString("5 == 5")).toBeTrue()
+				expect(user.$evaluateConditionString("5 != 3")).toBeTrue()
+			})
+
+			it("does not split on operator names inside identifiers", () => {
+				user.frequency = "weekly"
+				expect(user.$evaluateConditionString("this.frequency eq 'weekly'")).toBeTrue()
+				user.adult = true
+				expect(user.$evaluateConditionString("this.adult")).toBeTrue()
+			})
+
+			it("if validation runs when condition property name contains an operator substring", () => {
+				user.frequency = "weekly"
+				args.condition = "this.frequency eq 'weekly'"
+				user.validatesLengthOf(argumentCollection = args)
+				assert_test(user, false)
+			})
+
+			it("if validation runs when condition uses a symbolic gte comparison", () => {
+				user.score = 20
+				args.condition = "this.score >= 10"
+				user.validatesLengthOf(argumentCollection = args)
+				assert_test(user, false)
+			})
+
+			it("throws in development when a condition cannot be evaluated", () => {
+				args.condition = "noSuchMethod()"
+				user.validatesLengthOf(argumentCollection = args)
+				var callValid = () => {
+					user.valid()
+				}
+				expect(callValid).toThrow("Wheels.InvalidValidationCondition")
+			})
+
+			it("skips the validation without throwing in production when a condition cannot be evaluated", () => {
+				args.condition = "noSuchMethod()"
+				user.validatesLengthOf(argumentCollection = args)
+				var originalShowErrorInformation = application.wheels.showErrorInformation
+				try {
+					application.wheels.showErrorInformation = false
+					expect(user.valid()).toBeTrue()
+				} finally {
+					application.wheels.showErrorInformation = originalShowErrorInformation
+				}
+			})
 		})
 
 		describe("Tests default validations", () => {


### PR DESCRIPTION
## Summary

The validation condition evaluator (`condition=` / `unless=` strings on `validatesXOf`) had two compounding parser defects plus a fail-open exception swallow, located at `vendor/wheels/model/validations.cfc:580-584` (catch-all `return false`), `:841` (`$normalizeConditionOperators` `ReplaceList`), and `:849-860` (`$splitConditionOnOperator` unanchored `FindNoCase`) on pre-fix develop:

1. `ReplaceList` ran left-to-right, rewriting `<` before `<=` and `>` before `>=`, so `this.score >= 5` became `this.score gt= 5`, which `$resolveOperator` rejects.
2. The unanchored operator search split inside identifiers — `frequency` matched `eq`, `adult` matched `lt` — silently mis-evaluating conditions.
3. Any evaluation error was caught and resolved to "condition false → validation does NOT run": a silent fail-open on the data-integrity boundary, and a regression from the pre-rewrite code that re-threw.

Net effect: conditional validations using `<=`/`>=`, un-spaced operators, or property names containing `eq`/`lt`/`gt` substrings were silently skipped on every engine, with no error or log.

## Source

Internal multi-agent framework review, 2026-06-09 — finding T5 (validation-condition-evaluator; report Top 10 #5 / model-orm M1 [High]).

## Fix

- `$normalizeConditionOperators` now replaces two-character operators (`==`, `!=`, `<=`, `>=`) before one-character ones (`<`, `>`), pads replacements with spaces (also fixing un-spaced inputs like `a>=b`), and collapses whitespace.
- `$splitConditionOnOperator` now splits on the first whitespace-delimited operator token via a longest-first anchored regex (`REFindNoCase("\s(neq|lte|gte|eq|lt|gt)\s")` over a space-padded copy), with `LCase` so the token survives Adobe CF's case-sensitive `switch` in `$resolveOperator`. Embedded substrings inside identifiers and quoted operands can no longer match.
- `$evaluateCondition`'s catch now throws `Wheels.InvalidValidationCondition` when `showErrorInformation=true` (development/testing); production keeps the skip but logs to the `wheels-errors` log.

**Behavior change (development/testing only):** invalid `condition`/`unless` strings now throw `Wheels.InvalidValidationCondition` instead of silently skipping the validation. Production behavior is unchanged except the skip is now logged.

Deliberately deferred (pre-existing, outside this finding's scope):
- `$evaluateLogicalExpression` still passes the raw token to the case-sensitive switch, so a bare uppercase `1 EQ 1` (no `this.` prefix) throws in dev — it threw-and-was-swallowed pre-fix too. A one-line `LCase()` follow-up would align it with the `this.`-path.
- Typo'd property names (e.g. `this.frequencyy`) still evaluate false via `$resolveThisReference`'s empty-struct return — no exception is raised, so the new dev-throw doesn't fire. Plausibly intended semantics for unset model properties.
- `<`/`>` inside quoted operands are still normalized into `lt`/`gt` tokens; the old code did the same.

## Tests

7 new BDD specs in `vendor/wheels/tests/specs/model/validationsSpec.cfc`: unit-level assertions on `$normalizeConditionOperators` / `$splitConditionOnOperator` / `$evaluateCondition`, two `validatesLengthOf` integration cases (operator-substring property name, symbolic `>=` condition), a dev-mode `toThrow("Wheels.InvalidValidationCondition")` case, and a production-path skip case with try/finally flag restore.

Verified red→green on Lucee 7 + SQLite: 6 of the new specs fail against pre-fix develop (5 failures + 1 error), and the full validationsSpec bundle passes 125/125 with the fix.

## Cross-engine notes

- Helpers remain `public` with `$` prefix (mixin integration requirement).
- The catch body writes no local vars — it throws or returns (BoxLang catch-scope invariant).
- `cflog` uses explicit named attributes (no `attributeCollection=arguments`); `Throw(type/message/extendedInfo)` and `REFindNoCase(..., 1, true)` struct-return match pre-existing matrix-proven patterns in the same file.
- Local cross-engine matrix not run (every construct has in-repo precedent); the per-PR compat-matrix CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
