### PR TITLE
fix(dispatch): narrow binding catch, cache binding misses, unify route copy semantics

### DIFF
--- a/vendor/wheels/Dispatch.cfc
+++ b/vendor/wheels/Dispatch.cfc
@@ -154,13 +154,13 @@ component output="false" extends="wheels.Global"{
 		if (StructKeyExists(application.wheels, "staticRoutes")) {
 			local.staticKey = local.methodKey & ":/" & arguments.path;
 			if (StructKeyExists(application.wheels.staticRoutes, local.staticKey)) {
-				local.rv = StructCopy(application.wheels.staticRoutes[local.staticKey]);
+				local.rv = $copyRouteForRequest(application.wheels.staticRoutes[local.staticKey]);
 			}
 			// Also try the root path.
 			if (!StructKeyExists(local, "rv") && !Len(arguments.path)) {
 				local.staticKey = local.methodKey & ":/";
 				if (StructKeyExists(application.wheels.staticRoutes, local.staticKey)) {
-					local.rv = StructCopy(application.wheels.staticRoutes[local.staticKey]);
+					local.rv = $copyRouteForRequest(application.wheels.staticRoutes[local.staticKey]);
 				}
 			}
 		}
@@ -180,8 +180,13 @@ component output="false" extends="wheels.Global"{
 				}
 
 				// If route matches regular expression, set it for return.
-				if (ReFindNoCase(local.route.regex, arguments.path) || (!Len(arguments.path) && local.route.pattern == "/")) {
-					local.rv = Duplicate(local.route);
+				// Run the regex once with sub-expressions and stash the result on the
+				// per-request copy so $mergeRoutePattern can reuse it instead of
+				// re-executing the same regex against the same path.
+				local.match = ReFindNoCase(local.route.regex, arguments.path, 1, true);
+				if (local.match.pos[1] > 0 || (!Len(arguments.path) && local.route.pattern == "/")) {
+					local.rv = $copyRouteForRequest(local.route);
+					local.rv.regexMatch = local.match;
 					break;
 				}
 			}
@@ -222,6 +227,23 @@ component output="false" extends="wheels.Global"{
 			}
 		}
 
+		return local.rv;
+	}
+
+	/**
+	 * Returns a per-request copy of a matched route struct. Top-level keys are shallow-copied
+	 * and any non-simple members (constraints, middleware, etc.) are duplicated so request
+	 * code (middleware reading request.wheels.currentRoute, for example) can never mutate
+	 * the shared route table through the copy. Used by both the static fast path and the
+	 * regex fallback in $findMatchingRoute so the two paths share identical copy semantics.
+	 */
+	public struct function $copyRouteForRequest(required struct route) {
+		local.rv = StructCopy(arguments.route);
+		for (local.key in local.rv) {
+			if (!IsSimpleValue(local.rv[local.key])) {
+				local.rv[local.key] = Duplicate(local.rv[local.key]);
+			}
+		}
 		return local.rv;
 	}
 
