### PR TITLE
fix(config): isolate ServiceProvider register/boot failures per package

### DIFF
--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -3120,41 +3120,6 @@ return local.$wheels;
 		application[local.appKey].packageMeta = application[local.appKey].PackageLoaderObj.getPackageMeta();
 		application[local.appKey].failedPackages = application[local.appKey].PackageLoaderObj.getFailedPackages();
 
-		// Surface an aggregate summary when any packages failed to load. Without
-		// this, PackageLoader records each failure in variables.failedPackages and
-		// emits per-package WriteLog calls — but a developer who hits a downstream
-		// "No matching function [BASECOATINCLUDES]" error has no obvious place to
-		// look. Logging a single high-visibility WARN to wheels.log + a stronger
-		// one to wheels-errors.log gives a clear breadcrumb back to the root cause.
-		if (ArrayLen(application[local.appKey].failedPackages)) {
-			local.failNames = "";
-			local.failDetail = "";
-			for (local.fp in application[local.appKey].failedPackages) {
-				local.failNames = ListAppend(local.failNames, local.fp.name);
-				local.failDetail &= "  - " & local.fp.name & ": " & local.fp.error & Chr(10);
-			}
-			try {
-				writeLog(
-					file = "wheels",
-					type = "warning",
-					text = "Wheels: " & ArrayLen(application[local.appKey].failedPackages)
-						& " package(s) failed to load: " & local.failNames
-						& ". Helpers / services these packages provide will be unavailable —"
-						& " calling code typically surfaces this as 'No matching function [...]"
-						& "' or 'No service registered with the name [...]'."
-						& " Per-package detail in wheels-errors.log."
-				);
-				writeLog(
-					file = "wheels-errors",
-					type = "error",
-					text = "Wheels: " & ArrayLen(application[local.appKey].failedPackages)
-						& " package(s) failed to load:" & Chr(10) & local.failDetail
-				);
-			} catch (any e) {
-				// Logging is best-effort during application start.
-			}
-		}
-
 		// Ensure mixinCollisions exists (unset when no plugins loaded before packages)
 		if (!StructKeyExists(application[local.appKey], "mixinCollisions")) {
 			application[local.appKey].mixinCollisions = [];
@@ -3220,6 +3185,50 @@ return local.$wheels;
 		if (IsDefined("application.wheelsdi") && ArrayLen(application[local.appKey].PackageLoaderObj.getServiceProviders())) {
 			application[local.appKey].PackageLoaderObj.$invokeServiceProviderRegister(application.wheelsdi);
 			application[local.appKey].PackageLoaderObj.$invokeServiceProviderBoot(application[local.appKey]);
+			// Re-sync the application-scope copy so register()/boot() failure
+			// records are visible there too. Adobe CF copies arrays by value on
+			// assignment, so the copy taken above (pre-invoke) never receives
+			// lifecycle-phase entries on those engines — only Lucee/BoxLang share
+			// the reference. Re-assigning is harmless on Lucee/BoxLang (same
+			// reference) and required on Adobe (fresh copy including new entries).
+			application[local.appKey].failedPackages = application[local.appKey].PackageLoaderObj.getFailedPackages();
+		}
+
+		// Surface an aggregate summary when any packages failed to load. Without
+		// this, PackageLoader records each failure in variables.failedPackages and
+		// emits per-package WriteLog calls — but a developer who hits a downstream
+		// "No matching function [BASECOATINCLUDES]" error has no obvious place to
+		// look. Logging a single high-visibility WARN to wheels.log + a stronger
+		// one to wheels-errors.log gives a clear breadcrumb back to the root cause.
+		// Runs after the ServiceProvider lifecycle invoke so register()/boot()
+		// failures appear in the same summary as load-phase failures.
+		if (ArrayLen(application[local.appKey].failedPackages)) {
+			local.failNames = "";
+			local.failDetail = "";
+			for (local.fp in application[local.appKey].failedPackages) {
+				local.failNames = ListAppend(local.failNames, local.fp.name);
+				local.failDetail &= "  - " & local.fp.name & ": " & local.fp.error & Chr(10);
+			}
+			try {
+				writeLog(
+					file = "wheels",
+					type = "warning",
+					text = "Wheels: " & ArrayLen(application[local.appKey].failedPackages)
+						& " package(s) failed to load: " & local.failNames
+						& ". Helpers / services these packages provide will be unavailable —"
+						& " calling code typically surfaces this as 'No matching function [...]"
+						& "' or 'No service registered with the name [...]'."
+						& " Per-package detail in wheels-errors.log."
+				);
+				writeLog(
+					file = "wheels-errors",
+					type = "error",
+					text = "Wheels: " & ArrayLen(application[local.appKey].failedPackages)
+						& " package(s) failed to load:" & Chr(10) & local.failDetail
+				);
+			} catch (any e) {
+				// Logging is best-effort during application start.
+			}
 		}
 	}
 

