### PR TITLE
fix(view): imageTag id rename and vite manifest caching

### DIFF
--- a/vendor/wheels/tests/specs/view/assetsSpec.cfc
+++ b/vendor/wheels/tests/specs/view/assetsSpec.cfc
@@ -247,6 +247,17 @@ component extends="wheels.WheelsTest" {
 
 				expect(actual).toBe(expected)
 			})
+
+			it("does not corrupt attribute values containing the text wheelsid when renaming the id attribute", () => {
+				StructDelete(args, "class")
+				args.source = "http://www.wheels.dev/images/wheels-logo.png"
+				args.alt = "my wheelsid logo"
+				args.id = "logoid"
+				r = '<img alt="my wheelsid logo" src="#args.source#" id="logoid">'
+				e = _controller.imageTag(argumentcollection = args)
+
+				expect(e).toBe(r)
+			})
 		})
 
 		describe("Tests that javascriptIncludeTag", () => {

--- a/vendor/wheels/tests/specs/view/viteSpec.cfc
+++ b/vendor/wheels/tests/specs/view/viteSpec.cfc
@@ -617,11 +617,13 @@ component extends="wheels.WheelsTest" {
 				_controller = g.controller(name="dummy")
 				_origBuildPath = application.wheels.viteBuildPath
 				_origManifestFile = application.wheels.viteManifestFile
+				_origShowErr = application.wheels.showErrorInformation
 			})
 
 			afterEach(() => {
 				application.wheels.viteBuildPath = _origBuildPath
 				application.wheels.viteManifestFile = _origManifestFile
+				application.wheels.showErrorInformation = _origShowErr
 				var appKey = application.wo.$appKey()
 				StructDelete(application[appKey], "viteManifestCache")
 			})
@@ -646,6 +648,35 @@ component extends="wheels.WheelsTest" {
 				expect(function() {
 					_controller.$viteManifest()
 				}).toThrow("Wheels.ViteManifestNotFound")
+			})
+
+			it("caches the missing-manifest result when showErrorInformation is false", () => {
+				var appKey = application.wo.$appKey()
+				StructDelete(application[appKey], "viteManifestCache")
+				application.wheels.showErrorInformation = false
+				application.wheels.viteBuildPath = "nonexistent_build_path"
+				application.wheels.viteManifestFile = "nonexistent_manifest.json"
+
+				e = _controller.$viteManifest()
+
+				expect(e).toBeTypeOf("struct")
+				expect(StructCount(e)).toBe(0)
+				expect(StructKeyExists(application[appKey], "viteManifestCache")).toBeTrue()
+				expect(IsStruct(application[appKey].viteManifestCache)).toBeTrue()
+				expect(StructCount(application[appKey].viteManifestCache)).toBe(0)
+			})
+
+			it("does not cache anything when the missing manifest throws", () => {
+				var appKey = application.wo.$appKey()
+				StructDelete(application[appKey], "viteManifestCache")
+				application.wheels.showErrorInformation = true
+				application.wheels.viteBuildPath = "nonexistent_build_path"
+				application.wheels.viteManifestFile = "nonexistent_manifest.json"
+
+				expect(function() {
+					_controller.$viteManifest()
+				}).toThrow("Wheels.ViteManifestNotFound")
+				expect(StructKeyExists(application[appKey], "viteManifestCache")).toBeFalse()
 			})
 		})
 	}