@@ -482,7 +504,14 @@ component output="false" extends="wheels.Global"{
 	 */
 	public struct function $mergeRoutePattern(required struct params, required struct route, required string path) {
 		local.rv = arguments.params;
-		local.matches = ReFindNoCase(arguments.route.regex, arguments.path, 1, true);
+		// Reuse the match result stashed by $findMatchingRoute when present so the route
+		// regex only executes once per request. Fall back to a fresh match for routes that
+		// did not go through the regex fallback (static fast path or direct calls).
+		if (StructKeyExists(arguments.route, "regexMatch")) {
+			local.matches = arguments.route.regexMatch;
+		} else {
+			local.matches = ReFindNoCase(arguments.route.regex, arguments.path, 1, true);
+		}
 		local.iEnd = ArrayLen(local.matches.pos);
 		for (local.i = 2; local.i <= local.iEnd; local.i++) {
 			local.key = ListGetAt(arguments.route.foundVariables, local.i - 1);
@@ -513,7 +542,10 @@ component output="false" extends="wheels.Global"{
 	/**
 	 * Resolves a model instance from params.key when route model binding is enabled.
 	 * The resolved model is stored in params under the singularized controller name (e.g., params.user).
-	 * Throws Wheels.RecordNotFound if the record doesn't exist. Silently skips if the model class doesn't exist.
+	 * Throws Wheels.RecordNotFound if the record doesn't exist. Convention-derived bindings skip
+	 * silently (with a negative cache, cleared on reload) when the model class can't be resolved;
+	 * explicit bindings (binding="BlogPost") rethrow resolution failures since they indicate a
+	 * configuration error. Query errors from the finder always propagate.
 	 */
 	public struct function $resolveRouteModelBinding(required struct params, required struct route) {
 		local.rv = arguments.params;
@@ -540,7 +572,8 @@ component output="false" extends="wheels.Global"{
 		}
 
 		// Derive the model name.
-		if (IsSimpleValue(local.binding) && !IsBoolean(local.binding) && Len(local.binding)) {
+		local.explicitBinding = IsSimpleValue(local.binding) && !IsBoolean(local.binding) && Len(local.binding);
+		if (local.explicitBinding) {
 			// Explicit model name override (e.g., binding="BlogPost").
 			local.modelName = local.binding;
 		} else {
@@ -556,13 +589,50 @@ component output="false" extends="wheels.Global"{
 			local.modelName = capitalize(singularize(local.controllerName));
 		}
 
-		// Attempt to resolve the model instance.
-		try {
-			local.instance = model(local.modelName).findByKey(local.rv.key);
-		} catch (any e) {
-			// Model class doesn't exist — silently skip (don't break non-model routes).
+		// Negative cache: a conventional binding that previously failed to resolve is skipped
+		// without re-acquiring the app-wide model lock and re-running the model bootstrap
+		// (including its DB metadata query) on every request. Lives in the application.wheels
+		// struct so it's cleared on reload.
+		local.appKey = $appKey();
+		if (
+			!local.explicitBinding
+			&& StructKeyExists(application[local.appKey], "unresolvableRouteBindings")
+			&& StructKeyExists(application[local.appKey].unresolvableRouteBindings, local.modelName)
+		) {
 			return local.rv;
 		}
+
+		// Resolve the model class in its own try so only class/bootstrap resolution failures
+		// are handled here.
+		try {
+			local.modelClass = model(local.modelName);
+		} catch (any e) {
+			// An explicit binding name (binding="BlogPost") that fails to resolve is a
+			// configuration error — surface it instead of silently skipping.
+			if (local.explicitBinding) {
+				rethrow;
+			}
+			// Conventional binding against a non-model-backed controller: skip silently so
+			// non-model routes keep working, but negative-cache the miss so the failed
+			// bootstrap doesn't repeat on every request, and leave a dev-mode breadcrumb.
+			if (!StructKeyExists(application[local.appKey], "unresolvableRouteBindings")) {
+				application[local.appKey].unresolvableRouteBindings = {};
+			}
+			application[local.appKey].unresolvableRouteBindings[local.modelName] = true;
+			if ($get("environment") != "production") {
+				writeLog(
+					file = "wheels",
+					type = "warning",
+					text = "Route model binding could not resolve model `#local.modelName#` (#e.type#: #e.message#). Binding is skipped for this model until reload."
+				);
+			}
+			return local.rv;
+		}
+
+		// Run the finder outside the try so query errors (DB connection failures, missing
+		// tables at query time, SQL errors) propagate instead of being masked as a missing
+		// model class.
+		local.instance = local.modelClass.findByKey(local.rv.key);
 
 		// If no record was found, throw a 404.
 		if (IsBoolean(local.instance) && !local.instance) {
@@ -739,6 +809,7 @@ component output="false" extends="wheels.Global"{
 			StructDelete(local.rv, local.key & "($hour)");
 			StructDelete(local.rv, local.key & "($minute)");
 			StructDelete(local.rv, local.key & "($second)");
+			StructDelete(local.rv, local.key & "($ampm)");
 		}
 		return local.rv;
 	}

--- a/vendor/wheels/Mapper.cfc
+++ b/vendor/wheels/Mapper.cfc
@@ -148,7 +148,8 @@ component output="false" {
 
 		// Validate the regex compiles correctly (do not store the Java Pattern object
 		// in the route struct because Duplicate() cannot deep-copy Java objects reliably
-		// across all CFML engines, and route structs are duplicated at match time).
+		// across all CFML engines, and route structs are copied at match time with their
+		// non-simple members duplicated — see $copyRouteForRequest in Dispatch.cfc).
 		$compileRegex(argumentCollection = arguments);
 
 		// Determine if this is a static route (no variables in the pattern).

--- a/vendor/wheels/tests/specs/dispatch/createParamsSpec.cfc
+++ b/vendor/wheels/tests/specs/dispatch/createParamsSpec.cfc
@@ -53,6 +53,19 @@ component extends="wheels.WheelsTest" {
 				expect(datecompare(r, e)).toBe(0)
 			})
 
+			it("removes the ($ampm) part key after combining date parts", () => {
+				args.formScope["published($year)"] = 2000
+				args.formScope["published($month)"] = 2
+				args.formScope["published($day)"] = 15
+				args.formScope["published($hour)"] = 3
+				args.formScope["published($minute)"] = 30
+				args.formScope["published($ampm)"] = "PM"
+				_params = dispatch.$createParams(argumentCollection = args)
+
+				expect(_params).notToHaveKey("published($ampm)")
+				expect(datecompare(CreateDateTime(2000, 2, 15, 15, 30, 0), _params.published)).toBe(0)
+			})
+
 			it("checks that URL and FORM scope map the same", () => {
 				StructInsert(args.urlScope, "user[email]", "tpetruzzi@gmail.com", true)
 				StructInsert(args.urlScope, "user[name]", "tony petruzzi", true)

--- a/vendor/wheels/tests/specs/dispatch/findMatchingRouteSpec.cfc
+++ b/vendor/wheels/tests/specs/dispatch/findMatchingRouteSpec.cfc
@@ -289,6 +289,45 @@ component extends="wheels.WheelsTest" {
 				expect(route.name).toBe("users")
 				expect(route.methods).toBe("get")
 			})
+
+			it("returns a static-route copy whose nested members are not shared with the route table", () => {
+				request.cgi["request_method"] = "GET"
+				route = d.$findMatchingRoute(path = "users")
+				route.constraints["injected"] = "x"
+				rematch = d.$findMatchingRoute(path = "users")
+
+				expect(rematch.constraints).notToHaveKey("injected")
+			})
+
+			it("returns a regex-route copy whose nested members are not shared with the route table", () => {
+				request.cgi["request_method"] = "GET"
+				route = d.$findMatchingRoute(path = "users/1")
+				route.constraints["injected"] = "x"
+				rematch = d.$findMatchingRoute(path = "users/1")
+
+				expect(rematch.constraints).notToHaveKey("injected")
+			})
+
+			it("stashes the regex match result for reuse by $mergeRoutePattern", () => {
+				request.cgi["request_method"] = "GET"
+				route = d.$findMatchingRoute(path = "users/1")
+
+				expect(route).toHaveKey("regexMatch")
+
+				_params = d.$mergeRoutePattern(params = {}, route = route, path = "users/1")
+				expect(_params).toHaveKey("key")
+				expect(_params.key).toBe("1")
+			})
+
+			it("merges route pattern variables when no stashed match result is present", () => {
+				request.cgi["request_method"] = "GET"
+				route = d.$findMatchingRoute(path = "users/1")
+				StructDelete(route, "regexMatch")
+
+				_params = d.$mergeRoutePattern(params = {}, route = route, path = "users/1")
+				expect(_params).toHaveKey("key")
+				expect(_params.key).toBe("1")
+			})
 		})
 	}
 }

--- a/vendor/wheels/tests/specs/dispatch/routeModelBindingSpec.cfc
+++ b/vendor/wheels/tests/specs/dispatch/routeModelBindingSpec.cfc
@@ -18,6 +18,14 @@ component extends="wheels.WheelsTest" {
 
 			afterEach(function() {
 				g.$set(routeModelBinding = _originalBinding);
+				// Clean up any negative-cache entries created by these tests so other
+				// specs (and re-runs) are unaffected.
+				var appKey = g.$appKey();
+				if (StructKeyExists(application[appKey], "unresolvableRouteBindings")) {
+					StructDelete(application[appKey].unresolvableRouteBindings, "Post");
+					StructDelete(application[appKey].unresolvableRouteBindings, "NonexistentThing");
+					StructDelete(application[appKey].unresolvableRouteBindings, "NonexistentWidget");
+				}
 			});
 
 			describe("when binding is enabled on a route", function() {
@@ -98,6 +106,15 @@ component extends="wheels.WheelsTest" {
 					expect(result.author.key()).toBe(author.key());
 				});
 
+				it("throws when the explicitly named model cannot be resolved", function() {
+					var params = {controller = "writers", action = "show", key = "1"};
+					var route = {binding = "TotallyMissingBindingModel"};
+
+					expect(function() {
+						_dispatch.$resolveRouteModelBinding(params = params, route = route);
+					}).toThrow();
+				});
+
 			});
 
 			describe("controller resolution", function() {
@@ -143,6 +160,38 @@ component extends="wheels.WheelsTest" {
 					var result = _dispatch.$resolveRouteModelBinding(params = params, route = route);
 
 					expect(result).notToHaveKey("nonexistentThing");
+				});
+
+				it("negative-caches a conventional binding miss so the bootstrap is not repeated", function() {
+					var appKey = g.$appKey();
+					// Start clean in case a previous run already cached this miss.
+					if (StructKeyExists(application[appKey], "unresolvableRouteBindings")) {
+						StructDelete(application[appKey].unresolvableRouteBindings, "NonexistentWidget");
+					}
+
+					var params = {controller = "nonexistentWidgets", action = "show", key = "1"};
+					var route = {binding = true};
+
+					var result = _dispatch.$resolveRouteModelBinding(params = params, route = route);
+
+					expect(result).notToHaveKey("nonexistentWidget");
+					expect(application[appKey]).toHaveKey("unresolvableRouteBindings");
+					expect(application[appKey].unresolvableRouteBindings).toHaveKey("NonexistentWidget");
+				});
+
+				it("skips resolution for models present in the negative cache", function() {
+					var appKey = g.$appKey();
+					if (!StructKeyExists(application[appKey], "unresolvableRouteBindings")) {
+						application[appKey].unresolvableRouteBindings = {};
+					}
+					application[appKey].unresolvableRouteBindings["Post"] = true;
+
+					var params = {controller = "posts", action = "show", key = "1"};
+					var route = {binding = true};
+
+					var result = _dispatch.$resolveRouteModelBinding(params = params, route = route);
+
+					expect(result).notToHaveKey("post");
 				});
 
 				it("resolves models when global setting is enabled and no per-route binding", function() {


### PR DESCRIPTION
## Summary

Fixes six findings in the dispatch/route pipeline: route model binding no longer swallows finder-time query errors or silently absorbs explicit-binding configuration errors; conventional binding misses are negative-cached (cleared on reload) instead of repeating the app-wide model lock + base-model bootstrap + DB metadata probe on every keyed request; the static fast path and regex fallback in `$findMatchingRoute` now share a single `$copyRouteForRequest` helper (shallow top-level copy with non-simple members duplicated) so the static path can no longer leak shared nested route state and the regex path stops deep-`Duplicate`-ing the whole route struct per request; the matched route regex executes once per request (stashed match reused by `$mergeRoutePattern`); and `$translateDatePartSubmissions` cleans up the orphaned `field($ampm)` param key.

## Findings addressed

- **R8 [Medium] `$resolveRouteModelBinding` swallows all exceptions from `model().findByKey()` as "model class doesn't exist"** @ `vendor/wheels/Dispatch.cfc:550-646` — model class resolved in its own `try` (Dispatch.cfc:607-630); `findByKey()` moved outside it (Dispatch.cfc:636) so query errors propagate; explicit `binding="BlogPost"` resolution failures `rethrow`; conventional misses log a dev-mode `wheels` log breadcrumb with `e.type`/`e.message`.
- **R13 [High, perf] Route model binding miss path repeats exclusive lock + model bootstrap + DB metadata query on every request, silently** @ `vendor/wheels/Dispatch.cfc:593-604, 616-621` — negative cache `application.wheels.unresolvableRouteBindings`, written on conventional-binding misses, consulted before `model()`, cleared on reload (`onapplicationstart.cfc` resets `application.$wheels`). Explicit bindings never read or write the cache.
- **R12 [Low] Static-route fast path returns a shallow `StructCopy` while the regex path deep-`Duplicate`s — shared nested route state leaks to request code** @ `vendor/wheels/Dispatch.cfc:157, 163, 240-247` — both paths now call `$copyRouteForRequest()`, which duplicates non-simple members (`constraints`, `middleware`) so middleware reading `request.wheels.currentRoute` can never mutate the shared route table.
- **R16 [Low, perf] `$findMatchingRoute` fallback deep-`Duplicate`s the matched route per request while the static fast path proves a shallow copy suffices** @ `vendor/wheels/Dispatch.cfc:188`; `vendor/wheels/Mapper.cfc:149-152` — regex path switched to the same shallow-plus-duplicated-nested copy; Mapper comment synced to describe the new copy semantics.
- **R17 [Low, perf] Matched route regex executed twice per request** @ `vendor/wheels/Dispatch.cfc:186-189, 510-514` — `$findMatchingRoute` runs `ReFindNoCase(..., 1, true)` once and stashes the sub-expression result as `regexMatch` on the per-request copy; `$mergeRoutePattern` reuses it, falling back to a fresh match when absent (static fast path / direct calls). `pos[1] > 0` is equivalent to the old two-arg truthiness, including the root-path special case.
- **DC5 [Low] `$translateDatePartSubmissions` never deletes the `($ampm)` part key** @ `vendor/wheels/Dispatch.cfc:812` — `StructDelete(local.rv, local.key & "($ampm)")` added to the cleanup block; PM-to-24-hour conversion unchanged.

## Findings verified already-fixed

None — all six findings in this package were live against `origin/develop` (reviewer spot-checked the pre-fix code: develop's cleanup deleted only the six year-through-second keys, and develop's catch wrapped the whole `model().findByKey()` chain in a single swallow-all).

## Source

Internal multi-agent framework review 2026-06-09, wave 2 package `dispatch-route-pipeline`.

## Tests

8 new WheelsTest BDD specs across the existing dispatch spec files, each written to fail against the pre-fix code where the behavior allows it:

- `vendor/wheels/tests/specs/dispatch/createParamsSpec.cfc` — `($ampm)` key removed from params; PM time still converts to 24-hour.
- `vendor/wheels/tests/specs/dispatch/findMatchingRouteSpec.cfc` — static-path nested isolation (mutating `constraints` on the returned copy doesn't touch the route table), regex-path isolation, `regexMatch` stash present on regex-matched copies, `$mergeRoutePattern` fallback for routes without the stash.
- `vendor/wheels/tests/specs/dispatch/routeModelBindingSpec.cfc` — explicit-binding resolution failure throws; conventional miss writes the negative cache; cached miss is consulted (binding skipped without re-resolution); `afterEach` cleans every cache name the file can create.

Local verification (Lucee 7 + SQLite, prebuilt docker image, worktree dir-only mount): all three touched bundles green — `createParamsSpec` 13 pass / 0 fail / 0 error, `findMatchingRouteSpec` 34 pass / 0 fail / 0 error, `routeModelBindingSpec` 13 pass / 0 fail / 0 error. Full engine x DB coverage deferred to the CI compat-matrix (the real gate); worth watching the BoxLang and Adobe lanes for these three bundles.

## Cross-engine notes

- `$copyRouteForRequest` is `public` with a `$` prefix (mixin invariant 7 — `private` helpers are not integrated on Lucee/Adobe).
- No `local.X` writes inside `catch` bodies are read after the catch (BoxLang invariant 11) — the catch paths only write `application`-scope keys and return the pre-`try` `local.rv`; `local.modelClass` is assigned in the `try` body, which persists fine.
- `rethrow` in script, `writeLog(file/type/text)`, and the 4-arg `ReFindNoCase(..., 1, true)` form all have in-file prior art on develop that already passes the CI matrix.
- No reserved-scope parameter names, no inline closures as constructor named args, no `arguments`-as-`attributeCollection`, no `Left(str, 0)`.

## Changelog

Entry deliberately omitted; consolidated at campaign end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)