### PR TITLE
fix(view): redact secret-shaped settings on the /wheels/info HTML page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,6 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 
 ----
 
-# [Unreleased]
-
-### Security
-
-- The HTML branch of `/wheels/info` no longer renders `csrfCookieEncryptionSecretKey` in plaintext. The HTML branch had been routing every setting through `outputSetting() -> formatSettingOutput(get(...))`, which read and rendered the live CSRF cookie encryption key into the page; the JSON branch already omitted it via a hardcoded one-off compare, so the two branches could drift. A shared predicate `$isProtectedSetting()` and display helper `$settingDisplayValue()` on `wheels.Public` now serve as the single source of truth for both branches — secret-shaped setting names (`secret|password|passphrase|privatekey|apikey|credential|token`) render as `<em>[redacted]</em>` without ever being read, so an unset key cannot throw and the value never reaches the output buffer. `accessControlAllowCredentials` is exempt (it mirrors the boolean `Access-Control-Allow-Credentials` CORS response header, not a credential value); without the exemption it would have been redacted in HTML and silently dropped from the JSON `cors` collection. Reachability of `/wheels/info` is gated by `$blockInProduction()` independently — this change only narrows what leaks when the page is reachable. Verified red→green on Lucee 7 + SQLite (#2909)
-
-----
-
 # [4.0.3](https://github.com/wheels-dev/wheels/releases/tag/v4.0.3) => 2026-06-09
 
 > **Wheels 4.0.3** — third patch on the 4.0 line. Completes the CLI argument-parsing overhaul (`ArgSpec` consumes LuCLI's structured arguments in every command — `--no-*` negations and named-only flags now reach their parsers, and user-error paths exit non-zero) and lands the fixes from a full 24-command CLI audit; write-side commands (`migrate`, `seed`, `reload`, `generate admin`) now refuse to attach to a sibling project's server instead of running against the wrong database; PostgreSQL/CockroachDB foreign-key migrations and pre-23c Oracle `DROP TABLE`/`DROP VIEW` work again; framework helpers can no longer be invoked as controller actions from a URL; auto-derived model properties preserve database column casing; and scaffolded apps keep their reload password out of source control (`WHEELS_RELOAD_PASSWORD` in `.env`). ~45 PRs since the 4.0.2 GA (2026-05-27).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 
 ----
 
+# [Unreleased]
+
+### Security
+
+- The HTML branch of `/wheels/info` no longer renders `csrfCookieEncryptionSecretKey` in plaintext. The HTML branch had been routing every setting through `outputSetting() -> formatSettingOutput(get(...))`, which read and rendered the live CSRF cookie encryption key into the page; the JSON branch already omitted it via a hardcoded one-off compare, so the two branches could drift. A shared predicate `$isProtectedSetting()` and display helper `$settingDisplayValue()` on `wheels.Public` now serve as the single source of truth for both branches — secret-shaped setting names (`secret|password|passphrase|privatekey|apikey|credential|token`) render as `<em>[redacted]</em>` without ever being read, so an unset key cannot throw and the value never reaches the output buffer. `accessControlAllowCredentials` is exempt (it mirrors the boolean `Access-Control-Allow-Credentials` CORS response header, not a credential value); without the exemption it would have been redacted in HTML and silently dropped from the JSON `cors` collection. Reachability of `/wheels/info` is gated by `$blockInProduction()` independently — this change only narrows what leaks when the page is reachable. Verified red→green on Lucee 7 + SQLite (#2909)
+
+----
+
 # [4.0.3](https://github.com/wheels-dev/wheels/releases/tag/v4.0.3) => 2026-06-09
 
 > **Wheels 4.0.3** — third patch on the 4.0 line. Completes the CLI argument-parsing overhaul (`ArgSpec` consumes LuCLI's structured arguments in every command — `--no-*` negations and named-only flags now reach their parsers, and user-error paths exit non-zero) and lands the fixes from a full 24-command CLI audit; write-side commands (`migrate`, `seed`, `reload`, `generate admin`) now refuse to attach to a sibling project's server instead of running against the wrong database; PostgreSQL/CockroachDB foreign-key migrations and pre-23c Oracle `DROP TABLE`/`DROP VIEW` work again; framework helpers can no longer be invoked as controller actions from a URL; auto-derived model properties preserve database column casing; and scaffolded apps keep their reload password out of source control (`WHEELS_RELOAD_PASSWORD` in `.env`). ~45 PRs since the 4.0.2 GA (2026-05-27).

--- a/vendor/wheels/Public.cfc
+++ b/vendor/wheels/Public.cfc
@@ -76,6 +76,35 @@ component output="false" displayName="Internal GUI" extends="wheels.Global" {
 		return application.wheels.$packageRegistry;
 	}
 
+	/**
+	 * Returns true when a setting name looks like it holds a secret (keys,
+	 * passwords, passphrases, tokens, credentials). Single source of truth for
+	 * the /wheels/info page so the HTML and JSON branches cannot drift — the
+	 * JSON branch omits matching settings and the HTML branch redacts them.
+	 *
+	 * `accessControlAllowCredentials` (and any future `*allowCredentials` flag)
+	 * is exempt: it mirrors the boolean `Access-Control-Allow-Credentials` CORS
+	 * response header and is not a credential value.
+	 */
+	public boolean function $isProtectedSetting(required string settingName) {
+		if (ReFindNoCase("allowcredentials$", arguments.settingName)) {
+			return false;
+		}
+		return ReFindNoCase("(secret|password|passphrase|privatekey|apikey|credential|token)", arguments.settingName) > 0;
+	}
+
+	/**
+	 * Returns the display-safe HTML value for a setting row on the /wheels/info
+	 * page. Secret-shaped settings are redacted without ever being read, so an
+	 * unset key cannot throw and the raw value never reaches the output buffer.
+	 */
+	public string function $settingDisplayValue(required string settingName) {
+		if ($isProtectedSetting(arguments.settingName)) {
+			return "<em>[redacted]</em>";
+		}
+		return formatSettingOutput(get(arguments.settingName));
+	}
+
 	/*
 	This is just a proof of concept
 	*/

--- a/vendor/wheels/public/helpers.cfm
+++ b/vendor/wheels/public/helpers.cfm
@@ -91,7 +91,9 @@ function outputSetting(array setting) {
 		local.rv &= '<tr><td class="four wide">';
 		local.rv &= ReReplace(ReReplace(arguments.setting[i], "(^[a-z])", "\u\1"), "([A-Z])", " \1", "all");
 		local.rv &= '</td><td class="eight wide">';
-		local.rv &= formatSettingOutput(get(arguments.setting[i]));
+		// Resolves on wheels.Public (outputSetting is only invoked from info.cfm
+		// inside Public.cfc::info()) and redacts secret-shaped settings.
+		local.rv &= $settingDisplayValue(arguments.setting[i]);
 		local.rv &= '</td></tr>';
 	}
 	return local.rv;

--- a/vendor/wheels/public/views/info.cfm
+++ b/vendor/wheels/public/views/info.cfm
@@ -167,23 +167,24 @@ if (request.wheels.params.format == "json") {
 		"settings": {}
 	};
 
-	// Collect path settings
+	// Collect path settings (secret-shaped names are omitted via the shared
+	// $isProtectedSetting() predicate, same as the HTML branch's redaction)
 	for (local.path in paths) {
-		if (isDefined("application.wheels." & local.path)) {
+		if (isDefined("application.wheels." & local.path) && !$isProtectedSetting(local.path)) {
 			local.infoData.paths[local.path] = $get(local.path);
 		}
 	}
 
 	// Collect component settings
 	for (local.comp in components) {
-		if (isDefined("application.wheels." & local.comp)) {
+		if (isDefined("application.wheels." & local.comp) && !$isProtectedSetting(local.comp)) {
 			local.infoData.components[local.comp] = $get(local.comp);
 		}
 	}
 
 	// Collect environment settings
 	for (local.env in environment) {
-		if (isDefined("application.wheels." & local.env)) {
+		if (isDefined("application.wheels." & local.env) && !$isProtectedSetting(local.env)) {
 			local.infoData.environment[local.env] = $get(local.env);
 		}
 	}
@@ -191,8 +192,8 @@ if (request.wheels.params.format == "json") {
 	// Collect CSRF settings
 	for (local.csrfSetting in csrf) {
 		if (isDefined("application.wheels." & local.csrfSetting)) {
-			// Don't expose secret keys in JSON
-			if (local.csrfSetting != "csrfCookieEncryptionSecretKey") {
+			// Don't expose secret keys in JSON (shared predicate with the HTML branch)
+			if (!$isProtectedSetting(local.csrfSetting)) {
 				local.infoData.csrf[local.csrfSetting] = $get(local.csrfSetting);
 			}
 		}
@@ -200,7 +201,7 @@ if (request.wheels.params.format == "json") {
 
 	// Collect CORS settings
 	for (local.corsSetting in cors) {
-		if (isDefined("application.wheels." & local.corsSetting)) {
+		if (isDefined("application.wheels." & local.corsSetting) && !$isProtectedSetting(local.corsSetting)) {
 			local.infoData.cors[local.corsSetting] = $get(local.corsSetting);
 		}
 	}
@@ -210,7 +211,7 @@ if (request.wheels.params.format == "json") {
 		local.groupName = local.settingGroup.name;
 		local.infoData.settings[local.groupName] = {};
 		for (local.settingName in local.settingGroup.values) {
-			if (isDefined("application.wheels." & local.settingName)) {
+			if (isDefined("application.wheels." & local.settingName) && !$isProtectedSetting(local.settingName)) {
 				local.infoData.settings[local.groupName][local.settingName] = $get(local.settingName);
 			}
 		}

--- a/vendor/wheels/public/views/info.cfm
+++ b/vendor/wheels/public/views/info.cfm
@@ -189,13 +189,11 @@ if (request.wheels.params.format == "json") {
 		}
 	}
 
-	// Collect CSRF settings
+	// Collect CSRF settings (secret-shaped names are omitted via the shared
+	// $isProtectedSetting() predicate, same as the HTML branch's redaction)
 	for (local.csrfSetting in csrf) {
-		if (isDefined("application.wheels." & local.csrfSetting)) {
-			// Don't expose secret keys in JSON (shared predicate with the HTML branch)
-			if (!$isProtectedSetting(local.csrfSetting)) {
-				local.infoData.csrf[local.csrfSetting] = $get(local.csrfSetting);
-			}
+		if (isDefined("application.wheels." & local.csrfSetting) && !$isProtectedSetting(local.csrfSetting)) {
+			local.infoData.csrf[local.csrfSetting] = $get(local.csrfSetting);
 		}
 	}
 

--- a/vendor/wheels/tests/specs/security/InfoSecretRedactionSpec.cfc
+++ b/vendor/wheels/tests/specs/security/InfoSecretRedactionSpec.cfc
@@ -1,0 +1,155 @@
+/**
+ * The /wheels/info page must never render secret-shaped settings in plaintext.
+ *
+ * The JSON branch always omitted `csrfCookieEncryptionSecretKey`, but the HTML
+ * branch rendered it verbatim via outputSetting() -> formatSettingOutput(get()).
+ * Both branches now share a single predicate, `$isProtectedSetting()`, plus a
+ * display helper, `$settingDisplayValue()`, so they cannot drift.
+ *
+ * See the 2026-06-09 framework review (finding T3, info-secret-redaction).
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("/wheels/info secret redaction", () => {
+
+			describe("$isProtectedSetting() predicate", () => {
+
+				it("flags csrfCookieEncryptionSecretKey as protected", () => {
+					var publicCfc = createObject("component", "wheels.Public").$init();
+					expect(publicCfc.$isProtectedSetting("csrfCookieEncryptionSecretKey")).toBeTrue();
+				});
+
+				it("flags other secret-shaped names as protected", () => {
+					var publicCfc = createObject("component", "wheels.Public").$init();
+					var secretShaped = [
+						"reloadPassword",
+						"myApiKey",
+						"authToken",
+						"smtpCredential",
+						"awsCredentials",
+						"signingPassphrase",
+						"jwtPrivateKey",
+						"clientSecret"
+					];
+					for (var settingName in secretShaped) {
+						expect(publicCfc.$isProtectedSetting(settingName)).toBeTrue(
+							"Expected `#settingName#` to be treated as a protected setting."
+						);
+					}
+				});
+
+				it("does not flag ordinary settings", () => {
+					var publicCfc = createObject("component", "wheels.Public").$init();
+					var ordinary = [
+						"csrfStore",
+						"csrfCookieName",
+						"environment",
+						"csrfCookieSecure",
+						"dataSourceName",
+						"urlRewriting"
+					];
+					for (var settingName in ordinary) {
+						expect(publicCfc.$isProtectedSetting(settingName)).toBeFalse(
+							"Expected `#settingName#` NOT to be treated as a protected setting."
+						);
+					}
+				});
+
+				it("does not flag accessControlAllowCredentials (CORS boolean flag, not a credential value)", () => {
+					var publicCfc = createObject("component", "wheels.Public").$init();
+					expect(publicCfc.$isProtectedSetting("accessControlAllowCredentials")).toBeFalse(
+						"accessControlAllowCredentials mirrors the Access-Control-Allow-Credentials response "
+						& "header. Redacting it would garble the HTML CORS table and silently drop the key from "
+						& "the JSON branch, breaking consumers that read it."
+					);
+				});
+
+			});
+
+			describe("$settingDisplayValue()", () => {
+
+				// Shared struct (not a bare local) so the beforeEach/afterEach
+				// closures reliably mutate the same state on every engine.
+				var keyState = {existed = false, priorValue = ""};
+
+				beforeEach(() => {
+					keyState.existed = StructKeyExists(application.wheels, "csrfCookieEncryptionSecretKey");
+					if (keyState.existed) {
+						keyState.priorValue = application.wheels.csrfCookieEncryptionSecretKey;
+					}
+					application.wheels.csrfCookieEncryptionSecretKey = "sUpErSeCrEtTeStKeY123";
+				});
+
+				afterEach(() => {
+					if (keyState.existed) {
+						application.wheels.csrfCookieEncryptionSecretKey = keyState.priorValue;
+					} else {
+						StructDelete(application.wheels, "csrfCookieEncryptionSecretKey");
+					}
+				});
+
+				it("redacts the CSRF cookie encryption secret key", () => {
+					var publicCfc = createObject("component", "wheels.Public").$init();
+					var rendered = publicCfc.$settingDisplayValue("csrfCookieEncryptionSecretKey");
+					expect(Find("redacted", rendered) > 0).toBeTrue(
+						"Expected the rendered value for csrfCookieEncryptionSecretKey to be redacted."
+					);
+					expect(Find("sUpErSeCrEtTeStKeY123", rendered)).toBe(
+						0,
+						"The secret value must never reach the /wheels/info output buffer."
+					);
+				});
+
+				it("redacts protected settings without reading them, so an unset key cannot throw", () => {
+					var publicCfc = createObject("component", "wheels.Public").$init();
+					var rendered = publicCfc.$settingDisplayValue("someNonExistentApiKey");
+					expect(Find("redacted", rendered) > 0).toBeTrue(
+						"Protected settings must short-circuit to the redacted marker before any get() lookup."
+					);
+				});
+
+				it("renders ordinary settings through the standard formatter", () => {
+					var publicCfc = createObject("component", "wheels.Public").$init();
+					var rendered = publicCfc.$settingDisplayValue("environment");
+					expect(rendered).toBe(application.wheels.environment);
+				});
+
+			});
+
+			describe("Source coverage: HTML and JSON branches share the predicate", () => {
+
+				it("helpers.cfm outputSetting() renders via $settingDisplayValue()", () => {
+					var source = FileRead(ExpandPath("/wheels/public/helpers.cfm"));
+					expect(Find("$settingDisplayValue(arguments.setting", source) > 0).toBeTrue(
+						"outputSetting() must render each row through $settingDisplayValue() so secret-shaped "
+						& "settings are redacted on the HTML /wheels/info page."
+					);
+					expect(Find("formatSettingOutput(get(", source)).toBe(
+						0,
+						"outputSetting() must not call formatSettingOutput(get(...)) directly — that bypasses "
+						& "secret redaction."
+					);
+				});
+
+				it("info.cfm JSON branch uses $isProtectedSetting() instead of a hardcoded key compare", () => {
+					var source = FileRead(ExpandPath("/wheels/public/views/info.cfm"));
+					expect(Find("$isProtectedSetting", source) > 0).toBeTrue(
+						"The JSON branch of info.cfm must filter settings through the shared "
+						& "$isProtectedSetting() predicate."
+					);
+					expect(Find('!= "csrfCookieEncryptionSecretKey"', source)).toBe(
+						0,
+						"The hardcoded csrfCookieEncryptionSecretKey compare must be replaced by the shared "
+						& "predicate so the HTML and JSON branches cannot drift."
+					);
+				});
+
+			});
+
+		});
+
+	}
+
+}


### PR DESCRIPTION
## Summary

The HTML branch of the `/wheels/info` debug page rendered `csrfCookieEncryptionSecretKey` in plaintext: `vendor/wheels/public/views/info.cfm:366` renders `#outputSetting(csrf)#` over the CSRF settings array (which includes the key), and `outputSetting()` in `vendor/wheels/public/helpers.cfm:88-98` emitted the raw value via `formatSettingOutput(get(...))`. The JSON branch already redacted that one key via a hardcoded name compare at `info.cfm:195`, so the two branches had drifted and the HTML page leaked the live CSRF cookie encryption key. With `csrfStore="cookie"` that AES key signs the authenticity token (`vendor/wheels/controller/csrf.cfc`), so anyone who can view `/wheels/info` could forge valid CSRF cookies.

## Source

Internal multi-agent framework review, 2026-06-09, finding T3 (info-secret-redaction) — canonical writeup: Security Top 10 #3 / S1 ("CSRF cookie encryption secret rendered in plaintext on the HTML `/wheels/info` page"), also tracked as public-ui P4.

## Fix

Single source of truth on `wheels.Public`:

- `$isProtectedSetting(settingName)` — true for secret-shaped names matching `(secret|password|passphrase|privatekey|apikey|credential|token)`, with an explicit `allowcredentials$` exemption: `accessControlAllowCredentials` is the boolean CORS flag mirroring `Access-Control-Allow-Credentials`, not a credential value. It is the only other rendered setting name matching the regex, so JSON output stays byte-identical today while HTML changes exactly the one secret row.
- `$settingDisplayValue(settingName)` — returns `<em>[redacted]</em>` for protected names WITHOUT calling `get()` (an unset key cannot throw); otherwise renders through `formatSettingOutput(get(...))` as before.

`outputSetting()` now routes every HTML settings row (environment, paths, components, csrf, cors, settings tabs) through `$settingDisplayValue()`, and the JSON branch replaces the hardcoded `csrfCookieEncryptionSecretKey` compare with `!$isProtectedSetting()` on all six collection loops, so future secret-shaped settings are omitted uniformly.

Deliberately deferred (out of scope for T3):
- Production reachability of `/wheels/*` GUI pages (`$blockInProduction`) is a separate review finding; this change only fixes what leaks when the page is reachable.
- The JSON branch still serializes the full `getApplicationMetadata()` under `application.metadata` — pre-existing and orthogonal; flagged by the reviewer as a candidate for its own finding.

## Tests

Added `vendor/wheels/tests/specs/security/InfoSecretRedactionSpec.cfc` (WheelsTest BDD, modeled on `PublicComponentProductionSpec`): unit coverage of `$isProtectedSetting()` (secret-shaped names true, ordinary names false, `accessControlAllowCredentials` exempt) and `$settingDisplayValue()` (redacts without reading the value, passes ordinary settings through), plus source-inspection assertions that `helpers.cfm` renders via `$settingDisplayValue` and `info.cfm`'s JSON branch uses `!$isProtectedSetting`. Verified red on pre-fix code (0 pass / 2 fail / 7 error — the two new methods don't exist and the source pins don't match) and green post-fix (9 pass) on Lucee 7 + SQLite via the worktree docker recipe. Full engine x DB matrix runs in per-PR CI.

## Cross-engine notes

- Both new methods are `public` with a `$` prefix (mixin/internal invariant; `private` would not integrate).
- No closures, no `catch`-scoped locals, no `Left(str, 0)`, no reserved-scope parameter names, no `attributeCollection` usage.
- The regex uses a trailing-anchor exemption (`allowcredentials$`) instead of a lookbehind, which is safe on Adobe's ORO regex engine.
- The unqualified `$settingDisplayValue()` call inside the included `outputSetting()` UDF resolves through the Public component's `variables` scope — the same mechanism the pre-existing `get()` call already relied on. `helpers.cfm`'s double-include into non-Public contexts (tests/`html.cfm` via `_header.cfm`) is safe because `outputSetting()`'s only call site is `info.cfm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
