### PR TITLE
fix(sse): blank-line framing, DB cursor advance, channel pruning, bounded retention cleanup

### DIFF
--- a/vendor/wheels/Channel.cfc
+++ b/vendor/wheels/Channel.cfc
@@ -124,6 +124,20 @@ component {
 			return false;
 		}
 		local.removed = local.subscribers.remove(arguments.subscriberId);
+
+		// Prune the per-channel map once its last subscriber leaves so per-entity
+		// channel names (e.g. "user.42") don't accumulate empty maps in this
+		// app-scoped singleton for the application lifetime. The atomic two-argument
+		// remove(key, value) only removes the entry if the channel still maps to this
+		// same subscriber map, so it never discards a replacement map created by a
+		// concurrent subscribe(). Known (tiny) race: a subscriber that lands in this
+		// exact map between the isEmpty() check and the remove() is orphaned and
+		// receives no events until its connection times out and the client
+		// re-subscribes.
+		if (local.subscribers.isEmpty()) {
+			variables.channels.remove(arguments.channel, local.subscribers);
+		}
+
 		return !IsNull(local.removed);
 	}
 

--- a/vendor/wheels/channel/DatabaseAdapter.cfc
+++ b/vendor/wheels/channel/DatabaseAdapter.cfc
@@ -21,8 +21,14 @@ component {
 			variables.$datasource = application.wheels.dataSourceName;
 		}
 		variables.tableVerified = false;
-		variables.lastCleanup = 0;
+		// Start the throttle clock at instance creation so a fresh instance does
+		// not run a retention sweep on its very first publish()
+		variables.lastCleanup = GetTickCount() / 1000;
 		variables.retentionMinutes = 60;
+		// Cap on rows deleted per throttled publish-path cleanup pass
+		variables.cleanupBatchSize = 1000;
+		// True while a previous bounded pass hit its cap (backlog still draining)
+		variables.cleanupBacklog = false;
 		return this;
 	}
 
