### PR TITLE
fix(job): tenant context restore, retry counts, single-row claim poll, table bootstrap

### DIFF
--- a/vendor/wheels/Job.cfc
+++ b/vendor/wheels/Job.cfc
@@ -148,41 +148,27 @@ component {
 		local.now = $now();
 
 		try {
-			queryExecute(
-				"INSERT INTO wheels_jobs (id, jobClass, queue, data, priority, status, attempts, maxRetries, runAt, createdAt, updatedAt)
-				VALUES (:id, :jobClass, :queue, :data, :priority, 'pending', 0, :maxRetries, :runAt, :createdAt, :updatedAt)",
-				{
-					id = {value = local.id, cfsqltype = "cf_sql_varchar"},
-					jobClass = {value = arguments.jobClass, cfsqltype = "cf_sql_varchar"},
-					queue = {value = arguments.queue, cfsqltype = "cf_sql_varchar"},
-					data = {value = local.serializedData, cfsqltype = "cf_sql_longvarchar"},
-					priority = {value = arguments.priority, cfsqltype = "cf_sql_integer"},
-					maxRetries = {value = this.maxRetries, cfsqltype = "cf_sql_integer"},
-					runAt = {value = arguments.runAt, cfsqltype = "cf_sql_timestamp"},
-					createdAt = {value = local.now, cfsqltype = "cf_sql_timestamp"},
-					updatedAt = {value = local.now, cfsqltype = "cf_sql_timestamp"}
-				},
-				{datasource = variables.$datasource}
+			$insertJobRow(
+				id = local.id,
+				jobClass = arguments.jobClass,
+				queue = arguments.queue,
+				serializedData = local.serializedData,
+				priority = arguments.priority,
+				runAt = arguments.runAt,
+				enqueuedAt = local.now
 			);
 		} catch (any e) {
 			// Auto-create table on first use and retry
 			if ($ensureJobTable()) {
 				try {
-					queryExecute(
-						"INSERT INTO wheels_jobs (id, jobClass, queue, data, priority, status, attempts, maxRetries, runAt, createdAt, updatedAt)
-						VALUES (:id, :jobClass, :queue, :data, :priority, 'pending', 0, :maxRetries, :runAt, :createdAt, :updatedAt)",
-						{
-							id = {value = local.id, cfsqltype = "cf_sql_varchar"},
-							jobClass = {value = arguments.jobClass, cfsqltype = "cf_sql_varchar"},
-							queue = {value = arguments.queue, cfsqltype = "cf_sql_varchar"},
-							data = {value = local.serializedData, cfsqltype = "cf_sql_longvarchar"},
-							priority = {value = arguments.priority, cfsqltype = "cf_sql_integer"},
-							maxRetries = {value = this.maxRetries, cfsqltype = "cf_sql_integer"},
-							runAt = {value = arguments.runAt, cfsqltype = "cf_sql_timestamp"},
-							createdAt = {value = local.now, cfsqltype = "cf_sql_timestamp"},
-							updatedAt = {value = local.now, cfsqltype = "cf_sql_timestamp"}
-						},
-						{datasource = variables.$datasource}
+					$insertJobRow(
+						id = local.id,
+						jobClass = arguments.jobClass,
+						queue = arguments.queue,
+						serializedData = local.serializedData,
+						priority = arguments.priority,
+						runAt = arguments.runAt,
+						enqueuedAt = local.now
 					);
 				} catch (any e2) {
 					writeLog(text = "Job enqueue failed after table creation: #e2.message#", type = "error", file = "wheels_jobs");
@@ -201,6 +187,37 @@ component {
 		);
 
 		return {id = local.id, jobClass = arguments.jobClass, status = "pending", persisted = true};
+	}
+
+	/**
+	 * Internal: Execute the wheels_jobs INSERT for a new pending job.
+	 * Shared by the first-attempt and table-create-retry paths in $enqueueJob.
+	 */
+	private void function $insertJobRow(
+		required string id,
+		required string jobClass,
+		required string queue,
+		required string serializedData,
+		required numeric priority,
+		required date runAt,
+		required date enqueuedAt
+	) {
+		queryExecute(
+			"INSERT INTO wheels_jobs (id, jobClass, queue, data, priority, status, attempts, maxRetries, runAt, createdAt, updatedAt)
+			VALUES (:id, :jobClass, :queue, :data, :priority, 'pending', 0, :maxRetries, :runAt, :createdAt, :updatedAt)",
+			{
+				id = {value = arguments.id, cfsqltype = "cf_sql_varchar"},
+				jobClass = {value = arguments.jobClass, cfsqltype = "cf_sql_varchar"},
+				queue = {value = arguments.queue, cfsqltype = "cf_sql_varchar"},
+				data = {value = arguments.serializedData, cfsqltype = "cf_sql_longvarchar"},
+				priority = {value = arguments.priority, cfsqltype = "cf_sql_integer"},
+				maxRetries = {value = this.maxRetries, cfsqltype = "cf_sql_integer"},
+				runAt = {value = arguments.runAt, cfsqltype = "cf_sql_timestamp"},
+				createdAt = {value = arguments.enqueuedAt, cfsqltype = "cf_sql_timestamp"},
+				updatedAt = {value = arguments.enqueuedAt, cfsqltype = "cf_sql_timestamp"}
+			},
+			{datasource = variables.$datasource}
+		);
 	}
 
 	/**
@@ -284,29 +301,32 @@ component {
 			return local.result;
 		}
 
+		// Initialized before the try: the catch below also handles instantiation and
+		// deserialization failures, and the tenant cleanup after it must not read an
+		// undefined variable (which would escape $processJob and abort the whole batch,
+		// masking the real job failure).
+		local.hasTenantContext = false;
+
+		// Backoff settings for retry scheduling. Defaults come from this processing
+		// instance; overridden from the failing job's own class once it instantiates,
+		// mirroring JobWorker.$scheduleRetry so both paths share one retry schedule.
+		local.backoffBaseDelay = this.baseDelay;
+		local.backoffMaxDelay = this.maxDelay;
+
 		try {
 			// Instantiate and execute the job
 			local.jobInstance = CreateObject("component", arguments.jobRow.jobClass);
+			if (StructKeyExists(local.jobInstance, "baseDelay")) {
+				local.backoffBaseDelay = local.jobInstance.baseDelay;
+			}
+			if (StructKeyExists(local.jobInstance, "maxDelay")) {
+				local.backoffMaxDelay = local.jobInstance.maxDelay;
+			}
 			local.jobData = DeserializeJSON(arguments.jobRow.data);
 
-			// Restore tenant context if the job was enqueued within a tenant scope
-			local.hasTenantContext = false;
-			if (StructKeyExists(local.jobData, "$wheelsTenantContext") && IsStruct(local.jobData["$wheelsTenantContext"])) {
-				local.tenantCtx = local.jobData["$wheelsTenantContext"];
-				if (StructKeyExists(local.tenantCtx, "dataSource") && Len(local.tenantCtx.dataSource)) {
-					if (!StructKeyExists(request, "wheels")) {
-						request.wheels = {};
-					}
-					request.wheels.tenant = {
-						id = StructKeyExists(local.tenantCtx, "id") ? local.tenantCtx.id : "",
-						dataSource = local.tenantCtx.dataSource,
-						config = StructKeyExists(local.tenantCtx, "config") ? local.tenantCtx.config : {}
-					};
-					local.hasTenantContext = true;
-				}
-				// Remove internal key before passing data to perform()
-				StructDelete(local.jobData, "$wheelsTenantContext");
-			}
+			// Restore tenant context if the job was enqueued within a tenant scope and
+			// strip the internal $wheelsTenantContext key before passing data to perform()
+			local.hasTenantContext = $restoreTenantContext(local.jobData);
 
 			local.jobInstance.perform(data = local.jobData);
 
@@ -337,8 +357,10 @@ component {
 			local.maxRetries = Val(arguments.jobRow.maxRetries);
 
 			if (local.currentAttempts < local.maxRetries) {
-				// Schedule retry with configurable exponential backoff, capped at maxDelay
-				local.backoffSeconds = Min(this.baseDelay * (2 ^ local.currentAttempts), this.maxDelay);
+				// Schedule retry with configurable exponential backoff, capped at maxDelay.
+				// Settings were captured from the failing job's class above so subclass
+				// overrides apply (the base instance defaults are only the fallback).
+				local.backoffSeconds = Min(local.backoffBaseDelay * (2 ^ local.currentAttempts), local.backoffMaxDelay);
 				local.nextRunAt = DateAdd("s", local.backoffSeconds, $now());
 
 				queryExecute(
@@ -391,11 +413,48 @@ component {
 		}
 
 		// Clean up tenant context after job execution
-		if (local.hasTenantContext && StructKeyExists(request, "wheels")) {
-			StructDelete(request.wheels, "tenant");
+		if (local.hasTenantContext) {
+			$clearTenantContext();
 		}
 
 		return local.result;
+	}
+
+	/**
+	 * Restore tenant context from job data when the job was enqueued within a tenant
+	 * scope, and strip the internal $wheelsTenantContext key from the passed data
+	 * struct (by reference) before it reaches perform(). Returns true when a tenant
+	 * context was restored — the caller must $clearTenantContext() after execution.
+	 * Public with $ prefix so JobWorker's worker path shares the exact same logic.
+	 */
+	public boolean function $restoreTenantContext(required struct jobData) {
+		local.restored = false;
+		if (StructKeyExists(arguments.jobData, "$wheelsTenantContext") && IsStruct(arguments.jobData["$wheelsTenantContext"])) {
+			local.tenantCtx = arguments.jobData["$wheelsTenantContext"];
+			if (StructKeyExists(local.tenantCtx, "dataSource") && Len(local.tenantCtx.dataSource)) {
+				if (!StructKeyExists(request, "wheels")) {
+					request.wheels = {};
+				}
+				request.wheels.tenant = {
+					id = StructKeyExists(local.tenantCtx, "id") ? local.tenantCtx.id : "",
+					dataSource = local.tenantCtx.dataSource,
+					config = StructKeyExists(local.tenantCtx, "config") ? local.tenantCtx.config : {}
+				};
+				local.restored = true;
+			}
+			// Remove internal key before passing data to perform()
+			StructDelete(arguments.jobData, "$wheelsTenantContext");
+		}
+		return local.restored;
+	}
+
+	/**
+	 * Remove a previously restored tenant context from the request scope.
+	 */
+	public void function $clearTenantContext() {
+		if (StructKeyExists(request, "wheels")) {
+			StructDelete(request.wheels, "tenant");
+		}
 	}
 
 	/**
@@ -489,8 +548,9 @@ component {
 	 * Auto-create the wheels_jobs table if it doesn't exist.
 	 * Uses database-agnostic SQL compatible with MySQL, PostgreSQL, SQL Server, H2, and SQLite.
 	 * Returns true if the table was created or already exists, false if creation failed.
+	 * Public with $ prefix so JobWorker can bootstrap the table on a fresh database.
 	 */
-	private boolean function $ensureJobTable() {
+	public boolean function $ensureJobTable() {
 		try {
 			// Check if table already exists by querying it
 			queryExecute("SELECT COUNT(*) AS cnt FROM wheels_jobs WHERE 1=0", {}, {datasource = variables.$datasource});
@@ -573,8 +633,9 @@ component {
 	/**
 	 * Detect the database type from the actual datasource via JDBC metadata.
 	 * Returns: "oracle", "postgresql", "h2", "mysql", "sqlserver", "sqlite", or "default".
+	 * Public with $ prefix so JobWorker can pick database-appropriate SQL syntax.
 	 */
-	private string function $detectDatabaseType() {
+	public string function $detectDatabaseType() {
 		try {
 			cfdbinfo(type = "version", datasource = "#variables.$datasource#", name = "local.info");
 			local.product = local.info.database_productname;

--- a/vendor/wheels/JobWorker.cfc
+++ b/vendor/wheels/JobWorker.cfc
@@ -38,7 +38,10 @@ component {
 			runAt = {value = $now(), cfsqltype = "cf_sql_timestamp"}
 		};
 
-		local.sql = "SELECT id, jobClass, queue, data, attempts, maxRetries
+		// The candidate SELECT deliberately excludes the data column: at backlog scale
+		// dragging every pending row's payload across the wire per poll is expensive.
+		// The claimed job's payload is fetched by id after the claim succeeds.
+		local.sql = "SELECT id, jobClass, queue, attempts, maxRetries
 			FROM wheels_jobs
 			WHERE status = 'pending' AND runAt <= :runAt";
 
@@ -55,10 +58,24 @@ component {
 
 		local.sql &= " ORDER BY priority DESC, runAt ASC";
 
-		// Fetch candidates for optimistic locking.
-		// NOTE: Avoid maxrows option — BoxLang + PostgreSQL throws when setMaxRows()
-		// is called on the JDBC PreparedStatement with certain parameter combinations.
-		// The for-loop below processes only the first successful claim anyway.
+		// Bound the candidate scan in SQL text so the database never materializes the
+		// whole pending backlog. A handful of candidates is enough — the loop below
+		// claims the first one it wins and the rest only matter when claims are lost
+		// to concurrent workers.
+		// NOTE: Avoid the maxrows option — BoxLang + PostgreSQL throws when setMaxRows()
+		// is called on the JDBC PreparedStatement with certain parameter combinations,
+		// and maxrows only truncates client-side after the driver fetched everything.
+		local.candidateLimit = 25;
+		local.dbType = $dbType();
+		if (ListFindNoCase("mysql,postgresql,sqlite,h2", local.dbType)) {
+			local.sql &= " LIMIT #local.candidateLimit#";
+		} else if (local.dbType == "sqlserver") {
+			local.sql &= " OFFSET 0 ROWS FETCH NEXT #local.candidateLimit# ROWS ONLY";
+		} else if (local.dbType == "oracle") {
+			local.sql &= " FETCH FIRST #local.candidateLimit# ROWS ONLY";
+		}
+		// Unknown database type: leave unbounded rather than risk a syntax error.
+
 		try {
 			local.candidates = queryExecute(local.sql, local.params, {datasource = variables.$datasource});
 		} catch (any e) {
@@ -76,8 +93,16 @@ component {
 		for (local.row in local.candidates) {
 			local.claimed = $claimJob(local.row.id);
 			if (local.claimed) {
-				// We claimed it — now process
-				local.processResult = $executeJob(local.row);
+				// We claimed it — fetch the payload for just this job, then process
+				local.jobRow = {
+					id = local.row.id,
+					jobClass = local.row.jobClass,
+					queue = local.row.queue,
+					data = $fetchJobData(local.row.id),
+					attempts = local.row.attempts,
+					maxRetries = local.row.maxRetries
+				};
+				local.processResult = $executeJob(local.jobRow);
 				local.result.jobId = local.row.id;
 				local.result.jobClass = local.row.jobClass;
 
@@ -332,15 +357,18 @@ component {
 		}
 
 		try {
-			queryExecute(local.sql, local.params, {datasource = variables.$datasource});
-			// DML recordCount is unreliable across CFML engines; count via SELECT
-			local.countSql = "SELECT COUNT(*) AS cnt FROM wheels_jobs WHERE status = 'pending'";
+			// DML recordCount is unreliable across CFML engines; count the rows we are
+			// about to reset BEFORE the UPDATE. Counting status='pending' afterwards
+			// would also include unrelated jobs that were already pending.
+			local.countSql = "SELECT COUNT(*) AS cnt FROM wheels_jobs WHERE status = 'failed'";
 			local.countParams = {};
 			if (Len(arguments.queue)) {
 				local.countSql &= " AND queue = :queue";
 				local.countParams.queue = {value = arguments.queue, cfsqltype = "cf_sql_varchar"};
 			}
 			local.countResult = queryExecute(local.countSql, local.countParams, {datasource = variables.$datasource});
+
+			queryExecute(local.sql, local.params, {datasource = variables.$datasource});
 			return local.countResult.cnt ?: 0;
 		} catch (any e) {
 			$ensureJobTable();
@@ -415,9 +443,21 @@ component {
 	 */
 	private struct function $executeJob(required struct jobRow) {
 		local.result = {success = false, error = ""};
+
+		// Initialized before the try so the cleanup below never reads an undefined
+		// variable when instantiation/deserialization fails inside the try.
+		local.hasTenantContext = false;
+
 		try {
 			local.jobInstance = CreateObject("component", arguments.jobRow.jobClass);
 			local.jobData = DeserializeJSON(arguments.jobRow.data);
+
+			// Restore tenant context if the job was enqueued within a tenant scope and
+			// strip the internal $wheelsTenantContext key before passing data to
+			// perform() — shared with Job.$processJob so both processing paths run
+			// tenant jobs against the correct tenant datasource.
+			local.hasTenantContext = $jobBridge().$restoreTenantContext(local.jobData);
+
 			local.jobInstance.perform(data = local.jobData);
 
 			// Mark completed
@@ -442,6 +482,12 @@ component {
 		} catch (any e) {
 			local.result.error = Left(e.message, 1000);
 		}
+
+		// Clean up tenant context after job execution
+		if (local.hasTenantContext) {
+			$jobBridge().$clearTenantContext();
+		}
+
 		return local.result;
 	}
 
@@ -537,15 +583,61 @@ component {
 	}
 
 	/**
-	 * Ensure the wheels_jobs table exists. Delegates to Job.cfc's implementation.
+	 * Ensure the wheels_jobs table exists. Delegates to Job.cfc's real table bootstrap —
+	 * merely instantiating wheels.Job performs no database work, so on a fresh database
+	 * the worker could previously never create the table. Guarded so the many catch
+	 * paths that call this don't re-probe once the table has been verified.
 	 */
 	private boolean function $ensureJobTable() {
-		try {
-			local.job = new wheels.Job();
+		if (StructKeyExists(variables, "$tableVerified")) {
 			return true;
+		}
+		try {
+			if ($jobBridge().$ensureJobTable()) {
+				variables.$tableVerified = true;
+				return true;
+			}
+			return false;
 		} catch (any e) {
 			return false;
 		}
+	}
+
+	/**
+	 * Fetch a single job's data payload by id. Called only for the job this worker
+	 * actually claimed, so the candidate scan doesn't transfer every pending payload.
+	 */
+	private string function $fetchJobData(required string jobId) {
+		local.dataRow = queryExecute(
+			"SELECT data FROM wheels_jobs WHERE id = :id",
+			{id = {value = arguments.jobId, cfsqltype = "cf_sql_varchar"}},
+			{datasource = variables.$datasource}
+		);
+		if (local.dataRow.recordCount) {
+			return local.dataRow.data;
+		}
+		return "";
+	}
+
+	/**
+	 * Database type for SQL syntax selection, detected once per worker instance.
+	 */
+	private string function $dbType() {
+		if (!StructKeyExists(variables, "$dbTypeCached")) {
+			variables.$dbTypeCached = $jobBridge().$detectDatabaseType();
+		}
+		return variables.$dbTypeCached;
+	}
+
+	/**
+	 * Lazily instantiate the wheels.Job bridge used to share framework job helpers
+	 * (tenant context handling, table bootstrap, database type detection).
+	 */
+	private any function $jobBridge() {
+		if (!StructKeyExists(variables, "$jobBridgeInstance")) {
+			variables.$jobBridgeInstance = new wheels.Job();
+		}
+		return variables.$jobBridgeInstance;
 	}
 
 }

--- a/vendor/wheels/tests/_assets/jobs/FailingBackoffJob.cfc
+++ b/vendor/wheels/tests/_assets/jobs/FailingBackoffJob.cfc
@@ -1,0 +1,14 @@
+/**
+ * Test-only job with custom backoff settings that always fails.
+ * The settings live in the pseudo-constructor (not config()) because the queue
+ * processing paths instantiate job classes via CreateObject() without calling init().
+ */
+component extends="wheels.Job" {
+
+	this.baseDelay = 600;
+	this.maxDelay = 7200;
+
+	public void function perform(struct data = {}) {
+		throw(type = "Wheels.Tests.JobFailure", message = "FailingBackoffJob always fails");
+	}
+}

--- a/vendor/wheels/tests/_assets/jobs/ProbeJob.cfc
+++ b/vendor/wheels/tests/_assets/jobs/ProbeJob.cfc
@@ -1,0 +1,22 @@
+/**
+ * Test-only job that records what perform() actually received so specs can verify
+ * payload delivery, tenant restoration, and internal-key stripping on both the
+ * Job.$processJob and JobWorker.$executeJob processing paths.
+ */
+component extends="wheels.Job" {
+
+	public void function perform(struct data = {}) {
+		request.$wheelsJobProbe = {
+			data = Duplicate(arguments.data),
+			sawInternalKey = StructKeyExists(arguments.data, "$wheelsTenantContext"),
+			tenantRestored = false,
+			tenantDataSource = "",
+			tenantId = ""
+		};
+		if (IsDefined("request.wheels.tenant.dataSource")) {
+			request.$wheelsJobProbe.tenantRestored = true;
+			request.$wheelsJobProbe.tenantDataSource = request.wheels.tenant.dataSource;
+			request.$wheelsJobProbe.tenantId = request.wheels.tenant.id;
+		}
+	}
+}

--- a/vendor/wheels/tests/specs/jobs/JobRobustnessSpec.cfc
+++ b/vendor/wheels/tests/specs/jobs/JobRobustnessSpec.cfc
@@ -1,0 +1,249 @@
+/**
+ * Regression tests for job-system robustness fixes:
+ * - $processJob must surface job failures instead of throwing a secondary
+ *   "variable doesn't exist" error that aborts the whole processQueue batch
+ * - JobWorker.$executeJob must restore tenant context and strip the internal
+ *   $wheelsTenantContext key exactly like Job.$processJob
+ * - JobWorker.retryFailed without a limit must report only the rows actually reset
+ * - Retry backoff must honor the failing job class's own delay settings
+ * - JobWorker.processNext must deliver the full payload after the single-row claim
+ * - JobWorker.$ensureJobTable must actually create the table on a fresh database
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("Job processing robustness", function() {
+
+			beforeEach(function() {
+				// Make sure the table exists, then clear leftovers from prior runs
+				local.bootstrapJob = new wheels.Job();
+				local.bootstrapJob.$ensureJobTable();
+				try {
+					queryExecute("DELETE FROM wheels_jobs WHERE queue LIKE 'test_rob_%'", {}, {datasource = application.wheels.dataSourceName});
+				} catch (any e) {
+				}
+			});
+
+			afterEach(function() {
+				// Never leak tenant context or probe state into the rest of the suite
+				if (StructKeyExists(request, "wheels")) {
+					StructDelete(request.wheels, "tenant");
+				}
+				StructDelete(request, "$wheelsJobProbe");
+				try {
+					queryExecute("DELETE FROM wheels_jobs WHERE queue LIKE 'test_rob_%'", {}, {datasource = application.wheels.dataSourceName});
+				} catch (any e) {
+				}
+			});
+
+			it("reports an unresolvable job class as a job failure instead of throwing", function() {
+				local.id = CreateUUID();
+				$insertTestJob(id = local.id, jobClass = "wheels.tests._assets.jobs.NoSuchJobZZZ", queue = "test_rob_badclass");
+
+				local.processor = new wheels.Job();
+				prepareMock(local.processor);
+				makePublic(local.processor, "$processJob");
+				local.jobRow = {
+					id = local.id,
+					jobClass = "wheels.tests._assets.jobs.NoSuchJobZZZ",
+					queue = "test_rob_badclass",
+					data = "{}",
+					attempts = 0,
+					maxRetries = 3
+				};
+
+				// Pre-fix this threw "variable [hasTenantContext] doesn't exist", which
+				// escaped $processJob and aborted the whole processQueue batch
+				local.jobResult = local.processor.$processJob(jobRow = local.jobRow);
+
+				expect(local.jobResult.success).toBeFalse();
+				expect(local.jobResult.skipped).toBeFalse();
+				expect(local.jobResult.error).toInclude(local.id);
+			});
+
+			it("schedules retries using the failing job class's own backoff settings", function() {
+				local.id = CreateUUID();
+				$insertTestJob(id = local.id, jobClass = "wheels.tests._assets.jobs.FailingBackoffJob", queue = "test_rob_backoff");
+
+				local.processor = new wheels.Job();
+				prepareMock(local.processor);
+				makePublic(local.processor, "$processJob");
+				local.jobRow = {
+					id = local.id,
+					jobClass = "wheels.tests._assets.jobs.FailingBackoffJob",
+					queue = "test_rob_backoff",
+					data = "{}",
+					attempts = 0,
+					maxRetries = 3
+				};
+				local.jobResult = local.processor.$processJob(jobRow = local.jobRow);
+				expect(local.jobResult.success).toBeFalse();
+
+				// FailingBackoffJob declares baseDelay=600, so the first retry is
+				// scheduled Min(600 * 2^1, 7200) = 1200 seconds out. The base processing
+				// instance's defaults (baseDelay=2) would schedule it only 4 seconds out.
+				local.threshold = DateAdd("s", 600, Now());
+				local.check = queryExecute(
+					"SELECT COUNT(*) AS cnt FROM wheels_jobs WHERE id = :id AND status = 'pending' AND runAt > :threshold",
+					{
+						id = {value = local.id, cfsqltype = "cf_sql_varchar"},
+						threshold = {value = local.threshold, cfsqltype = "cf_sql_timestamp"}
+					},
+					{datasource = application.wheels.dataSourceName}
+				);
+				expect(local.check.cnt).toBe(1);
+			});
+
+			it("worker path restores tenant context and strips the internal key", function() {
+				local.payload = {orderId = 42};
+				local.payload["$wheelsTenantContext"] = {id = "tenant-1", dataSource = "wheels_test_tenant_ds", config = {}};
+
+				local.worker = new wheels.JobWorker();
+				prepareMock(local.worker);
+				makePublic(local.worker, "$executeJob");
+				local.jobRow = {
+					id = CreateUUID(),
+					jobClass = "wheels.tests._assets.jobs.ProbeJob",
+					queue = "test_rob_tenant",
+					data = SerializeJSON(local.payload),
+					attempts = 0,
+					maxRetries = 3
+				};
+				local.execResult = local.worker.$executeJob(jobRow = local.jobRow);
+
+				expect(local.execResult.success).toBeTrue();
+				expect(request).toHaveKey("$wheelsJobProbe");
+				expect(request.$wheelsJobProbe.sawInternalKey).toBeFalse();
+				expect(request.$wheelsJobProbe.tenantRestored).toBeTrue();
+				expect(request.$wheelsJobProbe.tenantDataSource).toBe("wheels_test_tenant_ds");
+				expect(request.$wheelsJobProbe.tenantId).toBe("tenant-1");
+
+				// And the context must be cleaned up after execution
+				expect(IsDefined("request.wheels.tenant")).toBeFalse();
+			});
+
+			it("in-app path still restores tenant context via the shared helper", function() {
+				local.id = CreateUUID();
+				local.payload = {orderId = 7};
+				local.payload["$wheelsTenantContext"] = {id = "tenant-2", dataSource = "wheels_test_tenant_ds", config = {}};
+				$insertTestJob(
+					id = local.id,
+					jobClass = "wheels.tests._assets.jobs.ProbeJob",
+					queue = "test_rob_tenant_app",
+					data = SerializeJSON(local.payload)
+				);
+
+				local.processor = new wheels.Job();
+				prepareMock(local.processor);
+				makePublic(local.processor, "$processJob");
+				local.jobRow = {
+					id = local.id,
+					jobClass = "wheels.tests._assets.jobs.ProbeJob",
+					queue = "test_rob_tenant_app",
+					data = SerializeJSON(local.payload),
+					attempts = 0,
+					maxRetries = 3
+				};
+				local.jobResult = local.processor.$processJob(jobRow = local.jobRow);
+
+				expect(local.jobResult.success).toBeTrue();
+				expect(request.$wheelsJobProbe.sawInternalKey).toBeFalse();
+				expect(request.$wheelsJobProbe.tenantRestored).toBeTrue();
+				expect(request.$wheelsJobProbe.tenantDataSource).toBe("wheels_test_tenant_ds");
+				expect(IsDefined("request.wheels.tenant")).toBeFalse();
+			});
+
+			it("retryFailed without a limit reports only the rows actually reset", function() {
+				local.failedId = CreateUUID();
+				local.pendingId = CreateUUID();
+				$insertTestJob(id = local.failedId, jobClass = "app.jobs.ProcessOrdersJob", queue = "test_rob_retry", status = "failed", attempts = 3);
+				$insertTestJob(id = local.pendingId, jobClass = "app.jobs.ProcessOrdersJob", queue = "test_rob_retry", status = "pending");
+
+				local.worker = new wheels.JobWorker();
+				local.count = local.worker.retryFailed(queue = "test_rob_retry");
+
+				// Pre-fix this returned 2: the count of ALL pending rows after the UPDATE
+				expect(local.count).toBe(1);
+
+				local.row = queryExecute(
+					"SELECT status, attempts FROM wheels_jobs WHERE id = :id",
+					{id = {value = local.failedId, cfsqltype = "cf_sql_varchar"}},
+					{datasource = application.wheels.dataSourceName}
+				);
+				expect(local.row.status).toBe("pending");
+				expect(local.row.attempts).toBe(0);
+			});
+
+			it("processNext delivers the full payload to perform after the single-row claim", function() {
+				StructDelete(request, "$wheelsJobProbe");
+				local.probe = CreateObject("component", "wheels.tests._assets.jobs.ProbeJob").init();
+				local.enqueued = local.probe.enqueue(data = {orderId = 99, note = "payload-check"}, queue = "test_rob_payload");
+				expect(local.enqueued.persisted).toBeTrue();
+
+				local.worker = new wheels.JobWorker();
+				local.result = local.worker.processNext(queues = "test_rob_payload");
+
+				expect(local.result.success).toBeTrue();
+				expect(request).toHaveKey("$wheelsJobProbe");
+				expect(request.$wheelsJobProbe.data).toHaveKey("orderId");
+				expect(request.$wheelsJobProbe.data.orderId).toBe(99);
+				expect(request.$wheelsJobProbe.data.note).toBe("payload-check");
+			});
+
+			it("worker can bootstrap the wheels_jobs table on a fresh database", function() {
+				try {
+					queryExecute("DROP TABLE wheels_jobs", {}, {datasource = application.wheels.dataSourceName});
+				} catch (any e) {
+					// If the drop is not permitted, the ensure call below still verifies existence
+				}
+
+				local.worker = new wheels.JobWorker();
+				prepareMock(local.worker);
+				makePublic(local.worker, "$ensureJobTable");
+				expect(local.worker.$ensureJobTable()).toBeTrue();
+
+				// Pre-fix $ensureJobTable returned true without creating anything, so this
+				// SELECT threw because the table still did not exist
+				local.check = queryExecute(
+					"SELECT COUNT(*) AS cnt FROM wheels_jobs WHERE 1=0",
+					{},
+					{datasource = application.wheels.dataSourceName}
+				);
+				expect(local.check.recordCount).toBe(1);
+			});
+		});
+	}
+
+	/**
+	 * Insert a wheels_jobs row directly so specs control class, status, and attempts.
+	 */
+	private void function $insertTestJob(
+		required string id,
+		required string jobClass,
+		required string queue,
+		string status = "pending",
+		string data = "{}",
+		numeric attempts = 0,
+		numeric maxRetries = 3
+	) {
+		local.now = Now();
+		queryExecute(
+			"INSERT INTO wheels_jobs (id, jobClass, queue, data, priority, status, attempts, maxRetries, runAt, createdAt, updatedAt)
+			VALUES (:id, :jobClass, :queue, :data, 0, :status, :attempts, :maxRetries, :runAt, :createdAt, :updatedAt)",
+			{
+				id = {value = arguments.id, cfsqltype = "cf_sql_varchar"},
+				jobClass = {value = arguments.jobClass, cfsqltype = "cf_sql_varchar"},
+				queue = {value = arguments.queue, cfsqltype = "cf_sql_varchar"},
+				data = {value = arguments.data, cfsqltype = "cf_sql_longvarchar"},
+				status = {value = arguments.status, cfsqltype = "cf_sql_varchar"},
+				attempts = {value = arguments.attempts, cfsqltype = "cf_sql_integer"},
+				maxRetries = {value = arguments.maxRetries, cfsqltype = "cf_sql_integer"},
+				runAt = {value = local.now, cfsqltype = "cf_sql_timestamp"},
+				createdAt = {value = local.now, cfsqltype = "cf_sql_timestamp"},
+				updatedAt = {value = local.now, cfsqltype = "cf_sql_timestamp"}
+			},
+			{datasource = application.wheels.dataSourceName}
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes seven review findings in the background job system (`vendor/wheels/Job.cfc`, `vendor/wheels/JobWorker.cfc`): an undefined-variable secondary error that aborted whole `processQueue` batches, missing tenant-context restore on the CLI worker path, an inflated `retryFailed` count, a duplicated 15-line INSERT, divergent retry-backoff schedules between the two processing paths, a worker poll that dragged the entire pending backlog (including data CLOBs) across the wire to claim one job, and a no-op `$ensureJobTable` that made worker-side table bootstrap impossible on a fresh database.

## Findings addressed

- **J1 [High] Undefined `local.hasTenantContext` aborts the batch and masks the real job failure** — `vendor/wheels/Job.cfc:308`: initialized to `false` before the try so instantiation/deserialization failures no longer trigger a secondary "variable doesn't exist" error that escapes `$processJob`.
- **J3 [High] `JobWorker.$executeJob` neither restores tenant context nor strips `$wheelsTenantContext`** — `vendor/wheels/JobWorker.cfc:459,488` now call shared `Job.$restoreTenantContext` / `$clearTenantContext` helpers (`vendor/wheels/Job.cfc:430,454`), so the CLI worker path runs tenant jobs against the tenant datasource and `perform()` no longer receives the internal key.
- **J4 [Medium] `retryFailed` (no-limit branch) returns the count of ALL pending jobs, not the number reset** — `vendor/wheels/JobWorker.cfc:363`: counts `status='failed'` rows before the UPDATE instead of all pending rows afterwards.
- **J5 [Low] 15-line `wheels_jobs` INSERT duplicated verbatim in `$enqueueJob`'s table-create retry path** — extracted into `$insertJobRow` (`vendor/wheels/Job.cfc:196`), called from both paths (`:151`, `:164`).
- **J6 [Medium] Retry backoff reads `this.baseDelay`/`this.maxDelay` from the processing instance, not the failing job's class** — `vendor/wheels/Job.cfc:313-321,363`: backoff settings are captured from the failing job's own class when it instantiates, mirroring `JobWorker.$scheduleRetry` so both paths share one retry schedule.
- **J11 [High, perf] Worker poll loads the entire pending backlog (including full data payloads) to claim one job** — `vendor/wheels/JobWorker.cfc:68-75`: candidate SELECT drops the `data` CLOB and is bounded in SQL text per detected database type (`LIMIT` / `OFFSET ... FETCH NEXT` / `FETCH FIRST`); the payload is fetched by id only for the claimed job via `$fetchJobData` (`:610`).
- **J13 [Medium, perf] `JobWorker.$ensureJobTable` is a no-op: instantiating `wheels.Job` never creates the table** — `vendor/wheels/JobWorker.cfc:591-597` delegates to `Job.cfc`'s real bootstrap, now reachable as public-`$` `Job.$ensureJobTable` (`vendor/wheels/Job.cfc:553`), with a one-time `$tableVerified` guard.

## Findings verified already-fixed

None — all seven package findings were verified still present on `origin/develop` before fixing. The finalize reviewer independently spot-checked J1 and J13 and confirmed both still broken on `origin/develop` pre-fix.

## Source

Internal multi-agent framework review 2026-06-09, wave 2, package `jobs-worker` (subsystem 4.10 jobs-misc, findings J1/J3/J4/J5/J6/J11/J13).

## Tests

- New spec: `vendor/wheels/tests/specs/jobs/JobRobustnessSpec.cfc` (WheelsTest BDD) plus test assets `vendor/wheels/tests/_assets/jobs/ProbeJob.cfc` and `vendor/wheels/tests/_assets/jobs/FailingBackoffJob.cfc`, covering all behavioral fixes; five of the seven specs map to concrete pre-fix failures (J5 is a pure extraction; J6's spec asserts path consistency).
- Local verification (fix phase): jobs suite on Lucee 7 + SQLite — 64 pass / 0 fail / 0 error.
- The SQL Server (`OFFSET ... FETCH NEXT`) and Oracle (`FETCH FIRST`) candidate-limit branches were not executed locally (SQLite-only run); syntax is standard (`ORDER BY` is present for OFFSET-FETCH) and the compat matrix covers SQL Server in CI (Oracle is soft-fail).

## Cross-engine notes

- Shared helpers (`$restoreTenantContext`, `$clearTenantContext`, `$ensureJobTable`) are `public` with `$` prefix per the mixin-integration invariant.
- Catch bodies only mutate pre-existing struct/local state; retry-backoff values are captured before/inside the try, avoiding the BoxLang catch-`local` persistence quirk.
- No inline closures as constructor named args, no reserved-scope parameter names, no `attributeCollection` usage, no `Left(str, 0)`.
- Candidate-limit SQL branches keyed off the detected database type; all emitted clauses are engine-portable SQL (database dialects, not CFML engine dialects).

## Changelog

Entry deliberately omitted; consolidated at campaign end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
