### PR TITLE
fix(model): key association JOIN memo by soft-delete and alias context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 
 ----
 
+## [Unreleased]
+
+### Fixed
+
+- `$expandedAssociations()` no longer poisons the shared application-scoped association struct with the first caller's JOIN context, so subsequent callers see the JOIN built for their own context instead of the one cached on first hit. Two related bugs are fixed in the same memo: (1) when an `include` that passed `includeSoftDeletes=true` ran first, the built JOIN string (without the `IS NULL` soft-delete predicate) was reused for every later default-context call, silently dropping the soft-delete filter and returning soft-deleted rows; (2) when a nested self-referential `include` with an alias ran first, the aliased JOIN was reused at the top level (and vice versa), producing the wrong table/alias on later includes of the same association. The memo is now keyed per context variant (soft-delete flag + alias flag, written `sd0_alias0` / `sd1_alias0` / etc. with a `1/0` ternary so the key stays engine-stable across Adobe CF's `YES`/`NO` boolean stringification), and the memo write happens under a double-checked named lock taken only on memo miss so the steady-state hot path stays lock-free. Callers receive a per-call shallow copy carrying the context-correct join, immune to concurrent re-memoization of other variants. **Plugin-compatibility note:** the legacy `join` key is no longer written to the shared `$classData().associations[name]` struct (no framework reader exists outside the returned arrays); any community plugin reading that key directly will find it absent and should read the join off the returned association entries instead (#2910)
+
+----
+
 # [4.0.3](https://github.com/wheels-dev/wheels/releases/tag/v4.0.3) => 2026-06-09
 
 > **Wheels 4.0.3** — third patch on the 4.0 line. Completes the CLI argument-parsing overhaul (`ArgSpec` consumes LuCLI's structured arguments in every command — `--no-*` negations and named-only flags now reach their parsers, and user-error paths exit non-zero) and lands the fixes from a full 24-command CLI audit; write-side commands (`migrate`, `seed`, `reload`, `generate admin`) now refuse to attach to a sibling project's server instead of running against the wrong database; PostgreSQL/CockroachDB foreign-key migrations and pre-23c Oracle `DROP TABLE`/`DROP VIEW` work again; framework helpers can no longer be invoked as controller actions from a URL; auto-derived model properties preserve database column casing; and scaffolded apps keep their reload password out of source control (`WHEELS_RELOAD_PASSWORD` in `.env`). ~45 PRs since the 4.0.2 GA (2026-05-27).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,6 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 
 ----
 
-## [Unreleased]
-
-### Fixed
-
-- `$expandedAssociations()` no longer poisons the shared application-scoped association struct with the first caller's JOIN context, so subsequent callers see the JOIN built for their own context instead of the one cached on first hit. Two related bugs are fixed in the same memo: (1) when an `include` that passed `includeSoftDeletes=true` ran first, the built JOIN string (without the `IS NULL` soft-delete predicate) was reused for every later default-context call, silently dropping the soft-delete filter and returning soft-deleted rows; (2) when a nested self-referential `include` with an alias ran first, the aliased JOIN was reused at the top level (and vice versa), producing the wrong table/alias on later includes of the same association. The memo is now keyed per context variant (soft-delete flag + alias flag, written `sd0_alias0` / `sd1_alias0` / etc. with a `1/0` ternary so the key stays engine-stable across Adobe CF's `YES`/`NO` boolean stringification), and the memo write happens under a double-checked named lock taken only on memo miss so the steady-state hot path stays lock-free. Callers receive a per-call shallow copy carrying the context-correct join, immune to concurrent re-memoization of other variants. **Plugin-compatibility note:** the legacy `join` key is no longer written to the shared `$classData().associations[name]` struct (no framework reader exists outside the returned arrays); any community plugin reading that key directly will find it absent and should read the join off the returned association entries instead (#2910)
-
-----
-
 # [4.0.3](https://github.com/wheels-dev/wheels/releases/tag/v4.0.3) => 2026-06-09
 
 > **Wheels 4.0.3** — third patch on the 4.0 line. Completes the CLI argument-parsing overhaul (`ArgSpec` consumes LuCLI's structured arguments in every command — `--no-*` negations and named-only flags now reach their parsers, and user-error paths exit non-zero) and lands the fixes from a full 24-command CLI audit; write-side commands (`migrate`, `seed`, `reload`, `generate admin`) now refuse to attach to a sibling project's server instead of running against the wrong database; PostgreSQL/CockroachDB foreign-key migrations and pre-23c Oracle `DROP TABLE`/`DROP VIEW` work again; framework helpers can no longer be invoked as controller actions from a URL; auto-derived model properties preserve database column casing; and scaffolded apps keep their reload password out of source control (`WHEELS_RELOAD_PASSWORD` in `.env`). ~45 PRs since the 4.0.2 GA (2026-05-27).

--- a/vendor/wheels/model/sql.cfc
+++ b/vendor/wheels/model/sql.cfc
@@ -1214,12 +1214,20 @@ component {
 			local.classAssociations[local.name].columnStruct = local.associatedClass.$classData().columnStruct;
 			local.classAssociations[local.name].propertyStruct = local.associatedClass.$classData().propertyStruct;
 
-			// create the join string if it hasn't already been done
-			if (!StructKeyExists(local.classAssociations[local.name], "join")) {
+			// the JOIN string depends on the calling context (soft-delete handling and whether the
+			// table needs to be aliased), so memoize it per context variant instead of globally
+			local.aliasJoin = ListFindNoCase(local.tables, local.classAssociations[local.name].tableName) > 0;
+			local.joinVariantKey = "sd" & (arguments.includeSoftDeletes ? 1 : 0) & "_alias" & (local.aliasJoin ? 1 : 0);
+
+			// create the join string if it hasn't already been done for this context variant
+			if (
+				!StructKeyExists(local.classAssociations[local.name], "joinVariants")
+				|| !StructKeyExists(local.classAssociations[local.name].joinVariants, local.joinVariantKey)
+			) {
 				local.joinType = UCase(ReplaceNoCase(local.classAssociations[local.name].joinType, "outer", "left outer", "one"));
 				local.join = local.joinType & " JOIN " & variables.wheels.class.adapter.$quoteIdentifier(local.classAssociations[local.name].tableName);
 				// alias the table as the association name when joining to itself
-				if (ListFindNoCase(local.tables, local.classAssociations[local.name].tableName)) {
+				if (local.aliasJoin) {
 					local.join = variables.wheels.class.adapter.$tableAlias(
 						local.join,
 						local.classAssociations[local.name].pluralizedName
@@ -1253,9 +1261,8 @@ component {
 
 					// alias the table as the association name when joining to itself
 					local.tableName = local.classAssociations[local.name].tableName;
-					if (ListFindNoCase(local.tables, local.classAssociations[local.name].tableName)) {
+					if (local.aliasJoin) {
 						local.tableName = local.classAssociations[local.name].pluralizedName;
-						;
 					}
 					local.toAppend = ListAppend(
 						local.toAppend,
@@ -1283,7 +1290,20 @@ component {
 					);
 				}
 
-				local.classAssociations[local.name].join = local.join & Replace(local.toAppend, ",", " AND ", "all");
+				// store the built string under a double-checked named lock so a concurrent first hit
+				// for another context cannot poison the shared application-scoped association struct;
+				// the lock is only taken on memo miss so the hot path stays lock-free
+				lock name="wheelsJoinMemo#application.applicationName#" type="exclusive" timeout="10" {
+					if (!StructKeyExists(local.classAssociations[local.name], "joinVariants")) {
+						local.classAssociations[local.name].joinVariants = {};
+					}
+					local.classAssociations[local.name].joinVariants[local.joinVariantKey] = local.join & Replace(
+						local.toAppend,
+						",",
+						" AND ",
+						"all"
+					);
+				}
 			}
 
 			// loop over each character in the delimiter sequence and move up / down the levels as appropriate
@@ -1300,8 +1320,12 @@ component {
 			// add table name to the list of used ones so we know to alias it when used a second time
 			local.tables = ListAppend(local.tables, local.classAssociations[local.name].tableName);
 
-			// add info to the array that we will return
-			ArrayAppend(local.rv, local.classAssociations[local.name]);
+			// add info to the array that we will return; use a per-call shallow copy carrying the
+			// context-correct join so callers are immune to concurrent re-memoization of other variants
+			local.entry = StructCopy(local.classAssociations[local.name]);
+			local.entry.join = local.classAssociations[local.name].joinVariants[local.joinVariantKey];
+			StructDelete(local.entry, "joinVariants");
+			ArrayAppend(local.rv, local.entry);
 		}
 		return local.rv;
 	}

--- a/vendor/wheels/tests/specs/model/ExpandedAssociationsJoinMemoSpec.cfc
+++ b/vendor/wheels/tests/specs/model/ExpandedAssociationsJoinMemoSpec.cfc
@@ -1,0 +1,85 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+		g = application.wo;
+
+		describe("$expandedAssociations JOIN memoization", () => {
+			beforeEach(() => {
+				$resetJoinMemo("author", "posts");
+				$resetJoinMemo("post", "author");
+			});
+
+			afterEach(() => {
+				$resetJoinMemo("author", "posts");
+				$resetJoinMemo("post", "author");
+			});
+
+			it("does not serve a soft-delete-free join to a default call (true then false)", () => {
+				var withDeleted = g.model("author").$expandedAssociations(include = "posts", includeSoftDeletes = true);
+				expect(withDeleted[1].join).notToInclude("IS NULL");
+
+				var withoutDeleted = g.model("author").$expandedAssociations(
+					include = "posts",
+					includeSoftDeletes = false
+				);
+				expect(withoutDeleted[1].join).toInclude("deletedat");
+				expect(withoutDeleted[1].join).toInclude("IS NULL");
+			});
+
+			it("does not serve a soft-delete-filtered join to an includeSoftDeletes call (false then true)", () => {
+				var withoutDeleted = g.model("author").$expandedAssociations(include = "posts");
+				expect(withoutDeleted[1].join).toInclude("IS NULL");
+
+				var withDeleted = g.model("author").$expandedAssociations(include = "posts", includeSoftDeletes = true);
+				expect(withDeleted[1].join).notToInclude("IS NULL");
+			});
+
+			it("does not serve an aliased self-join to a top-level include", () => {
+				// In the nested context c_o_r_e_posts is already in the table list (it is the root
+				// model's table), so the posts join must be aliased as the pluralized association name.
+				var nested = g.model("post").$expandedAssociations(include = "author(posts)");
+				var aliasedFragment = $aliasedPostsFragment();
+				expect(nested[2].join).toInclude(aliasedFragment);
+
+				// In the top-level context there is no table collision, so no alias must be present.
+				var topLevel = g.model("author").$expandedAssociations(include = "posts");
+				expect(topLevel[1].join).notToInclude(aliasedFragment);
+				expect(topLevel[1].join).notToBe(nested[2].join);
+			});
+
+			it("still memoizes the join string per context variant", () => {
+				var first = g.model("author").$expandedAssociations(include = "posts", includeSoftDeletes = false);
+				var second = g.model("author").$expandedAssociations(include = "posts", includeSoftDeletes = false);
+				expect(second[1].join).toBe(first[1].join);
+
+				var assoc = g.model("author").$classData().associations["posts"];
+				expect(StructKeyExists(assoc, "joinVariants")).toBeTrue();
+				expect(StructCount(assoc.joinVariants)).toBe(1);
+				expect(StructKeyExists(assoc.joinVariants, "sd0_alias0")).toBeTrue();
+			});
+		});
+	}
+
+	/**
+	 * Deletes both the legacy `join` memo key and the variant-aware `joinVariants` memo key from the
+	 * shared application-scoped association struct so each case starts clean and never leaks a
+	 * poisoned memo into other specs.
+	 */
+	private void function $resetJoinMemo(required string modelName, required string association) {
+		var associations = application.wo.model(arguments.modelName).$classData().associations;
+		if (StructKeyExists(associations, arguments.association)) {
+			StructDelete(associations[arguments.association], "join");
+			StructDelete(associations[arguments.association], "joinVariants");
+		}
+	}
+
+	/**
+	 * Builds the alias fragment exactly the way $expandedAssociations does (adapter-specific, e.g.
+	 * Oracle uses a space instead of " AS ") so the assertions hold on every database.
+	 */
+	private string function $aliasedPostsFragment() {
+		var adapter = application.wo.model("post").getClass().adapter;
+		return adapter.$tableAlias(adapter.$quoteIdentifier("c_o_r_e_posts"), "posts");
+	}
+
+}


### PR DESCRIPTION
## Summary

`$expandedAssociations()` in `vendor/wheels/model/sql.cfc` (memo site at ~lines 1221-1303) memoized the built association `JOIN` string onto the shared, application-scoped association struct keyed only on existence — so the first caller's context won permanently for the lifetime of the app:

- A join built with `includeSoftDeletes=true` was later served to default calls, **dropping the soft-delete `IS NULL` predicate** (soft-deleted rows silently leak into results).
- An aliased self-join built in a nested-include context was served to top-level includes (and vice versa), producing wrong table references.
- The unlocked write also raced across concurrent first hits.

## Source

Internal multi-agent framework review, 2026-06-09 — finding **H4** (join-memo-poisoning).

## Fix

- Memoize per context variant: a `joinVariants` struct keyed by soft-delete flag + alias flag (`sd{0|1}_alias{0|1}`, `1/0` ternary so keys stay engine-stable on Adobe CF). These two flags are the only per-call inputs to the join build; all other inputs are stable per association struct per app lifecycle.
- Write the memo under a named exclusive lock (`wheelsJoinMemo#application.applicationName#`, matching the framework's established lock-name convention) taken only on memo miss, with an in-lock container-existence re-check to prevent the lost-update race between concurrent first hits for different variants. Steady-state reads stay lock-free, preserving the perf benefit.
- Return per-call shallow copies carrying the context-correct `join` (with `joinVariants` stripped), so callers can never hold a reference that another request re-poisons. Every returned element always carries a `join` key, preserving the existing `StructKeyExists` guards on the `$whereClause` UPDATE paths.
- Stop writing the legacy shared `join` key — no framework reader of `$classData().associations[x].join` exists outside the returned arrays (grepped across `vendor/wheels`, `cli`, `app`, and all test suites). Theoretical third-party-plugin readers of that key are the only behavior change.

**Deliberately deferred:** the context-independent metadata fill-ins above the memo (`foreignKey`/`joinKey`/`tableName`/etc., sql.cfc ~1183-1216) still write to the shared struct unlocked — those writes are idempotent and benign, and are left for a follow-up.

## Tests

New spec `vendor/wheels/tests/specs/model/ExpandedAssociationsJoinMemoSpec.cfc` (WheelsTest BDD) pins all four poisoning mechanisms:

1. `includeSoftDeletes=true` first, then default — default must keep the `deletedat IS NULL` predicate.
2. Default first, then `includeSoftDeletes=true` — the soft-delete variant must drop it.
3. Nested-alias context first, then top-level — top-level must not inherit the alias.
4. Memoization retained — repeat call serves the per-variant memo (perf-preservation contract).

Verified locally (Lucee 7 + SQLite): all four cases **fail against the pre-fix code** and pass post-fix; full model area at 848 pass / 0 fail / 0 error. Per-PR CI runs the full engine × DB compat matrix.

## Cross-engine notes

- Memo keys use a `1/0` ternary instead of boolean string interpolation, avoiding Adobe CF's `YES`/`NO` boolean stringification.
- cfscript `lock` with attributes matches existing framework usage (`Global.cfc`).
- The spec derives the alias fragment from the live adapter's `$tableAlias`/`$quoteIdentifier`, so assertions hold on Oracle (space vs `" AS "`); `toInclude` in the vendored TestBox is case-insensitive.
- No inline-closure constructor args, no catch-local persistence assumptions, no reserved-scope parameter names, no `attributeCollection`, no `Left(str, 0)` introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
