### PR TITLE
fix(auth): JWT secret validation and token strategy hardening

### DIFF
--- a/vendor/wheels/auth/JwtService.cfc
+++ b/vendor/wheels/auth/JwtService.cfc
@@ -50,8 +50,9 @@ component output="false" {
 		variables.issuer = arguments.issuer;
 		variables.allowedClockSkew = arguments.allowedClockSkew;
 
-		// Cache the Java class handle used on the per-request decode path
+		// Cache the Java class handles used on the per-request encode/decode paths
 		variables.messageDigest = CreateObject("java", "java.security.MessageDigest");
+		variables.javaSystem = CreateObject("java", "java.lang.System");
 
 		return this;
 	}
@@ -307,9 +308,14 @@ component output="false" {
 
 	/**
 	 * Get current time as Unix epoch seconds (UTC).
+	 *
+	 * Uses the cached java.lang.System handle: currentTimeMillis() is guaranteed wall-clock
+	 * epoch time on every engine, unlike GetTickCount(), whose contract only promises a
+	 * relative millisecond clock (JVM uptime on some engines) — unusable for RFC 7519
+	 * iat/exp/nbf claims.
 	 */
 	private numeric function $epochSeconds() {
-		return Int(GetTickCount() / 1000);
+		return Int(variables.javaSystem.currentTimeMillis() / 1000);
 	}
 
 }

--- a/vendor/wheels/auth/JwtService.cfc
+++ b/vendor/wheels/auth/JwtService.cfc
@@ -5,7 +5,7 @@
  * Used standalone or by JwtStrategy for request authentication.
  *
  * Usage:
- *   var jwt = new wheels.auth.JwtService(secretKey="my-secret-key");
+ *   var jwt = new wheels.auth.JwtService(secretKey="a-random-secret-of-at-least-32-bytes");
  *   var token = jwt.encode({sub=42, role="admin"});
  *   var claims = jwt.decode(token);
  *   var refreshed = jwt.refresh(token);
