### PR TITLE
perf(model): drop per-query adapter version probe and fix doubled IN parens in Base

### DIFF
--- a/vendor/wheels/databaseAdapters/Base.cfc
+++ b/vendor/wheels/databaseAdapters/Base.cfc
@@ -17,17 +17,6 @@ component output=false extends="wheels.Global"{
 		local.sqlArray = args.sql;
 		local.sqlLen   = arrayLen(sqlArray);
 
-		// Detect datasource info once
-		local.ds = args.queryAttributes;
-		local.dsInfo = ( structKeyExists(ds, "DATASOURCE") && len(ds.DATASOURCE) )
-			? $dbinfo(type="version", datasource=ds.DATASOURCE)
-			: $dbinfo(
-				type     = "version",
-				datasource = application.wheels.dataSourceName,
-				username   = application.wheels.dataSourceUserName,
-				password   = application.wheels.dataSourcePassword
-			);
-
 		// Build query
 		cfquery(attributeCollection = args.queryAttributes) {
 			local.pos = 1;
@@ -54,7 +43,10 @@ component output=false extends="wheels.Global"{
 						if (args.parameterize) {
 							cfqueryParam(attributeCollection = qp);
 						} else {
-							writeOutput("(" & preserveSingleQuotes(part.value) & ")");
+							// No inner parentheses here — the outer pair above / below
+							// already wraps the list ("IN ((1,2,3))" is a row-constructor
+							// syntax error on every supported database).
+							writeOutput(preserveSingleQuotes(part.value));
 						}
 						writeOutput(")");
 					}
@@ -79,18 +71,7 @@ component output=false extends="wheels.Global"{
 
 			// LIMIT / OFFSET logic
 			if (args.limit) {
-				if (findNoCase("Oracle", dsInfo.database_productname)) {
-					if (args.offset) {
-						writeOutput("OFFSET " & args.offset & " ROWS" & newLine & "FETCH NEXT " & args.limit & " ROWS ONLY");
-					} else {
-						writeOutput("FETCH FIRST " & args.limit & " ROWS ONLY");
-					}
-				} else {
-					writeOutput("LIMIT " & args.limit);
-					if (args.offset) {
-						writeOutput(newLine & "OFFSET " & args.offset);
-					}
-				}
+				writeOutput($limitOffsetClause(limit = args.limit, offset = args.offset));
 			}
 
 			// Comment block
@@ -609,6 +590,20 @@ component output=false extends="wheels.Global"{
 	}
 
 	/**
+	 * Returns the SQL clause used to limit (and optionally offset) query results.
+	 * Individual database adapters override this when their dialect differs (e.g. Oracle
+	 * uses OFFSET/FETCH). The adapter type already identifies the database product, so
+	 * no per-query metadata probe is needed to choose the syntax.
+	 */
+	public string function $limitOffsetClause(required numeric limit, required numeric offset) {
+		local.rv = "LIMIT " & arguments.limit;
+		if (arguments.offset) {
+			local.rv &= Chr(13) & Chr(10) & "OFFSET " & arguments.offset;
+		}
+		return local.rv;
+	}
+
+	/**
 	 * Remove the maxRows argument and add a limit argument instead.
 	 * The args argument is the original arguments passed in by reference so we just modify it without passing it back.
 	 */
@@ -636,13 +631,23 @@ component output=false extends="wheels.Global"{
 		local.hasGroupBy = false;
 		local.havingPos = 0;
 		local.iEnd = ArrayLen(arguments.args.sql);
+
+		// Cheap GROUP BY scan first — the rewrite below is only needed when a GROUP BY
+		// is present, so skip the per-fragment aggregate regex entirely otherwise.
 		for (local.i = 1; local.i <= local.iEnd; local.i++) {
 			if (IsSimpleValue(arguments.args.sql[local.i]) && Left(arguments.args.sql[local.i], 8) == "GROUP BY") {
 				local.hasGroupBy = true;
 				local.havingPos = local.i + 1;
 			}
+		}
+		if (!local.hasGroupBy) {
+			return;
+		}
+
+		for (local.i = 1; local.i <= local.iEnd; local.i++) {
 			if (IsSimpleValue(arguments.args.sql[local.i]) && $isAggregateFunction(arguments.args.sql[local.i])) {
 				local.hasAggregate = true;
+				break;
 			}
 		}
 		if (local.hasGroupBy && local.hasAggregate) {
@@ -731,14 +736,13 @@ component output=false extends="wheels.Global"{
 		}
 
 		// Overloaded arguments are settings for the query.
-		local.orgArgs = Duplicate(arguments);
-		StructDelete(local.orgArgs, "sql");
-		StructDelete(local.orgArgs, "parameterize");
-		StructDelete(local.orgArgs, "$debugName");
-		StructDelete(local.orgArgs, "limit");
-		StructDelete(local.orgArgs, "offset");
-		StructDelete(local.orgArgs, "$primaryKey");
-		StructAppend(local.queryAttributes, local.orgArgs);
+		// Copy only the non-excluded keys by reference — Duplicate(arguments) would
+		// deep-clone the entire SQL fragment array (including param structs) per query.
+		for (local.key in arguments) {
+			if (!ListFindNoCase("sql,parameterize,$debugName,limit,offset,$primaryKey", local.key)) {
+				local.queryAttributes[local.key] = arguments[local.key];
+			}
+		}
 		return $executeQuery(
 			queryAttributes = local.queryAttributes,
 			sql = arguments.sql,

--- a/vendor/wheels/databaseAdapters/Oracle/OracleModel.cfc
+++ b/vendor/wheels/databaseAdapters/Oracle/OracleModel.cfc
@@ -114,6 +114,17 @@ component extends="wheels.databaseAdapters.Base" output=false {
 
 	/**
 	 * Override Base adapter's function.
+	 * Oracle does not support LIMIT/OFFSET — use the OFFSET/FETCH syntax (12c+) instead.
+	 */
+	public string function $limitOffsetClause(required numeric limit, required numeric offset) {
+		if (arguments.offset) {
+			return "OFFSET " & arguments.offset & " ROWS" & Chr(13) & Chr(10) & "FETCH NEXT " & arguments.limit & " ROWS ONLY";
+		}
+		return "FETCH FIRST " & arguments.limit & " ROWS ONLY";
+	}
+
+	/**
+	 * Override Base adapter's function.
 	 */
 	public string function $generatedKey() {
 		return "lastId";

--- a/vendor/wheels/tests/specs/model/adapterBaseQueryPathSpec.cfc
+++ b/vendor/wheels/tests/specs/model/adapterBaseQueryPathSpec.cfc
@@ -1,0 +1,57 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		g = application.wo
+
+		// Coverage for the Base adapter query path (vendor/wheels/databaseAdapters/Base.cfc).
+
+		describe("Base adapter non-parameterized IN lists", () => {
+
+			// Regression: the parameterize=false branch used to add its own parentheses
+			// inside the outer pair, emitting "IN ((1,2))" — a row-constructor syntax
+			// error on every supported database.
+			it("executes a multi-value IN clause without doubled parentheses when parameterize=false", () => {
+				var sample = g.model("author").findAll(maxRows = 2, order = "id");
+				expect(sample.recordCount).toBe(2);
+				var idList = ValueList(sample.id);
+				var expected = g.model("author").findAll(where = "id IN (#idList#)", order = "id");
+				var actual = g.model("author").findAll(
+					where = "id IN (#idList#)",
+					order = "id",
+					parameterize = false,
+					reload = true
+				);
+				expect(actual.recordCount).toBe(2);
+				expect(actual.recordCount).toBe(expected.recordCount);
+			})
+		})
+
+		describe("Adapter $limitOffsetClause", () => {
+
+			// The limit/offset dialect now comes from the adapter type instead of a
+			// per-query $dbinfo version probe (a JDBC metadata round-trip per query).
+			it("emits LIMIT/OFFSET from the Base adapter", () => {
+				var adapter = new wheels.databaseAdapters.Base();
+				expect(adapter.$limitOffsetClause(limit = 10, offset = 0)).toBe("LIMIT 10");
+				var clause = adapter.$limitOffsetClause(limit = 10, offset = 20);
+				expect(clause).toInclude("LIMIT 10");
+				expect(clause).toInclude("OFFSET 20");
+			})
+
+			it("emits OFFSET/FETCH from the Oracle adapter", () => {
+				var adapter = new wheels.databaseAdapters.Oracle.OracleModel();
+				expect(adapter.$limitOffsetClause(limit = 10, offset = 0)).toBe("FETCH FIRST 10 ROWS ONLY");
+				var clause = adapter.$limitOffsetClause(limit = 10, offset = 20);
+				expect(clause).toInclude("OFFSET 20 ROWS");
+				expect(clause).toInclude("FETCH NEXT 10 ROWS ONLY");
+			})
+
+			it("applies limit and offset end-to-end via paginated findAll", () => {
+				var paged = g.model("author").findAll(order = "id", page = 2, perPage = 1);
+				expect(paged.recordCount).toBe(1);
+			})
+		})
+	}
+
+}


### PR DESCRIPTION
## Summary

Fixes four findings against the Base database-adapter query path (`vendor/wheels/databaseAdapters/Base.cfc`): a per-query JDBC metadata round-trip used only to pick the LIMIT dialect, a doubled-parentheses syntax error in non-parameterized `IN` lists, a per-query deep clone of the entire SQL fragment array, and a missing GROUP BY early-out in the HAVING rewrite. The version probe is replaced by a new overridable `$limitOffsetClause()` adapter method (Base emits `LIMIT`/`OFFSET`; `OracleModel` overrides with byte-identical `OFFSET`/`FETCH` output).

## Findings addressed

- **DA2 [Medium] Non-parameterized IN lists emitted with doubled parentheses** @ `vendor/wheels/databaseAdapters/Base.cfc:49` — the `parameterize=false` branch kept its own parentheses inside the pair the 33cf69b5b refactor hoisted out, emitting `IN ((1,2,3))` — a row-constructor syntax error on every supported database (SQLite: "row value misused"). Inner pair removed, restoring single-pair output.
- **DA4 [High, perf] `$executeQuery` probes `$dbinfo(type="version")` on every single query** @ `vendor/wheels/databaseAdapters/Base.cfc:74,598` and `vendor/wheels/databaseAdapters/Oracle/OracleModel.cfc:119` — the uncached `cfdbinfo` probe (a JDBC metadata round-trip per INSERT/UPDATE/DELETE/SELECT) was used only to choose Oracle OFFSET/FETCH vs LIMIT. The adapter type already identifies the database product, so the probe is deleted and the dialect resolves polymorphically via the new `$limitOffsetClause()`.
- **DA12 [Medium, perf] `$performQuery` deep-copies the entire SQL fragment array via `Duplicate(arguments)` per query** @ `vendor/wheels/databaseAdapters/Base.cfc:740-745` — replaced with a by-reference copy of the non-excluded keys (identical six-key exclusion list and overwrite semantics as the old `StructDelete` chain).
- **DA13 [Low, perf] `$moveAggregateToHaving` runs the aggregate regex on every fragment with no GROUP BY early-out** @ `vendor/wheels/databaseAdapters/Base.cfc:629-655` — cheap GROUP BY scan first (unchanged last-wins `havingPos` semantics), early return when absent, and `break` on the first aggregate hit. Rewrite block untouched.

## Findings verified already-fixed

None — all four findings were confirmed still present on `origin/develop` before fixing, and the reviewer's staleRefs spot-checks re-confirmed each (including the 33cf69b5b blame ref behind DA2).

## Source

Internal multi-agent framework review 2026-06-09, wave 2, package `adapter-base`.

## Tests

New spec `vendor/wheels/tests/specs/model/adapterBaseQueryPathSpec.cfc`:
- multi-value `IN` with `parameterize=false` round-trips through `findAll` (RED pre-fix: SQLite "row value misused")
- `$limitOffsetClause()` dialect output for the Base and Oracle adapters (RED pre-fix: method not found)
- paginated `findAll` end-to-end through the new clause path

Verified locally on Lucee 7 + SQLite alongside `sqlSpec` and `calculationsSpec`: 57 pass, 0 fail, 0 error. Full engine x database matrix runs in CI.

## Cross-engine notes

- The `$performQuery` arguments-copy loop is the plain-struct-before-`attributeCollection` pattern recommended by cross-engine invariant 10; all formal params are defaulted and overloaded values are simple `cfquery` attributes.
- `Left(fragment, 8)` uses a constant positive length, so the Lucee 7 `Left(str, 0)` trap does not apply.
- New methods are `public` with `$` prefix per the mixin-integration invariant.
- Spec idioms (`g = application.wo`, `new wheels.databaseAdapters.X()`) have exact prior art in `sqlSpec.cfc` and `oracleBulkInsertSqlSpec.cfc`, both proven on the full matrix.
- Dialect coverage of the removed branch is complete: MySQL/PostgreSQL/SQLite/H2/CockroachDB inherit Base's `LIMIT` default (matching the removed non-Oracle path), MSSQL deletes `limit`/`offset` before ever reaching the branch, and the Oracle override emits output byte-identical to the removed Oracle path.

## Changelog

Entry deliberately omitted; consolidated at campaign end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)