--- a/vendor/wheels/view/assets.cfc
+++ b/vendor/wheels/view/assets.cfc
@@ -142,7 +142,9 @@ component {
 	) {
 		$args(name = "imageTag", reserved = "src", args = arguments);
 
-		// Ugly fix due to the fact that id can't be passed along to cfinvoke.
+		// Workaround: an `id` key clashes with reserved attribute handling in the internal
+		// invocation layer used by the caching code below ($doubleCheckedLock -> $invoke -> cfinvoke),
+		// so it's renamed to `wheelsId` while the tag is generated and renamed back further down.
 		if (StructKeyExists(arguments, "id")) {
 			arguments.wheelsId = arguments.id;
 			StructDelete(arguments, "id");
@@ -169,9 +171,11 @@ component {
 			local.rv = $imageTag(argumentCollection = arguments);
 		}
 
-		// Ugly fix continued.
+		// Workaround continued: rename the generated `wheelsid` attribute back to `id`.
+		// Match only at an attribute-name boundary (whitespace before, `="` after) so that
+		// attribute values that happen to contain the text "wheelsid" are left untouched.
 		if (StructKeyExists(arguments, "wheelsId")) {
-			local.rv = ReplaceNoCase(local.rv, "wheelsId", "id");
+			local.rv = REReplaceNoCase(local.rv, "(\s)wheelsid(="")", "\1id\2", "one");
 		}
 
 		return local.rv;
@@ -208,7 +212,7 @@ component {
 				local.file &= $get("imagePath") & "/" & SpanExcluding(arguments.source, "?");
 			}
 			if ($get("showErrorInformation") && arguments.required) {
-				if (local.localFile && !FileExists(local.file)) {
+				if (!FileExists(local.file)) {
 					Throw(
 						type = "Wheels.ImageFileNotFound",
 						message = "Wheels could not find `#local.file#` on the local file system.",

--- a/vendor/wheels/view/vite.cfc
+++ b/vendor/wheels/view/vite.cfc
@@ -139,7 +139,9 @@ component {
 
 	/**
 	 * Reads and caches the Vite manifest.json file. The manifest is cached in the application
-	 * scope for the lifetime of the application (cleared on reload).
+	 * scope for the lifetime of the application (cleared on reload). A missing manifest is also
+	 * cached (as an empty struct) when not throwing, so opted-out production apps don't re-hit
+	 * the file system on every call.
 	 */
 	public struct function $viteManifest() {
 		local.appKey = $appKey();
@@ -149,26 +151,30 @@ component {
 		) {
 			return application[local.appKey].viteManifestCache;
 		}
+		lock name="viteManifest#application.applicationName#" timeout="30" {
+			// Double-check inside the lock since another thread may have populated the cache while we waited.
+			if (
+				!StructKeyExists(application[local.appKey], "viteManifestCache")
+				|| !IsStruct(application[local.appKey].viteManifestCache)
+			) {
+				local.manifestPath = $viteManifestPath();
+				if (!FileExists(local.manifestPath)) {
+					if ($get("showErrorInformation")) {
+						Throw(
+							type="Wheels.ViteManifestNotFound",
+							message="Vite manifest not found at '#local.manifestPath#'.",
+							extendedInfo="Run your Vite build (e.g. `npx vite build`) to generate the manifest, or check the `viteBuildPath` and `viteManifestFile` settings."
+						);
+					}
 
-		local.manifestPath = $viteManifestPath();
-		if (!FileExists(local.manifestPath)) {
-			if ($get("showErrorInformation")) {
-				Throw(
-					type="Wheels.ViteManifestNotFound",
-					message="Vite manifest not found at '#local.manifestPath#'.",
-					extendedInfo="Run your Vite build (e.g. `npx vite build`) to generate the manifest, or check the `viteBuildPath` and `viteManifestFile` settings."
-				);
+					// Cache the negative result so subsequent calls skip the file system check.
+					application[local.appKey].viteManifestCache = {};
+				} else {
+					application[local.appKey].viteManifestCache = DeserializeJSON(FileRead(local.manifestPath));
+				}
 			}
-			return {};
 		}
-
-		local.manifestContent = FileRead(local.manifestPath);
-		local.manifest = DeserializeJSON(local.manifestContent);
-
-		// Cache in application scope
-		application[local.appKey].viteManifestCache = local.manifest;
-
-		return local.manifest;
+		return application[local.appKey].viteManifestCache;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes two view-helper findings from the internal framework review: `imageTag()` corrupted attribute values containing the text "wheelsid" when renaming its internal `wheelsId` attribute back to `id`, and `$viteManifest()` never cached a missing-manifest result, re-hitting the file system on every vite tag in opted-out production apps (and writing the positive cache without a lock). Also removes an always-true dead condition in `$imageTag()` and replaces a stale "cfinvoke" comment with one describing the actual invocation path (`$doubleCheckedLock` -> `$invoke` -> `cfinvoke`).

## Findings addressed

- **V4 — imageTag wheelsid rename corrupts attribute values** @ `vendor/wheels/view/assets.cfc:178` — `$tag()` sorts attributes alphabetically, so an `alt` containing "wheelsid" rendered before the real `wheelsid` attribute and the old first-occurrence whole-string `ReplaceNoCase()` corrupted it (e.g. `alt="my wheelsid logo"` became `alt="my id logo"`). Now uses `REReplaceNoCase(local.rv, "(\s)wheelsid(="")", "\1id\2", "one")`, which only matches the attribute-name position since `$tagAttribute()` always emits ` name="`.
- **V4 (same finding, dead code)** @ `vendor/wheels/view/assets.cfc:215` — removed the always-true `local.localFile &&` guard inside the local-file branch of `$imageTag()`; behavior-identical.
- **V18 — $viteManifest negative result never cached / unlocked cache write** @ `vendor/wheels/view/vite.cfc:146-177` — textbook double-checked locking: fast path outside, named lock, re-check inside. A missing manifest is now cached as an empty struct on the non-throwing path (`viteStrictManifest` opt-out / `showErrorInformation=false`), so production apps no longer run `GetDirectoryFromPath` + `FileExists` on every call. Dev mode (`showErrorInformation=true`) still throws uncached, so a manifest built mid-session is picked up. No caller mutates the returned manifest struct, so sharing the cached struct is safe.

## Findings verified already-fixed

None — staleRefs was empty. Both findings were live on `develop` at branch time (whole-string `ReplaceNoCase` + dead condition at `assets.cfc:174/211`; uncached negative result + unlocked write at `vite.cfc:162-169`).

## Source

Internal multi-agent framework review 2026-06-09, wave 2, package `view-assets-vite`.

## Tests

- `vendor/wheels/tests/specs/view/assetsSpec.cfc` — new spec: `alt` text containing "wheelsid" survives the id rename (RED pre-fix: alt became "my id logo").
- `vendor/wheels/tests/specs/view/viteSpec.cfc` — new specs: missing manifest populates `viteManifestCache` with an empty struct when not throwing (RED pre-fix: cache key absent), plus a passes-pre-fix regression guard that dev mode still throws `Wheels.ViteManifestNotFound` uncached. Save/restore includes `showErrorInformation`.
- Local verification (during the fix phase, worktree-safe docker single-bundle, Lucee 7 + SQLite): both primary specs traced RED on pre-fix code; post-fix `assetsSpec` 32 pass / `viteSpec` 36 pass, 0 fail, 0 error. Branch unchanged since; full engine x DB matrix runs in CI.

## Cross-engine notes

- `REReplaceNoCase` with backreferences has in-repo prior art (`vendor/wheels/model/sql.cfc:427`), so the `\1id\2` replacement is safe on Lucee 5/6/7, Adobe CF 2018-2025, and BoxLang.
- All touched functions remain `public` with the `$` prefix (mixin-integration requirement); no closures as constructor named args, no `arguments`-as-`attributeCollection`, no `local.X` writes inside `catch`.
- The script-style named `lock` matches the existing `$simpleLock` pattern used elsewhere in the framework.
- Known non-blocking edge (reviewer-confirmed): under the non-default global `booleanAttributes=true` mode, a boolean-ish `id` emits a bare ` wheelsid` attribute the boundary regex won't rename — nonsensical input; default config unaffected.

## Changelog

Entry deliberately omitted; consolidated at campaign end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