@@ -18,9 +18,9 @@ component output="false" {
 	/**
 	 * Creates a new JwtService instance.
 	 *
-	 * @secretKey The HMAC-SHA256 signing key.
+	 * @secretKey The HMAC-SHA256 signing key. Must be at least 32 bytes (256 bits) per RFC 7518 Section 3.2; construction throws otherwise.
 	 * @defaultExpiry Default token lifetime in seconds (default 3600 = 1 hour).
-	 * @issuer Default issuer claim (iss). Empty string means no iss claim added.
+	 * @issuer Default issuer claim (iss). Empty string means no iss claim added and no iss validation on decode.
 	 * @allowedClockSkew Seconds of clock skew tolerance for expiry checks (default 0).
 	 */
 	public JwtService function init(
@@ -29,10 +29,29 @@ component output="false" {
 		string issuer = "",
 		numeric allowedClockSkew = 0
 	) {
+		// Fail fast on missing or weak secrets — a short HMAC key makes every issued token brute-forceable
+		if (!Len(arguments.secretKey)) {
+			Throw(
+				type = "Wheels.Auth.JWT.InvalidSecretKey",
+				message = "JWT secret key cannot be empty.",
+				extendedInfo = "Provide a random secret of at least 32 bytes (256 bits) as required for HMAC-SHA256 by RFC 7518 Section 3.2."
+			);
+		}
+		if (Len(CharsetDecode(arguments.secretKey, "UTF-8")) < 32) {
+			Throw(
+				type = "Wheels.Auth.JWT.WeakSecretKey",
+				message = "JWT secret key is too short.",
+				extendedInfo = "HMAC-SHA256 requires a secret of at least 32 bytes (256 bits) per RFC 7518 Section 3.2. Generate a random secret of 32 or more bytes and store it outside source control."
+			);
+		}
+
 		variables.secretKey = arguments.secretKey;
 		variables.defaultExpiry = arguments.defaultExpiry;
 		variables.issuer = arguments.issuer;
 		variables.allowedClockSkew = arguments.allowedClockSkew;
+
+		// Cache the Java class handle used on the per-request decode path
+		variables.messageDigest = CreateObject("java", "java.security.MessageDigest");
 
 		return this;
 	}
@@ -78,8 +97,9 @@ component output="false" {
 	/**
 	 * Decode and validate a JWT token, returning the claims struct.
 	 *
-	 * Verifies the signature and checks expiry/nbf claims.
-	 * Throws on invalid token, bad signature, or expired token.
+	 * Verifies the signature and checks expiry/nbf claims. When an issuer was
+	 * configured, the iss claim must be present and match it (case-sensitive).
+	 * Throws on invalid token, bad signature, wrong issuer, or expired token.
 	 *
 	 * @token The JWT token string to decode.
 	 * @ignoreExpiry If true, skip expiry validation (used for refresh). Default false.
@@ -111,7 +131,7 @@ component output="false" {
 		local.signingInput = local.parts[1] & "." & local.parts[2];
 		local.expectedSig = $sign(local.signingInput);
 
-		if (!CreateObject("java", "java.security.MessageDigest").isEqual(
+		if (!variables.messageDigest.isEqual(
 			local.expectedSig.getBytes("UTF-8"),
 			local.parts[3].getBytes("UTF-8")
 		)) {
@@ -124,6 +144,19 @@ component output="false" {
 		// Decode payload
 		local.payloadJson = $base64UrlDecode(local.parts[2]);
 		local.claims = DeserializeJSON(local.payloadJson);
+
+		// Validate issuer when one was configured (case-sensitive, hence Compare instead of EQ)
+		if (Len(variables.issuer)) {
+			if (
+				!StructKeyExists(local.claims, "iss")
+				|| Compare(ToString(local.claims.iss), variables.issuer) != 0
+			) {
+				throw(
+					type = "Wheels.Auth.JWT.InvalidIssuer",
+					message = "JWT issuer validation failed"
+				);
+			}
+		}
 
 		// Validate time-based claims
 		if (!arguments.ignoreExpiry) {
@@ -276,7 +309,7 @@ component output="false" {
 	 * Get current time as Unix epoch seconds (UTC).
 	 */
 	private numeric function $epochSeconds() {
-		return Int(CreateObject("java", "java.lang.System").currentTimeMillis() / 1000);
+		return Int(GetTickCount() / 1000);
 	}
 
 }

--- a/vendor/wheels/auth/JwtService.cfc
+++ b/vendor/wheels/auth/JwtService.cfc
@@ -31,14 +31,14 @@ component output="false" {
 	) {
 		// Fail fast on missing or weak secrets — a short HMAC key makes every issued token brute-forceable
 		if (!Len(arguments.secretKey)) {
-			Throw(
+			throw(
 				type = "Wheels.Auth.JWT.InvalidSecretKey",
 				message = "JWT secret key cannot be empty.",
 				extendedInfo = "Provide a random secret of at least 32 bytes (256 bits) as required for HMAC-SHA256 by RFC 7518 Section 3.2."
 			);
 		}
 		if (Len(CharsetDecode(arguments.secretKey, "UTF-8")) < 32) {
-			Throw(
+			throw(
 				type = "Wheels.Auth.JWT.WeakSecretKey",
 				message = "JWT secret key is too short.",
 				extendedInfo = "HMAC-SHA256 requires a secret of at least 32 bytes (256 bits) per RFC 7518 Section 3.2. Generate a random secret of 32 or more bytes and store it outside source control."
@@ -121,7 +121,7 @@ component output="false" {
 		local.header = DeserializeJSON(local.headerJson);
 		if (!StructKeyExists(local.header, "alg") || local.header.alg != "HS256") {
 			local.claimedAlg = StructKeyExists(local.header, "alg") ? local.header.alg : "none";
-			Throw(
+			throw(
 				type = "Wheels.Auth.JWT.InvalidAlgorithm",
 				message = "JWT algorithm mismatch.",
 				extendedInfo = "Expected algorithm HS256 but token header specifies '#EncodeForHTML(local.claimedAlg)#'. This may indicate an algorithm substitution attack."

--- a/vendor/wheels/auth/JwtStrategy.cfc
+++ b/vendor/wheels/auth/JwtStrategy.cfc
@@ -6,7 +6,7 @@
  * claims as the authentication principal.
  *
  * Registration:
- *   var jwtService = new wheels.auth.JwtService(secretKey="my-secret");
+ *   var jwtService = new wheels.auth.JwtService(secretKey="a-random-secret-of-at-least-32-bytes");
  *   var jwtStrategy = new wheels.auth.JwtStrategy(jwtService=jwtService);
  *   authenticator.registerStrategy(name="jwt", strategy=jwtStrategy);
  *

--- a/vendor/wheels/auth/TokenStrategy.cfc
+++ b/vendor/wheels/auth/TokenStrategy.cfc
@@ -38,7 +38,7 @@ component implements="wheels.auth.AuthStrategy" output="false" {
 	 * Creates a new TokenStrategy instance.
 	 *
 	 * @validator Callback function that receives a token string and returns a principal struct on success or false on failure.
-	 * @tokens Static struct mapping token strings to principal structs. Used when no validator is provided. Matched case-sensitively.
+	 * @tokens Static struct mapping token strings to principal structs. Used when no validator is provided. Matched case-sensitively. Always quote the keys (e.g. {"AbC-123": {id: 1}}): Adobe CF uppercases unquoted struct-literal keys, so an unquoted mixed-case key would never match its token.
 	 * @queryParam Name of the query parameter to check for a token. Empty string (the default) disables query-string tokens; set a name (e.g. "api_key") to opt in.
 	 * @headerName Name of the HTTP header to check (default "authorization"). Set to empty string to disable.
 	 * @scheme Expected scheme prefix in the header value (default "Bearer"). Case-insensitive.

--- a/vendor/wheels/auth/TokenStrategy.cfc
+++ b/vendor/wheels/auth/TokenStrategy.cfc
@@ -1,9 +1,11 @@
 /**
  * Token-based authentication strategy for API keys and bearer tokens.
  *
- * Extracts a token from the `Authorization: Bearer <token>` header or
- * a configurable query parameter (default `api_key`). Validates the
- * token using either a validator callback or a static lookup struct.
+ * Extracts a token from the `Authorization: Bearer <token>` header or,
+ * when explicitly enabled via `queryParam`, a query parameter (disabled
+ * by default — query strings leak into access logs, browser history, and
+ * Referer headers). Validates the token using either a validator callback
+ * or a static lookup struct.
  *
  * Validator callback signature:
  *   function(required string token) returns struct or false
@@ -36,15 +38,15 @@ component implements="wheels.auth.AuthStrategy" output="false" {
 	 * Creates a new TokenStrategy instance.
 	 *
 	 * @validator Callback function that receives a token string and returns a principal struct on success or false on failure.
-	 * @tokens Static struct mapping token strings to principal structs. Used when no validator is provided.
-	 * @queryParam Name of the query parameter to check for a token (default "api_key"). Set to empty string to disable.
+	 * @tokens Static struct mapping token strings to principal structs. Used when no validator is provided. Matched case-sensitively.
+	 * @queryParam Name of the query parameter to check for a token. Empty string (the default) disables query-string tokens; set a name (e.g. "api_key") to opt in.
 	 * @headerName Name of the HTTP header to check (default "authorization"). Set to empty string to disable.
 	 * @scheme Expected scheme prefix in the header value (default "Bearer"). Case-insensitive.
 	 */
 	public TokenStrategy function init(
 		any validator = "",
 		struct tokens = {},
-		string queryParam = "api_key",
+		string queryParam = "",
 		string headerName = "authorization",
 		string scheme = "Bearer"
 	) {
@@ -54,6 +56,8 @@ component implements="wheels.auth.AuthStrategy" output="false" {
 		variables.headerName = LCase(arguments.headerName);
 		variables.scheme = arguments.scheme;
 		variables.authResult = new wheels.auth.AuthResult();
+		// Cache the Java class handle used for constant-time token comparison
+		variables.messageDigest = CreateObject("java", "java.security.MessageDigest");
 		return this;
 	}
 
@@ -223,10 +227,17 @@ component implements="wheels.auth.AuthStrategy" output="false" {
 			return {};
 		}
 
-		// Static token lookup
+		// Static token lookup — struct key lookups are case-insensitive, so iterate
+		// the keys and compare each one case-sensitively and in constant time
 		if (!StructIsEmpty(variables.tokens)) {
-			if (StructKeyExists(variables.tokens, arguments.token)) {
-				local.principal = variables.tokens[arguments.token];
+			local.matchedKey = "";
+			for (local.candidate in variables.tokens) {
+				if ($secureCompare(local.candidate, arguments.token)) {
+					local.matchedKey = local.candidate;
+				}
+			}
+			if (Len(local.matchedKey)) {
+				local.principal = variables.tokens[local.matchedKey];
 				if (IsStruct(local.principal)) {
 					return local.principal;
 				}
@@ -236,6 +247,20 @@ component implements="wheels.auth.AuthStrategy" output="false" {
 
 		// No validator and no tokens configured — reject
 		return {};
+	}
+
+	/**
+	 * Compare two strings case-sensitively in constant time to prevent timing attacks.
+	 *
+	 * @candidate The configured token to compare against.
+	 * @actual The token supplied by the request.
+	 * @return True when both strings are byte-for-byte identical.
+	 */
+	private boolean function $secureCompare(required string candidate, required string actual) {
+		return variables.messageDigest.isEqual(
+			arguments.candidate.getBytes("UTF-8"),
+			arguments.actual.getBytes("UTF-8")
+		);
 	}
 
 }

--- a/vendor/wheels/tests/specs/auth/JwtServiceSpec.cfc
+++ b/vendor/wheels/tests/specs/auth/JwtServiceSpec.cfc
@@ -6,9 +6,31 @@ component extends="wheels.WheelsTest" {
 
 			beforeEach(function() {
 				jwt = new wheels.auth.JwtService(
-					secretKey = "test-secret-key-for-jwt-specs",
+					secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes",
 					defaultExpiry = 3600
 				);
+			});
+
+			describe("init() secret validation", function() {
+
+				it("throws InvalidSecretKey for an empty secret", function() {
+					expect(function() {
+						var svc = new wheels.auth.JwtService(secretKey = "");
+					}).toThrow("Wheels.Auth.JWT.InvalidSecretKey");
+				});
+
+				it("throws WeakSecretKey for a secret shorter than 32 bytes", function() {
+					expect(function() {
+						var svc = new wheels.auth.JwtService(secretKey = "short-secret");
+					}).toThrow("Wheels.Auth.JWT.WeakSecretKey");
+				});
+
+				it("accepts a secret of exactly 32 bytes", function() {
+					var svc = new wheels.auth.JwtService(secretKey = RepeatString("k", 32));
+					var token = svc.encode(claims = {sub = 1});
+					expect(svc.verify(token)).toBeTrue();
+				});
+
 			});
 
 			describe("encode()", function() {
@@ -50,7 +72,7 @@ component extends="wheels.WheelsTest" {
 
 				it("adds issuer when configured", function() {
 					var jwtWithIssuer = new wheels.auth.JwtService(
-						secretKey = "test-secret-key-for-jwt-specs",
+						secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes",
 						issuer = "wheels-app"
 					);
 					var token = jwtWithIssuer.encode(claims = {sub = 1});
@@ -60,11 +82,16 @@ component extends="wheels.WheelsTest" {
 
 				it("does not overwrite explicit issuer in claims", function() {
 					var jwtWithIssuer = new wheels.auth.JwtService(
-						secretKey = "test-secret-key-for-jwt-specs",
+						secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes",
 						issuer = "default-issuer"
 					);
 					var token = jwtWithIssuer.encode(claims = {sub = 1, iss = "custom-issuer"});
-					var claims = jwtWithIssuer.decode(token);
+					// Decode with a service that has no configured issuer: the issuing
+					// service itself would reject the mismatched iss claim on decode.
+					var verifier = new wheels.auth.JwtService(
+						secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes"
+					);
+					var claims = verifier.decode(token);
 					expect(claims.iss).toBe("custom-issuer");
 				});
 
@@ -117,7 +144,7 @@ component extends="wheels.WheelsTest" {
 				});
 
 				it("throws InvalidSignature for tokens signed with wrong key", function() {
-					var otherJwt = new wheels.auth.JwtService(secretKey = "different-secret");
+					var otherJwt = new wheels.auth.JwtService(secretKey = "different-secret-padded-to-at-least-32-bytes");
 					var token = otherJwt.encode(claims = {sub = 1});
 					expect(function() {
 						jwt.decode(token);
@@ -161,7 +188,7 @@ component extends="wheels.WheelsTest" {
 				});
 
 				it("still validates signature when ignoreExpiry is true", function() {
-					var otherJwt = new wheels.auth.JwtService(secretKey = "wrong-key");
+					var otherJwt = new wheels.auth.JwtService(secretKey = "wrong-key-padded-to-at-least-32-bytes");
 					var now = Int(CreateObject("java", "java.lang.System").currentTimeMillis() / 1000);
 					var token = otherJwt.encode(claims = {sub = 1, exp = now - 3600});
 					expect(function() {
@@ -171,11 +198,79 @@ component extends="wheels.WheelsTest" {
 
 			});
 
+			describe("issuer validation", function() {
+
+				it("decodes a token whose iss matches the configured issuer", function() {
+					var issuerJwt = new wheels.auth.JwtService(
+						secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes",
+						issuer = "expected-issuer"
+					);
+					var token = issuerJwt.encode(claims = {sub = 7});
+					var claims = issuerJwt.decode(token);
+					expect(claims.sub).toBe(7);
+					expect(claims.iss).toBe("expected-issuer");
+				});
+
+				it("throws InvalidIssuer when iss does not match the configured issuer", function() {
+					var issuerJwt = new wheels.auth.JwtService(
+						secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes",
+						issuer = "expected-issuer"
+					);
+					var otherJwt = new wheels.auth.JwtService(
+						secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes",
+						issuer = "other-issuer"
+					);
+					var token = otherJwt.encode(claims = {sub = 1});
+					expect(function() {
+						issuerJwt.decode(token);
+					}).toThrow("Wheels.Auth.JWT.InvalidIssuer");
+				});
+
+				it("throws InvalidIssuer when iss is missing but an issuer is configured", function() {
+					var plainJwt = new wheels.auth.JwtService(
+						secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes"
+					);
+					var issuerJwt = new wheels.auth.JwtService(
+						secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes",
+						issuer = "expected-issuer"
+					);
+					var token = plainJwt.encode(claims = {sub = 1});
+					expect(function() {
+						issuerJwt.decode(token);
+					}).toThrow("Wheels.Auth.JWT.InvalidIssuer");
+				});
+
+				it("validates the issuer case-sensitively", function() {
+					var issuerJwt = new wheels.auth.JwtService(
+						secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes",
+						issuer = "Wheels-App"
+					);
+					var otherJwt = new wheels.auth.JwtService(
+						secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes",
+						issuer = "wheels-app"
+					);
+					var token = otherJwt.encode(claims = {sub = 1});
+					expect(function() {
+						issuerJwt.decode(token);
+					}).toThrow("Wheels.Auth.JWT.InvalidIssuer");
+				});
+
+				it("does not validate iss when no issuer is configured", function() {
+					var plainJwt = new wheels.auth.JwtService(
+						secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes"
+					);
+					var token = plainJwt.encode(claims = {sub = 1, iss = "anything-goes"});
+					var claims = plainJwt.decode(token);
+					expect(claims.iss).toBe("anything-goes");
+				});
+
+			});
+
 			describe("allowedClockSkew", function() {
 
 				it("permits tokens within clock skew window", function() {
 					var jwtWithSkew = new wheels.auth.JwtService(
-						secretKey = "test-secret-key-for-jwt-specs",
+						secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes",
 						allowedClockSkew = 60
 					);
 					var now = Int(CreateObject("java", "java.lang.System").currentTimeMillis() / 1000);
@@ -187,7 +282,7 @@ component extends="wheels.WheelsTest" {
 
 				it("rejects tokens beyond clock skew window", function() {
 					var jwtWithSkew = new wheels.auth.JwtService(
-						secretKey = "test-secret-key-for-jwt-specs",
+						secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes",
 						allowedClockSkew = 60
 					);
 					var now = Int(CreateObject("java", "java.lang.System").currentTimeMillis() / 1000);
@@ -200,7 +295,7 @@ component extends="wheels.WheelsTest" {
 
 				it("permits nbf tokens within clock skew window", function() {
 					var jwtWithSkew = new wheels.auth.JwtService(
-						secretKey = "test-secret-key-for-jwt-specs",
+						secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes",
 						allowedClockSkew = 60
 					);
 					var now = Int(CreateObject("java", "java.lang.System").currentTimeMillis() / 1000);
@@ -288,7 +383,7 @@ component extends="wheels.WheelsTest" {
 				});
 
 				it("rejects tokens with invalid signature during refresh", function() {
-					var otherJwt = new wheels.auth.JwtService(secretKey = "wrong-key");
+					var otherJwt = new wheels.auth.JwtService(secretKey = "wrong-key-padded-to-at-least-32-bytes");
 					var token = otherJwt.encode(claims = {sub = 1});
 					expect(function() {
 						jwt.refresh(token);

--- a/vendor/wheels/tests/specs/auth/JwtStrategySpec.cfc
+++ b/vendor/wheels/tests/specs/auth/JwtStrategySpec.cfc
@@ -6,7 +6,7 @@ component extends="wheels.WheelsTest" {
 
 			beforeEach(function() {
 				jwtService = new wheels.auth.JwtService(
-					secretKey = "test-secret-for-strategy-specs",
+					secretKey = "test-secret-for-strategy-specs-padded-to-32",
 					defaultExpiry = 3600
 				);
 				strategy = new wheels.auth.JwtStrategy(jwtService = jwtService);
@@ -109,7 +109,7 @@ component extends="wheels.WheelsTest" {
 				});
 
 				it("fails with an invalid signature", function() {
-					var otherService = new wheels.auth.JwtService(secretKey = "wrong-key");
+					var otherService = new wheels.auth.JwtService(secretKey = "wrong-key-padded-to-at-least-32-bytes");
 					var token = otherService.encode(claims = {sub = 1});
 					var req = {headers = {authorization = "Bearer " & token}};
 					var result = strategy.authenticate(req);
@@ -192,7 +192,7 @@ component extends="wheels.WheelsTest" {
 					);
 
 					// Send an invalid JWT so the JWT strategy fails
-					var otherService = new wheels.auth.JwtService(secretKey = "wrong-key");
+					var otherService = new wheels.auth.JwtService(secretKey = "wrong-key-padded-to-at-least-32-bytes");
 					var badToken = otherService.encode(claims = {sub = 1});
 					var req = {headers = {authorization = "Bearer " & badToken}};
 					var result = auth.authenticate(request = req);

--- a/vendor/wheels/tests/specs/auth/TokenStrategySpec.cfc
+++ b/vendor/wheels/tests/specs/auth/TokenStrategySpec.cfc
@@ -21,8 +21,14 @@ component extends="wheels.WheelsTest" {
 					expect(strategy.supports(req)).toBeTrue();
 				});
 
-				it("returns true when query param api_key is present", function() {
+				it("does not read query param tokens by default", function() {
 					var strategy = new wheels.auth.TokenStrategy();
+					var req = {params = {api_key = "abc-123"}};
+					expect(strategy.supports(req)).toBeFalse();
+				});
+
+				it("returns true when query param is present and explicitly enabled", function() {
+					var strategy = new wheels.auth.TokenStrategy(queryParam = "api_key");
 					var req = {params = {api_key = "abc-123"}};
 					expect(strategy.supports(req)).toBeTrue();
 				});
@@ -80,13 +86,25 @@ component extends="wheels.WheelsTest" {
 					expect(result.statusCode).toBe(200);
 				});
 
-				it("succeeds with a valid token from query param", function() {
+				it("succeeds with a valid token from an explicitly enabled query param", function() {
+					var qpStrategy = new wheels.auth.TokenStrategy(
+						tokens = {"valid-key-2" = {id = 2, role = "reader"}},
+						queryParam = "api_key"
+					);
 					var req = {params = {api_key = "valid-key-2"}};
-					var result = strategy.authenticate(req);
+					var result = qpStrategy.authenticate(req);
 
 					expect(result.success).toBeTrue();
 					expect(result.principal.id).toBe(2);
 					expect(result.principal.role).toBe("reader");
+				});
+
+				it("ignores query param tokens by default", function() {
+					var req = {params = {api_key = "valid-key-2"}};
+					var result = strategy.authenticate(req);
+
+					expect(result.success).toBeFalse();
+					expect(result.error).toBe("No token provided");
 				});
 
 				it("fails with an invalid token", function() {
@@ -109,11 +127,44 @@ component extends="wheels.WheelsTest" {
 				});
 
 				it("prefers header token over query param", function() {
+					var qpStrategy = new wheels.auth.TokenStrategy(
+						tokens = {
+							"valid-key-1" = {id = 1, role = "admin"},
+							"valid-key-2" = {id = 2, role = "reader"}
+						},
+						queryParam = "api_key"
+					);
 					var req = {
 						headers = {authorization = "Bearer valid-key-1"},
 						params = {api_key = "valid-key-2"}
 					};
-					var result = strategy.authenticate(req);
+					var result = qpStrategy.authenticate(req);
+
+					expect(result.success).toBeTrue();
+					expect(result.principal.id).toBe(1);
+				});
+
+			});
+
+			describe("static token case sensitivity", function() {
+
+				it("rejects a token that differs from the configured key only in case", function() {
+					var caseStrategy = new wheels.auth.TokenStrategy(
+						tokens = {"AbC-123" = {id = 1, role = "admin"}}
+					);
+					var req = {headers = {authorization = "Bearer abc-123"}};
+					var result = caseStrategy.authenticate(req);
+
+					expect(result.success).toBeFalse();
+					expect(result.statusCode).toBe(401);
+				});
+
+				it("accepts a token with the exact configured case", function() {
+					var caseStrategy = new wheels.auth.TokenStrategy(
+						tokens = {"AbC-123" = {id = 1, role = "admin"}}
+					);
+					var req = {headers = {authorization = "Bearer AbC-123"}};
+					var result = caseStrategy.authenticate(req);
 
 					expect(result.success).toBeTrue();
 					expect(result.principal.id).toBe(1);
@@ -337,9 +388,9 @@ component extends="wheels.WheelsTest" {
 					expect(strategy.supports(req)).toBeFalse();
 				});
 
-				it("reads from urlParams as fallback for query param", function() {
+				it("reads from urlParams as fallback for an enabled query param", function() {
 					var tokenMap = {"url-token" = {id = 7}};
-					var strategy = new wheels.auth.TokenStrategy(tokens = tokenMap);
+					var strategy = new wheels.auth.TokenStrategy(tokens = tokenMap, queryParam = "api_key");
 
 					var req = {urlParams = {api_key = "url-token"}};
 					var result = strategy.authenticate(req);

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/authentication-patterns.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/authentication-patterns.mdx
@@ -29,7 +29,7 @@ Wheels ships four auth components under `wheels.auth.*`:
 |-----------|------|
 | `Authenticator` | Registry that tries registered strategies in order and returns the first success. |
 | `SessionStrategy` | Reads a principal struct from the `session` scope. Handles login/logout. |
-| `TokenStrategy` | Validates an `Authorization: Bearer <token>` header (or `?api_key=`) against a validator callback or a static token map. |
+| `TokenStrategy` | Validates an `Authorization: Bearer <token>` header (or an opt-in query parameter) against a validator callback or a static token map. |
 | `JwtStrategy` | Validates a signed JWT (`Authorization: Bearer <jwt>`) via `JwtService`. |
 
 Each strategy implements a small interface (`getName()`, `supports(request)`, `authenticate(request)`). The authenticator picks the first strategy whose `supports()` returns true, runs its `authenticate()`, and returns a result struct:
@@ -184,7 +184,7 @@ component extends="Model" {
 
 ## Token auth with `TokenStrategy`
 
-`TokenStrategy` extracts a bearer token from `Authorization: Bearer <token>` (or a `?api_key=` query parameter) and validates it against either a **validator callback** — typical for database-backed API keys — or a **static token map** — useful for tests and seeded dev keys.
+`TokenStrategy` extracts a bearer token from `Authorization: Bearer <token>` (or, when explicitly enabled via `queryParam`, a query parameter) and validates it against either a **validator callback** — typical for database-backed API keys — or a **static token map** — useful for tests and seeded dev keys. Static tokens are matched case-sensitively and compared in constant time.
 
 ### Validator callback (database-backed)
 
@@ -265,7 +265,7 @@ if (StructKeyExists(application, "wheelsdi") && application.wheelsdi.containsIns
 }
 ```
 
-The secret lives in the environment (`env("JWT_SECRET")`) — never commit it. `defaultExpiry` is seconds; 3600 = one hour. `issuer` is stamped as the `iss` claim and can be used by downstream validators to reject tokens meant for other services.
+The secret lives in the environment (`env("JWT_SECRET")`) — never commit it, and make it at least 32 random bytes (`JwtService` throws at construction for empty or shorter secrets, per RFC 7518 §3.2). `defaultExpiry` is seconds; 3600 = one hour. `issuer` is stamped as the `iss` claim, and `decode()` rejects tokens whose `iss` is missing or doesn't match it.
 
 ### Issue tokens on login
 
@@ -361,7 +361,8 @@ You don't have to. `Authenticator`, `SessionStrategy`, `TokenStrategy`, and `Jwt
 - **Timing-safe comparison.** The stopgap `authenticate()` uses `==` to compare hashes, which is not timing-safe. Under load an attacker can measure response times to recover the hash byte-by-byte. Swap for a constant-time comparator (`Compare()` in CFML is not guaranteed constant-time either — use a dedicated Java helper) when you ship bcrypt.
 - **Secret rotation.** `JwtService` takes a single `secretKey`. Rotating it invalidates every outstanding token. For gradual rotation, validate against a list of current + previous secrets during the cutover window; the shipped `JwtService` doesn't do this natively, so you'll need to wrap it.
 - **JWT revocation.** JWTs are stateless by design — you cannot revoke an issued token before it expires unless you maintain a server-side deny-list and check it on every request. Keep token expiry short (minutes, not days) and use a refresh-token flow if you need long sessions.
-- **Token leakage in URLs.** `TokenStrategy` accepts `?api_key=` by default. Query strings show up in access logs, referer headers, and browser history. Prefer headers; set `queryParam=""` on `TokenStrategy` init to disable query-string auth entirely.
+- **Token leakage in URLs.** Query-string tokens are disabled by default on both `TokenStrategy` and `JwtStrategy` (`queryParam=""`). Query strings show up in access logs, referer headers, and browser history — prefer the `Authorization` header, and only set `queryParam` if you must support URL-based keys.
+- **Weak JWT secrets.** `JwtService` refuses to construct with an empty secret (`Wheels.Auth.JWT.InvalidSecretKey`) or one shorter than 32 bytes (`Wheels.Auth.JWT.WeakSecretKey`), per RFC 7518 §3.2 — HMAC-SHA256 needs at least 256 bits of key material. Generate a random 32+ byte secret and load it from the environment.
 
 ## Related guides
 


### PR DESCRIPTION
## Summary

Hardens the `wheels.auth.*` primitives against weak-key and credential-leak misconfiguration:

- `JwtService.init()` fails fast on bad HMAC secrets: empty secret throws `Wheels.Auth.JWT.InvalidSecretKey`; a secret under 32 UTF-8 bytes throws `Wheels.Auth.JWT.WeakSecretKey` (RFC 7518 §3.2), instead of failing obscurely inside `HMac()` or silently signing every token with a brute-forceable key.
- `JwtService.decode()` now validates the `iss` claim (present + case-sensitive match) whenever an issuer was configured, throwing `Wheels.Auth.JWT.InvalidIssuer` after signature verification. `refresh()` inherits the check; `JwtStrategy` maps the failure to a 401 (no 500s).
- `TokenStrategy` static token map entries are matched case-sensitively and in constant time (`MessageDigest.isEqual` over UTF-8 bytes, iterating all keys without early break) — CFML struct key lookups are case-insensitive, so `"AbC123"` previously authenticated as `"abc123"`.
- `TokenStrategy.queryParam` now defaults to `""` (disabled), matching `JwtStrategy`, so bearer credentials are no longer accepted from the URL by default and cannot leak into access logs, browser history, or `Referer` headers. Set `queryParam` explicitly (e.g. `"api_key"`) to opt back in — this is a deliberate, documented breaking change.
- Perf: the `java.security.MessageDigest` and `java.lang.System` class handles are cached in `init()`; `$epochSeconds()` keeps wall-clock `currentTimeMillis()` semantics with zero per-call object creation.

The authentication-patterns guide and the `JwtStrategy` doc-comment example (whose old `"my-secret"` sample would now throw `WeakSecretKey`) are updated to match.

## Findings addressed

- **MA10 [Medium]** `JwtService` accepts an empty or trivially weak HMAC secret with no fail-fast validation; `decode()` never validates `iss` @ `vendor/wheels/auth/JwtService.cfc:31-46` (secret validation) and `vendor/wheels/auth/JwtService.cfc:150-160` (issuer validation)
- **MA11 [Medium]** `TokenStrategy` static token map matches API keys case-insensitively, and tokens are accepted via query string by default @ `vendor/wheels/auth/TokenStrategy.cfc:49` (`queryParam` default) and `vendor/wheels/auth/TokenStrategy.cfc:229-244` (constant-time case-sensitive lookup)
- **MA16 [Low, perf]** `JwtService` creates Java class handles per call instead of caching them @ `vendor/wheels/auth/JwtService.cfc:54` (cached `MessageDigest` handle) and `vendor/wheels/auth/JwtService.cfc:312` (`GetTickCount` epoch idiom)
- **SEC-18 [Medium]** — security-pass duplicate of MA10; resolved by the same change
- **SEC-19 [Medium]** — security-pass duplicate of MA11; resolved by the same change

## Findings verified already-fixed

None — `staleRefs` for this package is empty (spot-checked for MA10 and MA11 against `origin/develop` during review; all five findings required code changes on this branch).

## Source

Internal multi-agent framework review 2026-06-09, wave 2, package `auth-services` (findings middleware-auth:10/11/16, security-pass:18/19).

## Tests

New/updated specs under `vendor/wheels/tests/specs/auth/` (WheelsTest BDD), each verified red against the pre-fix `origin/develop` source:

- `JwtServiceSpec.cfc` — empty-secret throws `InvalidSecretKey`; <32-byte secret throws `WeakSecretKey`; exactly-32-byte boundary accepted; issuer match decodes; mismatched / missing / case-variant `iss` throw `InvalidIssuer`; no `iss` validation when no issuer configured.
- `TokenStrategySpec.cfc` — query-param tokens ignored by default in both `supports()` and extraction; explicit `queryParam` opt-in works for `params` and `urlParams`; static token rejected when it differs only in case; exact-case token accepted.
- `JwtStrategySpec.cfc` — fixtures updated for the >=32-byte secret requirement.

Local verification: ran the full `wheels.tests.specs.auth` area via the worktree-safe docker recipe on Lucee 7 + SQLite **and** Adobe CF 2023 + SQLite — **167 pass, 0 fail, 0 error (HTTP 200)** on each. This also exercised the `Len(CharsetDecode(...))` byte-counting idiom on real engines. Full cross-engine coverage is deferred to the CI compat matrix, which constructs `JwtService` in every auth spec.

## Cross-engine notes

- Checked against the CLAUDE.md invariants list: no inline closures as constructor named args, no `local.X` assignments inside `catch`, no reserved-scope parameter names, no `Left(str, 0)`; `Throw` + `extendedInfo` has same-file prior art.
- `Compare()` is used for the case-sensitive issuer check and `MessageDigest.isEqual` for token bytes — both behave identically across Lucee 5/6/7, Adobe 2018-2025, and BoxLang.
- Adobe CF uppercases unquoted struct-literal keys, so a user-defined static token map with unquoted keys would not match under case-sensitive comparison; the guide examples use quoted keys, and the `@tokens` doc-comment now carries the quoted-keys caveat (bot review round 1).
- `$epochSeconds()` uses the cached `java.lang.System` handle's `currentTimeMillis()` — guaranteed wall-clock epoch on every engine. The earlier `GetTickCount()` form was reverted per bot review: although it empirically equals `currentTimeMillis()` on Adobe CF 2023 and Lucee 7 (probed in-container), its documented contract only promises a relative millisecond clock, which is not a safe basis for RFC 7519 claims.

## Changelog

Entry deliberately omitted; consolidated at campaign end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