@@ -136,36 +142,84 @@ component {
 	/**
 	 * Delete events older than the specified number of minutes.
 	 *
+	 * On busy multi-server deployments prefer calling this from a scheduled task
+	 * or worker (with a maxRows bound) rather than relying solely on the
+	 * throttled publish-path sweep.
+	 *
 	 * @olderThanMinutes Delete events older than this many minutes (default: retentionMinutes).
+	 * @maxRows Maximum number of rows to delete in this pass. 0 (default) deletes all expired rows.
+	 * @return Number of rows deleted (best effort; 0 on error or when the engine doesn't report it).
 	 */
-	public void function cleanup(numeric olderThanMinutes = variables.retentionMinutes) {
+	public numeric function cleanup(
+		numeric olderThanMinutes = variables.retentionMinutes,
+		numeric maxRows = 0
+	) {
 		$ensureEventsTable();
 
+		local.cutoff = DateAdd("n", -arguments.olderThanMinutes, Now());
+
 		try {
+			if (arguments.maxRows > 0) {
+				// Bounded pass: select the oldest expired ids first, then delete only
+				// those, so the DELETE (the lock-holding statement) stays small and
+				// indexed even when a large backlog has accumulated
+				local.candidates = queryExecute(
+					"SELECT id FROM wheels_events WHERE createdAt < :cutoff ORDER BY createdAt ASC",
+					{
+						cutoff: {value: local.cutoff, cfsqltype: "cf_sql_timestamp"}
+					},
+					{datasource: variables.$datasource, maxrows: arguments.maxRows}
+				);
+				if (local.candidates.recordCount == 0) {
+					return 0;
+				}
+				// Repeat the cutoff predicate so the blast radius stays limited to
+				// expired rows even if an application-supplied event id contains a comma
+				queryExecute(
+					"DELETE FROM wheels_events WHERE createdAt < :cutoff AND id IN (:ids)",
+					{
+						cutoff: {value: local.cutoff, cfsqltype: "cf_sql_timestamp"},
+						ids: {value: ValueList(local.candidates.id), cfsqltype: "cf_sql_varchar", list: true}
+					},
+					{datasource: variables.$datasource}
+				);
+				return local.candidates.recordCount;
+			}
+
 			queryExecute(
 				"DELETE FROM wheels_events WHERE createdAt < :cutoff",
 				{
-					cutoff: {value: DateAdd("n", -arguments.olderThanMinutes, Now()), cfsqltype: "cf_sql_timestamp"}
+					cutoff: {value: local.cutoff, cfsqltype: "cf_sql_timestamp"}
 				},
-				{datasource: variables.$datasource}
+				{datasource: variables.$datasource, result: "local.deleteResult"}
 			);
+			if (StructKeyExists(local, "deleteResult") && StructKeyExists(local.deleteResult, "recordCount")) {
+				return local.deleteResult.recordCount;
+			}
+			return 0;
 		} catch (any e) {
 			writeLog(
 				text="DatabaseAdapter cleanup error: #e.message#",
 				type="error",
 				file="wheels_channels"
 			);
+			return 0;
 		}
 	}
 
 	/**
-	 * Throttled cleanup — runs at most once every 5 minutes.
+	 * Throttled cleanup on the publish path — runs at most once every 5 minutes
+	 * (every 15 seconds while a backlog is draining) and deletes at most
+	 * cleanupBatchSize rows per pass so no single publish() blocks on a large
+	 * DELETE. Full sweeps remain available via cleanup() for scheduled tasks.
 	 */
 	private void function $maybeCleanup() {
 		local.now = GetTickCount() / 1000;
-		if (local.now - variables.lastCleanup > 300) {
+		local.interval = variables.cleanupBacklog ? 15 : 300;
+		if (local.now - variables.lastCleanup > local.interval) {
 			variables.lastCleanup = local.now;
-			cleanup();
+			local.deleted = cleanup(maxRows = variables.cleanupBatchSize);
+			variables.cleanupBacklog = local.deleted >= variables.cleanupBatchSize;
 		}
 	}
 

--- a/vendor/wheels/controller/channels.cfc
+++ b/vendor/wheels/controller/channels.cfc
@@ -254,6 +254,10 @@ component {
 
 				if (local.events.recordCount > 0) {
 					for (local.row = 1; local.row <= local.events.recordCount; local.row++) {
+						// Advance the cursor before filtering so non-matching events are
+						// not re-fetched and re-filtered on every subsequent poll
+						local.currentLastId = local.events.id[local.row];
+
 						// Filter by event type if specified
 						if (ArrayLen(arguments.eventFilter) && !ArrayFind(arguments.eventFilter, local.events.event[local.row])) {
 							continue;
@@ -265,7 +269,6 @@ component {
 							event = local.events.event[local.row],
 							id = local.events.id[local.row]
 						);
-						local.currentLastId = local.events.id[local.row];
 					}
 					local.lastHeartbeat = local.now;
 				}

--- a/vendor/wheels/controller/sse.cfc
+++ b/vendor/wheels/controller/sse.cfc
@@ -189,7 +189,9 @@ component {
 		if (Len(arguments.data)) {
 			local.normalizedData = Replace(arguments.data, Chr(13) & Chr(10), Chr(10), "all");
 			local.normalizedData = Replace(local.normalizedData, Chr(13), Chr(10), "all");
-			local.dataLines = ListToArray(local.normalizedData, Chr(10));
+			// includeEmptyFields=true so blank lines in multi-line data are preserved
+			// as empty "data:" lines instead of being silently dropped
+			local.dataLines = ListToArray(local.normalizedData, Chr(10), true);
 			for (local.line in local.dataLines) {
 				ArrayAppend(local.lines, "data: #local.line#");
 			}

--- a/vendor/wheels/tests/specs/channel/DatabaseAdapterSpec.cfc
+++ b/vendor/wheels/tests/specs/channel/DatabaseAdapterSpec.cfc
@@ -160,6 +160,68 @@ component extends="wheels.WheelsTest" {
 				expect(remaining.recordCount).toBe(0);
 			});
 
+			it("publish on a fresh instance does not run an immediate retention sweep", function() {
+				// Ensure the table exists before inserting directly
+				adapter.poll(channel = "test.freshsweep", since = DateAdd("n", -1, Now()));
+
+				// Insert an event older than the retention window
+				queryExecute(
+					"INSERT INTO wheels_events (id, channel, event, data, createdAt)
+					VALUES (:id, :channel, :event, :data, :createdAt)",
+					{
+						id: {value: "fresh-sweep-guard", cfsqltype: "cf_sql_varchar"},
+						channel: {value: "test.freshsweep", cfsqltype: "cf_sql_varchar"},
+						event: {value: "old", cfsqltype: "cf_sql_varchar"},
+						data: {value: "expired", cfsqltype: "cf_sql_longvarchar"},
+						createdAt: {value: DateAdd("h", -2, Now()), cfsqltype: "cf_sql_timestamp"}
+					},
+					{datasource: application.wheels.dataSourceName}
+				);
+
+				// A brand-new adapter's first publish must not block on a retention DELETE
+				var freshAdapter = new wheels.channel.DatabaseAdapter();
+				freshAdapter.publish(channel = "test.freshsweep", event = "e", data = "d");
+
+				var remaining = queryExecute(
+					"SELECT id FROM wheels_events WHERE id = :id",
+					{id: {value: "fresh-sweep-guard", cfsqltype: "cf_sql_varchar"}},
+					{datasource: application.wheels.dataSourceName}
+				);
+				expect(remaining.recordCount).toBe(1);
+			});
+
+			it("cleanup with maxRows bounds the number of rows deleted per pass", function() {
+				// Ensure the table exists and flush any pre-existing expired rows so the
+				// bounded pass below only sees the five rows inserted here
+				adapter.poll(channel = "test.bounded", since = DateAdd("n", -1, Now()));
+				adapter.cleanup();
+
+				for (var i = 1; i <= 5; i++) {
+					queryExecute(
+						"INSERT INTO wheels_events (id, channel, event, data, createdAt)
+						VALUES (:id, :channel, :event, :data, :createdAt)",
+						{
+							id: {value: "bounded-evt-#i#", cfsqltype: "cf_sql_varchar"},
+							channel: {value: "test.bounded", cfsqltype: "cf_sql_varchar"},
+							event: {value: "old", cfsqltype: "cf_sql_varchar"},
+							data: {value: "expired", cfsqltype: "cf_sql_longvarchar"},
+							createdAt: {value: DateAdd("h", -2, Now()), cfsqltype: "cf_sql_timestamp"}
+						},
+						{datasource: application.wheels.dataSourceName}
+					);
+				}
+
+				var deleted = adapter.cleanup(olderThanMinutes = 60, maxRows = 2);
+				expect(deleted).toBe(2);
+
+				var remaining = queryExecute(
+					"SELECT id FROM wheels_events WHERE channel = :channel",
+					{channel: {value: "test.bounded", cfsqltype: "cf_sql_varchar"}},
+					{datasource: application.wheels.dataSourceName}
+				);
+				expect(remaining.recordCount).toBe(3);
+			});
+
 			it("auto-creates wheels_events table on first use", function() {
 				// The table should already exist from previous tests,
 				// but verify we can query it

--- a/vendor/wheels/tests/specs/controller/channelSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/channelSpec.cfc
@@ -119,6 +119,25 @@ component extends="wheels.WheelsTest" {
 				expect(removed).toBeFalse();
 			});
 
+			it("unsubscribe prunes the channel when the last subscriber leaves", function() {
+				var id = engine.subscribe(channel = "prune.me", callback = function(e) {});
+				expect(engine.getChannels()).toInclude("prune.me");
+
+				engine.unsubscribe("prune.me", id);
+
+				expect(engine.getChannels()).notToInclude("prune.me");
+			});
+
+			it("unsubscribe keeps the channel while other subscribers remain", function() {
+				var firstId = engine.subscribe(channel = "keep.me", callback = function(e) {});
+				engine.subscribe(channel = "keep.me", callback = function(e) {});
+
+				engine.unsubscribe("keep.me", firstId);
+
+				expect(engine.getChannels()).toInclude("keep.me");
+				expect(engine.subscriberCount("keep.me")).toBe(1);
+			});
+
 			it("error in one subscriber does not affect others", function() {
 				var results = {count: 0};
 
@@ -220,6 +239,69 @@ component extends="wheels.WheelsTest" {
 			it("$getChannelEngine defaults to memory adapter", function() {
 				var engine = _controller.$getChannelEngine();
 				expect(engine).toBeInstanceOf("wheels.Channel");
+			});
+		});
+
+		describe("$subscribeDatabase cursor handling", function() {
+
+			beforeEach(function() {
+				params = {controller = "dummy", action = "dummy"};
+				_controller = g.controller("dummy", params);
+			});
+
+			it("advances the poll cursor past filtered events", function() {
+				// MockBox writes its generated method stubs to /testbox/system/stubs
+				// (webroot-relative) and removes them after mixing in — make sure the
+				// directory exists
+				var stubDir = ExpandPath("/testbox/system/stubs");
+				if (!DirectoryExists(stubDir)) {
+					DirectoryCreate(stubDir, true);
+				}
+
+				// First poll returns two events whose type does NOT match the filter;
+				// second poll must resume after the newest of them, not re-fetch them
+				var firstPoll = QueryNew(
+					"id,channel,event,data,createdAt",
+					"varchar,varchar,varchar,varchar,timestamp",
+					[
+						{id: "evt-1", channel: "test.cursor", event: "ignored", data: "a", createdAt: Now()},
+						{id: "evt-2", channel: "test.cursor", event: "ignored", data: "b", createdAt: Now()}
+					]
+				);
+				var emptyPoll = QueryNew(
+					"id,channel,event,data,createdAt",
+					"varchar,varchar,varchar,varchar,timestamp",
+					[]
+				);
+
+				var fakeAdapter = createStub();
+				fakeAdapter.$("poll").$results(firstPoll, emptyPoll);
+
+				var fakeWriter = createStub();
+				fakeWriter.$("checkError").$results(false, true);
+
+				prepareMock(_controller);
+				_controller.$(method = "initSSEStream", returns = fakeWriter);
+				_controller.$(method = "$getChannelEngine", returns = fakeAdapter);
+				_controller.$(method = "sendSSEEvent");
+				_controller.$(method = "sendSSEComment");
+				_controller.$(method = "closeSSEStream");
+
+				_controller.$subscribeDatabase(
+					channel = "test.cursor",
+					eventFilter = ["wanted"],
+					lastEventId = "start-id",
+					pollInterval = 0.01,
+					timeout = 30,
+					heartbeatInterval = 60
+				);
+
+				var pollLog = fakeAdapter.$callLog().poll;
+				expect(ArrayLen(pollLog)).toBeGTE(2);
+				// The cursor must have advanced past the filtered events
+				expect(pollLog[2].lastEventId).toBe("evt-2");
+				// Filtered events must not be delivered to the client
+				expect(ArrayLen(_controller.$callLog().sendSSEEvent)).toBe(0);
 			});
 		});
 

--- a/vendor/wheels/tests/specs/controller/channelSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/channelSpec.cfc
@@ -253,10 +253,11 @@ component extends="wheels.WheelsTest" {
 				// MockBox writes its generated method stubs to /testbox/system/stubs
 				// (webroot-relative) and removes them after mixing in — make sure the
 				// directory exists
+				// DirectoryCreate(path, true) is Lucee-only (issue ##2567);
+				// java.io.File.mkdirs() recurses parents on every engine and
+				// is a no-op when the directory already exists.
 				var stubDir = ExpandPath("/testbox/system/stubs");
-				if (!DirectoryExists(stubDir)) {
-					DirectoryCreate(stubDir, true);
-				}
+				CreateObject("java", "java.io.File").init(stubDir).mkdirs();
 
 				// First poll returns two events whose type does NOT match the filter;
 				// second poll must resume after the newest of them, not re-fetch them

--- a/vendor/wheels/tests/specs/controller/sseSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/sseSpec.cfc
@@ -129,6 +129,16 @@ component extends="wheels.WheelsTest" {
 				local.result = _controller.$formatSSEEvent(data = "");
 				expect(local.result).toInclude("data: ");
 			});
+
+			it("preserves blank lines in multi-line data", function() {
+				local.input = "line one" & Chr(10) & Chr(10) & "line two";
+				local.result = _controller.$formatSSEEvent(data = local.input);
+				// The blank line must survive as an empty data: field so the client
+				// reconstructs "line one\n\nline two" instead of "line one\nline two"
+				expect(local.result).toBe(
+					"data: line one" & Chr(10) & "data: " & Chr(10) & "data: line two" & Chr(10) & Chr(10)
+				);
+			});
 		});
 
 		describe("SSE Newline Injection Prevention", function() {


### PR DESCRIPTION
## Summary

Fixes four channels/SSE findings from the internal framework review: SSE blank-line framing loss, a database-channel poll cursor that never advanced past filtered events, empty-channel map leakage in the in-memory Channel engine, and an unbounded retention `DELETE` running inside `DatabaseAdapter.publish()`. A review follow-up commit replaces a Lucee-only `DirectoryCreate(path, true)` call in the new spec with the engine-agnostic `java.io.File.mkdirs()` pattern so the spec compiles on Adobe CF.

## Findings addressed

- **C12 — blank lines silently dropped from multi-line SSE data** @ `vendor/wheels/controller/sse.cfc:194` — `$formatSSEEvent` now passes `includeEmptyFields=true` to `ListToArray`, so blank lines are preserved as empty `data:` fields per the SSE spec instead of collapsing adjacent lines.
- **C15 — `$subscribeDatabase` poll cursor stuck behind filtered events** @ `vendor/wheels/controller/channels.cfc:257-259` — the cursor advances per-row before the event-type filter `continue`, so non-matching events newer than the last match are no longer re-fetched and re-filtered on every poll for the life of the connection.
- **J9 — `Channel.unsubscribe()` never prunes empty channel maps** @ `vendor/wheels/Channel.cfc:126-141` — the last unsubscriber now removes the per-channel `ConcurrentHashMap` via the atomic two-arg `remove(key, value)`; the residual subscribe/prune race (same orphan class as before, self-healing) is documented inline.
- **J12 — unbounded retention `DELETE` inside `publish()`** @ `vendor/wheels/channel/DatabaseAdapter.cfc:26-29,150-171,213-222` — `lastCleanup` initializes to now (no sweep on a fresh instance's first publish); the throttled publish-path pass is bounded to `cleanupBatchSize` (1000) oldest expired rows via an indexed id IN-list `DELETE`, with a 15s catch-up interval while a backlog drains; `cleanup()` gains a `maxRows` argument and a deleted-row-count return for scheduled-task use. Documented deviation from the review recommendation: the sweep stays on the publish path (now bounded, so non-blocking) rather than introducing the framework's first runtime `cfthread`.

### Review follow-up (blocking item)

- `vendor/wheels/tests/specs/controller/channelSpec.cfc` used `DirectoryCreate(stubDir, true)` — the `createPath` flag is Lucee-only (Adobe CF rejects the second argument, and a compile error in any spec crashes the whole directory-compiled core suite). Replaced with `CreateObject("java", "java.io.File").init(stubDir).mkdirs()`, the pattern established in `reloadGlobalsSpec.cfc` for exactly this issue (#2567); mkdirs is a no-op when the directory exists, so the `DirectoryExists` guard was dropped.

## Findings verified already-fixed

None — all four findings reproduced against the pre-fix code on `develop` (`staleRefs=[]`; the reviewer independently confirmed via diff minus-lines that develop had the 2-arg `ListToArray`, the post-`continue` cursor assignment, no channel pruning, and `lastCleanup=0`).

## Source

Internal multi-agent framework review 2026-06-09, wave 2, package `channels-sse`.

## Tests

- `vendor/wheels/tests/specs/controller/sseSpec.cfc` — new spec asserting `$formatSSEEvent` emits `data: line one\ndata: \ndata: line two\n\n` for input containing a blank line (fails pre-fix: blank line dropped).
- `vendor/wheels/tests/specs/controller/channelSpec.cfc` — new MockBox-driven spec bounding `$subscribeDatabase` to exactly two polls (stubbed `checkError` false→true) and asserting `pollLog[2].lastEventId == "evt-2"` (pre-fix it stays `"start-id"`), plus zero deliveries of filtered events.
- `vendor/wheels/tests/specs/controller/channelSpec.cfc` / `vendor/wheels/tests/specs/channel/DatabaseAdapterSpec.cfc` — pruning + bounded-cleanup specs (empty-channel map removed after last unsubscribe; fresh-instance first publish performs no sweep; `cleanup(maxRows=N)` deletes at most N rows and returns the count).
- Local verification: Lucee 7 + SQLite green at implementation time (sseSpec 22, channelSpec 25, DatabaseAdapterSpec 10). After the follow-up fix, the `channelSpec` bundle was re-verified on **Adobe 2023 + SQLite** via the worktree single-bundle Docker recipe: **25 pass, 0 fail, 0 error** — exercising the suite's first MockBox `$()`/`$results()` stub-generation path on an Adobe engine, as the reviewer requested. Full matrix deferred to CI (`compat-matrix.yml`).

## Cross-engine notes

- The follow-up commit removes the only Adobe-incompatible construct (`DirectoryCreate` 2-arg form). `java.io.File.mkdirs()` is the repo's established engine-agnostic pattern (`reloadGlobalsSpec.cfc`, issue #2567).
- The new specs avoid the known traps: no inline closures as constructor named args, `##`-escaped issue references in comments, shared-struct state where closures are involved.
- MockBox stub generation writes (and normally removes) stubs under `/testbox/system/stubs`, which resolves under `public/` (no `/testbox` mapping in `public/Application.cfc`) — in bind-mounted dev trees this can leave an untracked `public/testbox/` directory behind (observed and cleaned during local Adobe verification). Harmless and test-infra-only; flagged here per the reviewer's non-blocking observation.
- `cleanupBatchSize=1000` sits exactly at Oracle's ORA-01795 IN-list limit (1000 itself is allowed); any future increase must chunk the IN-list — the surrounding try/catch would degrade to log-and-return-0 rather than fail publishes.

## Changelog

Entry deliberately omitted; consolidated at campaign end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
