### PR TITLE
fix(cli): exit non-zero when wheels validate finds errors

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -1754,9 +1754,7 @@ component extends="modules.BaseModule" {
 				out("  [#uCase(issue.severity)#] #fileName# — #issue.message#", severity);
 			}
 
-			// Record failure so the command exits non-zero AFTER the full
-			// report is flushed. Throwing here would be swallowed by the
-			// catch below (same pattern as runTests / CLI audit H6).
+			// Capture before try ends; throwing inside would be swallowed by the catch.
 			validationFailed = !results.valid;
 			issueCount = results.totalIssues;
 		} catch (any e) {
@@ -1765,11 +1763,7 @@ component extends="modules.BaseModule" {
 			rethrow;
 		}
 
-		// Exit non-zero when validation found errors so CI and shells can gate
-		// on it. Previously validate always returned "" → `wheels validate`
-		// exited 0 even when errors were reported (framework review H5).
-		// Warnings-only stays green: results.valid is true when no
-		// severity=="error" issues exist.
+		// Throw after the full report flushes — errors exit non-zero, warnings stay green.
 		if (validationFailed) {
 			throw(type = "Wheels.ValidationFailed", message = "Validation found #issueCount# issue(s) — see the report above.");
 		}

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -1728,11 +1728,15 @@ component extends="modules.BaseModule" {
 	public string function validate() {
 		if (!directoryExists(variables.projectRoot & "/app")) {
 			out("No app/ directory found. Are you in a Wheels project?", "red");
-			return "";
+			// throw maps to non-zero exit; return "" would silently succeed.
+			throw(type = "Wheels.InvalidArguments", message = "No app/ directory found — run wheels validate from a Wheels project root.");
 		}
 
 		out("Validating...", "cyan");
 		out("");
+
+		var validationFailed = false;
+		var issueCount = 0;
 
 		try {
 			var analysis = getService("analysis");
@@ -1749,8 +1753,25 @@ component extends="modules.BaseModule" {
 				var severity = issue.severity == "error" ? "red" : "yellow";
 				out("  [#uCase(issue.severity)#] #fileName# — #issue.message#", severity);
 			}
+
+			// Record failure so the command exits non-zero AFTER the full
+			// report is flushed. Throwing here would be swallowed by the
+			// catch below (same pattern as runTests / CLI audit H6).
+			validationFailed = !results.valid;
+			issueCount = results.totalIssues;
 		} catch (any e) {
 			out("Validation failed: #e.message#", "red");
+			// rethrow maps to non-zero exit; an analyzer crash must not exit 0.
+			rethrow;
+		}
+
+		// Exit non-zero when validation found errors so CI and shells can gate
+		// on it. Previously validate always returned "" → `wheels validate`
+		// exited 0 even when errors were reported (framework review H5).
+		// Warnings-only stays green: results.valid is true when no
+		// severity=="error" issues exist.
+		if (validationFailed) {
+			throw(type = "Wheels.ValidationFailed", message = "Validation found #issueCount# issue(s) — see the report above.");
 		}
 
 		return "";

--- a/cli/lucli/tests/specs/commands/ValidateCommandSpec.cfc
+++ b/cli/lucli/tests/specs/commands/ValidateCommandSpec.cfc
@@ -1,0 +1,94 @@
+/**
+ * Tests the validate command's exit-code behaviour via Module.cfc.
+ *
+ * `wheels validate` must exit non-zero when validation finds errors so CI
+ * can gate on it (framework review H5). LuCLI maps an uncaught throw to a
+ * non-zero exit, so these specs use toThrow as the exit-code proxy — the
+ * same convention as the migrate/db/generate exit-code fixes (#2890) and
+ * the runTests Wheels.TestsFailed throw (CLI audit H6).
+ *
+ * Each case gets its own minimal temp project and Module instance so the
+ * fixtures can't contaminate each other (the analysis service is cached
+ * per Module with its projectRoot baked in).
+ */
+component extends="wheels.wheelstest.system.BaseSpec" {
+
+	function beforeAll() {
+		variables.roots = [];
+
+		// Project whose model is missing extends="Model" → severity "error"
+		// from Analysis.validateModel → results.valid = false.
+		variables.errorRoot = $makeProject();
+		fileWrite(variables.errorRoot & "/app/models/Bad.cfc", "component { function config() {} }");
+		variables.errorMod = new cli.lucli.Module(cwd = variables.errorRoot);
+
+		// Project with no offending files at all.
+		variables.cleanRoot = $makeProject();
+		variables.cleanMod = new cli.lucli.Module(cwd = variables.cleanRoot);
+
+		// Project whose only issue is a warning: a view that uses ## without
+		// any cfparam/cfset (Analysis.validateView severity "warning").
+		// results.valid stays true, so validate must NOT throw.
+		variables.warningRoot = $makeProject();
+		directoryCreate(variables.warningRoot & "/app/views/things", true, true);
+		fileWrite(variables.warningRoot & "/app/views/things/index.cfm", "<p>##foo##</p>");
+		variables.warningMod = new cli.lucli.Module(cwd = variables.warningRoot);
+
+		// Project root with no app/ directory — user-error path.
+		variables.noAppRoot = $makeProject(includeApp = false);
+		variables.noAppMod = new cli.lucli.Module(cwd = variables.noAppRoot);
+	}
+
+	function afterAll() {
+		for (var root in variables.roots) {
+			if (len(root) > 10 && directoryExists(root)) {
+				directoryDelete(root, true);
+			}
+		}
+	}
+
+	/**
+	 * Build a minimal temp project. The vendor/wheels stub anchors
+	 * resolveProjectRoot so the Module treats the temp dir itself as the
+	 * project root instead of walking up to the repo checkout.
+	 */
+	private string function $makeProject(boolean includeApp = true) {
+		var root = getTempDirectory() & "wheels-cli-validate-" & createUUID();
+		directoryCreate(root & "/vendor/wheels", true, true);
+		if (arguments.includeApp) {
+			directoryCreate(root & "/app/models", true, true);
+			directoryCreate(root & "/app/controllers", true, true);
+			directoryCreate(root & "/app/views", true, true);
+			directoryCreate(root & "/config", true, true);
+		}
+		arrayAppend(variables.roots, root);
+		return root;
+	}
+
+	function run() {
+
+		describe("wheels validate exit codes", () => {
+
+			it("throws Wheels.ValidationFailed when validation finds errors", () => {
+				expect(() => variables.errorMod.validate()).toThrow(type = "Wheels.ValidationFailed");
+			});
+
+			it("returns normally on a clean project", () => {
+				variables.cleanMod.validate();
+				expect(true).toBeTrue();
+			});
+
+			it("stays green when only warnings exist", () => {
+				variables.warningMod.validate();
+				expect(true).toBeTrue();
+			});
+
+			it("throws Wheels.InvalidArguments when no app directory exists", () => {
+				expect(() => variables.noAppMod.validate()).toThrow(type = "Wheels.InvalidArguments");
+			});
+
+		});
+
+	}
+
+}

--- a/cli/lucli/tests/specs/commands/ValidateCommandSpec.cfc
+++ b/cli/lucli/tests/specs/commands/ValidateCommandSpec.cfc
@@ -4,8 +4,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 	function beforeAll() {
 		variables.roots = [];
 
-		// Project whose model is missing extends="Model" → severity "error"
-		// from Analysis.validateModel → results.valid = false.
+		// Missing extends="Model" → Analysis.validateModel error → results.valid = false.
 		variables.errorRoot = $makeProject();
 		fileWrite(variables.errorRoot & "/app/models/Bad.cfc", "component { function config() {} }");
 		variables.errorMod = new cli.lucli.Module(cwd = variables.errorRoot);
@@ -14,9 +13,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 		variables.cleanRoot = $makeProject();
 		variables.cleanMod = new cli.lucli.Module(cwd = variables.cleanRoot);
 
-		// Project whose only issue is a warning: a view that uses ## without
-		// any cfparam/cfset (Analysis.validateView severity "warning").
-		// results.valid stays true, so validate must NOT throw.
+		// Hash without cfparam → validateView warning; results.valid stays true.
 		variables.warningRoot = $makeProject();
 		directoryCreate(variables.warningRoot & "/app/views/things", true, true);
 		fileWrite(variables.warningRoot & "/app/views/things/index.cfm", "<p>##foo##</p>");

--- a/cli/lucli/tests/specs/commands/ValidateCommandSpec.cfc
+++ b/cli/lucli/tests/specs/commands/ValidateCommandSpec.cfc
@@ -1,16 +1,4 @@
-/**
- * Tests the validate command's exit-code behaviour via Module.cfc.
- *
- * `wheels validate` must exit non-zero when validation finds errors so CI
- * can gate on it (framework review H5). LuCLI maps an uncaught throw to a
- * non-zero exit, so these specs use toThrow as the exit-code proxy — the
- * same convention as the migrate/db/generate exit-code fixes (#2890) and
- * the runTests Wheels.TestsFailed throw (CLI audit H6).
- *
- * Each case gets its own minimal temp project and Module instance so the
- * fixtures can't contaminate each other (the analysis service is cached
- * per Module with its projectRoot baked in).
- */
+// Covers all four validate() exit paths; each case gets its own temp project.
 component extends="wheels.wheelstest.system.BaseSpec" {
 
 	function beforeAll() {
@@ -47,11 +35,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 		}
 	}
 
-	/**
-	 * Build a minimal temp project. The vendor/wheels stub anchors
-	 * resolveProjectRoot so the Module treats the temp dir itself as the
-	 * project root instead of walking up to the repo checkout.
-	 */
+	// vendor/wheels stub anchors resolveProjectRoot to the temp dir.
 	private string function $makeProject(boolean includeApp = true) {
 		var root = getTempDirectory() & "wheels-cli-validate-" & createUUID();
 		directoryCreate(root & "/vendor/wheels", true, true);

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-quality.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-quality.mdx
@@ -140,7 +140,7 @@ wheels validate
 wheels analyze
 ```
 
-Run `validate` first and read its output for any ✗ errors or ⚠ warnings. Then run `analyze` for a broader look at health scores and anti-patterns. Both commands always exit 0 regardless of findings, so read each report before moving on — the results are in the output, not the exit code.
+Run `validate` first and read its output for any ✗ errors or ⚠ warnings. Then run `analyze` for a broader look at health scores and anti-patterns. `wheels validate` exits non-zero when it finds error-severity issues, so you can gate CI on it. `wheels analyze` always exits 0 — its findings live in the output only.
 
 ### Scope the analysis
 


### PR DESCRIPTION
## Summary

`wheels validate` printed its report and returned `""` on every code path, with a swallowing catch-all around the analyzer call — so the process exited 0 even when validation found error-severity issues, and an analyzer crash also exited 0. CI pipelines could not gate on `wheels validate`. Finding location: `cli/lucli/Module.cfc:1728-1757` (pre-fix `validate()`).

## Source

Internal multi-agent framework review, 2026-06-09, finding H5 (cli-exit-codes). Same family as the CLI audit's H6 fix for `runTests` (#2890); `runTests` and `migrate` already exit non-zero on develop, so `validate()` was the remaining H5 gap.

## Fix

Throw typed errors so the LuCLI runtime maps them to a non-zero exit (the documented convention in `cli/CLAUDE.md`, prior art #2890):

- **Errors found**: record `validationFailed` / `issueCount` inside the `try`, then throw `Wheels.ValidationFailed` *after* the try/catch — the full report flushes first and the catch-all cannot swallow the throw (same pattern as `runTests`' `Wheels.TestsFailed`).
- **Analyzer crash**: the catch now prints the message then `rethrow`s instead of swallowing, matching `migrate()`.
- **No `app/` directory**: throws `Wheels.InvalidArguments` after the red hint, matching the other user-error paths.
- **Warnings-only / clean**: stays exit 0 — `Analysis.cfc::validate()` sets `valid = true` when no `severity=="error"` issues exist, so `wheels validate` remains usable as a soft linter. Output text and ordering are unchanged.

**Intentional behavior change**: scripts that relied on exit 0 despite reported errors will now fail, and the MCP `wheels_validate` tool surfaces a proper tool error instead of a silent empty result. That is the point of the fix, but flagging it since CHANGELOG.md is deliberately untouched (reconciled at release).

**Deferred scope**: U1 (`wheels upgrade check` exit code) and the `runTests` mid-run HTTP catch-swallow are out of scope for this PR.

## Tests

Adds `cli/lucli/tests/specs/commands/ValidateCommandSpec.cfc` covering all four paths (errors → `Wheels.ValidationFailed`, no-app → `Wheels.InvalidArguments`, warnings-only → no throw, clean → no throw) using the established per-case temp-project + `vendor/wheels` anchor pattern. The spec pins the bug: pre-fix `validate()` never throws on any path, so both `toThrow` cases fail by construction against the old code. Fixtures verified against `Analysis.cfc` (`validateModel`: missing `extends="Model"` → error; `validateView`: hash without cfparam → warning).

Local verification on the Lucee 7 docker harness: full CLI suite 762 pass; 3 non-green are pre-existing environment-dependent specs (SSH, live-server reload). `InfoCommandSpec`'s existing `wheels validate` case stays green (demo app validates clean). Zero internal callers of `Module.validate()`; `tools/test-cli-e2e.sh` validates a fresh clean scaffold and stays green.

## Cross-engine notes

The CLI suite runs on Lucee only (LuCLI runtime), so the engine matrix does not apply. The diff still violates no invariants: no `attributeCollection` from `arguments`, no `Left(str, 0)`, no reserved-scope parameter names, assignments happen inside the `try` body (not the `catch`, avoiding the BoxLang catch-local discard), and no inline closures as constructor named args.

🤖 Generated with [Claude Code](https://claude.com/claude-code)