### PR TITLE
fix(controller): usesLayout crash, verifies bounds, only/except dedup, scoped loop vars

### DIFF
--- a/vendor/wheels/Controller.cfc
+++ b/vendor/wheels/Controller.cfc
@@ -48,8 +48,7 @@ component output="false" displayName="Controller" extends="wheels.Global"{
 		variables.$class.formats = {};
 		variables.$class.formats.default = "html";
 		variables.$class.formats.actions = {};
-		variables.$class.formats.existingTemplates = "";
-		variables.$class.formats.nonExistingTemplates = "";
+		variables.$class.formats.templateCache = {};
 
 		// Storage for declared service injections (populated by inject() in config)
 		variables.$class.services = [];
@@ -78,31 +77,27 @@ component output="false" displayName="Controller" extends="wheels.Global"{
 		local.template = $get("viewPath") & "/" & LCase(ListChangeDelims(arguments.name, '/', '.')) & "/helpers.cfm";
 
 		// Check if the file exists on the file system if we have not already checked in a previous request.
-		// When the file is not found in either the existing or nonexisting list we know that we have not yet checked for it.
+		// When the controller is not present in the cache we know that we have not yet checked for it.
 		local.helperFileExists = false;
-		if (
-			!ListFindNoCase(application.wheels.existingHelperFiles, arguments.name)
-			&& !ListFindNoCase(application.wheels.nonExistingHelperFiles, arguments.name)
-		) {
+		if (!StructKeyExists(application.wheels.helperFileCache, arguments.name)) {
 			if (FileExists(ExpandPath(local.template))) {
 				local.helperFileExists = true;
 			}
 			if ($get("cacheFileChecking")) {
-				if (local.helperFileExists) {
-					application.wheels.existingHelperFiles = ListAppend(application.wheels.existingHelperFiles, arguments.name);
-				} else {
-					application.wheels.nonExistingHelperFiles = ListAppend(
-						application.wheels.nonExistingHelperFiles,
-						arguments.name
-					);
-				}
+				application.wheels.helperFileCache[arguments.name] = local.helperFileExists;
 			}
 		}
 
 		// Include controller specific helper file if it exists.
 		if (
 			Len(arguments.name)
-			&& (ListFindNoCase(application.wheels.existingHelperFiles, arguments.name) || local.helperFileExists)
+			&& (
+				local.helperFileExists
+				|| (
+					StructKeyExists(application.wheels.helperFileCache, arguments.name)
+					&& application.wheels.helperFileCache[arguments.name]
+				)
+			)
 		) {
 			$include(template = local.template);
 		}

--- a/vendor/wheels/controller/caching.cfc
+++ b/vendor/wheels/controller/caching.cfc
@@ -49,7 +49,7 @@ component {
 		// Only remove specific actions from the cache list
 		local.filtered = [];
 		for (local.i = 1; local.i <= ArrayLen(variables.$class.cachableActions); local.i++) {
-			local.cachableAction = variables.$class.cachableActions[i];
+			local.cachableAction = variables.$class.cachableActions[local.i];
 			if (!ListFindNoCase(arguments.action, local.cachableAction.action)) {
 				ArrayAppend(local.filtered, local.cachableAction);
 			}

--- a/vendor/wheels/controller/csrf.cfc
+++ b/vendor/wheels/controller/csrf.cfc
@@ -37,11 +37,7 @@ component {
 	public function $runCsrfProtection(string action) {
 		if (StructKeyExists(variables.$class, "csrf")) {
 			local.csrf = variables.$class.csrf;
-			if (
-				(!Len(local.csrf.only) && !Len(local.csrf.except))
-				|| (Len(local.csrf.only) && ListFindNoCase(local.csrf.only, arguments.action))
-				|| (Len(local.csrf.except) && !ListFindNoCase(local.csrf.except, arguments.action))
-			) {
+			if ($appliesToAction(action = arguments.action, only = local.csrf.only, except = local.csrf.except)) {
 				$storeAuthenticityToken();
 				$flagRequestAsProtected();
 				$setAuthenticityToken();

--- a/vendor/wheels/controller/filters.cfc
+++ b/vendor/wheels/controller/filters.cfc
@@ -109,10 +109,7 @@ component {
 		local.iEnd = ArrayLen(local.filters);
 		for (local.i = 1; local.i <= local.iEnd; local.i++) {
 			local.filter = local.filters[local.i];
-			local.listsNotSpecified = !Len(local.filter.only) && !Len(local.filter.except);
-			local.inOnlyList = Len(local.filter.only) && ListFindNoCase(local.filter.only, arguments.action);
-			local.notInExceptionList = Len(local.filter.except) && !ListFindNoCase(local.filter.except, arguments.action);
-			if (local.listsNotSpecified || local.inOnlyList || local.notInExceptionList) {
+			if ($appliesToAction(action = arguments.action, only = local.filter.only, except = local.filter.except)) {
 				if (!StructKeyExists(variables, local.filter.through)) {
 					Throw(
 						type = "Wheels.FilterNotFound",

--- a/vendor/wheels/controller/layouts.cfc
+++ b/vendor/wheels/controller/layouts.cfc
@@ -47,8 +47,14 @@ component {
 				if (StructCount(local.layout) eq StructCount(arguments)) {
 					local.oneKeyIsDifferent = false;
 					for (local.key in arguments) {
-						// Compare key presence first since an equal key count does not guarantee the same key set (e.g. one declaration using `only` and another using `except`).
-						if (!StructKeyExists(local.layout, local.key) || local.layout[local.key] neq arguments[local.key]) {
+						// Iterating the arguments scope can yield declared-but-unset keys (null-valued on Lucee / Adobe), for which StructKeyExists() returns false.
+						// Treat a key as equal when it is unset on both sides, and as different when it is set on only one side (e.g. one declaration using `only` and another using `except`) or when both are set with different values.
+						local.keyInArguments = StructKeyExists(arguments, local.key);
+						local.keyInLayout = StructKeyExists(local.layout, local.key);
+						if (
+							local.keyInArguments neq local.keyInLayout
+							|| (local.keyInArguments && local.layout[local.key] neq arguments[local.key])
+						) {
 							local.oneKeyIsDifferent = true;
 							break;
 						}

--- a/vendor/wheels/controller/layouts.cfc
+++ b/vendor/wheels/controller/layouts.cfc
@@ -47,13 +47,15 @@ component {
 				if (StructCount(local.layout) eq StructCount(arguments)) {
 					local.oneKeyIsDifferent = false;
 					for (local.key in arguments) {
-						if (local.layout[local.key] neq arguments[key]) {
+						// Compare key presence first since an equal key count does not guarantee the same key set (e.g. one declaration using `only` and another using `except`).
+						if (!StructKeyExists(local.layout, local.key) || local.layout[local.key] neq arguments[local.key]) {
 							local.oneKeyIsDifferent = true;
+							break;
 						}
 					}
 					if (!local.oneKeyIsDifferent) {
 						local.layoutInArray = true;
-						local.layoutPostionInArray = local.i;
+						local.layoutPositionInArray = local.i;
 					}
 				}
 			}
@@ -63,7 +65,7 @@ component {
 
 		// If this layout was is in the array, we need to delete it to respect the order of declaration
 		if (local.layoutInArray) {
-			ArrayDeleteAt(variables.$class.layouts, local.layoutPostionInArray);
+			ArrayDeleteAt(variables.$class.layouts, local.layoutPositionInArray);
 		}
 	}
 
@@ -123,31 +125,21 @@ component {
 			local.include = local.viewPath;
 			if (IsBoolean(arguments.$layout)) {
 				local.layoutFileExists = false;
-				if (
-					!ListFindNoCase(application.wheels.existingLayoutFiles, variables.params.controller)
-					&& !ListFindNoCase(application.wheels.nonExistingLayoutFiles, variables.params.controller)
-				) {
+				if (!StructKeyExists(application.wheels.layoutFileCache, variables.params.controller)) {
 					local.file = local.viewPath & "/" & LCase(variables.params.controller) & "/layout.cfm";
 					if (FileExists(ExpandPath(local.file))) {
 						local.layoutFileExists = true;
 					}
 					if ($get("cacheFileChecking")) {
-						if (local.layoutFileExists) {
-							application.wheels.existingLayoutFiles = ListAppend(
-								application.wheels.existingLayoutFiles,
-								variables.params.controller
-							);
-						} else {
-							application.wheels.nonExistingLayoutFiles = ListAppend(
-								application.wheels.nonExistingLayoutFiles,
-								variables.params.controller
-							);
-						}
+						application.wheels.layoutFileCache[variables.params.controller] = local.layoutFileExists;
 					}
 				}
 				if (
-					ListFindNoCase(application.wheels.existingLayoutFiles, variables.params.controller)
-					|| local.layoutFileExists
+					local.layoutFileExists
+					|| (
+						StructKeyExists(application.wheels.layoutFileCache, variables.params.controller)
+						&& application.wheels.layoutFileCache[variables.params.controller]
+					)
 				) {
 					local.include &= "/" & variables.params.controller & "/" & "layout.cfm";
 				} else {

--- a/vendor/wheels/controller/miscellaneous.cfc
+++ b/vendor/wheels/controller/miscellaneous.cfc
@@ -367,4 +367,17 @@ component {
 	public boolean function isOptions() {
 		return request.cgi.request_method == "options";
 	}
+
+	/**
+	 * Internal function.
+	 * Returns whether an `only` / `except` action gating declaration applies to the supplied action.
+	 * Applies when neither list is provided, when `only` is provided and contains the action, or when `except` is provided and does not contain the action.
+	 * When both lists are provided the conditions are OR'ed, so the declaration applies when the action is in `only` or when it's missing from `except`.
+	 * Used by filters, verifications and CSRF protection.
+	 */
+	public boolean function $appliesToAction(required string action, string only = "", string except = "") {
+		return (!Len(arguments.only) && !Len(arguments.except))
+		|| (Len(arguments.only) && ListFindNoCase(arguments.only, arguments.action) > 0)
+		|| (Len(arguments.except) && !ListFindNoCase(arguments.except, arguments.action));
+	}
 }

--- a/vendor/wheels/controller/processing.cfc
+++ b/vendor/wheels/controller/processing.cfc
@@ -63,21 +63,27 @@ component {
 					if (Len(local.appendToKey)) {
 						for (local.item in ListToArray(local.appendToKey)) {
 							if (IsDefined(local.item)) {
-								scopeMap = {
-									"request": request,
-									"arguments": arguments,
-									"application": application,
-									"session": session,
-									"variables": variables
-								};
+								// Build the scope lookup once (and keep it in the local scope so it doesn't leak into the controller's variables scope).
+								if (!StructKeyExists(local, "scopeMap")) {
+									local.scopeMap = {
+										"request": request,
+										"arguments": arguments,
+										"application": application,
+										"session": session,
+										"variables": variables
+									};
+								}
 
 								// Extract scope name and variable name from local.item
-								local.scopeName = listFirst(local.item, ".");
-								local.varName = listLast(local.item, ".");
-								if (structKeyExists(scopeMap, local.scopeName) && structKeyExists(scopeMap[local.scopeName], local.varName)) {
-									local.key &= scopeMap[local.scopeName][local.varName];
+								local.scopeName = ListFirst(local.item, ".");
+								local.varName = ListLast(local.item, ".");
+								if (
+									StructKeyExists(local.scopeMap, local.scopeName)
+									&& StructKeyExists(local.scopeMap[local.scopeName], local.varName)
+								) {
+									local.key &= local.scopeMap[local.scopeName][local.varName];
 								} else {
-									throw(type = "Wheels.KeyNotFound", message = "The `#local.item#` argument was not found.");
+									Throw(type = "Wheels.KeyNotFound", message = "The `#local.item#` argument was not found.");
 								}
 							}
 						}

--- a/vendor/wheels/controller/redirection.cfc
+++ b/vendor/wheels/controller/redirection.cfc
@@ -112,7 +112,8 @@ component {
 					local.params = $constructParams(params = arguments.params, encode = arguments.encode);
 					if (Find("?", request.cgi.http_referer)) {
 						local.params = Replace(local.params, "?", "&");
-					} else if (Left(local.params, 1) == "&" && !Find(request.cgi.http_referer, "?")) {
+					} else if (Left(local.params, 1) == "&") {
+						// The referrer has no query string (checked above) so turn the leading "&" into a "?".
 						local.params = Replace(local.params, "&", "?", "one");
 					}
 					local.url &= local.params;

--- a/vendor/wheels/controller/rendering.cfc
+++ b/vendor/wheels/controller/rendering.cfc
@@ -705,28 +705,14 @@ component {
 			$template = arguments.$name
 		);
 		local.rv = false;
-		if (
-			!ListFindNoCase(variables.$class.formats.existingTemplates, arguments.$name)
-			&& !ListFindNoCase(variables.$class.formats.nonExistingTemplates, arguments.$name)
-		) {
+		if (!StructKeyExists(variables.$class.formats.templateCache, arguments.$name)) {
 			if (FileExists(ExpandPath(local.templatePath))) {
 				local.rv = true;
 			}
 			if ($get("cacheFileChecking")) {
-				if (local.rv) {
-					variables.$class.formats.existingTemplates = ListAppend(
-						variables.$class.formats.existingTemplates,
-						arguments.$name
-					);
-				} else {
-					variables.$class.formats.nonExistingTemplates = ListAppend(
-						variables.$class.formats.nonExistingTemplates,
-						arguments.$name
-					);
-				}
+				variables.$class.formats.templateCache[arguments.$name] = local.rv;
 			}
-		}
-		if (!local.rv && ListFindNoCase(variables.$class.formats.existingTemplates, arguments.$name)) {
+		} else if (variables.$class.formats.templateCache[arguments.$name]) {
 			local.rv = true;
 		}
 		return local.rv;

--- a/vendor/wheels/controller/verifies.cfc
+++ b/vendor/wheels/controller/verifies.cfc
@@ -34,6 +34,20 @@ component {
 		string paramsTypes = ""
 	) {
 		$args(name = "verifies", args = arguments);
+
+		// The type lists are matched by position against their corresponding variable lists at request time, so catch length mismatches here at declaration time instead of failing with a raw array out-of-bounds error when the verification runs.
+		local.typeCheckedArguments = ["cookie", "session", "params"];
+		for (local.item in local.typeCheckedArguments) {
+			local.typesList = arguments[local.item & "Types"];
+			if (Len(local.typesList) && ListLen(local.typesList) != ListLen(arguments[local.item])) {
+				Throw(
+					type = "Wheels.InvalidVerification",
+					message = "The `#local.item#Types` argument contains #ListLen(local.typesList)# item(s) while the `#local.item#` argument contains #ListLen(arguments[local.item])# item(s).",
+					extendedInfo = "When using the `#local.item#Types` argument, supply exactly one type for each variable listed in the `#local.item#` argument."
+				);
+			}
+		}
+
 		ArrayAppend(variables.$class.verifications, Duplicate(arguments));
 	}
 
@@ -74,28 +88,37 @@ component {
 		struct sessionScope = {},
 		struct cookieScope = cookie
 	) {
-		// Only access the session scope when session management is enabled in the app.
-		// Default to the Wheels setting but get it on a per request basis if possible (from Application.cfc).
-		local.sessionManagement = $get("sessionManagement");
-		try {
-			local.sessionManagement = GetApplicationMetadata().sessionManagement;
-		} catch (any e) {
-		}
-		if (StructIsEmpty(arguments.sessionScope) && local.sessionManagement) {
-			arguments.sessionScope = session;
+		// Exit early when no verifications are declared so we don't pay for the session management probing below on every request.
+		local.verifications = verificationChain();
+		if (ArrayIsEmpty(local.verifications)) {
+			return;
 		}
 
-		local.verifications = verificationChain();
+		// Only access the session scope when session management is enabled in the app.
+		// Default to the Wheels setting but get it on a per request basis if possible (from Application.cfc).
+		// The resolved value is cached in the request scope since repeated controller processing within the same request (e.g. in the test suite) can't change it.
+		if (StructIsEmpty(arguments.sessionScope)) {
+			if (StructKeyExists(request, "$wheelsSessionManagement")) {
+				local.sessionManagement = request.$wheelsSessionManagement;
+			} else {
+				local.sessionManagement = $get("sessionManagement");
+				try {
+					local.sessionManagement = GetApplicationMetadata().sessionManagement;
+				} catch (any e) {
+				}
+				request.$wheelsSessionManagement = local.sessionManagement;
+			}
+			if (local.sessionManagement) {
+				arguments.sessionScope = session;
+			}
+		}
+
 		local.$args = "only,except,post,get,ajax,cookie,session,params,cookieTypes,sessionTypes,paramsTypes,handler";
 		local.abort = false;
 		local.iEnd = ArrayLen(local.verifications);
 		for (local.i = 1; local.i <= local.iEnd; local.i++) {
 			local.element = local.verifications[local.i];
-			if (
-				(!Len(local.element.only) && !Len(local.element.except)) || (
-					Len(local.element.only) && ListFindNoCase(local.element.only, arguments.action)
-				) || (Len(local.element.except) && !ListFindNoCase(local.element.except, arguments.action))
-			) {
+			if ($appliesToAction(action = arguments.action, only = local.element.only, except = local.element.except)) {
 				if (IsBoolean(local.element.post) && ((local.element.post && !isPost()) || (!local.element.post && isPost()))) {
 					local.abort = true;
 				}

--- a/vendor/wheels/events/onapplicationstart.cfc
+++ b/vendor/wheels/events/onapplicationstart.cfc
@@ -103,11 +103,9 @@ component {
 		}
 		application.$wheels.controllers = {};
 		application.$wheels.models = {};
-		application.$wheels.existingHelperFiles = "";
-		application.$wheels.existingLayoutFiles = "";
+		application.$wheels.helperFileCache = {};
+		application.$wheels.layoutFileCache = {};
 		application.$wheels.existingObjectFiles = "";
-		application.$wheels.nonExistingHelperFiles = "";
-		application.$wheels.nonExistingLayoutFiles = "";
 		application.$wheels.nonExistingObjectFiles = "";
 		application.$wheels.directoryFiles = {};
 		application.$wheels.routes = [];

--- a/vendor/wheels/tests/specs/controller/appliesToActionSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/appliesToActionSpec.cfc
@@ -1,0 +1,36 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("$appliesToAction() shared only/except gating", () => {
+
+			beforeEach(() => {
+				params = {controller = "dummy", action = "index"}
+				_controller = application.wo.controller("dummy", params)
+			})
+
+			it("applies when neither only nor except is provided", () => {
+				expect(_controller.$appliesToAction(action = "index")).toBeTrue()
+			})
+
+			it("applies only to actions in the only list", () => {
+				expect(_controller.$appliesToAction(action = "index", only = "index,show")).toBeTrue()
+				expect(_controller.$appliesToAction(action = "edit", only = "index,show")).toBeFalse()
+			})
+
+			it("applies to all actions not in the except list", () => {
+				expect(_controller.$appliesToAction(action = "edit", except = "index")).toBeTrue()
+				expect(_controller.$appliesToAction(action = "index", except = "index")).toBeFalse()
+			})
+
+			it("ORs the conditions when both lists are provided", () => {
+				// Matching `only` applies even when the action is also in `except`.
+				expect(_controller.$appliesToAction(action = "index", only = "index", except = "index")).toBeTrue()
+				// Being absent from `except` applies even when the action is missing from `only`.
+				expect(_controller.$appliesToAction(action = "edit", only = "index", except = "show")).toBeTrue()
+				// In `except` and not in `only` does not apply.
+				expect(_controller.$appliesToAction(action = "show", only = "index", except = "show")).toBeFalse()
+			})
+		})
+	}
+}

--- a/vendor/wheels/tests/specs/controller/miscellaneousSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/miscellaneousSpec.cfc
@@ -69,13 +69,13 @@ component extends="wheels.WheelsTest" {
 				if (StructKeyExists(request, "test")) {
 					StructDelete(request, "test")
 				}
-				application.wheels.existingHelperFiles = "test"
+				application.wheels.helperFileCache["test"] = true
 				params = {controller = "test", action = "helperCaller"}
 				_controller = application.wo.controller("test", params)
 			})
 
 			afterEach(() => {
-				application.wheels.existingHelperFiles = ""
+				StructDelete(application.wheels.helperFileCache, "test")
 			})
 
 			it("is including global helper file", () => {

--- a/vendor/wheels/tests/specs/controller/renderingSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/renderingSpec.cfc
@@ -76,7 +76,7 @@ component extends="wheels.WheelsTest" {
 			it("is rendering with default layout in controller folder", () => {
 				tempFile = ExpandPath("/wheels/tests/_assets/views/test/layout.cfm")
 				FileWrite(tempFile, "<cfoutput>start:controllerlayout##includeContent()##end:controllerlayout</cfoutput>")
-				application.wheels.existingLayoutFiles = "test"
+				application.wheels.layoutFileCache["test"] = true
 				_controller.renderView()
 				r = _controller.response()
 
@@ -84,7 +84,7 @@ component extends="wheels.WheelsTest" {
 				expect(r).toInclude("start:controllerlayout")
 				expect(r).toInclude("end:controllerlayout")
 
-				application.wheels.existingLayoutFiles = ""
+				StructDelete(application.wheels.layoutFileCache, "test")
 				FileDelete(tempFile)
 			})
 

--- a/vendor/wheels/tests/specs/controller/usesLayoutDedupSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/usesLayoutDedupSpec.cfc
@@ -1,0 +1,41 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("usesLayout() duplicate detection", () => {
+
+			beforeEach(() => {
+				params = {controller = "usesLayoutDedupTest", action = "index"}
+				_controller = application.wo.controller("usesLayoutDedupTest", params)
+				// Layouts are stored on the class level so clear them to keep each test independent.
+				ArrayClear(_controller.$getControllerClassData().layouts)
+			})
+
+			afterEach(() => {
+				ArrayClear(_controller.$getControllerClassData().layouts)
+			})
+
+			it("does not crash when two declarations have the same key count but different key sets", () => {
+				// Pre-fix this threw a "key doesn't exist" error because equal struct counts were treated as the same shape.
+				_controller.usesLayout(template = "myLayout", only = "index")
+				_controller.usesLayout(template = "otherLayout", except = "index")
+
+				expect(ArrayLen(_controller.$getControllerClassData().layouts)).toBe(2)
+			})
+
+			it("replaces an identical declaration instead of duplicating it", () => {
+				_controller.usesLayout(template = "myLayout", only = "index")
+				_controller.usesLayout(template = "myLayout", only = "index")
+
+				expect(ArrayLen(_controller.$getControllerClassData().layouts)).toBe(1)
+			})
+
+			it("keeps declarations that differ only by a value", () => {
+				_controller.usesLayout(template = "myLayout", only = "index")
+				_controller.usesLayout(template = "otherLayout", only = "index")
+
+				expect(ArrayLen(_controller.$getControllerClassData().layouts)).toBe(2)
+			})
+		})
+	}
+}

--- a/vendor/wheels/tests/specs/controller/verifiesSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/verifiesSpec.cfc
@@ -98,6 +98,23 @@ component extends="wheels.WheelsTest" {
 
 				expect(_controller.$abortIssued()).toBeTrue()
 			})
+
+			it("throws at declaration time when a types list length does not match its variable list", () => {
+				params = {controller = "verifies", action = "actionGet"}
+				_controller = application.wo.controller("verifies", params)
+
+				expect(function() {
+					_controller.verifies(params = "username,password", paramsTypes = "string")
+				}).toThrow("Wheels.InvalidVerification")
+
+				expect(function() {
+					_controller.verifies(session = "userId", sessionTypes = "integer,string")
+				}).toThrow("Wheels.InvalidVerification")
+
+				expect(function() {
+					_controller.verifies(post = "true", cookieTypes = "string")
+				}).toThrow("Wheels.InvalidVerification")
+			})
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Wave-2 remediation for the `controller-mixin-quality` review package: 7 findings (C3-C7, C18, C19) across the controller mixins — a config-time crash in `usesLayout()` duplicate detection, a triplicated only/except action-gating predicate, unscoped loop variables leaking into the controller's `variables` scope, a dead transposed `Find()` condition, request-time array out-of-bounds from mismatched `verifies()` type lists, redundant per-request work in `$runVerifications()`, and unbounded comma-list file-existence caches with racy `ListAppend` lost updates. Includes a finalize fix-up (533091ff7) for Lucee/Adobe arguments-scope semantics in the new dedup guard, caught by local verification.

## Findings addressed

- **C3 — `usesLayout()` dedup crashed on equal key count + different key sets** @ `vendor/wheels/controller/layouts.cfc:42-75` — key-presence guard before value comparison, scoped `arguments[key]` read, `layoutPostionInArray` typo fix, early `break`. Finalize fix-up 533091ff7: on Lucee/Adobe, iterating the `arguments` scope yields declared-but-unset (null) keys for which `StructKeyExists()` returns false, so the guard wrongly marked identical declarations as different; presence is now compared on both sides (unset-on-both = equal) so identical declarations are replaced, not duplicated.
- **C4 — only/except predicate triplicated** — extracted shared `$appliesToAction()` @ `vendor/wheels/controller/miscellaneous.cfc:378`; callers `filters.cfc:112`, `verifies.cfc:121`, `csrf.cfc:40`. The AND-composed variant in `layouts.cfc` (`$useLayout`) is intentionally untouched — its semantics differ.
- **C5 — unscoped `scopeMap` rebuilt per loop item (leaking into `variables`)** @ `vendor/wheels/controller/processing.cfc:67-84` — now `local.scopeMap`, lazily built once (prior art `Dispatch.cfc`); bare `i` loop index @ `vendor/wheels/controller/caching.cfc:51` — now `local.i`.
- **C6 — dead transposed `Find(request.cgi.http_referer, "?")` condition removed** @ `vendor/wheels/controller/redirection.cfc:113` — the enclosing else branch already guarantees the referer contains no query string.
- **C7 — `verifies()` validates type-list lengths at declaration time** @ `vendor/wheels/controller/verifies.cfc:22-48` — `cookieTypes` / `sessionTypes` / `paramsTypes` must match their variable lists or `Wheels.InvalidVerification` is thrown, replacing a raw array out-of-bounds at request time. `setVerificationChain()` routes through `verifies()`, so it is covered too.
- **C18 — `$runVerifications()` early return + request-scoped metadata probe** @ `vendor/wheels/controller/verifies.cfc:84-106` — returns immediately when no verifications are declared; the `GetApplicationMetadata().sessionManagement` probe is cached in the request scope.
- **C19 — comma-list file-existence caches replaced with boolean struct caches** @ `vendor/wheels/Controller.cfc:82-98` (`helperFileCache`), `vendor/wheels/controller/layouts.cfc:134-147` (`layoutFileCache`), `vendor/wheels/controller/rendering.cfc:708-716` (`formats.templateCache`), initialized @ `vendor/wheels/events/onapplicationstart.cfc:106-107` — eliminates repeated linear list scans and racy `ListAppend` lost updates; both `cacheFileChecking` on/off paths preserved. The cased-path `existingObjectFiles` list in `Global.cfc` is intentionally retained (it stores paths, not booleans).

## Findings verified already-fixed

None — all 7 findings reproduced against `origin/develop` at branch time (spot-checked: the transposed `Find()` still present at `redirection.cfc:115` and the comma-list caches at `Controller.cfc:84-105` on develop).

## Source

Internal multi-agent framework review 2026-06-09, wave 2, package `controller-mixin-quality`.

## Tests

- New `vendor/wheels/tests/specs/controller/usesLayoutDedupSpec.cfc` — 3 cases (no crash on different key sets, replace identical declaration, keep value-differing declarations); all three fail pre-fix.
- New `vendor/wheels/tests/specs/controller/appliesToActionSpec.cfc` — only/except/both-lists semantics of the shared helper.
- Extended `vendor/wheels/tests/specs/controller/verifiesSpec.cfc` — declaration-time `Wheels.InvalidVerification` case (fails pre-fix).
- Updated `miscellaneousSpec.cfc` / `renderingSpec.cfc` to inject the new struct caches instead of the removed list caches.
- Local verification (worktree docker single-area recipe, Lucee 7 + SQLite): controller area = 18 bundles, **452 pass / 0 fail / 0 error** (1 pre-existing skip). The first run caught a real regression in the dedup guard ("replaces an identical declaration" expected 1, got 2 — Lucee arguments-scope null keys), fixed in 533091ff7 and re-verified green. Full engine x DB matrix deferred to CI.

## Cross-engine notes

- The dedup fix-up codifies an engine gotcha: Lucee/Adobe `arguments` scopes expose every declared parameter to `for-in` / `StructCount` (null-valued when unset) while `StructKeyExists()` returns false for them, and bracket-reading an unset key throws — presence must be checked on both sides before any value read.
- `$appliesToAction()` is public `$`-prefixed (mixin invariant: private mixin functions are not integrated) and lands on controllers via the standard `wheels.controller` mixin surface.
- No closures in framework code, no reserved-scope parameter names, no `attributeCollection = arguments` usage; struct cache keys accessed via bracket notation.
- Specs avoid inline-closure constructor args and unescaped `##` in strings; isolation via a unique controller name + `ArrayClear` of class-level layout data in `beforeEach`/`afterEach`.

## Changelog

Entry deliberately omitted; consolidated at campaign end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