--- a/vendor/wheels/PackageLoader.cfc
+++ b/vendor/wheels/PackageLoader.cfc
@@ -851,19 +851,69 @@ component output="false" {
 	/**
 	 * Invokes register(container) on all packages that implement ServiceProviderInterface.
 	 * Also triggers instantiation of lazy ServiceProvider packages.
+	 *
+	 * Each provider is invoked with the same per-package error isolation the
+	 * loader applies everywhere else: a throwing register() is logged, recorded
+	 * in failedPackages, and rolled back via $rollbackPackage — which also
+	 * removes the key from variables.serviceProviders so the boot phase skips
+	 * it — and the remaining providers still run. Mixins/middleware this
+	 * package contributed are unwound from the loader registries by the
+	 * rollback, but copies already merged into the application scope by
+	 * Global.cfc::$loadPackages are intentionally NOT unwound here: that merge
+	 * happens before this lifecycle invoke.
 	 */
 	public void function $invokeServiceProviderRegister(required any container) {
-		for (local.pkgKey in variables.serviceProviders) {
-			variables.packages[local.pkgKey].register(arguments.container);
+		// Iterate a snapshot: $rollbackPackage deletes from
+		// variables.serviceProviders, and mutating the array mid-iteration
+		// would skip the provider after a failing one.
+		local.providerKeys = Duplicate(variables.serviceProviders);
+		for (local.pkgKey in local.providerKeys) {
+			try {
+				variables.packages[local.pkgKey].register(arguments.container);
+			} catch (any e) {
+				WriteLog(
+					text = "[Wheels] Package '#local.pkgKey#' ServiceProvider register() failed: #e.message#",
+					type = "error",
+					file = "wheels"
+				);
+				ArrayAppend(variables.failedPackages, {
+					name = local.pkgKey,
+					error = "ServiceProvider register() failed: " & e.message,
+					detail = StructKeyExists(e, "detail") ? e.detail : ""
+				});
+				$rollbackPackage(local.pkgKey);
+			}
 		}
 	}
 
 	/**
 	 * Invokes boot(app) on all packages that implement ServiceProviderInterface.
+	 *
+	 * Same per-provider isolation as $invokeServiceProviderRegister: a throwing
+	 * boot() is logged, recorded in failedPackages, and rolled back so the
+	 * remaining providers still boot. Services the failing provider already
+	 * registered in the DI container during register() cannot be unwound — the
+	 * Injector has no per-package tracking.
 	 */
 	public void function $invokeServiceProviderBoot(required struct app) {
-		for (local.pkgKey in variables.serviceProviders) {
-			variables.packages[local.pkgKey].boot(arguments.app);
+		// Iterate a snapshot: $rollbackPackage deletes from variables.serviceProviders.
+		local.providerKeys = Duplicate(variables.serviceProviders);
+		for (local.pkgKey in local.providerKeys) {
+			try {
+				variables.packages[local.pkgKey].boot(arguments.app);
+			} catch (any e) {
+				WriteLog(
+					text = "[Wheels] Package '#local.pkgKey#' ServiceProvider boot() failed: #e.message#",
+					type = "error",
+					file = "wheels"
+				);
+				ArrayAppend(variables.failedPackages, {
+					name = local.pkgKey,
+					error = "ServiceProvider boot() failed: " & e.message,
+					detail = StructKeyExists(e, "detail") ? e.detail : ""
+				});
+				$rollbackPackage(local.pkgKey);
+			}
 		}
 	}
 

--- a/vendor/wheels/Plugins.cfc
+++ b/vendor/wheels/Plugins.cfc
@@ -510,11 +510,28 @@ component output="false" extends="wheels.Global"{
 	 * Invokes register(container) on all plugins that implement ServiceProviderInterface.
 	 * Called after all plugins are loaded, passing the DI Injector so plugins can register services.
 	 *
+	 * A throwing register() is logged and the plugin is dropped from the
+	 * ServiceProvider registry (so the boot phase skips it too) — the
+	 * remaining providers still run instead of the whole boot aborting.
+	 *
 	 * @container The Wheels DI container (Injector instance)
 	 */
 	public void function $invokeServiceProviderRegister(required any container) {
-		for (local.pluginKey in variables.$class.serviceProviders) {
-			variables.$class.plugins[local.pluginKey].register(arguments.container);
+		// Iterate a snapshot: a failing provider is removed from
+		// variables.$class.serviceProviders below, and mutating the array
+		// mid-iteration would skip the provider after a failing one.
+		local.providerKeys = Duplicate(variables.$class.serviceProviders);
+		for (local.pluginKey in local.providerKeys) {
+			try {
+				variables.$class.plugins[local.pluginKey].register(arguments.container);
+			} catch (any e) {
+				WriteLog(
+					text = "[Wheels] Plugin '#local.pluginKey#' ServiceProvider register() failed: #e.message#",
+					type = "error",
+					file = "wheels"
+				);
+				$dropServiceProvider(local.pluginKey);
+			}
 		}
 	}
 
@@ -523,11 +540,41 @@ component output="false" extends="wheels.Global"{
 	 * Called after ALL register() methods have completed and user services.cfm has been loaded,
 	 * so plugins can safely resolve services from the container.
 	 *
+	 * Same per-plugin isolation as $invokeServiceProviderRegister: a throwing
+	 * boot() is logged and the plugin is dropped from the registry while the
+	 * remaining providers still boot.
+	 *
 	 * @app The Wheels application configuration struct (application.wheels or application.$wheels during init)
 	 */
 	public void function $invokeServiceProviderBoot(required struct app) {
-		for (local.pluginKey in variables.$class.serviceProviders) {
-			variables.$class.plugins[local.pluginKey].boot(arguments.app);
+		// Iterate a snapshot: a failing provider is removed mid-loop below.
+		local.providerKeys = Duplicate(variables.$class.serviceProviders);
+		for (local.pluginKey in local.providerKeys) {
+			try {
+				variables.$class.plugins[local.pluginKey].boot(arguments.app);
+			} catch (any e) {
+				WriteLog(
+					text = "[Wheels] Plugin '#local.pluginKey#' ServiceProvider boot() failed: #e.message#",
+					type = "error",
+					file = "wheels"
+				);
+				$dropServiceProvider(local.pluginKey);
+			}
+		}
+	}
+
+	/**
+	 * Removes a plugin key from the ServiceProvider registry. Called when a
+	 * provider's register()/boot() throws so the remaining lifecycle phases
+	 * skip it. Log-and-skip only: the legacy plugin system has no
+	 * failedPackages registry or rollback machinery to mirror.
+	 *
+	 * @pluginKey The plugin folder key as stored in the registry
+	 */
+	private void function $dropServiceProvider(required string pluginKey) {
+		local.idx = ArrayFind(variables.$class.serviceProviders, arguments.pluginKey);
+		if (local.idx > 0) {
+			ArrayDeleteAt(variables.$class.serviceProviders, local.idx);
 		}
 	}
 

--- a/vendor/wheels/tests/_assets/packages_sp/failboot/Failboot.cfc
+++ b/vendor/wheels/tests/_assets/packages_sp/failboot/Failboot.cfc
@@ -1,0 +1,23 @@
+/**
+ * Test fixture: ServiceProvider package whose register() succeeds but boot()
+ * always throws. Used by ServiceProviderIsolationSpec to prove a boot-phase
+ * failure is logged, recorded in failedPackages, and skipped without aborting
+ * the boot of sibling providers.
+ */
+component implements="wheels.ServiceProviderInterface" {
+
+	public any function init() {
+		this.version = "1.0.0";
+		this.registerCalled = false;
+		return this;
+	}
+
+	public void function register(required any container) {
+		this.registerCalled = true;
+	}
+
+	public void function boot(required struct app) {
+		Throw(type = "Tests.SPBootBoom", message = "boot() failure fixture");
+	}
+
+}

--- a/vendor/wheels/tests/_assets/packages_sp/failboot/package.json
+++ b/vendor/wheels/tests/_assets/packages_sp/failboot/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "wheels-failboot",
+	"version": "1.0.0",
+	"description": "Test fixture: ServiceProvider whose boot() throws — exercises per-provider isolation in the boot phase.",
+	"provides": {
+		"mixins": "none"
+	}
+}

--- a/vendor/wheels/tests/_assets/packages_sp/failregister/Failregister.cfc
+++ b/vendor/wheels/tests/_assets/packages_sp/failregister/Failregister.cfc
@@ -1,0 +1,23 @@
+/**
+ * Test fixture: ServiceProvider package whose register() always throws.
+ * Used by ServiceProviderIsolationSpec to prove a broken provider is logged,
+ * recorded in failedPackages, and skipped — without aborting the lifecycle
+ * for sibling providers. boot() sets a request flag so specs can assert the
+ * boot phase never reaches a provider whose register() failed.
+ */
+component implements="wheels.ServiceProviderInterface" {
+
+	public any function init() {
+		this.version = "1.0.0";
+		return this;
+	}
+
+	public void function register(required any container) {
+		Throw(type = "Tests.SPRegisterBoom", message = "register() failure fixture");
+	}
+
+	public void function boot(required struct app) {
+		request.$spFailregisterBootCalled = true;
+	}
+
+}

--- a/vendor/wheels/tests/_assets/packages_sp/failregister/package.json
+++ b/vendor/wheels/tests/_assets/packages_sp/failregister/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "wheels-failregister",
+	"version": "1.0.0",
+	"description": "Test fixture: ServiceProvider whose register() throws — exercises per-provider isolation.",
+	"provides": {
+		"mixins": "none"
+	}
+}

--- a/vendor/wheels/tests/_assets/packages_sp/goodsp/Goodsp.cfc
+++ b/vendor/wheels/tests/_assets/packages_sp/goodsp/Goodsp.cfc
@@ -1,0 +1,25 @@
+/**
+ * Test fixture: healthy ServiceProvider package. Records register()/boot()
+ * invocations so ServiceProviderIsolationSpec can assert the lifecycle still
+ * reaches it when a sibling provider throws.
+ */
+component implements="wheels.ServiceProviderInterface" {
+
+	public any function init() {
+		this.version = "1.0.0";
+		this.registerCalled = false;
+		this.bootCalled = false;
+		this.containerReceived = JavaCast("null", "");
+		return this;
+	}
+
+	public void function register(required any container) {
+		this.registerCalled = true;
+		this.containerReceived = arguments.container;
+	}
+
+	public void function boot(required struct app) {
+		this.bootCalled = true;
+	}
+
+}

--- a/vendor/wheels/tests/_assets/packages_sp/goodsp/package.json
+++ b/vendor/wheels/tests/_assets/packages_sp/goodsp/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "wheels-goodsp",
+	"version": "1.0.0",
+	"description": "Test fixture: healthy ServiceProvider — proves a broken sibling provider didn't abort the lifecycle.",
+	"provides": {
+		"mixins": "none"
+	}
+}

--- a/vendor/wheels/tests/_assets/plugins/serviceproviderfailing/FailingProvider/FailingProvider.cfc
+++ b/vendor/wheels/tests/_assets/plugins/serviceproviderfailing/FailingProvider/FailingProvider.cfc
@@ -1,0 +1,23 @@
+/**
+ * Test fixture: legacy plugin implementing ServiceProviderInterface whose
+ * register() always throws. Used by pluginsModernSpec to prove a broken
+ * provider is logged and skipped without aborting the lifecycle for sibling
+ * providers. boot() sets a request flag so specs can assert the boot phase
+ * never reaches a plugin whose register() failed.
+ */
+component implements="wheels.ServiceProviderInterface" {
+
+	function init() {
+		this.version = "3.0";
+		return this;
+	}
+
+	public void function register(required any container) {
+		Throw(type = "Tests.PluginSPRegisterBoom", message = "plugin register() failure fixture");
+	}
+
+	public void function boot(required struct app) {
+		request.$spPluginFailingBootCalled = true;
+	}
+
+}

--- a/vendor/wheels/tests/_assets/plugins/serviceproviderfailing/WorkingProvider/WorkingProvider.cfc
+++ b/vendor/wheels/tests/_assets/plugins/serviceproviderfailing/WorkingProvider/WorkingProvider.cfc
@@ -1,0 +1,23 @@
+/**
+ * Test fixture: healthy legacy plugin implementing ServiceProviderInterface.
+ * Sorted plugin order loads FailingProvider first, so this plugin proves the
+ * lifecycle continues past a throwing sibling provider.
+ */
+component implements="wheels.ServiceProviderInterface" {
+
+	function init() {
+		this.version = "3.0";
+		this.registerCalled = false;
+		this.bootCalled = false;
+		return this;
+	}
+
+	public void function register(required any container) {
+		this.registerCalled = true;
+	}
+
+	public void function boot(required struct app) {
+		this.bootCalled = true;
+	}
+
+}

--- a/vendor/wheels/tests/specs/packages/ServiceProviderIsolationSpec.cfc
+++ b/vendor/wheels/tests/specs/packages/ServiceProviderIsolationSpec.cfc
@@ -1,0 +1,107 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("ServiceProvider lifecycle isolation", () => {
+
+			beforeEach(() => {
+				spFixturesPath = ExpandPath("/wheels/tests/_assets/packages_sp");
+				spPrefix = "wheels.tests._assets.packages_sp";
+			});
+
+			it("isolates a register() failure and continues with remaining providers", () => {
+				var loader = new wheels.PackageLoader(
+					vendorPath = spFixturesPath,
+					componentPrefix = spPrefix
+				);
+				var fakeContainer = CreateObject(
+					"component",
+					"wheels.tests._assets.plugins.serviceprovider.FakeContainer"
+				).init();
+
+				// Must complete without throwing even though failregister's register() throws.
+				loader.$invokeServiceProviderRegister(fakeContainer);
+
+				// The healthy sibling provider still registered.
+				var pkgs = loader.getPackages();
+				expect(pkgs).toHaveKey("goodsp");
+				expect(pkgs.goodsp.registerCalled).toBeTrue();
+				expect(pkgs.goodsp.containerReceived).toBe(fakeContainer);
+
+				// The failure is recorded with the standard {name, error, detail} shape.
+				var failed = loader.getFailedPackages();
+				var foundFailure = false;
+				for (var f in failed) {
+					if (f.name == "failregister") {
+						foundFailure = true;
+						expect(f.error).toInclude("register()");
+						expect(f).toHaveKey("detail");
+					}
+				}
+				expect(foundFailure).toBeTrue();
+
+				// The failing provider is rolled back: dropped from both the
+				// service-provider registry and the loaded-packages map.
+				expect(ArrayFind(loader.getServiceProviders(), "failregister")).toBe(0);
+				expect(loader.getPackages()).notToHaveKey("failregister");
+			});
+
+			it("skips boot() for a provider whose register() failed", () => {
+				StructDelete(request, "$spFailregisterBootCalled");
+				var loader = new wheels.PackageLoader(
+					vendorPath = spFixturesPath,
+					componentPrefix = spPrefix
+				);
+				var fakeContainer = CreateObject(
+					"component",
+					"wheels.tests._assets.plugins.serviceprovider.FakeContainer"
+				).init();
+
+				loader.$invokeServiceProviderRegister(fakeContainer);
+				loader.$invokeServiceProviderBoot({});
+
+				// failregister was rolled back at register time, so its boot() never ran.
+				expect(StructKeyExists(request, "$spFailregisterBootCalled")).toBeFalse();
+				// The healthy provider still booted.
+				expect(loader.getPackages().goodsp.bootCalled).toBeTrue();
+			});
+
+			it("isolates a boot() failure and continues with remaining providers", () => {
+				var loader = new wheels.PackageLoader(
+					vendorPath = spFixturesPath,
+					componentPrefix = spPrefix
+				);
+				var fakeContainer = CreateObject(
+					"component",
+					"wheels.tests._assets.plugins.serviceprovider.FakeContainer"
+				).init();
+
+				loader.$invokeServiceProviderRegister(fakeContainer);
+
+				// Must complete without throwing even though failboot's boot() throws.
+				loader.$invokeServiceProviderBoot({});
+
+				var failed = loader.getFailedPackages();
+				var foundFailure = false;
+				for (var f in failed) {
+					if (f.name == "failboot") {
+						foundFailure = true;
+						expect(f.error).toInclude("boot()");
+						expect(f).toHaveKey("detail");
+					}
+				}
+				expect(foundFailure).toBeTrue();
+
+				// The healthy provider still booted (presence asserted, not order —
+				// ModuleGraph order for independent packages is not contractual).
+				expect(loader.getPackages().goodsp.bootCalled).toBeTrue();
+				// The boot-failing provider is rolled back from the registries.
+				expect(ArrayFind(loader.getServiceProviders(), "failboot")).toBe(0);
+				expect(loader.getPackages()).notToHaveKey("failboot");
+			});
+
+		});
+
+	}
+
+}

--- a/vendor/wheels/tests/specs/pluginsModernSpec.cfc
+++ b/vendor/wheels/tests/specs/pluginsModernSpec.cfc
@@ -419,6 +419,45 @@ component extends="wheels.WheelsTest" {
 
 				application.wheels.pluginComponentPath = originalPluginComponentPath
 			})
+
+			it("isolates a register() failure so remaining providers still register and boot", function() {
+				originalPluginComponentPath = application.wheels.pluginComponentPath
+				StructDelete(request, "$spPluginFailingBootCalled")
+
+				var config = {
+					path = "wheels",
+					fileName = "Plugins",
+					method = "$init",
+					pluginPath = "/wheels/tests/_assets/plugins/serviceproviderfailing",
+					deletePluginDirectories = false,
+					overwritePlugins = false,
+					loadIncompatiblePlugins = true
+				}
+				application.wheels.pluginComponentPath = "/wheels/tests/_assets/plugins/serviceproviderfailing"
+
+				PluginObj = $pluginObj(config)
+				var fakeContainer = CreateObject("component",
+					"wheels.tests._assets.plugins.serviceprovider.FakeContainer").init()
+
+				// Must complete without throwing even though FailingProvider's
+				// register() throws (sorted order loads FailingProvider first).
+				PluginObj.$invokeServiceProviderRegister(fakeContainer)
+
+				// The healthy provider after the failing one still registered.
+				var plugin = PluginObj.getPlugins().WorkingProvider
+				expect(plugin.registerCalled).toBeTrue()
+
+				// The failing provider is dropped from the registry so boot() skips it.
+				expect(ArrayFind(PluginObj.getServiceProviders(), "FailingProvider")).toBe(0)
+				expect(ArrayFind(PluginObj.getServiceProviders(), "WorkingProvider")).toBeGT(0)
+
+				PluginObj.$invokeServiceProviderBoot({environment = "testing"})
+
+				expect(plugin.bootCalled).toBeTrue()
+				expect(StructKeyExists(request, "$spPluginFailingBootCalled")).toBeFalse()
+
+				application.wheels.pluginComponentPath = originalPluginComponentPath
+			})
 		})
 
 		describe("Tests that plugin.json manifest parsing", function() {


### PR DESCRIPTION
## Summary

ServiceProvider `register()`/`boot()` ran with **no per-package error isolation** in `vendor/wheels/PackageLoader.cfc` (`$invokeServiceProviderRegister` / `$invokeServiceProviderBoot`, invoked from `vendor/wheels/Global.cfc::$loadPackages` at the lifecycle block around line 3184) — one throwing provider aborted the entire application boot. This contradicted the loader's documented per-package log-and-skip contract, which already applies at manifest-parse and load time ("Each package loads in its own try/catch — a broken one is logged and skipped"). The legacy `vendor/wheels/Plugins.cfc` lifecycle invokers had the same gap.

## Source

Internal multi-agent framework review, 2026-06-09 — finding **H2** (serviceprovider-isolation).

## Fix

- **`PackageLoader.cfc`**: `$invokeServiceProviderRegister` / `$invokeServiceProviderBoot` now iterate a `Duplicate()` snapshot of `variables.serviceProviders` (rollback deletes mid-iteration would otherwise skip the next provider) and wrap each provider in try/catch. A failure is logged to `wheels.log`, recorded in `failedPackages` with the standard `{name, error, detail}` shape, and rolled back via the existing `$rollbackPackage` — which also removes the key from `serviceProviders`, so the boot phase skips a register-failed provider with no extra tracking state.
- **`Global.cfc`** (review follow-up): re-sync `application[appKey].failedPackages` from `getFailedPackages()` immediately after the lifecycle invoke. Adobe CF copies arrays by value on assignment, so the pre-invoke copy never received lifecycle-phase entries on Adobe 2018–2025 (only Lucee/BoxLang share the reference) — and that copy is what the debug surfaces read (`events/onrequestend/debug.cfm`, `public/views/packagelist.cfm`). The aggregate failed-package WARN summary also moved below the lifecycle invoke so register/boot failures appear in the same `wheels.log` / `wheels-errors.log` breadcrumb as load-phase failures.
- **`Plugins.cfc`** (legacy, deprecated): same snapshot + per-plugin try/catch, log-and-skip; a failing provider is dropped from `$class.serviceProviders` via a new private `$dropServiceProvider` helper (the legacy system has no `failedPackages` registry to mirror).

**Behavior change (deliberate):** a throwing provider previously hard-failed boot with a visible error page; the app now boots with the package skipped, an error log line, a `failedPackages` entry, and an aggregate WARN — consistent with the loader's existing per-package contract.

**Known limitations (documented in docstrings):** mixins/middleware already merged into the application scope by `$loadPackages` are not unwound (the merge runs before the lifecycle invoke); DI registrations made by a boot-failing provider cannot be unwound (the Injector has no per-package tracking). Legacy plugin provider failures are log-only (no registry). Deliberately deferred: the lazy-provider lifecycle gap (`$instantiateLazyPackage` never invokes register/boot) and its stale docstring belong to review finding DI9; the sibling unguarded legacy hooks `$invokeOnPluginLoad`/`$invokeOnPluginActivate` are a candidate follow-up finding.

## Tests

New fixtures + specs, all of which **error pre-fix** (the fixture `Throw` propagates straight out of the previously unguarded loops):

- `vendor/wheels/tests/_assets/packages_sp/{failregister,goodsp,failboot}` + `vendor/wheels/tests/specs/packages/ServiceProviderIsolationSpec.cfc` — register-failure isolation, boot-skip after register failure, boot-failure isolation (asserting the `{name, error, detail}` record shape and rollback from both registries).
- `plugins/{FailingProvider,WorkingProvider}` fixtures + `pluginsModernSpec.cfc` mirror case (fixture sort order FailingProvider < WorkingProvider proves continuation past the failure).

Local verification (worktree docker recipe, Lucee 7 + SQLite): `ServiceProviderIsolationSpec` 3/3 pass; `pluginsModernSpec` 32/32 and full packages directory 122/122 on the original commit; app boot through the edited `$loadPackages` path clean after the follow-up. Full engine × DB coverage via per-PR compat-matrix CI.

The Adobe `failedPackages` re-sync itself is by-inspection (array copy-by-value semantics): a spec asserting the application-scope copy would have to re-run `$loadPackages` against the live test application, which is side-effectful on shared app state, and the suite asserts on the loader object — which is exactly why CI alone could not catch this divergence.

## Cross-engine notes

- No closures, no `attributeCollection`, no reserved-scope names, no `Left(str, 0)`.
- No `local.X = ...` lexically inside any catch body (BoxLang nested-local discard): catch bodies contain only reads and function calls; helper-internal locals get fresh frames.
- `application[appKey].packages` / `packageMeta` need no re-sync — they are structs (reference semantics on all engines, Adobe included); only the `failedPackages` **array** had the Adobe copy-by-value divergence.
- Private `$dropServiceProvider` is safe because `Plugins.cfc` is an instantiated manager object (never mixin-integrated), with ~10 existing private `$`-helpers as prior art.

🤖 Generated with [Claude Code](https://claude.com/claude-code)