### PR TITLE
fix(dispatch): onapplicationstart else-if chain and debug-bar output encoding

### DIFF
--- a/vendor/wheels/events/onapplicationstart.cfc
+++ b/vendor/wheels/events/onapplicationstart.cfc
@@ -31,9 +31,10 @@ component {
 			application.$wheels.reloadPassword = local.oldReloadPassword;
 		}
 
-
 		// Check and store server engine name, throw error if using a version that we don't support.
-		else if (StructKeyExists(server, "boxlang")) {
+		// Note: this must NOT be chained to the reloadPassword carryover above with `else` —
+		// engine detection has to run unconditionally or serverVersion is never set.
+		if (StructKeyExists(server, "boxlang")) {
 			application.$wheels.serverName = "BoxLang";
 			application.$wheels.serverVersion = server.boxlang.version;
 		} else if (StructKeyExists(server, "lucee")) {

--- a/vendor/wheels/events/onrequestend/debug.cfm
+++ b/vendor/wheels/events/onrequestend/debug.cfm
@@ -140,7 +140,7 @@ OR (StructKeyExists(url, "format") AND ListFindNoCase("json,xml,csv,pdf", url.fo
 	<!--- Request tab --->
 	<button class="wdb-tab" onclick="wdbToggle('request')" id="wdb-tab-request" title="Request">
 		<svg viewBox="0 0 512 512"><path d="M256 512A256 256 0 10256 0a256 256 0 000 512zm-24-176h24V272h-24c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24h-80c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 110 64 32 32 0 010-64z"/></svg>
-		#request.wheels.params.controller#.#request.wheels.params.action#
+		#EncodeForHTML(request.wheels.params.controller)#.#EncodeForHTML(request.wheels.params.action)#
 	</button>
 
 	<!--- Timing tab --->
@@ -186,7 +186,7 @@ OR (StructKeyExists(url, "format") AND ListFindNoCase("json,xml,csv,pdf", url.fo
 
 	<!--- Reload button --->
 	<cfif NOT Len($get("reloadPassword"))>
-		<a href="#local.baseReloadURL#true" class="wdb-tab" title="Reload Application" style="color:##f9e2af;">
+		<a href="#EncodeForHTMLAttribute(local.baseReloadURL)#true" class="wdb-tab" title="Reload Application" style="color:##f9e2af;">
 			<svg viewBox="0 0 512 512" style="width:13px;height:13px;fill:##f9e2af;"><path d="M105.1 202.6c7.7-21.8 20.2-42.3 37.8-59.8c62.5-62.5 163.8-62.5 226.3 0L386.3 160H352c-17.7 0-32 14.3-32 32s14.3 32 32 32h127.9c17.7 0 32-14.3 32-32V64c0-17.7-14.3-32-32-32s-32 14.3-32 32v35.2L430.6 81.9c-87.5-87.5-229.3-87.5-316.8 0C85.7 109.9 61 143.5 44.5 180.2l60.6 22.4z"/></svg>
 		</a>
 	</cfif>
@@ -207,20 +207,20 @@ OR (StructKeyExists(url, "format") AND ListFindNoCase("json,xml,csv,pdf", url.fo
 		<dl class="wdb-kv">
 			<cfif StructKeyExists(request.wheels.params, "route")>
 				<dt>Route</dt>
-				<dd><code>#request.wheels.params.route#</code></dd>
+				<dd><code>#EncodeForHTML(request.wheels.params.route)#</code></dd>
 			</cfif>
 			<dt>Controller</dt>
-			<dd><code>#request.wheels.params.controller#</code></dd>
+			<dd><code>#EncodeForHTML(request.wheels.params.controller)#</code></dd>
 			<dt>Action</dt>
-			<dd><code>#request.wheels.params.action#</code></dd>
+			<dd><code>#EncodeForHTML(request.wheels.params.action)#</code></dd>
 			<cfif StructKeyExists(request.wheels.params, "key")>
 				<dt>Key</dt>
-				<dd><code>#request.wheels.params.key#</code></dd>
+				<dd><code>#EncodeForHTML(request.wheels.params.key)#</code></dd>
 			</cfif>
 			<dt>HTTP Method</dt>
 			<dd><code>#UCase(cgi.request_method)#</code></dd>
 			<dt>URL</dt>
-			<dd><code>#cgi.server_name##cgi.path_info#<cfif Len(cgi.query_string)>?#cgi.query_string#</cfif></code></dd>
+			<dd><code>#EncodeForHTML(cgi.server_name)##EncodeForHTML(cgi.path_info)#<cfif Len(cgi.query_string)>?#EncodeForHTML(cgi.query_string)#</cfif></code></dd>
 			<dt>Application</dt>
 			<dd>#application.applicationName#</dd>
 			<dt>Data Source</dt>
@@ -274,7 +274,7 @@ OR (StructKeyExists(url, "format") AND ListFindNoCase("json,xml,csv,pdf", url.fo
 				<tbody>
 				<cfloop from="1" to="#ArrayLen(local.paramsList)#" index="local.pIdx">
 					<tr>
-						<td><code>#local.paramsList[local.pIdx].name#</code></td>
+						<td><code>#EncodeForHTML(local.paramsList[local.pIdx].name)#</code></td>
 						<td style="font-family:monospace;max-width:500px;overflow:hidden;text-overflow:ellipsis;">#EncodeForHTML(local.paramsList[local.pIdx].value)#</td>
 						<td><span class="wdb-badge wdb-badge-blue">#local.paramsList[local.pIdx].type#</span></td>
 					</tr>
@@ -306,7 +306,7 @@ OR (StructKeyExists(url, "format") AND ListFindNoCase("json,xml,csv,pdf", url.fo
 						&mdash;
 						<cfloop list="#local.environments#" index="local.ei">
 							<cfif $get("environment") IS NOT local.ei>
-								<a href="#local.baseReloadURL##local.ei#" style="color:##89b4fa;font-size:11px;margin-left:4px;">#capitalize(local.ei)#</a>
+								<a href="#EncodeForHTMLAttribute(local.baseReloadURL & local.ei)#" style="color:##89b4fa;font-size:11px;margin-left:4px;">#capitalize(local.ei)#</a>
 							</cfif>
 						</cfloop>
 					</cfif>

--- a/vendor/wheels/tests/specs/events/debugBarEncodingSpec.cfc
+++ b/vendor/wheels/tests/specs/events/debugBarEncodingSpec.cfc
@@ -1,0 +1,62 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+		describe("debug.cfm output encoding", () => {
+			// The dev debug bar reflects client-controlled request data (params.key,
+			// param names, controller/action/route and the query string) into its
+			// HTML. These must be HTML-encoded or any link a developer clicks becomes
+			// reflected XSS on every dev page — and, via allowIPBasedDebugAccess,
+			// in non-dev environments for allowlisted admins as well. Param VALUES
+			// were already encoded; this locks in encoding for params.key and param
+			// NAMES (the cgi.query_string site is fixed in the same way but cannot
+			// be exercised here because the CGI scope is read-only in a spec).
+			it("HTML-encodes params.key and param names in the debug bar", () => {
+				var keyPayload = '"><script>alert(1)</script>';
+				var namePayload = "<script>alert(2)</script>";
+				var priorReqWheels = StructKeyExists(request, "wheels") ? Duplicate(request.wheels) : {};
+
+				try {
+					if (!StructKeyExists(request, "wheels")) {
+						request.wheels = {};
+					}
+					request.wheels.execution = {total = 0};
+					request.wheels.params = {controller = "wheels", action = "tests", route = ""};
+					request.wheels.params.key = keyPayload;
+					request.wheels.params[namePayload] = "benign-value";
+
+					// debug.cfm bails out (cfexit) when url.format is one of
+					// json/xml/csv/pdf so it never breaks an API response. The
+					// test runner is hit with format=json — clear it for the
+					// duration of the include so the template renders.
+					var hadUrlFormat = StructKeyExists(url, "format");
+					var priorUrlFormat = hadUrlFormat ? url.format : "";
+					if (hadUrlFormat) {
+						StructDelete(url, "format");
+					}
+
+					var output = "";
+					try {
+						output = application.wo.$includeAndReturnOutput($template = "/wheels/events/onrequestend/debug.cfm");
+					} finally {
+						if (hadUrlFormat) {
+							url.format = priorUrlFormat;
+						}
+					}
+
+					expect(output contains "<script>alert(1)").toBeFalse(
+						"params.key must be HTML-encoded in the debug bar Request panel"
+					);
+					expect(output contains "<script>alert(2)").toBeFalse(
+						"param names must be HTML-encoded in the debug bar Params panel"
+					);
+					expect(output contains "&lt;script&gt;").toBeTrue(
+						"the injected payloads should still be visible in HTML-encoded form"
+					);
+				} finally {
+					request.wheels = priorReqWheels;
+				}
+			});
+		});
+	}
+
+}


### PR DESCRIPTION
## Summary

Fixes two findings from the internal framework review in the events/bootstrap/debug-bar area:

- **DC1**: `onapplicationstart.cfc` had engine detection accidentally chained to the reloadPassword carryover block with `else if` (introduced in 4cda23e79). If the carryover branch ever fired, engine detection was skipped and the `application.$wheels.serverVersion` deref on the next line would throw. The `else` is dropped so detection always runs; branch order (BoxLang → Lucee → RustCFML → Adobe) is preserved and the two blocks touch disjoint keys, so this is strictly safer.
- **DC10 / SEC-7**: the dev debug bar reflected client-controlled values into HTML without encoding — reflected XSS on every development-mode page and, via `allowIPBasedDebugAccess`, in non-dev environments for allowlisted admins. All flagged sites plus the same-template sibling reflections are now encoded with `EncodeForHTML` (element content) / `EncodeForHTMLAttribute` (href attributes). `baseReloadURL` starts with `cgi.script_name`, so `javascript:` scheme injection via the hrefs is not possible; attribute encoding closes the quote-breakout vector from `cgi.query_string`.

## Findings addressed

- DC1 — engine detection chained to reloadPassword carryover via `else if` @ `vendor/wheels/events/onapplicationstart.cfc:34-37`
- DC10 / SEC-7 — unencoded `params.key` reflection @ `vendor/wheels/events/onrequestend/debug.cfm:218`
- DC10 / SEC-7 — unencoded `cgi.server_name` / `cgi.path_info` / `cgi.query_string` reflection @ `vendor/wheels/events/onrequestend/debug.cfm:223`
- DC10 / SEC-7 — unencoded param names in the Request-tab params table @ `vendor/wheels/events/onrequestend/debug.cfm:277`
- SEC-7 (same-template sweep) — collapsed-bar `controller.action` tab label @ `vendor/wheels/events/onrequestend/debug.cfm:143`; `route` / `controller` / `action` rows @ `:210-215`; query-string-bearing `baseReloadURL` hrefs @ `:189` and `:309` (attribute context, `EncodeForHTMLAttribute`)

## Findings verified already-fixed

None — staleRefs was empty for this package; both findings were confirmed live at `origin/develop` before patching (the `else if` chain in `onapplicationstart.cfc` and the raw `params.key` / query-string / param-name emission in `debug.cfm`).

## Source

Internal multi-agent framework review, 2026-06-09, wave 2, package `events-bootstrap-debugbar`.

## Tests

- New spec `vendor/wheels/tests/specs/events/debugBarEncodingSpec.cfc` — renders `debug.cfm` via `$includeAndReturnOutput()` with `<script>` payloads in `params.key` and in a param name, asserting the raw payload does not appear and the encoded form does. Mirrors the prior-art `debugPanelPackagesSpec.cfc` pattern (`url.format` delete/restore, state restored via `try/finally`).
- Local verification (worktree-safe docker harness, Lucee 7 + SQLite): spec verified **red against the pre-fix template (417)** and **green after the fix (200)**; full `events` spec area green (31 pass / 0 fail).
- CI runs the full engine × DB matrix as the real gate.

## Cross-engine notes

- `EncodeForHTML` was already in use in this same template (param values, `:278`); `EncodeForHTMLAttribute` is CI-proven elsewhere in the framework (`Global.cfc`, `view/miscellaneous.cfc`, `public/views/migrator.cfm`). Both are available on Lucee 5/6/7, Adobe CF 2018–2025, and BoxLang.
- No function signatures changed, so no sibling-caller risk; the `onapplicationstart.cfc` change only de-chains two blocks that touch disjoint `application.$wheels` keys.
- The spec violates none of the 11 cross-engine invariants (no inline closures as constructor args, no `local.X` in catch reliance, no reserved-scope parameter names).

## Changelog

Entry deliberately omitted; consolidated at campaign end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
