### PR TITLE
fix(migrator): addIndex alias order, dbtype caching, helper dedup, diffAll rethrow

### DIFF
--- a/vendor/wheels/migrator/AutoMigrator.cfc
+++ b/vendor/wheels/migrator/AutoMigrator.cfc
@@ -179,6 +179,16 @@ component extends="wheels.migrator.Base" {
 			? arguments.options.heuristicThreshold
 			: 0.7;
 
+		// Validate the threshold up front: when it's out of range every per-model
+		// diff() throws, and the catch below would swallow all of them — silently
+		// reporting "no drift" instead of surfacing the configuration error.
+		if (local.threshold < 0 || local.threshold > 1) {
+			Throw(
+				type = "Wheels.InvalidThreshold",
+				message = "heuristicThreshold must be between 0 and 1, got " & local.threshold
+			);
+		}
+
 		if (StructKeyExists(application[local.appKey], "models")) {
 			for (local.modelName in application[local.appKey].models) {
 				try {
@@ -208,7 +218,18 @@ component extends="wheels.migrator.Base" {
 						local.results[local.modelName] = local.diffResult;
 					}
 				} catch (any e) {
-					// Skip models that fail to load (e.g. missing tables)
+					// Skip models that fail to load (e.g. missing tables) — but
+					// deliberate validation throws (bad rename hints, type-mismatch
+					// hints, out-of-range thresholds) must surface to the caller
+					// instead of silently dropping the model from the results.
+					if (
+						ListFindNoCase(
+							"Wheels.InvalidThreshold,Wheels.InvalidRenameHint,Wheels.DuplicateRenameHint,Wheels.RenameHintTypeMismatch",
+							e.type
+						)
+					) {
+						rethrow;
+					}
 					continue;
 				}
 			}

--- a/vendor/wheels/migrator/Base.cfc
+++ b/vendor/wheels/migrator/Base.cfc
@@ -15,6 +15,19 @@ component extends="wheels.Global"{
 	public string function $getDBType(string dataSource = "") {
 		local.appKey = $appKey();
 		local.dsName = Len(arguments.dataSource) ? arguments.dataSource : application[local.appKey].dataSourceName;
+
+		// Memoize the resolved adapter name per datasource: engine identity is
+		// stable for the life of the application, and discovery paths (e.g.
+		// Migrator.getAvailableMigrations()) instantiate every migration CFC —
+		// without this cache each init() triggers a fresh $dbinfo(version)
+		// round-trip (plus a SELECT version() on PostgreSQL).
+		if (
+			StructKeyExists(application[local.appKey], "$migratorAdapterNames")
+			&& StructKeyExists(application[local.appKey].$migratorAdapterNames, local.dsName)
+		) {
+			return application[local.appKey].$migratorAdapterNames[local.dsName];
+		}
+
 		local.info = $dbinfo(
 			type = "version",
 			datasource = local.dsName,
@@ -76,19 +89,36 @@ component extends="wheels.Global"{
 		} else if (local.info.driver_name Contains "SQLite") {
 			local.adapterName = "SQLite";
 		}
+		// Only cache successful detection — an empty string means the engine
+		// could not be identified and callers surface their own errors.
+		if (Len(local.adapterName)) {
+			if (!StructKeyExists(application[local.appKey], "$migratorAdapterNames")) {
+				application[local.appKey].$migratorAdapterNames = {};
+			}
+			application[local.appKey].$migratorAdapterNames[local.dsName] = local.adapterName;
+		}
 		return local.adapterName;
 	}
 
 	private string function $getForeignKeys(required string table) {
 		local.appKey = $appKey();
 		local.foreignKeyList = "";
-		local.tables = $dbinfo(
-			type = "tables",
-			datasource = application[local.appKey].dataSourceName,
-			username = application[local.appKey].dataSourceUserName,
-			password = application[local.appKey].dataSourcePassword
-		);
-		if (ListFindNoCase(ValueList(local.tables.table_name), arguments.table)) {
+		// Probe the single table for existence instead of listing every table
+		// in the schema — a failed zero-row SELECT means the table doesn't
+		// exist, so there are no foreign keys to report. (Mutate a struct field
+		// rather than assigning a bare local inside catch: BoxLang discards
+		// `local.X = ...` assignments made in a catch body.)
+		local.state = {tableExists = true};
+		local.quotedTable = StructKeyExists(this, "adapter") ? this.adapter.quoteTableName(arguments.table) : arguments.table;
+		try {
+			$query(
+				datasource = application[local.appKey].dataSourceName,
+				sql = "SELECT 1 FROM #local.quotedTable# WHERE 1=0"
+			);
+		} catch (any e) {
+			local.state.tableExists = false;
+		}
+		if (local.state.tableExists) {
 			local.foreignKeys = $dbinfo(
 				type = "foreignkeys",
 				table = arguments.table,
@@ -114,49 +144,41 @@ component extends="wheels.Global"{
 		}
 		local.appKey = $appKey();
 		local.dsName = Len(arguments.dataSource) ? arguments.dataSource : application[local.appKey].dataSourceName;
-		local.sql = Trim(arguments.sql);
-		local.info = $dbinfo(
-			type = "version",
-			datasource = local.dsName,
-			username = application[local.appKey].dataSourceUserName,
-			password = application[local.appKey].dataSourcePassword
-		);
-		if (Right(local.sql, 1) neq ";" && !FindNoCase("Oracle", local.info.database_productname)) {
-			local.sql = local.sql &= ";";
-		}
-		if (StructKeyExists(request, "$wheelsMigrationSQLFile") && application[local.appKey].writeMigratorSQLFiles) {
-			$file(
-				action = "append",
-				file = request.$wheelsMigrationSQLFile,
-				output = "#local.sql#",
-				addNewLine = "yes",
-				fixNewLine = "yes"
-			);
-		}
-		if (StructKeyExists(request, "$wheelsDebugSQL") && request.$wheelsDebugSQL) {
-			if (!StructKeyExists(request, "$wheelsDebugSQLResult")) {
-				request.$wheelsDebugSQLResult = [];
-			}
-			ArrayAppend(request.$wheelsDebugSQLResult, local.sql);
-		} else {
-			$query(datasource = local.dsName, sql = local.sql);
+		// Executed statements may change the schema — drop the request-scoped
+		// column cache so the next $getColumns() re-probes.
+		StructDelete(request, "$wheelsMigratorColumns");
+		local.prepared = $prepareMigrationSql(sql = arguments.sql, dsName = local.dsName);
+		if (!local.prepared.captured) {
+			$query(datasource = local.dsName, sql = local.prepared.sql);
 		}
 	}
 
 	/**
 	 * Executes a parameterized SQL statement for safe data operations.
 	 */
-	private void function $executeWithParams(required string sql, required array params) {
+	private void function $executeWithParams(required string sql, required array params, string dataSource = "") {
+		local.appKey = $appKey();
+		local.dsName = Len(arguments.dataSource) ? arguments.dataSource : application[local.appKey].dataSourceName;
+		local.prepared = $prepareMigrationSql(sql = arguments.sql, dsName = local.dsName);
+		if (!local.prepared.captured) {
+			queryExecute(local.prepared.sql, arguments.params, {datasource: local.dsName});
+		}
+	}
+
+	/**
+	 * Shared pre-execution pipeline for $execute()/$executeWithParams(): trims
+	 * the statement, appends the ";" terminator (except on Oracle — resolved
+	 * via the memoized $getDBType() rather than a per-statement $dbinfo
+	 * round-trip), appends to the migration SQL file when enabled, and captures
+	 * the statement on request.$wheelsDebugSQLResult in dry-run mode.
+	 * Returns {sql, captured}; captured=true means the caller must not execute
+	 * the statement.
+	 */
+	private struct function $prepareMigrationSql(required string sql, required string dsName) {
 		local.appKey = $appKey();
 		local.sql = Trim(arguments.sql);
-		local.info = $dbinfo(
-			type = "version",
-			datasource = application[local.appKey].dataSourceName,
-			username = application[local.appKey].dataSourceUserName,
-			password = application[local.appKey].dataSourcePassword
-		);
-		if (Right(local.sql, 1) neq ";" && !FindNoCase("Oracle", local.info.database_productname)) {
-			local.sql = local.sql & ";";
+		if (Right(local.sql, 1) neq ";" && $getDBType(arguments.dsName) != "Oracle") {
+			local.sql &= ";";
 		}
 		if (StructKeyExists(request, "$wheelsMigrationSQLFile") && application[local.appKey].writeMigratorSQLFiles) {
 			$file(
@@ -167,18 +189,30 @@ component extends="wheels.Global"{
 				fixNewLine = "yes"
 			);
 		}
-		if (StructKeyExists(request, "$wheelsDebugSQL") && request.$wheelsDebugSQL) {
+		local.captured = StructKeyExists(request, "$wheelsDebugSQL") && request.$wheelsDebugSQL;
+		if (local.captured) {
 			if (!StructKeyExists(request, "$wheelsDebugSQLResult")) {
 				request.$wheelsDebugSQLResult = [];
 			}
 			ArrayAppend(request.$wheelsDebugSQLResult, local.sql);
-		} else {
-			queryExecute(local.sql, arguments.params, {datasource: application[local.appKey].dataSourceName});
 		}
+		return {sql: local.sql, captured: local.captured};
 	}
 
 	public string function $getColumns(required string tableName) {
 		local.appKey = $appKey();
+		// Request-scoped cache: addRecord()/updateRecord() consult the column
+		// list for every inserted/updated row, so a multi-row seed migration
+		// would otherwise issue a full table-metadata round-trip per row.
+		// $execute() drops the cache whenever a statement runs, so DDL in the
+		// same request (addColumn() etc.) is reflected on the next read.
+		local.cacheKey = LCase(application[local.appKey].dataSourceName & "|" & arguments.tableName);
+		if (
+			StructKeyExists(request, "$wheelsMigratorColumns")
+			&& StructKeyExists(request.$wheelsMigratorColumns, local.cacheKey)
+		) {
+			return request.$wheelsMigratorColumns[local.cacheKey];
+		}
 		local.columns = $dbinfo(
 			datasource = application[local.appKey].dataSourceName,
 			username = application[local.appKey].dataSourceUserName,
@@ -186,7 +220,12 @@ component extends="wheels.Global"{
 			type = "columns",
 			table = arguments.tableName
 		);
-		return ValueList(local.columns.COLUMN_NAME);
+		local.columnList = ValueList(local.columns.COLUMN_NAME);
+		if (!StructKeyExists(request, "$wheelsMigratorColumns")) {
+			request.$wheelsMigratorColumns = {};
+		}
+		request.$wheelsMigratorColumns[local.cacheKey] = local.columnList;
+		return local.columnList;
 	}
 
 	/**

--- a/vendor/wheels/migrator/Migration.cfc
+++ b/vendor/wheels/migrator/Migration.cfc
@@ -115,7 +115,8 @@ component extends="Base" {
 	 */
 	public void function dropTable(required string name) {
 		local.appKey = $appKey();
-		local.adapterName = $getDBType();
+		// init() already resolved the engine — no need to re-sniff via $getDBType().
+		local.adapterName = this.adapter.adapterName();
 		if (application[local.appKey].serverName != "lucee" && local.adapterName != "SQLite") {
 			local.foreignKeys = $getForeignKeys(arguments.name);
 			local.foreignKeysArray = ListToArray(local.foreignKeys);
@@ -410,6 +411,7 @@ component extends="Base" {
 	 *
 	 * @table The table name to perform the index operation on
 	 * @columnNames One or more column names to index, comma separated
+	 * @columnName Singular alias for `columnNames` (matches the convention every other migrator helper follows). Pass one or the other — not both.
 	 * @unique If true will create a unique index constraint
 	 * @indexName The name of the index to add: Defaults to table name + underscore + first column name
 	 */
@@ -417,9 +419,16 @@ component extends="Base" {
 		required string table,
 		string columnNames,
 		boolean unique = "false",
-		string indexName = objectCase("#arguments.table#_#ListFirst(arguments.columnNames)#")
+		string indexName = ""
 	) {
 		$combineArguments(args = arguments, combine = "columnNames,columnName", required = true);
+		// Compute the default index name here, AFTER $combineArguments has
+		// resolved the columnName alias — a parameter-default expression would
+		// dereference arguments.columnNames before the alias resolves and throw
+		// an undefined-key error on the documented columnName path.
+		if (!Len(arguments.indexName)) {
+			arguments.indexName = objectCase("#arguments.table#_#ListFirst(arguments.columnNames)#");
+		}
 		$execute(this.adapter.addIndex(argumentCollection = arguments));
 		announce("Added index to column(s) #arguments.columnNames# in table #arguments.table#");
 	}
@@ -467,16 +476,20 @@ component extends="Base" {
 		local.columnNames = "";
 		local.placeholders = "";
 		local.params = [];
+		// One metadata probe per record (cached per request inside $getColumns)
+		// — previously each timestamp check below issued its own full
+		// table-column round-trip.
+		local.tableColumns = $getColumns(arguments.table);
 		if (
 			!StructKeyExists(arguments, application[local.appKey].timeStampOnCreateProperty)
-			&& ListFindNoCase($getColumns(arguments.table), application[local.appKey].timeStampOnCreateProperty)
+			&& ListFindNoCase(local.tableColumns, application[local.appKey].timeStampOnCreateProperty)
 		) {
 			arguments[application[local.appKey].timeStampOnCreateProperty] = $timestamp();
 		}
 		if (
 			application[local.appKey].setUpdatedAtOnCreate
 			&& !StructKeyExists(arguments, application[local.appKey].timeStampOnUpdateProperty)
-			&& ListFindNoCase($getColumns(arguments.table), application[local.appKey].timeStampOnUpdateProperty)
+			&& ListFindNoCase(local.tableColumns, application[local.appKey].timeStampOnUpdateProperty)
 		) {
 			arguments[application[local.appKey].timeStampOnUpdateProperty] = $timestamp();
 		}

--- a/vendor/wheels/migrator/TableDefinition.cfc
+++ b/vendor/wheels/migrator/TableDefinition.cfc
@@ -124,21 +124,32 @@ component extends="Base" {
 	}
 
 	/**
+	 * Shared implementation for the typed column helpers below: resolves the
+	 * columnNames/columnName alias, stamps the column type, and adds one column
+	 * per (comma-delimited) name. `args` is the caller's arguments scope, so
+	 * type-specific options (limit, default, allowNull, precision, scale, size)
+	 * pass straight through to column().
+	 */
+	private any function $addTypedColumns(required string columnType, required struct args) {
+		$combineArguments(args = arguments.args, combine = "columnNames,columnName", required = true);
+		arguments.args.columnType = arguments.columnType;
+		local.columnNamesArray = ListToArray(arguments.args.columnNames);
+		local.iEnd = ArrayLen(local.columnNamesArray);
+		for (local.i = 1; local.i <= local.iEnd; local.i++) {
+			arguments.args.columnName = Trim(local.columnNamesArray[local.i]);
+			column(argumentCollection = arguments.args);
+		}
+		return this;
+	}
+
+	/**
 	 * Adds integer columns to table definition.
 	 *
 	 * [section: Migrator]
 	 * [category: Table Definition Functions]
 	 */
 	public any function bigInteger(string columnNames, numeric limit, string default, boolean allowNull) {
-		$combineArguments(args = arguments, combine = "columnNames,columnName", required = true);
-		arguments.columnType = "biginteger";
-		local.columnNamesArray = ListToArray(arguments.columnNames);
-		local.iEnd = ArrayLen(local.columnNamesArray);
-		for (local.i = 1; local.i <= local.iEnd; local.i++) {
-			arguments.columnName = Trim(local.columnNamesArray[local.i]);
-			column(argumentCollection = arguments);
-		}
-		return this;
+		return $addTypedColumns(columnType = "biginteger", args = arguments);
 	}
 
 	/**
@@ -148,15 +159,7 @@ component extends="Base" {
 	 * [category: Table Definition Functions]
 	 */
 	public any function binary(string columnNames, string default, boolean allowNull) {
-		$combineArguments(args = arguments, combine = "columnNames,columnName", required = true);
-		arguments.columnType = "binary";
-		local.columnNamesArray = ListToArray(arguments.columnNames);
-		local.iEnd = ArrayLen(local.columnNamesArray);
-		for (local.i = 1; local.i <= local.iEnd; local.i++) {
-			arguments.columnName = Trim(local.columnNamesArray[local.i]);
-			column(argumentCollection = arguments);
-		}
-		return this;
+		return $addTypedColumns(columnType = "binary", args = arguments);
 	}
 
 	/**
@@ -166,15 +169,7 @@ component extends="Base" {
 	 * [category: Table Definition Functions]
 	 */
 	public any function boolean(string columnNames, string default, boolean allowNull) {
-		$combineArguments(args = arguments, combine = "columnNames,columnName", required = true);
-		arguments.columnType = "boolean";
-		local.columnNamesArray = ListToArray(arguments.columnNames);
-		local.iEnd = ArrayLen(local.columnNamesArray);
-		for (local.i = 1; local.i <= local.iEnd; local.i++) {
-			arguments.columnName = Trim(local.columnNamesArray[local.i]);
-			column(argumentCollection = arguments);
-		}
-		return this;
+		return $addTypedColumns(columnType = "boolean", args = arguments);
 	}
 
 	/**
@@ -184,15 +179,7 @@ component extends="Base" {
 	 * [category: Table Definition Functions]
 	 */
 	public any function date(string columnNames, string default, boolean allowNull) {
-		$combineArguments(args = arguments, combine = "columnNames,columnName", required = true);
-		arguments.columnType = "date";
-		local.columnNamesArray = ListToArray(arguments.columnNames);
-		local.iEnd = ArrayLen(local.columnNamesArray);
-		for (local.i = 1; local.i <= local.iEnd; local.i++) {
-			arguments.columnName = Trim(local.columnNamesArray[local.i]);
-			column(argumentCollection = arguments);
-		}
-		return this;
+		return $addTypedColumns(columnType = "date", args = arguments);
 	}
 
 	/**
@@ -202,15 +189,7 @@ component extends="Base" {
 	 * [category: Table Definition Functions]
 	 */
 	public any function datetime(string columnNames, string default, boolean allowNull) {
-		$combineArguments(args = arguments, combine = "columnNames,columnName", required = true);
-		arguments.columnType = "datetime";
-		local.columnNamesArray = ListToArray(arguments.columnNames);
-		local.iEnd = ArrayLen(local.columnNamesArray);
-		for (local.i = 1; local.i <= local.iEnd; local.i++) {
-			arguments.columnName = Trim(local.columnNamesArray[local.i]);
-			column(argumentCollection = arguments);
-		}
-		return this;
+		return $addTypedColumns(columnType = "datetime", args = arguments);
 	}
 
 	/**
@@ -220,15 +199,7 @@ component extends="Base" {
 	 * [category: Table Definition Functions]
 	 */
 	public any function decimal(string columnNames, string default, boolean allowNull, numeric precision, numeric scale) {
-		$combineArguments(args = arguments, combine = "columnNames,columnName", required = true);
-		arguments.columnType = "decimal";
-		local.columnNamesArray = ListToArray(arguments.columnNames);
-		local.iEnd = ArrayLen(local.columnNamesArray);
-		for (local.i = 1; local.i <= local.iEnd; local.i++) {
-			arguments.columnName = Trim(local.columnNamesArray[local.i]);
-			column(argumentCollection = arguments);
-		}
-		return this;
+		return $addTypedColumns(columnType = "decimal", args = arguments);
 	}
 
 	/**
@@ -238,15 +209,11 @@ component extends="Base" {
 	 * [category: Table Definition Functions]
 	 */
 	public any function float(string columnNames, string default = "", boolean allowNull = "true") {
-		$combineArguments(args = arguments, combine = "columnNames,columnName", required = true);
-		arguments.columnType = "float";
-		local.columnNamesArray = ListToArray(arguments.columnNames);
-		local.iEnd = ArrayLen(local.columnNamesArray);
-		for (local.i = 1; local.i <= local.iEnd; local.i++) {
-			arguments.columnName = Trim(local.columnNamesArray[local.i]);
-			column(argumentCollection = arguments);
-		}
-		return this;
+		// NOTE: the default=""/allowNull="true" parameter defaults are a
+		// long-standing outlier among these helpers — preserved as-is for
+		// backward compatibility (addColumnOptions renders default="" as
+		// DEFAULT NULL).
+		return $addTypedColumns(columnType = "float", args = arguments);
 	}
 
 	/**
@@ -256,15 +223,7 @@ component extends="Base" {
 	 * [category: Table Definition Functions]
 	 */
 	public any function integer(string columnNames, numeric limit, string default, boolean allowNull) {
-		$combineArguments(args = arguments, combine = "columnNames,columnName", required = true);
-		arguments.columnType = "integer";
-		local.columnNamesArray = ListToArray(arguments.columnNames);
-		local.iEnd = ArrayLen(local.columnNamesArray);
-		for (local.i = 1; local.i <= local.iEnd; local.i++) {
-			arguments.columnName = Trim(local.columnNamesArray[local.i]);
-			column(argumentCollection = arguments);
-		}
-		return this;
+		return $addTypedColumns(columnType = "integer", args = arguments);
 	}
 
 	/**
@@ -274,15 +233,7 @@ component extends="Base" {
 	 * [category: Table Definition Functions]
 	 */
 	public any function string(string columnNames, any limit, string default, boolean allowNull) {
-		$combineArguments(args = arguments, combine = "columnNames,columnName", required = true);
-		arguments.columnType = "string";
-		local.columnNamesArray = ListToArray(arguments.columnNames);
-		local.iEnd = ArrayLen(local.columnNamesArray);
-		for (local.i = 1; local.i <= local.iEnd; local.i++) {
-			arguments.columnName = Trim(local.columnNamesArray[local.i]);
-			column(argumentCollection = arguments);
-		}
-		return this;
+		return $addTypedColumns(columnType = "string", args = arguments);
 	}
 
 	/**
@@ -292,15 +243,7 @@ component extends="Base" {
 	 * [category: Table Definition Functions]
 	 */
 	public any function char(string columnNames, any limit, string default, boolean allowNull) {
-		$combineArguments(args = arguments, combine = "columnNames,columnName", required = true);
-		arguments.columnType = "char";
-		local.columnNamesArray = ListToArray(arguments.columnNames);
-		local.iEnd = ArrayLen(local.columnNamesArray);
-		for (local.i = 1; local.i <= local.iEnd; local.i++) {
-			arguments.columnName = Trim(local.columnNamesArray[local.i]);
-			column(argumentCollection = arguments);
-		}
-		return this;
+		return $addTypedColumns(columnType = "char", args = arguments);
 	}
 
 	/**
@@ -317,15 +260,7 @@ component extends="Base" {
 	 * [category: Table Definition Functions]
 	 */
 	public any function text(string columnNames, string default, boolean allowNull, string size) {
-		$combineArguments(args = arguments, combine = "columnNames,columnName", required = true);
-		arguments.columnType = "text";
-		local.columnNamesArray = ListToArray(arguments.columnNames);
-		local.iEnd = ArrayLen(local.columnNamesArray);
-		for (local.i = 1; local.i <= local.iEnd; local.i++) {
-			arguments.columnName = Trim(local.columnNamesArray[local.i]);
-			column(argumentCollection = arguments);
-		}
-		return this;
+		return $addTypedColumns(columnType = "text", args = arguments);
 	}
 
 	/**
@@ -335,15 +270,10 @@ component extends="Base" {
 	 * [category: Table Definition Functions]
 	 */
 	public any function uniqueidentifier(string columnNames, string default = "newid()", boolean allowNull) {
-		$combineArguments(args = arguments, combine = "columnNames,columnName", required = true);
-		arguments.columnType = "uniqueidentifier";
-		local.columnNamesArray = ListToArray(arguments.columnNames);
-		local.iEnd = ArrayLen(local.columnNamesArray);
-		for (local.i = 1; local.i <= local.iEnd; local.i++) {
-			arguments.columnName = Trim(local.columnNamesArray[local.i]);
-			column(argumentCollection = arguments);
-		}
-		return this;
+		// NOTE: the default="newid()" parameter default is MSSQL syntax — this
+		// helper is only registered by the MicrosoftSQLServer adapter, so the
+		// outlier default is preserved as-is.
+		return $addTypedColumns(columnType = "uniqueidentifier", args = arguments);
 	}
 
 	/**
@@ -353,15 +283,7 @@ component extends="Base" {
 	 * [category: Table Definition Functions]
 	 */
 	public any function time(string columnNames, string default, boolean allowNull) {
-		$combineArguments(args = arguments, combine = "columnNames,columnName", required = true);
-		arguments.columnType = "time";
-		local.columnNamesArray = ListToArray(arguments.columnNames);
-		local.iEnd = ArrayLen(local.columnNamesArray);
-		for (local.i = 1; local.i <= local.iEnd; local.i++) {
-			arguments.columnName = Trim(local.columnNamesArray[local.i]);
-			column(argumentCollection = arguments);
-		}
-		return this;
+		return $addTypedColumns(columnType = "time", args = arguments);
 	}
 
 	/**
@@ -371,14 +293,9 @@ component extends="Base" {
 	 * [category: Table Definition Functions]
 	 */
 	public any function timestamp(string columnNames, string default, boolean allowNull, string columnType = "datetime") {
-		$combineArguments(args = arguments, combine = "columnNames,columnName", required = true);
-		local.columnNamesArray = ListToArray(arguments.columnNames);
-		local.iEnd = ArrayLen(local.columnNamesArray);
-		for (local.i = 1; local.i <= local.iEnd; local.i++) {
-			arguments.columnName = Trim(local.columnNamesArray[local.i]);
-			column(argumentCollection = arguments);
-		}
-		return this;
+		// columnType is caller-overridable here (defaults to "datetime") —
+		// unlike the sibling helpers, which stamp a fixed type.
+		return $addTypedColumns(columnType = arguments.columnType, args = arguments);
 	}
 
 	/**

--- a/vendor/wheels/tests/specs/migrator/MigratorBaseCachingSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/MigratorBaseCachingSpec.cfc
@@ -1,0 +1,80 @@
+/**
+ * Coverage for the migrator Base.cfc caching layers:
+ *
+ *   1. $getDBType() memoizes the resolved adapter name per datasource on the
+ *      application scope — discovery paths (Migrator.getAvailableMigrations())
+ *      instantiate every migration CFC, and each init() used to trigger a
+ *      fresh $dbinfo(version) round-trip.
+ *   2. $getColumns() caches the column list per request — addRecord() /
+ *      updateRecord() consult it for every row, so a multi-row seed migration
+ *      used to issue a full table-metadata round-trip per row (two per row in
+ *      addRecord's case). Any statement routed through $execute() drops the
+ *      cache so DDL in the same request is reflected on the next read.
+ *
+ * Both tests use the "poison the cache with a sentinel" technique: if the
+ * implementation consults the cache, the sentinel comes back; if it re-probes
+ * the database, the real value comes back and the test fails.
+ */
+component extends="wheels.WheelsTest" {
+
+	function beforeAll() {
+		variables.migration = CreateObject("component", "wheels.migrator.Migration").init();
+	}
+
+	function run() {
+
+		describe("Migrator Base.cfc caching", () => {
+
+			it("memoizes the $getDBType() adapter name per datasource", () => {
+				var dsName = application.wheels.dataSourceName;
+				var realType = variables.migration.$getDBType();
+				expect(Len(realType)).toBeGT(0);
+				expect(StructKeyExists(application.wheels, "$migratorAdapterNames")).toBeTrue();
+				expect(StructKeyExists(application.wheels.$migratorAdapterNames, dsName)).toBeTrue();
+				expect(application.wheels.$migratorAdapterNames[dsName]).toBe(realType);
+
+				// Poison the cache to prove subsequent calls consume it instead
+				// of re-probing the database.
+				application.wheels.$migratorAdapterNames[dsName] = "SentinelAdapter";
+				try {
+					expect(variables.migration.$getDBType()).toBe("SentinelAdapter");
+				} finally {
+					application.wheels.$migratorAdapterNames[dsName] = realType;
+				}
+			});
+
+			it("caches $getColumns() per request and invalidates on $execute()", () => {
+				var tableName = "c_o_r_e_authors";
+				var cacheKey = LCase(application.wheels.dataSourceName & "|" & tableName);
+				StructDelete(request, "$wheelsMigratorColumns");
+
+				var realColumns = variables.migration.$getColumns(tableName);
+				expect(Len(realColumns)).toBeGT(0);
+				expect(StructKeyExists(request, "$wheelsMigratorColumns")).toBeTrue();
+				expect(StructKeyExists(request.$wheelsMigratorColumns, cacheKey)).toBeTrue();
+
+				// Poison the cache to prove the next read consumes it.
+				request.$wheelsMigratorColumns[cacheKey] = "sentinelcolumn";
+				expect(variables.migration.$getColumns(tableName)).toBe("sentinelcolumn");
+
+				// Any statement routed through $execute() may change the schema,
+				// so it must drop the cache (dry-run capture keeps the DB
+				// untouched here).
+				request.$wheelsDebugSQL = true;
+				request.$wheelsDebugSQLResult = [];
+				try {
+					variables.migration.execute("SELECT 1 FROM #tableName# WHERE 1=0");
+				} finally {
+					StructDelete(request, "$wheelsDebugSQL");
+					StructDelete(request, "$wheelsDebugSQLResult");
+				}
+				expect(
+					StructKeyExists(request, "$wheelsMigratorColumns")
+					&& StructKeyExists(request.$wheelsMigratorColumns, cacheKey)
+				).toBeFalse();
+				expect(variables.migration.$getColumns(tableName)).toBe(realColumns);
+			});
+
+		});
+	}
+}

--- a/vendor/wheels/tests/specs/migrator/autoMigratorSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/autoMigratorSpec.cfc
@@ -415,6 +415,25 @@ component extends="wheels.WheelsTest" {
 					expect(local.result).toBeStruct();
 				});
 
+				it("throws on an out-of-range heuristicThreshold instead of reporting no drift", () => {
+					// Pre-fix, the per-model catch swallowed the InvalidThreshold
+					// throw from every diff() call and diffAll() returned an empty
+					// struct — silently reporting "no drift" for a config error.
+					expect(() => {
+						autoMigrator.diffAll(options = {heuristicThreshold: 5});
+					}).toThrow("Wheels.InvalidThreshold");
+				});
+
+				it("rethrows invalid rename hints instead of silently skipping the model", () => {
+					// Ensure the Author model is registered so diffAll() reaches it.
+					g.model("Author");
+					expect(() => {
+						autoMigrator.diffAll(options = {
+							hints: {"Author": {renames: {"no_such_column_xyz": "also_missing_xyz"}}}
+						});
+					}).toThrow("Wheels.InvalidRenameHint");
+				});
+
 			});
 
 			describe("diff() — rename integration", () => {

--- a/vendor/wheels/tests/specs/migrator/migrationCommandsSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/migrationCommandsSpec.cfc
@@ -115,6 +115,26 @@ component extends="wheels.WheelsTest" {
 				expect(aliasAccepted).toBeTrue();
 			});
 
+			it("addIndex accepts the columnName alias without an explicit indexName", () => {
+				// Regression guard: the indexName parameter default used to
+				// dereference arguments.columnNames BEFORE $combineArguments had
+				// resolved the columnName alias, throwing an undefined-key error
+				// on the documented columnName path. Use dry-run capture so no
+				// DDL actually runs.
+				request.$wheelsDebugSQL = true;
+				request.$wheelsDebugSQLResult = [];
+				try {
+					variables.migration.addIndex(table = "dbm_cmd_addidx_test", columnName = "email");
+					expect(ArrayLen(request.$wheelsDebugSQLResult)).toBe(1);
+					var capturedSql = request.$wheelsDebugSQLResult[1];
+					// Default index name = table + underscore + first column name.
+					expect(FindNoCase("dbm_cmd_addidx_test_email", capturedSql)).toBeGT(0);
+				} finally {
+					StructDelete(request, "$wheelsDebugSQL");
+					StructDelete(request, "$wheelsDebugSQLResult");
+				}
+			});
+
 		});
 
 		describe("Migration.cfc — required-arg regression guards", () => {


### PR DESCRIPTION
## Summary

Wave-2 remediation for the **migration-helpers** package of the internal framework review. Seven migrator findings fixed in a single commit: a crash on the documented `columnName` path of `addIndex()`, two redundant-DB-round-trip hotspots (engine sniffing and table-metadata probes), a duplicated SQL pre-execution pipeline, an engine re-sniff in `dropTable()` plus a whole-schema FK probe, fourteen byte-identical typed column helpers, and `diffAll()` swallowing its own validation throws.

## Findings addressed

- **MG3 — `addIndex()` default `indexName` dereferences `arguments.columnNames` before `$combineArguments` resolves the `columnName` alias (undefined-key throw)** @ `vendor/wheels/migrator/Migration.cfc:418-432` — default now computed in the body after `$combineArguments`.
- **MG5 — `$execute()` / `$executeWithParams()` duplicate the terminator / SQL-file / debug-capture pipeline, with a per-statement `$dbinfo(version)` round-trip** @ `vendor/wheels/migrator/Base.cfc:177` — extracted into `$prepareMigrationSql()` preserving the exact old pipeline order; Oracle-terminator check now uses memoized `$getDBType()`; `$executeWithParams()` gains the `dataSource` override its sibling already had (`Base.cfc:159`).
- **MG7 — fourteen byte-identical typed column helpers in `TableDefinition`** @ `vendor/wheels/migrator/TableDefinition.cfc:133` — deduped into shared `$addTypedColumns()`, preserving the `float()` / `uniqueidentifier()` outlier defaults and `timestamp()`'s `columnType` pass-through verbatim.
- **MG9 — `diffAll()` swallows deliberate validation throws in the per-model missing-table catch and reports "no drift"** @ `vendor/wheels/migrator/AutoMigrator.cfc:185-231` — `heuristicThreshold` validated up front (mirroring `RenameDetector`'s range check); `Wheels.InvalidThreshold`, `Wheels.InvalidRenameHint`, `Wheels.DuplicateRenameHint`, `Wheels.RenameHintTypeMismatch` are rethrown.
- **MG11 — every migration CFC `init()` triggers a fresh `$dbinfo(version)` round-trip during discovery** @ `vendor/wheels/migrator/Base.cfc:15` — `$getDBType()` memoizes the resolved adapter name per datasource on the application scope.
- **MG13 — `addRecord()` probes table metadata twice per record** @ `vendor/wheels/migrator/Base.cfc:202` — `$getColumns()` gets a request-scoped cache keyed by datasource + table; `$execute()` (DDL) invalidates the cache (`Base.cfc:148-150`) while `$executeWithParams()` (data-only) does not.
- **MG14 — `dropTable()` re-sniffs the engine and `$getForeignKeys()` lists every table in the schema** @ `vendor/wheels/migrator/Migration.cfc:119` + `vendor/wheels/migrator/Base.cfc:103` — uses `this.adapter.adapterName()` (byte-identical to `$getDBType()` strings across all 7 adapters) and a zero-row single-table SELECT probe.

## Findings verified already-fixed

None — all seven findings reproduced against current `origin/develop` (spot-confirmed by the reviewer for MG3 at `Migration.cfc:416-420` and MG13).

## Source

Internal multi-agent framework review 2026-06-09, wave 2, package **migration-helpers**.

## Tests

- New BDD specs under `vendor/wheels/tests/specs/migrator/` (written red against pre-fix code, green post-fix):
  - `MigratorBaseCachingSpec.cfc` — both caches; uses a poison-the-cache technique to distinguish cached reads from re-probes, and verifies `$execute()` invalidates the `$getColumns()` cache.
  - `migrationCommandsSpec.cfc` — `addIndex()` via the `columnName` alias (the MG3 crash path).
  - `autoMigratorSpec.cfc` — `diffAll()` throws on invalid threshold and rethrows rename-hint validation errors.
- Local verification: full migrator area on Lucee 7 + SQLite — 270 pass / 0 fail / 0 error / 6 skipped.
- Full engine x DB coverage deferred to the CI compat matrix (the real gate per repo policy).

## Cross-engine notes

- Catch-body state in the new specs uses the shared-struct pattern (cross-engine invariant #11 — `local.X` in `catch` does not persist on BoxLang).
- `argumentCollection = arguments.args` forwarding in `$addTypedColumns()` has in-tree precedent (`Injector.cfc:174`, `controller/filters.cfm:66`).
- The single-table FK probe SQL is valid under every adapter's `quoteTableName` override; `adapterName()` returns are byte-identical to the old `$getDBType()` strings for all 7 adapters.
- Locally verified on Lucee 7 + SQLite only — the TableDefinition arguments-forwarding refactor and the new probe SQL should be confirmed by the adobe2023 / adobe2025 / boxlang legs of the CI matrix before merge.
- Known non-blocking follow-ups flagged in review: the same param-default pattern survives at `databaseAdapters/Abstract.cfc:300` (unreachable via the fixed Migration path); `$getForeignKeys()` now maps any probe failure to "no FKs", shifting failure to the subsequent DROP; two parallel application-scope engine caches could be unified later.

## Changelog

Entry deliberately omitted; consolidated at campaign end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
