### PR TITLE
fix(model): SQLite recreate rollback, DEFAULT quote escaping, pg advisory-lock timeout

### DIFF
--- a/vendor/wheels/Model.cfc
+++ b/vendor/wheels/Model.cfc
@@ -371,6 +371,24 @@ component output="false" displayName="Model" extends="wheels.Global"{
 	 * Internal function.
 	 */
 	public any function $assignAdapter() {
+		// Memoize the resolved adapter per datasource: the engine behind a
+		// datasource doesn't change at runtime, so probing the database
+		// ($dbinfo version plus a SELECT version() roundtrip for
+		// PostgreSQL-driver datasources) on every model class init is
+		// redundant. The cache lives in the application scope and is rebuilt
+		// on framework reload.
+		if (!StructKeyExists(application.wheels, "adapterCache")) {
+			application.wheels.adapterCache = {};
+		}
+		if (StructKeyExists(application.wheels.adapterCache, variables.wheels.class.dataSource)) {
+			local.cached = application.wheels.adapterCache[variables.wheels.class.dataSource];
+			$set(adapterName = local.cached.name);
+			return CreateObject("component", "wheels.databaseAdapters.#local.cached.namespace#.#local.cached.name#").$init(
+				dataSource = variables.wheels.class.dataSource,
+				username = variables.wheels.class.username,
+				password = variables.wheels.class.password
+			);
+		}
 		if ($get("showErrorInformation")) {
 			try {
 				local.info = $dbinfo(
@@ -439,6 +457,10 @@ component output="false" displayName="Model" extends="wheels.Global"{
 				extendedInfo = "Use SQL Server, MySQL, MariaDB, PostgreSQL, CockroachDB, Oracle, SQLite or H2."
 			);
 		}
+		application.wheels.adapterCache[variables.wheels.class.dataSource] = {
+			namespace: local.adapterNamespace,
+			name: local.adapterName
+		};
 		$set(adapterName = local.adapterName);
 		return CreateObject("component", "wheels.databaseAdapters.#local.adapterNamespace#.#local.adapterName#").$init(
 			dataSource = variables.wheels.class.dataSource,

--- a/vendor/wheels/databaseAdapters/Abstract.cfc
+++ b/vendor/wheels/databaseAdapters/Abstract.cfc
@@ -126,13 +126,13 @@ component extends="wheels.migrator.Base"{
 		}
 		if (
 			StructKeyExists(arguments.options, 'type') && ListFindNoCase(
-				"binary,date,datetime,time,timestamp",
+				"binary,date,datetime,time,timestamp,text,string",
 				arguments.options.type
 			)
 		) {
-			arguments.value = "'#arguments.value#'";
-		} else if (StructKeyExists(arguments.options, 'type') && ListFindNoCase("text,string", arguments.options.type)) {
-			arguments.value = "'#ReplaceNoCase(arguments.value, "'", "''")#'";
+			// Escape every embedded single quote (not just the first) so the
+			// generated DDL stays balanced for values like "O'Brien's".
+			arguments.value = "'#Replace(arguments.value, "'", "''", "all")#'";
 		}
 		return arguments.value;
 	}

--- a/vendor/wheels/databaseAdapters/H2/H2Model.cfc
+++ b/vendor/wheels/databaseAdapters/H2/H2Model.cfc
@@ -194,17 +194,17 @@ component extends="wheels.databaseAdapters.Base" output=false {
 	) {
 		arguments.type = "index";
 		local.index = $dbinfo(argumentCollection = arguments);
-		pkList = "";
-		for (row in local.index) {
-			if (Find('primary_key', row.INDEX_NAME)) {
-				pkList = ListAppend(pkList, row.COLUMN_NAME);
+		local.pkList = "";
+		for (local.row in local.index) {
+			if (Find('primary_key', local.row.INDEX_NAME)) {
+				local.pkList = ListAppend(local.pkList, local.row.COLUMN_NAME);
 			}
 		}
 		arguments.type = "columns";
 		local.columns = $dbinfo(argumentCollection = arguments);
-		for (local.i = 1; i <= local.columns.recordCount; i++) {
-			if (ListFind(pkList, local.columns["COLUMN_NAME"][i])) {
-				QuerySetCell(local.columns, "IS_PRIMARYKEY", "YES", i);
+		for (local.i = 1; local.i <= local.columns.recordCount; local.i++) {
+			if (ListFind(local.pkList, local.columns["COLUMN_NAME"][local.i])) {
+				QuerySetCell(local.columns, "IS_PRIMARYKEY", "YES", local.i);
 			}
 		}
 

--- a/vendor/wheels/databaseAdapters/PostgreSQL/PostgreSQLModel.cfc
+++ b/vendor/wheels/databaseAdapters/PostgreSQL/PostgreSQLModel.cfc
@@ -193,16 +193,34 @@ component extends="wheels.databaseAdapters.Base" output=false {
 	}
 
 	/**
-	 * Acquire a PostgreSQL advisory lock using pg_advisory_lock.
-	 * This is a session-level lock that blocks until acquired.
-	 * The lock name is hashed to an integer using hashtext().
+	 * Acquire a PostgreSQL session-level advisory lock by polling
+	 * pg_try_advisory_lock until the timeout expires. The lock name is hashed
+	 * to an integer using hashtext(). Throws `Wheels.AdvisoryLockTimeout` when
+	 * the lock cannot be acquired in time, matching the MySQL adapter's
+	 * contract (a blocking pg_advisory_lock would ignore the timeout and wait
+	 * forever).
 	 */
 	public void function $acquireAdvisoryLock(required string name, numeric timeout = 10) {
-		queryExecute(
-			"SELECT pg_advisory_lock(hashtext(?))",
-			[arguments.name],
-			{datasource: variables.dataSource, username: variables.username, password: variables.password}
-		);
+		local.startedAt = GetTickCount();
+		local.timeoutMs = arguments.timeout * 1000;
+		while (true) {
+			local.result = queryExecute(
+				"SELECT pg_try_advisory_lock(hashtext(?)) AS lockresult",
+				[arguments.name],
+				{datasource: variables.dataSource, username: variables.username, password: variables.password}
+			);
+			if (IsQuery(local.result) && IsBoolean(local.result.lockresult) && local.result.lockresult) {
+				return;
+			}
+			if (GetTickCount() - local.startedAt >= local.timeoutMs) {
+				Throw(
+					type = "Wheels.AdvisoryLockTimeout",
+					message = "Could not acquire advisory lock '#arguments.name#' within #arguments.timeout# seconds.",
+					extendedInfo = "The PostgreSQL pg_try_advisory_lock function kept returning false, indicating another session holds the lock."
+				);
+			}
+			Sleep(250);
+		}
 	}
 
 	/**

--- a/vendor/wheels/databaseAdapters/SQLite/SQLiteMigrator.cfc
+++ b/vendor/wheels/databaseAdapters/SQLite/SQLiteMigrator.cfc
@@ -213,22 +213,41 @@ component extends="wheels.databaseAdapters.Abstract" {
 			sql = "SELECT sql FROM sqlite_master WHERE type = 'index' AND tbl_name = '#local.tableName#' AND sql IS NOT NULL"
 		);
 
-		// PRAGMA foreign_keys must toggle outside any active transaction.
-		local.statements = [
-			"PRAGMA foreign_keys = OFF",
-			"BEGIN TRANSACTION",
-			local.createSQL,
-			"INSERT INTO #local.quotedTempTable# (#local.columnList#) SELECT #local.columnList# FROM #local.quotedTable#",
-			"DROP TABLE #local.quotedTable#",
-			"ALTER TABLE #local.quotedTempTable# RENAME TO #quoteTableName(local.tableName)#",
-			"COMMIT"
-		];
+		// When the migrator's cftransaction already wraps this call (issue #2789
+		// sets request.$wheelsTransactionWrapper) the engine owns BEGIN / COMMIT /
+		// ROLLBACK: emitting our own would collide with the active transaction,
+		// PRAGMA foreign_keys is a silent no-op inside one, and a raw COMMIT would
+		// defeat the wrapper's rollback (leaving the temp table behind on a
+		// mid-sequence failure). Use PRAGMA defer_foreign_keys instead — it is
+		// allowed mid-transaction, moves FK enforcement to COMMIT, and auto-resets
+		// on commit/rollback — and let the wrapper provide atomicity.
+		local.inWrappingTransaction = StructKeyExists(request, "$wheelsTransactionWrapper")
+		&& request.$wheelsTransactionWrapper;
+		if (local.inWrappingTransaction) {
+			local.statements = ["PRAGMA defer_foreign_keys = ON"];
+		} else {
+			// Standalone execution: PRAGMA foreign_keys must toggle outside any
+			// active transaction, so wrap the recreate in our own.
+			local.statements = ["PRAGMA foreign_keys = OFF", "BEGIN TRANSACTION"];
+		}
+		ArrayAppend(local.statements, local.createSQL);
+		ArrayAppend(
+			local.statements,
+			"INSERT INTO #local.quotedTempTable# (#local.columnList#) SELECT #local.columnList# FROM #local.quotedTable#"
+		);
+		ArrayAppend(local.statements, "DROP TABLE #local.quotedTable#");
+		ArrayAppend(local.statements, "ALTER TABLE #local.quotedTempTable# RENAME TO #quoteTableName(local.tableName)#");
+		if (!local.inWrappingTransaction) {
+			ArrayAppend(local.statements, "COMMIT");
+		}
 		if (IsQuery(local.indexes)) {
 			for (local.j = 1; local.j <= local.indexes.recordCount; local.j++) {
 				ArrayAppend(local.statements, local.indexes.sql[local.j]);
 			}
 		}
-		ArrayAppend(local.statements, "PRAGMA foreign_keys = ON");
+		if (!local.inWrappingTransaction) {
+			ArrayAppend(local.statements, "PRAGMA foreign_keys = ON");
+		}
 		return local.statements;
 	}
 

--- a/vendor/wheels/tests/specs/migrator/adapterQuoteEscapingSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/adapterQuoteEscapingSpec.cfc
@@ -1,0 +1,61 @@
+/**
+ * Regression coverage for db-adapters review findings DA10 / SEC-24 —
+ * `Abstract.quote()` (the only quote() implementation, inherited by every
+ * adapter) escaped only the FIRST embedded single quote in migration DEFAULT
+ * values because `ReplaceNoCase()` defaults to scope "one", so
+ * `default="O'Brien's"` produced unbalanced DDL. The date/datetime/binary
+ * branch did no escaping at all.
+ *
+ * These specs run at the adapter unit layer — the Abstract adapter is
+ * instantiated directly so the assertions are independent of the
+ * currently-configured test datasource (the postgreSQLForeignKeyOptionsSpec
+ * pattern).
+ */
+component extends="wheels.WheelsTest" {
+
+	function beforeAll() {
+		variables.adapter = CreateObject("component", "wheels.databaseAdapters.Abstract");
+	}
+
+	function run() {
+
+		describe("Abstract.quote() single-quote escaping (DA10 / SEC-24)", () => {
+
+			it("escapes every embedded single quote for string types", () => {
+				expect(variables.adapter.quote(value = "O'Brien's", options = {type: "string"})).toBe("'O''Brien''s'");
+			});
+
+			it("escapes every embedded single quote for text types", () => {
+				expect(variables.adapter.quote(value = "it's a 'quoted' default", options = {type: "text"})).toBe(
+					"'it''s a ''quoted'' default'"
+				);
+			});
+
+			it("escapes embedded single quotes in the date/datetime branch", () => {
+				expect(variables.adapter.quote(value = "o'clock", options = {type: "date"})).toBe("'o''clock'");
+				expect(variables.adapter.quote(value = "12 o'clock's chime", options = {type: "datetime"})).toBe(
+					"'12 o''clock''s chime'"
+				);
+			});
+
+			it("still quotes plain date values without altering them", () => {
+				expect(variables.adapter.quote(value = "2026-01-01 12:00:00", options = {type: "datetime"})).toBe(
+					"'2026-01-01 12:00:00'"
+				);
+			});
+
+			it("still passes CURRENT_TIMESTAMP through unquoted", () => {
+				expect(variables.adapter.quote(value = "CURRENT_TIMESTAMP", options = {type: "datetime"})).toBe(
+					"CURRENT_TIMESTAMP"
+				);
+			});
+
+			it("leaves untyped values unquoted", () => {
+				expect(variables.adapter.quote(value = "42")).toBe("42");
+			});
+
+		});
+
+	}
+
+}

--- a/vendor/wheels/tests/specs/migrator/sqliteChangeColumnTransactionSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/sqliteChangeColumnTransactionSpec.cfc
@@ -1,0 +1,126 @@
+/**
+ * Regression coverage for db-adapters review finding DA7 — SQLite's
+ * recreate-table pattern (`SQLiteMigrator.changeColumnInTable()`) emitted raw
+ * `PRAGMA foreign_keys` / `BEGIN TRANSACTION` / `COMMIT` statements
+ * unconditionally. When the migrator's cftransaction wraps `up()` (issue
+ * ##2789 sets `request.$wheelsTransactionWrapper`), the literal BEGIN collides
+ * with the engine transaction, PRAGMA foreign_keys is a silent no-op inside an
+ * active transaction, and the raw COMMIT defeats the wrapper's rollback —
+ * leaving the `_wheels_new_*` temp table behind on a mid-sequence failure.
+ *
+ * Inside the wrapper the adapter must instead emit
+ * `PRAGMA defer_foreign_keys = ON` (allowed mid-transaction, auto-resets on
+ * commit/rollback) and let the wrapper own atomicity. Standalone execution
+ * keeps the original explicit transaction.
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+		g = application.wo
+		migration = CreateObject("component", "wheels.migrator.Migration").init()
+		tableName = "dbm_sqlite_txn_aware"
+		columnName = "stringcolumn"
+
+		describe("SQLiteMigrator.changeColumnInTable() transaction awareness (DA7)", () => {
+
+			beforeEach(() => {
+				if (get("adapterName") neq 'SQLiteModel') {
+					skip("SQLite-specific recreate-table behavior")
+				}
+				StructDelete(request, "$wheelsTransactionWrapper")
+				t = migration.createTable(name = tableName, force = true)
+				t.string(columnNames = columnName, limit = 10, allowNull = true)
+				t.create()
+			})
+
+			afterEach(() => {
+				StructDelete(request, "$wheelsTransactionWrapper")
+				if (get("adapterName") eq 'SQLiteModel') {
+					try {
+						migration.dropTable(tableName)
+					} catch (any e) {
+					}
+				}
+			})
+
+			it("omits raw BEGIN/COMMIT and foreign_keys toggles inside the migrator transaction wrapper", () => {
+				request.$wheelsTransactionWrapper = true
+				t = migration.changeTable(tableName)
+				t.string(columnNames = columnName, limit = 50, allowNull = false, default = "foo")
+				statements = migration.adapter.changeColumnInTable(name = tableName, column = t.columns[1])
+				StructDelete(request, "$wheelsTransactionWrapper")
+
+				joined = ArrayToList(statements, "||")
+				expect(statements[1]).toBe("PRAGMA defer_foreign_keys = ON")
+				expect(joined).notToInclude("BEGIN TRANSACTION")
+				expect(joined).notToInclude("COMMIT")
+				expect(joined).notToInclude("PRAGMA foreign_keys")
+			})
+
+			it("keeps its own explicit transaction and foreign_keys toggles when standalone", () => {
+				t = migration.changeTable(tableName)
+				t.string(columnNames = columnName, limit = 50, allowNull = false, default = "foo")
+				statements = migration.adapter.changeColumnInTable(name = tableName, column = t.columns[1])
+
+				joined = ArrayToList(statements, "||")
+				expect(statements[1]).toBe("PRAGMA foreign_keys = OFF")
+				expect(statements[2]).toBe("BEGIN TRANSACTION")
+				expect(joined).toInclude("COMMIT")
+				expect(statements[ArrayLen(statements)]).toBe("PRAGMA foreign_keys = ON")
+				expect(joined).notToInclude("defer_foreign_keys")
+			})
+
+			it("changes a column successfully when run inside an engine-level transaction like the migrator's", () => {
+				g.$query(
+					datasource = application.wheels.dataSourceName,
+					sql = "INSERT INTO #tableName# (#columnName#) VALUES ('keep')"
+				)
+
+				transaction {
+					try {
+						// Mirrors Migrator.cfc's BoxLang datasource-establishing query.
+						if (StructKeyExists(server, "boxlang")) {
+							g.$query(datasource = application.wheels.dataSourceName, sql = "SELECT 1 AS test")
+						}
+						request.$wheelsTransactionWrapper = true
+						migration.changeColumn(
+							table = tableName,
+							columnName = columnName,
+							columnType = 'string',
+							limit = 50,
+							allowNull = false,
+							default = "foo"
+						)
+					} catch (any e) {
+						StructDelete(request, "$wheelsTransactionWrapper")
+						transaction action="rollback";
+						rethrow;
+					}
+					StructDelete(request, "$wheelsTransactionWrapper")
+					transaction action="commit";
+				}
+
+				pragma = g.$query(datasource = application.wheels.dataSourceName, sql = "PRAGMA table_info(#tableName#)")
+				changedRow = 0
+				for (i = 1; i <= pragma.recordCount; i++) {
+					if (pragma.name[i] == columnName) {
+						changedRow = i
+						break
+					}
+				}
+				rowCheck = g.$query(
+					datasource = application.wheels.dataSourceName,
+					sql = "SELECT #columnName# FROM #tableName# WHERE #columnName# = 'keep'"
+				)
+
+				expect(changedRow).toBeGT(0)
+				expect(pragma.notnull[changedRow]).toBe(1)
+				expect(pragma.dflt_value[changedRow]).toInclude("foo")
+				expect(rowCheck.recordCount).toBe(1)
+			})
+
+		});
+
+	}
+
+}

--- a/vendor/wheels/tests/specs/migrator/sqliteChangeColumnTransactionSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/sqliteChangeColumnTransactionSpec.cfc
@@ -16,73 +16,73 @@
 component extends="wheels.WheelsTest" {
 
 	function run() {
-		g = application.wo
-		migration = CreateObject("component", "wheels.migrator.Migration").init()
-		tableName = "dbm_sqlite_txn_aware"
-		columnName = "stringcolumn"
+		g = application.wo;
+		migration = CreateObject("component", "wheels.migrator.Migration").init();
+		tableName = "dbm_sqlite_txn_aware";
+		columnName = "stringcolumn";
 
 		describe("SQLiteMigrator.changeColumnInTable() transaction awareness (DA7)", () => {
 
 			beforeEach(() => {
 				if (get("adapterName") neq 'SQLiteModel') {
-					skip("SQLite-specific recreate-table behavior")
+					skip("SQLite-specific recreate-table behavior");
 				}
-				StructDelete(request, "$wheelsTransactionWrapper")
-				t = migration.createTable(name = tableName, force = true)
-				t.string(columnNames = columnName, limit = 10, allowNull = true)
-				t.create()
-			})
+				StructDelete(request, "$wheelsTransactionWrapper");
+				t = migration.createTable(name = tableName, force = true);
+				t.string(columnNames = columnName, limit = 10, allowNull = true);
+				t.create();
+			});
 
 			afterEach(() => {
-				StructDelete(request, "$wheelsTransactionWrapper")
+				StructDelete(request, "$wheelsTransactionWrapper");
 				if (get("adapterName") eq 'SQLiteModel') {
 					try {
-						migration.dropTable(tableName)
+						migration.dropTable(tableName);
 					} catch (any e) {
 					}
 				}
-			})
+			});
 
 			it("omits raw BEGIN/COMMIT and foreign_keys toggles inside the migrator transaction wrapper", () => {
-				request.$wheelsTransactionWrapper = true
-				t = migration.changeTable(tableName)
-				t.string(columnNames = columnName, limit = 50, allowNull = false, default = "foo")
-				statements = migration.adapter.changeColumnInTable(name = tableName, column = t.columns[1])
-				StructDelete(request, "$wheelsTransactionWrapper")
+				request.$wheelsTransactionWrapper = true;
+				t = migration.changeTable(tableName);
+				t.string(columnNames = columnName, limit = 50, allowNull = false, default = "foo");
+				statements = migration.adapter.changeColumnInTable(name = tableName, column = t.columns[1]);
+				StructDelete(request, "$wheelsTransactionWrapper");
 
-				joined = ArrayToList(statements, "||")
-				expect(statements[1]).toBe("PRAGMA defer_foreign_keys = ON")
-				expect(joined).notToInclude("BEGIN TRANSACTION")
-				expect(joined).notToInclude("COMMIT")
-				expect(joined).notToInclude("PRAGMA foreign_keys")
-			})
+				joined = ArrayToList(statements, "||");
+				expect(statements[1]).toBe("PRAGMA defer_foreign_keys = ON");
+				expect(joined).notToInclude("BEGIN TRANSACTION");
+				expect(joined).notToInclude("COMMIT");
+				expect(joined).notToInclude("PRAGMA foreign_keys");
+			});
 
 			it("keeps its own explicit transaction and foreign_keys toggles when standalone", () => {
-				t = migration.changeTable(tableName)
-				t.string(columnNames = columnName, limit = 50, allowNull = false, default = "foo")
-				statements = migration.adapter.changeColumnInTable(name = tableName, column = t.columns[1])
+				t = migration.changeTable(tableName);
+				t.string(columnNames = columnName, limit = 50, allowNull = false, default = "foo");
+				statements = migration.adapter.changeColumnInTable(name = tableName, column = t.columns[1]);
 
-				joined = ArrayToList(statements, "||")
-				expect(statements[1]).toBe("PRAGMA foreign_keys = OFF")
-				expect(statements[2]).toBe("BEGIN TRANSACTION")
-				expect(joined).toInclude("COMMIT")
-				expect(statements[ArrayLen(statements)]).toBe("PRAGMA foreign_keys = ON")
-				expect(joined).notToInclude("defer_foreign_keys")
-			})
+				joined = ArrayToList(statements, "||");
+				expect(statements[1]).toBe("PRAGMA foreign_keys = OFF");
+				expect(statements[2]).toBe("BEGIN TRANSACTION");
+				expect(joined).toInclude("COMMIT");
+				expect(statements[ArrayLen(statements)]).toBe("PRAGMA foreign_keys = ON");
+				expect(joined).notToInclude("defer_foreign_keys");
+			});
 
 			it("changes a column successfully when run inside an engine-level transaction like the migrator's", () => {
 				g.$query(
 					datasource = application.wheels.dataSourceName,
 					sql = "INSERT INTO #tableName# (#columnName#) VALUES ('keep')"
-				)
+				);
 
 				transaction {
 					try {
 						// Mirrors Migrator.cfc's BoxLang datasource-establishing query.
 						if (StructKeyExists(server, "boxlang")) {
-							g.$query(datasource = application.wheels.dataSourceName, sql = "SELECT 1 AS test")
+							g.$query(datasource = application.wheels.dataSourceName, sql = "SELECT 1 AS test");
 						}
-						request.$wheelsTransactionWrapper = true
+						request.$wheelsTransactionWrapper = true;
 						migration.changeColumn(
 							table = tableName,
 							columnName = columnName,
@@ -90,34 +90,34 @@ component extends="wheels.WheelsTest" {
 							limit = 50,
 							allowNull = false,
 							default = "foo"
-						)
+						);
 					} catch (any e) {
-						StructDelete(request, "$wheelsTransactionWrapper")
+						StructDelete(request, "$wheelsTransactionWrapper");
 						transaction action="rollback";
 						rethrow;
 					}
-					StructDelete(request, "$wheelsTransactionWrapper")
+					StructDelete(request, "$wheelsTransactionWrapper");
 					transaction action="commit";
 				}
 
-				pragma = g.$query(datasource = application.wheels.dataSourceName, sql = "PRAGMA table_info(#tableName#)")
-				changedRow = 0
+				pragma = g.$query(datasource = application.wheels.dataSourceName, sql = "PRAGMA table_info(#tableName#)");
+				changedRow = 0;
 				for (i = 1; i <= pragma.recordCount; i++) {
 					if (pragma.name[i] == columnName) {
-						changedRow = i
-						break
+						changedRow = i;
+						break;
 					}
 				}
 				rowCheck = g.$query(
 					datasource = application.wheels.dataSourceName,
 					sql = "SELECT #columnName# FROM #tableName# WHERE #columnName# = 'keep'"
-				)
+				);
 
-				expect(changedRow).toBeGT(0)
-				expect(pragma.notnull[changedRow]).toBe(1)
-				expect(pragma.dflt_value[changedRow]).toInclude("foo")
-				expect(rowCheck.recordCount).toBe(1)
-			})
+				expect(changedRow).toBeGT(0);
+				expect(pragma.notnull[changedRow]).toBe(1);
+				expect(pragma.dflt_value[changedRow]).toInclude("foo");
+				expect(rowCheck.recordCount).toBe(1);
+			});
 
 		});
 

--- a/vendor/wheels/tests/specs/model/adapterMemoizationSpec.cfc
+++ b/vendor/wheels/tests/specs/model/adapterMemoizationSpec.cfc
@@ -1,0 +1,40 @@
+/**
+ * Regression coverage for db-adapters review finding DA15 — `$assignAdapter()`
+ * re-probed the database ($dbinfo version plus a SELECT version() roundtrip on
+ * PostgreSQL-driver datasources) on every model class init. The resolved
+ * adapter is now memoized per datasource in `application.wheels.adapterCache`
+ * (rebuilt on framework reload) so subsequent model class inits skip the
+ * probe.
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		g = application.wo
+
+		describe("$assignAdapter per-datasource memoization (DA15)", () => {
+
+			it("caches the resolved adapter per datasource in the application scope", () => {
+				StructDelete(application.wheels, "adapterCache");
+				g.model("author").$assignAdapter();
+				expect(StructKeyExists(application.wheels, "adapterCache")).toBeTrue();
+				expect(StructKeyExists(application.wheels.adapterCache, application.wheels.dataSourceName)).toBeTrue();
+				var cached = application.wheels.adapterCache[application.wheels.dataSourceName];
+				expect(cached).toHaveKey("namespace");
+				expect(cached).toHaveKey("name");
+				expect(cached.name).toBe(get("adapterName"));
+			});
+
+			it("returns the same adapter type from the cached path as from a fresh probe", () => {
+				StructDelete(application.wheels, "adapterCache");
+				var probed = g.model("author").$assignAdapter();
+				var cachedResult = g.model("author").$assignAdapter();
+				expect(GetMetaData(cachedResult).name).toBe(GetMetaData(probed).name);
+				expect(ListLast(GetMetaData(cachedResult).name, ".")).toBe(get("adapterName"));
+			});
+
+		});
+
+	}
+
+}

--- a/vendor/wheels/tests/specs/model/adapterMemoizationSpec.cfc
+++ b/vendor/wheels/tests/specs/model/adapterMemoizationSpec.cfc
@@ -10,7 +10,7 @@ component extends="wheels.WheelsTest" {
 
 	function run() {
 
-		g = application.wo
+		g = application.wo;
 
 		describe("$assignAdapter per-datasource memoization (DA15)", () => {
 


### PR DESCRIPTION
## Summary

Hardens five adapter-layer sites found in the 2026-06-09 internal framework review (package `adapter-misc`): SQLite table-recreate now cooperates with the migrator's wrapping transaction instead of defeating its rollback, `Abstract.quote()` escapes every embedded single quote in DDL DEFAULT values, the PostgreSQL advisory lock honors its timeout (matching the MySQL contract), `H2Model.$getColumnInfo()` no longer leaks unscoped variables into the shared adapter instance, and `$assignAdapter()` memoizes the resolved adapter per datasource instead of re-probing the database on every model class init.

## Findings addressed

- **DA7 — SQLite `changeColumnInTable()` raw BEGIN/COMMIT defeats migrator transaction rollback** @ `vendor/wheels/databaseAdapters/SQLite/SQLiteMigrator.cfc:224` — when `request.$wheelsTransactionWrapper` is set (Migrator.cfc wraps migrations in `cftransaction`, #2789), the adapter now emits `PRAGMA defer_foreign_keys = ON` (SQLite's documented in-transaction alternative, auto-resets on commit/rollback) and lets the engine transaction own atomicity; standalone execution keeps the original explicit `PRAGMA foreign_keys` + `BEGIN`/`COMMIT` sequence unchanged.
- **DA10 / SEC-24 — `Abstract.quote()` escaped only the first embedded single quote** @ `vendor/wheels/databaseAdapters/Abstract.cfc:135` — `ReplaceNoCase` defaulted to scope `one`, so `default="O'Brien's"` produced unbalanced DDL; the `binary/date/datetime/time/timestamp` branch did no escaping at all. Both branches are merged and now escape every quote via `Replace(..., "''", "all")`. `CURRENT_TIMESTAMP` passthrough is preserved and spec-asserted.
- **DA11 — PostgreSQL `$acquireAdvisoryLock()` blocked forever, ignoring its timeout** @ `vendor/wheels/databaseAdapters/PostgreSQL/PostgreSQLModel.cfc:203` — replaced blocking `pg_advisory_lock` with a `pg_try_advisory_lock` poll loop (250ms interval) that throws `Wheels.AdvisoryLockTimeout` on expiry, matching the MySQL adapter's contract verbatim; `timeout=0` gives one try then throws. The CockroachDB override is unaffected.
- **DA6 — `H2Model.$getColumnInfo()` leaked unscoped `pkList`/`row`/loop counter into the shared adapter instance** @ `vendor/wheels/databaseAdapters/H2/H2Model.cfc:197` — mechanical `local.` scoping of all three.
- **DA15 — `$assignAdapter()` re-probed the database on every model class init** @ `vendor/wheels/Model.cfc:380` — resolved adapter (namespace + name) is now memoized per datasource in `application.wheels.adapterCache`, rebuilt on framework reload. No negative caching: the probe throws before any cache write, and the cached path preserves `$set(adapterName=...)` and credential parity. Sole caller is the lock-guarded class-init path in `Model.cfc`, so the check-then-set is benign.

## Findings verified already-fixed

None — all five findings in this package were live on `origin/develop` (the `quote()` single-escape and blocking `pg_advisory_lock` were re-verified against the develop tip before patching).

## Source

Internal multi-agent framework review, 2026-06-09 — wave 2, package `adapter-misc`.

## Tests

New specs, each written first and verified red against pre-fix code, then green post-fix (Lucee 7 + SQLite locally):

- `vendor/wheels/tests/specs/migrator/adapterQuoteEscapingSpec.cfc` — multi-quote escaping in both type branches + `CURRENT_TIMESTAMP` passthrough (3 failures pre-fix).
- `vendor/wheels/tests/specs/migrator/sqliteChangeColumnTransactionSpec.cfc` — wrapped path emits no raw `BEGIN`/`COMMIT`/`PRAGMA foreign_keys` and uses `defer_foreign_keys`; standalone path byte-identical to before (1 failure + 1 error pre-fix). Skips itself on non-SQLite databases.
- `vendor/wheels/tests/specs/model/adapterMemoizationSpec.cfc` — cache populated per datasource, adapter identity stable across re-resolution (1 failure pre-fix).

The PostgreSQL polling path (`lockingSpec` on the postgres matrix leg) and Adobe/BoxLang compilation of the new specs are exercised by CI's full engine x DB matrix, per campaign rules.

## Cross-engine notes

- All 11 cross-engine invariants checked against the diff: no inline closures as constructor named args, no `obj.map()`, no `attributeCollection = arguments`, no `Left(str, 0)`, no reserved-scope parameter names, no `local.X`-in-catch assertions.
- The `skip()` guard in the SQLite spec's `beforeEach` is safe on every engine: TestBox runs `beforeEach` inside the try whose catch handles `TestBox.SkipSpec`, so non-SQLite legs mark the spec Skipped (not errored), and the guard is the first statement so no cleanup is bypassed.
- `Sleep()`, `GetTickCount()`, `Replace(..., "all")`, and struct-literal cache entries are portable across Lucee 5/6/7, Adobe 2018-2025, and BoxLang.

## Changelog

Entry deliberately omitted; consolidated at campaign end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
