### PR TITLE
fix(cli): upgrade-check exit code, breaker-scan coverage, ArgSpec positional gaps

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -98,12 +98,20 @@ component extends="modules.BaseModule" {
 	 * `create` → `new`, and unit tests). That array is reconstructed into the
 	 * same structured shape LuCLI would have produced, so a command behaves
 	 * identically whether LuCLI dispatched it or another command delegated to it.
+	 *
+	 * `__arguments` is consume-once: it is cleared on every call so a stale
+	 * stash can never replay. One-shot CLI runs hid the leak, but the stdio
+	 * MCP server (`wheels mcp wheels`) is a persistent process — after any
+	 * delegating call (create/generate app → new) a later zero-arg tool call
+	 * (e.g. wheels_test()) would otherwise re-parse the stale argv and turn
+	 * into a completely different invocation.
 	 */
 	private struct function structuredArgs(struct callerArgs = {}) {
+		var raw = __arguments ?: [];
+		__arguments = [];
 		if (!structIsEmpty(arguments.callerArgs)) {
 			return arguments.callerArgs;
 		}
-		var raw = __arguments ?: [];
 		return argvToCollection(isArray(raw) ? raw : []);
 	}
 
@@ -2724,10 +2732,12 @@ component extends="modules.BaseModule" {
 		var parsed = new services.ArgSpec()
 			.positional(name = "subcommand", default = "")
 			.option(name = "to", default = "")
+			.option(name = "format", default = "")
 			.parse(arguments.coll);
 		return {
 			isCheck = lCase(parsed.subcommand) == "check",
 			targetVersion = parsed.to,
+			format = parsed.format,
 			sawTo = structKeyExists(arguments.coll, "to"),
 			sawDryRun = structKeyExists(arguments.coll, "dry-run")
 		};
@@ -2744,9 +2754,14 @@ component extends="modules.BaseModule" {
 	 * Despite occasional appearances in older help output, `--dry-run` is not
 	 * supported — the command is already read-only by design.
 	 *
+	 * Breaking findings throw Wheels.UpgradeCheckFailed after the report is
+	 * printed, so the command exits non-zero and can gate CI. Advisory
+	 * (opt-in recommendation) findings never affect the exit code.
+	 *
 	 * Examples:
-	 *   wheels upgrade check                 - scan against the latest stable release
-	 *   wheels upgrade check --to=4.0.0      - scan against a specific target version
+	 *   wheels upgrade check                       - scan against the latest stable release
+	 *   wheels upgrade check --to=4.0.0            - scan against a specific target version
+	 *   wheels upgrade check --format=json         - machine-readable report (CI pipelines)
 	 */
 	public string function upgrade() {
 		var opts = parseUpgradeArgs(structuredArgs(arguments));
@@ -2760,6 +2775,10 @@ component extends="modules.BaseModule" {
 				& nl
 				& "Options:" & nl
 				& "  --to=<version>    Target Wheels version (default: latest stable)" & nl
+				& "  --format=json     Emit a machine-readable JSON report" & nl
+				& nl
+				& "Exit status:" & nl
+				& "  Non-zero when breaking changes are found (advisories never fail the check)." & nl
 				& nl
 				& "Unsupported flags:" & nl
 				& "  --dry-run is not supported — the command is already read-only," & nl
@@ -2781,7 +2800,7 @@ component extends="modules.BaseModule" {
 			return help;
 		}
 
-		return runUpgradeCheck(opts.targetVersion);
+		return runUpgradeCheck(opts.targetVersion, opts.format);
 	}
 
 	// ─────────────────────────────────────────────────
@@ -4039,8 +4058,15 @@ component extends="modules.BaseModule" {
 
 	/**
 	 * Scan app for breaking changes between current and target version.
+	 *
+	 * Breaking findings throw Wheels.UpgradeCheckFailed after the report is
+	 * flushed (same pattern as validate()'s Wheels.ValidationFailed), so the
+	 * command exits non-zero and can gate CI. Advisory findings never affect
+	 * the exit code. `format="json"` replaces the human report with a single
+	 * JSON document for pipelines.
 	 */
-	private string function runUpgradeCheck(string targetVersion = "") {
+	private string function runUpgradeCheck(string targetVersion = "", string format = "") {
+		var jsonMode = lCase(arguments.format) == "json";
 		// Detect current version. Prefer wheels.json (post-rename) and fall back
 		// to box.json so apps with pre-rename vendor/wheels/ committed in their
 		// repo still work. The fallback can be removed two releases after the
@@ -4066,21 +4092,24 @@ component extends="modules.BaseModule" {
 				var releaseData = deserializeJSON(response);
 				target = replace(releaseData.tag_name, "v", "");
 			} catch (any e) {
-				out("Could not fetch latest version. Use --to=<version> to specify.", "yellow");
+				var fetchMsg = "Could not fetch latest version. Use --to=<version> to specify.";
+				out(jsonMode ? serializeJSON({"error": fetchMsg}) : fetchMsg, "yellow");
 				return "";
 			}
 		}
 
-		out("Current version: #currentVersion#", "bold");
-		out("Target version:  #target#", "bold");
-		out("");
+		if (!jsonMode) {
+			out("Current version: #currentVersion#", "bold");
+			out("Target version:  #target#", "bold");
+			out("");
+		}
 
 		// Compare major versions
 		var currentMajor = val(listFirst(currentVersion, "."));
 		var targetMajor = val(listFirst(target, "."));
 		var sameMajor = (currentMajor == targetMajor);
 
-		if (sameMajor) {
+		if (sameMajor && !jsonMode) {
 			out("Same major version — no known breaking changes.", "green");
 			out("Scanning for opt-in recommendations...", "green");
 			out("");
@@ -4094,16 +4123,23 @@ component extends="modules.BaseModule" {
 
 		// 2.x -> 3.x
 		if (currentMajor <= 2 && targetMajor >= 3) {
+			// 2.x plugins lived at the webroot's /plugins (the previous
+			// `app/plugins` path never existed in any Wheels layout, so the
+			// check was dead). The 3.x -> 4.x block adds an identical root
+			// /plugins check, so skip this one on a 2.x -> 4.x jump to avoid
+			// reporting the same directory twice.
+			if (targetMajor < 4) {
+				arrayAppend(checks, {
+					description: "Legacy plugin directory",
+					pattern: "",
+					checkType: "directory",
+					path: "plugins",
+					fix: "Migrate to packages/ + vendor/ activation model"
+				});
+			}
 			arrayAppend(checks, {
-				description: "Legacy plugin directory",
-				pattern: "",
-				checkType: "directory",
-				path: "app/plugins",
-				fix: "Migrate to packages/ + vendor/ activation model"
-			});
-			arrayAppend(checks, {
-				description: "Old test base class (wheels.Test)",
-				pattern: 'extends\s*=\s*"wheels\.Test"',
+				description: "Old test base class (wheels.Test / wheels.Testbox)",
+				pattern: 'extends\s*=\s*["'']wheels\.Test(box)?["'']',
 				checkType: "grep",
 				scanDir: "tests",
 				extensions: "cfc",
@@ -4120,21 +4156,68 @@ component extends="modules.BaseModule" {
 				path: "plugins",
 				fix: "Migrate to packages/ + vendor/ system"
 			});
+			// Matches both quote styles and the silent wheels.Testbox shim
+			// (deprecated alias of wheels.WheelsTest, removal target 5.0) —
+			// the previous double-quote-only wheels.Test pattern missed both.
 			arrayAppend(checks, {
-				description: "Old test base class (wheels.Test)",
-				pattern: 'extends\s*=\s*"wheels\.Test"',
+				description: "Old test base class (wheels.Test / wheels.Testbox)",
+				pattern: 'extends\s*=\s*["'']wheels\.Test(box)?["'']',
 				checkType: "grep",
 				scanDir: "tests",
 				extensions: "cfc",
 				fix: 'Change to extends="wheels.WheelsTest"'
 			});
+			// application.wirebox → application.wheelsdi (guide item 10). The
+			// hardest real-world case is a root Application.cfc bootstrap that
+			// calls `new wirebox.system.ioc.Injector(...)` — the WireBox
+			// package no longer ships in vendor/wheels/ — so scan the root
+			// Application.cfc and config/ in addition to app/.
 			arrayAppend(checks, {
-				description: "Direct WireBox references",
-				pattern: "application\.wirebox",
+				description: "Direct WireBox references (application.wirebox / wirebox.system.ioc)",
+				pattern: "application\.wirebox|wirebox\.system\.ioc",
 				checkType: "grep",
 				scanDir: "app",
 				extensions: "cfc,cfm",
-				fix: "Use service() or inject() from the DI container instead"
+				scanTargets: [
+					{path: "Application.cfc"},
+					{path: "config", extensions: "cfm,cfc", recurse: true}
+				],
+				fix: "Use service() / application.wheelsdi instead of application.wirebox; replace `new wirebox.system.ioc.Injector(...)` bootstraps with `new wheels.Injector()`. The legacy adapter does NOT shim this item."
+			});
+			// renderPage()/renderPageToString() removed in 4.0 — shimmed by
+			// the optional wheels-legacy-adapter package, but unshimmed apps
+			// throw at first render.
+			arrayAppend(checks, {
+				description: "Removed renderPage()/renderPageToString() helpers",
+				pattern: "renderPage(ToString)?\s*\(",
+				checkType: "grep",
+				scanDir: "app",
+				extensions: "cfc,cfm",
+				fix: 'Replace renderPage() with renderView() and renderPageToString() with renderView(returnAs="string"), or install the soft-landing shim: wheels packages add wheels-legacy-adapter'
+			});
+			// HSTS defaults on in production (guide item 2, ##2081). Advisory:
+			// fires on SecurityHeaders usage so proxied/LB setups know the
+			// header now emits by default.
+			arrayAppend(checks, {
+				description: "SecurityHeaders middleware — HSTS defaults on in production in 4.0 (advisory)",
+				severity: "advisory",
+				pattern: "new\s+wheels\.middleware\.SecurityHeaders",
+				checkType: "grep",
+				scanDir: "config",
+				extensions: "cfm,cfc",
+				fix: "4.0 emits Strict-Transport-Security (max-age=31536000; includeSubDomains) by default in production. Pass hsts=false to the middleware if your load balancer already sets it."
+			});
+			// CSRF cookie now sets SameSite (guide item 6, ##2035). Advisory:
+			// fires on CSRF protection usage — same-site flows are unaffected,
+			// but cross-site POSTs from third-party frames will break.
+			arrayAppend(checks, {
+				description: "CSRF cookie sets SameSite in 4.0 (advisory: review cross-site POST flows)",
+				severity: "advisory",
+				pattern: "protectsFromForgery",
+				checkType: "grep",
+				scanDir: "app",
+				extensions: "cfc",
+				fix: "The CSRF cookie now sets the SameSite attribute. Cross-site POSTs from third-party frames that relied on the missing attribute will break; same-site app flows are unaffected."
 			});
 			// CORS default flip — wildcard "*" → deny-all (#2039). A bare
 			// `new wheels.middleware.Cors()` accepts no requests in 4.0.
@@ -4344,18 +4427,21 @@ component extends="modules.BaseModule" {
 				}
 
 				if (structKeyExists(check, "scanTargets") && isArray(check.scanTargets)) {
-					for (var target in check.scanTargets) {
-						var targetPath = variables.projectRoot & "/" & target.path;
+					// `scanTarget`, not `target` — the function-level `target`
+					// above holds the target VERSION string and a same-named
+					// loop var would shadow (then clobber) it.
+					for (var scanTarget in check.scanTargets) {
+						var targetPath = variables.projectRoot & "/" & scanTarget.path;
 						if (fileExists(targetPath)) {
 							arrayAppend(filesToScan, targetPath);
 						} else if (directoryExists(targetPath)) {
-							var recurse = structKeyExists(target, "recurse") ? target.recurse : true;
+							var recurse = structKeyExists(scanTarget, "recurse") ? scanTarget.recurse : true;
 							// Avoid Elvis `?:` on `check.extensions` — Adobe CF
 							// throws when the key is absent. The `wheels snippets`
 							// check has no top-level `extensions`, so this branch
 							// is reached on every Adobe CF run when a target is a
 							// directory without its own `extensions` key.
-							var exts = structKeyExists(target, "extensions") ? target.extensions
+							var exts = structKeyExists(scanTarget, "extensions") ? scanTarget.extensions
 								: (structKeyExists(check, "extensions") ? check.extensions : "");
 							for (var ext in listToArray(exts)) {
 								var dirFiles2 = directoryList(targetPath, recurse, "path", "*." & ext);
@@ -4418,44 +4504,79 @@ component extends="modules.BaseModule" {
 			}
 		}
 
-		// Output — three sections in priority order: Breaking → Recommended → All Clear
+		// The version-appropriate guide + the soft-landing adapter, surfaced
+		// whenever breaking findings are reported (and always in JSON output).
+		var guideUrl = "https://guides.wheels.dev/v4-0-0/upgrading/"
+			& (targetMajor >= 4 ? "3x-to-4x" : "2x-to-3x") & "/";
+
+		// JSON mode — one machine-readable document, no human report. The
+		// breaking-findings throw below still fires so pipelines can gate on
+		// the exit code without parsing stdout.
+		if (jsonMode) {
+			out(serializeJSON({
+				"currentVersion": currentVersion,
+				"targetVersion": target,
+				"success": arrayLen(issues) == 0,
+				"breaking": issues,
+				"advisories": advisories,
+				"passed": passed,
+				"guide": guideUrl
+			}));
+		} else {
+			// Output — three sections in priority order: Breaking → Recommended → All Clear
+			if (arrayLen(issues)) {
+				out("Breaking Changes (#arrayLen(issues)# found):", "yellow");
+				for (var issue in issues) {
+					out("  ! #issue.description#", "yellow");
+					for (var match in issue.matches) {
+						out("    #match#");
+					}
+					out("    -> #issue.fix#", "cyan");
+					out("");
+				}
+				out("Upgrade guide: #guideUrl#", "cyan");
+				if (targetMajor >= 4) {
+					out("Soft landing: wheels packages add wheels-legacy-adapter (shims renderPage()/renderPageToString() while you migrate)", "cyan");
+				}
+				out("");
+			}
+
+			if (arrayLen(advisories)) {
+				out("Recommended Improvements (#arrayLen(advisories)# found):", "cyan");
+				for (var advisory in advisories) {
+					out("  ~ #advisory.description#", "cyan");
+					for (var match in advisory.matches) {
+						out("    #match#");
+					}
+					// Advisory fix lines are intentionally uncolored so the
+					// section header and description carry the cyan accent and
+					// opt-in items read lighter than breaking-change fixes
+					// (which use cyan on the fix line for stronger emphasis).
+					out("    -> #advisory.fix#");
+					out("");
+				}
+			}
+
+			if (arrayLen(passed)) {
+				out("All Clear (#arrayLen(passed)# checks):", "green");
+				for (var p in passed) {
+					out("  + #p#", "green");
+				}
+			}
+
+			out("");
+			out("Upgrade with: brew upgrade wheels");
+		}
+
+		// Throw after the full report flushes — breaking findings exit
+		// non-zero (CI gate), advisories and all-clear exit 0. Mirrors
+		// validate()'s Wheels.ValidationFailed convention.
 		if (arrayLen(issues)) {
-			out("Breaking Changes (#arrayLen(issues)# found):", "yellow");
-			for (var issue in issues) {
-				out("  ! #issue.description#", "yellow");
-				for (var match in issue.matches) {
-					out("    #match#");
-				}
-				out("    -> #issue.fix#", "cyan");
-				out("");
-			}
+			throw(
+				type = "Wheels.UpgradeCheckFailed",
+				message = "Upgrade check found #arrayLen(issues)# breaking change(s) — see the report above."
+			);
 		}
-
-		if (arrayLen(advisories)) {
-			out("Recommended Improvements (#arrayLen(advisories)# found):", "cyan");
-			for (var advisory in advisories) {
-				out("  ~ #advisory.description#", "cyan");
-				for (var match in advisory.matches) {
-					out("    #match#");
-				}
-				// Advisory fix lines are intentionally uncolored so the
-				// section header and description carry the cyan accent and
-				// opt-in items read lighter than breaking-change fixes
-				// (which use cyan on the fix line for stronger emphasis).
-				out("    -> #advisory.fix#");
-				out("");
-			}
-		}
-
-		if (arrayLen(passed)) {
-			out("All Clear (#arrayLen(passed)# checks):", "green");
-			for (var p in passed) {
-				out("  + #p#", "green");
-			}
-		}
-
-		out("");
-		out("Upgrade with: brew upgrade wheels");
 
 		return "";
 	}

--- a/cli/lucli/services/ArgSpec.cfc
+++ b/cli/lucli/services/ArgSpec.cfc
@@ -84,13 +84,19 @@ component {
 			result[optName] = variables.named[optName]["default"];
 		}
 
-		// 2. Bind positionals from coll.arg1, arg2, ... in declaration order.
+		// 2. Bind positionals in declaration order. LuCLI numbers positionals
+		//    by GLOBAL token index, so a named option/flag between positionals
+		//    leaves a numbering gap (`wheels new --port=3000 blog` arrives as
+		//    {port="3000", arg2="blog"} — there is no arg1). Collect every
+		//    arg<N> key and sort numerically instead of probing literal
+		//    arg1..argN; fixed-index probing made gap-following positionals
+		//    silently bind nothing (the appName above was ignored).
+		var positionalIndices = $positionalIndices(arguments.coll);
 		var positionalCount = arrayLen(variables.positionals);
 		for (var i = 1; i <= positionalCount; i++) {
 			var pSpec = variables.positionals[i];
-			var collKey = "arg" & i;
-			if (structKeyExists(arguments.coll, collKey)) {
-				result[pSpec.name] = $coerce(arguments.coll[collKey], pSpec.type);
+			if (i <= arrayLen(positionalIndices)) {
+				result[pSpec.name] = $coerce(arguments.coll["arg" & positionalIndices[i]], pSpec.type);
 			} else if (pSpec.required) {
 				throw(
 					type = "Wheels.CLI.MissingArgument",
@@ -135,13 +141,14 @@ component {
 	public array function toArgv(required struct coll) {
 		var result = [];
 
-		// Positionals in arg1..argN order. Stops at the first index gap,
-		// mirroring the legacy argsFromCollection — dispatchers always pass
-		// the sub-verb as the leading positional, so a gap never elides one.
-		var i = 1;
-		while (structKeyExists(arguments.coll, "arg" & i)) {
-			arrayAppend(result, arguments.coll["arg" & i]);
-			i++;
+		// Positionals in numeric arg<N> order. LuCLI numbers positionals by
+		// global token index, so a flag between two positionals leaves a gap
+		// (arg1, arg2, arg4, ...). The previous loop stopped at the first gap
+		// and silently dropped every positional after a flag — `wheels g
+		// scaffold Post --force title:string body:text` lost both columns.
+		// Collect-and-sort heals the gaps (mirrors parseTestArgs).
+		for (var idx in $positionalIndices(arguments.coll)) {
+			arrayAppend(result, arguments.coll["arg" & idx]);
 		}
 
 		// Named keys, re-prefixed. --no-X for false preserves the negation.
@@ -160,6 +167,24 @@ component {
 		}
 
 		return result;
+	}
+
+	/**
+	 * Collect the numeric index of every positional (arg<N>) key in the
+	 * collection, sorted ascending. LuCLI numbers positionals by global token
+	 * index — a named option/flag consumes an index without producing an
+	 * arg<N> key — so consumers must never assume the indices are contiguous
+	 * or start at 1.
+	 */
+	private array function $positionalIndices(required struct coll) {
+		var indices = [];
+		for (var key in arguments.coll) {
+			if (reFindNoCase("^arg\d+$", key)) {
+				arrayAppend(indices, val(mid(key, 4, len(key))));
+			}
+		}
+		arraySort(indices, "numeric");
+		return indices;
 	}
 
 	private any function $coerce(required any v, required string type) {

--- a/cli/lucli/tests/_fixtures/commands/ModuleArgvProbe.cfc
+++ b/cli/lucli/tests/_fixtures/commands/ModuleArgvProbe.cfc
@@ -29,6 +29,16 @@ component extends="cli.lucli.Module" {
 		return structuredArgs(arguments.callerArgs);
 	}
 
+	/**
+	 * Calls structuredArgs WITHOUT reseeding variables.__arguments — pins the
+	 * consume-once contract: a prior delegation stash (create/generate app →
+	 * new) must not replay into a later zero-arg call. One-shot CLI runs hid
+	 * the leak; the persistent stdio MCP server did not.
+	 */
+	public struct function $structuredArgsWithoutReseed(struct callerArgs = {}) {
+		return structuredArgs(arguments.callerArgs);
+	}
+
 	public struct function $parseNewArgs(required struct coll) {
 		return parseNewArgs(arguments.coll);
 	}

--- a/cli/lucli/tests/specs/commands/CommandArgParsingSpec.cfc
+++ b/cli/lucli/tests/specs/commands/CommandArgParsingSpec.cfc
@@ -71,6 +71,17 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 				expect(c.sqlite).toBe("false");
 			});
 
+			it("consumes __arguments once — stale argv must not replay on a later zero-arg call", () => {
+				// The stdio MCP server is a persistent process: after a delegating
+				// call stashes argv (create/generate app -> new), a later zero-arg
+				// tool call (e.g. wheels_test()) must see an EMPTY collection, not
+				// a replay of the stale stash.
+				var first = probe.$structuredArgs({}, ["blog"]);
+				expect(first.arg1).toBe("blog");
+				var second = probe.$structuredArgsWithoutReseed({});
+				expect(second).toBeEmpty();
+			});
+
 		});
 
 		describe("parseNewArgs", () => {
@@ -118,6 +129,22 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 				// the old getArgs() arg1-gate, which dropped named-only args and fell
 				// through to the usage guide.
 				expect(probe.$parseNewArgs({sqlite: "false"}).isEmpty).toBeFalse();
+			});
+
+			it("binds the app name across a LuCLI numbering gap (option before the name)", () => {
+				// `wheels new --port=3000 blog` — LuCLI numbers positionals by
+				// global token index, so the name arrives as arg2 with no arg1.
+				// Fixed-index probing ignored the supplied name and threw
+				// Wheels.InvalidArguments.
+				var o = probe.$parseNewArgs({port: "3000", arg2: "blog"});
+				expect(o.appName).toBe("blog");
+				expect(o.port).toBe(3000);
+			});
+
+			it("binds the app name across a flag-induced gap (--setup-h2 blog)", () => {
+				var o = probe.$parseNewArgs({"setup-h2": "true", arg2: "blog"});
+				expect(o.appName).toBe("blog");
+				expect(o.setupH2).toBeTrue();
 			});
 
 		});
@@ -210,6 +237,12 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 				var o = probe.$parseUpgradeArgs({arg1: "oops", "dry-run": "true", to: "4.0.0"});
 				expect(o.sawDryRun).toBeTrue();
 				expect(o.sawTo).toBeTrue();
+			});
+
+			it("reads --format=json for machine-readable CI output", () => {
+				var o = probe.$parseUpgradeArgs({arg1: "check", format: "json"});
+				expect(o.format).toBe("json");
+				expect(probe.$parseUpgradeArgs({arg1: "check"}).format).toBe("");
 			});
 
 		});

--- a/cli/lucli/tests/specs/packages/LegacyAdapterResolutionSpec.cfc
+++ b/cli/lucli/tests/specs/packages/LegacyAdapterResolutionSpec.cfc
@@ -1,0 +1,78 @@
+/**
+ * Regression coverage for wheels-legacy-adapter registry resolution.
+ *
+ * `wheels upgrade check` points users with breaking 3.x findings at
+ * `wheels packages add wheels-legacy-adapter` as the soft-landing path
+ * (it shims renderPage()/renderPageToString() while they migrate). Nothing
+ * previously pinned that the packages Registry + VersionResolver actually
+ * resolve that package name end-to-end — manifest URL construction against
+ * the default wheels-dev/wheels-packages repo, manifest parsing, and a
+ * 4.x-compatible version pick — so the recommendation could silently rot.
+ *
+ * Uses FakeHttpClient (no network), mirroring RegistrySpec.
+ */
+component extends="wheels.wheelstest.system.BaseSpec" {
+
+	function run() {
+		describe("wheels-legacy-adapter registry resolution", () => {
+
+			var $freshCache = () => {
+				var root = GetTempDirectory() & "wheels-registry-" & CreateUUID() & "/";
+				return new cli.lucli.services.packages.ManifestCache(root = root);
+			};
+
+			var $adapterManifest = SerializeJSON({
+				name: "wheels-legacy-adapter",
+				description: "3.x -> 4.x compatibility shims",
+				source: {type: "github", repo: "wheels-dev/wheels-legacy-adapter"},
+				versions: [
+					{version: "1.0.0", wheelsVersion: ">=4.0", tarball: "x", sha256: "a"},
+					{version: "1.1.0", wheelsVersion: ">=4.0", tarball: "x", sha256: "b"}
+				]
+			});
+
+			it("fetches and parses the adapter manifest from the canonical registry repo", () => {
+				var fake = new cli.lucli.tests.specs.packages._stubs.FakeHttpClient();
+				var cache = $freshCache();
+				var r = new cli.lucli.services.packages.Registry(
+					httpClient = fake, cache = cache, registryRepo = "wheels-dev/wheels-packages"
+				);
+				fake.seed(
+					"https://raw.githubusercontent.com/wheels-dev/wheels-packages/main/packages/wheels-legacy-adapter/manifest.json",
+					{status: 200, body: $adapterManifest}
+				);
+				var m = r.fetchManifest("wheels-legacy-adapter");
+				expect(m.name).toBe("wheels-legacy-adapter");
+				expect(ArrayLen(m.versions)).toBe(2);
+				cache.refresh();
+			});
+
+			it("appears in the registry index listing (hyphenated name survives)", () => {
+				var fake = new cli.lucli.tests.specs.packages._stubs.FakeHttpClient();
+				var cache = $freshCache();
+				var r = new cli.lucli.services.packages.Registry(
+					httpClient = fake, cache = cache, registryRepo = "wheels-dev/wheels-packages"
+				);
+				fake.seed(
+					"https://api.github.com/repos/wheels-dev/wheels-packages/contents/packages?ref=main",
+					{status: 200, body: SerializeJSON([
+						{name: "wheels-legacy-adapter", type: "dir"},
+						{name: "wheels-sentry", type: "dir"}
+					])}
+				);
+				expect(r.listPackageNames()).toInclude("wheels-legacy-adapter");
+				cache.refresh();
+			});
+
+			it("VersionResolver picks the highest 4.x-compatible adapter version", () => {
+				var manifest = DeserializeJSON($adapterManifest);
+				var picked = new cli.lucli.services.packages.VersionResolver().pick(
+					manifest, "4.0.2"
+				);
+				expect(picked.version).toBe("1.1.0");
+			});
+
+		});
+	}
+
+}

--- a/cli/lucli/tests/specs/services/ArgSpecSpec.cfc
+++ b/cli/lucli/tests/specs/services/ArgSpecSpec.cfc
@@ -47,6 +47,35 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					expect(out.templateName).toBe("default");
 				});
 
+				it("binds positionals across LuCLI numbering gaps (option consumed an index)", () => {
+					// `wheels new --port=3000 blog` — LuCLI numbers positionals by
+					// global token index, so the name arrives as arg2 with NO arg1.
+					// Fixed-index probing bound nothing and the supplied name was
+					// silently ignored.
+					var spec = new cli.lucli.services.ArgSpec()
+						.positional(name = "appName")
+						.option(name = "port", default = 8080, type = "numeric");
+					var out = spec.parse({"port": "3000", "arg2": "blog"});
+					expect(out.appName).toBe("blog");
+					expect(out.port).toBe(3000);
+				});
+
+				it("binds multiple gap-numbered positionals in numeric index order", () => {
+					var spec = new cli.lucli.services.ArgSpec()
+						.positional(name = "first")
+						.positional(name = "second");
+					var out = spec.parse({"arg2": "a", "arg5": "b", "force": "true"});
+					expect(out.first).toBe("a");
+					expect(out.second).toBe("b");
+				});
+
+				it("satisfies a required positional delivered after a gap", () => {
+					var spec = new cli.lucli.services.ArgSpec()
+						.positional(name = "appName", required = true);
+					var out = spec.parse({"arg3": "blog"});
+					expect(out.appName).toBe("blog");
+				});
+
 			});
 
 			describe("parse() — flags (the --no-X regression surface)", () => {
@@ -164,6 +193,38 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 
 				it("returns an empty argv for an empty collection", () => {
 					expect(new cli.lucli.services.ArgSpec().toArgv({})).toBeEmpty();
+				});
+
+				it("does not stop at a numbering gap — positionals after a flag survive", () => {
+					// `wheels g scaffold Post --force title:string body:text` arrives
+					// as {arg1, arg2, force, arg4, arg5}. The old loop stopped at the
+					// missing arg3, so scaffold silently generated the model and
+					// migration with no columns while reporting success.
+					var argv = new cli.lucli.services.ArgSpec().toArgv({
+						"arg1": "scaffold",
+						"arg2": "Post",
+						"force": "true",
+						"arg4": "title:string",
+						"arg5": "body:text"
+					});
+					expect(argv[1]).toBe("scaffold");
+					expect(argv[2]).toBe("Post");
+					expect(argv[3]).toBe("title:string");
+					expect(argv[4]).toBe("body:text");
+					expect(argv).toInclude("--force");
+				});
+
+				it("emits a gap-numbered leading positional (flag before the first positional)", () => {
+					// `wheels create --setup-h2 app myapp` style ordering: the flag
+					// consumes index 1, so the first positional is arg2.
+					var argv = new cli.lucli.services.ArgSpec().toArgv({
+						"setup-h2": "true",
+						"arg2": "app",
+						"arg3": "myapp"
+					});
+					expect(argv[1]).toBe("app");
+					expect(argv[2]).toBe("myapp");
+					expect(argv).toInclude("--setup-h2");
 				});
 
 			});

--- a/vendor/wheels/Testbox.cfc
+++ b/vendor/wheels/Testbox.cfc
@@ -1,7 +1,13 @@
 /**
  * DEPRECATED: Use wheels.WheelsTest instead.
- * This file is retained for backward compatibility only.
- * All new tests should extend wheels.WheelsTest.
+ *
+ * `wheels.Testbox` is a pure alias of `wheels.WheelsTest`, retained for
+ * backward compatibility with specs written before the 4.0 rename. It adds
+ * no behavior. Deprecated since 4.0; removal target: 5.0.
+ *
+ * `wheels upgrade check` flags `extends="wheels.Testbox"` (and the legacy
+ * `wheels.Test`) under "Old test base class" — migrate to wheels.WheelsTest
+ * before 5.0.
  */
 component extends="wheels.WheelsTest" {
 }

--- a/vendor/wheels/tests/specs/cli/UpgradeCheckCoverageSpec.cfc
+++ b/vendor/wheels/tests/specs/cli/UpgradeCheckCoverageSpec.cfc
@@ -31,15 +31,18 @@ component extends="wheels.WheelsTest" {
 
 			// Slice out the 3.x -> 4.x branch so assertions don't accidentally
 			// match the 2.x -> 3.x checks (which also reference wheels.Test,
-			// the legacy plugin directory, etc.).
+			// the legacy plugin directory, etc.). `fullSource` is kept for
+			// assertions on the scanner's surroundings (exit-code throw,
+			// --format=json plumbing) that live outside the checks block.
 			var block = "";
+			var fullSource = "";
 			if (fileExists(modulePath)) {
-				var moduleSource = fileRead(modulePath);
-				var start = find("currentMajor <= 3 && targetMajor >= 4", moduleSource);
+				fullSource = fileRead(modulePath);
+				var start = find("currentMajor <= 3 && targetMajor >= 4", fullSource);
 				if (start > 0) {
-					var endIdx = find("// Run checks", moduleSource, start);
-					var sliceLen = endIdx > 0 ? endIdx - start : len(moduleSource) - start + 1;
-					block = sliceLen > 0 ? mid(moduleSource, start, sliceLen) : "";
+					var endIdx = find("// Run checks", fullSource, start);
+					var sliceLen = endIdx > 0 ? endIdx - start : len(fullSource) - start + 1;
+					block = sliceLen > 0 ? mid(fullSource, start, sliceLen) : "";
 				}
 			}
 
@@ -91,6 +94,58 @@ component extends="wheels.WheelsTest" {
 			it("scans for deprecated paginationLinks() helper", () => {
 				expect(findNoCase("paginationLinks", block) > 0).toBeTrue(
 					"3.x -> 4.x checks should grep views for paginationLinks( (renamed to paginationNav(), CHANGELOG ##2714)."
+				);
+			});
+
+			it("scans for wirebox.system.ioc bootstraps including the root Application.cfc", () => {
+				expect(findNoCase("wirebox.system.ioc", block) > 0).toBeTrue(
+					"3.x -> 4.x checks should grep for wirebox.system.ioc (the guide's hardest item-10 case is a "
+					& "`new wirebox.system.ioc.Injector(...)` bootstrap in the root Application.cfc)."
+				);
+				expect(findNoCase("Application.cfc", block) > 0).toBeTrue(
+					"The WireBox check must scan the root Application.cfc, not only app/ — the 3.x bootstrap lives at the project root."
+				);
+			});
+
+			it("covers wheels.Testbox and single-quoted extends forms in the test base class grep", () => {
+				expect(findNoCase("wheels\.Test(box)?", block) > 0).toBeTrue(
+					"The test base class grep should match wheels.Testbox (the silent WheelsTest alias, removal target 5.0) "
+					& "and both quote styles via a quote character class, not a hardcoded double quote."
+				);
+			});
+
+			it("scans for removed renderPage()/renderPageToString() helpers", () => {
+				expect(findNoCase("renderPage", block) > 0).toBeTrue(
+					"3.x -> 4.x checks should grep app/ for renderPage()/renderPageToString() — removed in 4.0, "
+					& "shimmed only by the optional wheels-legacy-adapter package."
+				);
+			});
+
+			it("carries an HSTS advisory (SecurityHeaders defaults on in production)", () => {
+				expect(findNoCase("SecurityHeaders", block) > 0).toBeTrue(
+					"3.x -> 4.x checks should carry an advisory for the HSTS default flip (guide item 2, CHANGELOG ##2081)."
+				);
+			});
+
+			it("carries a CSRF SameSite advisory", () => {
+				expect(findNoCase("SameSite", block) > 0).toBeTrue(
+					"3.x -> 4.x checks should carry an advisory for the CSRF cookie SameSite attribute (guide item 6, CHANGELOG ##2035)."
+				);
+				expect(findNoCase("protectsFromForgery", block) > 0).toBeTrue(
+					"The SameSite advisory should key off protectsFromForgery usage so only CSRF-protected apps are flagged."
+				);
+			});
+
+			it("exits non-zero when breaking findings exist (Wheels.UpgradeCheckFailed)", () => {
+				expect(findNoCase("Wheels.UpgradeCheckFailed", fullSource) > 0).toBeTrue(
+					"runUpgradeCheck must throw Wheels.UpgradeCheckFailed after the report flushes so breaking findings "
+					& "gate CI with a non-zero exit (mirrors validate()'s Wheels.ValidationFailed)."
+				);
+			});
+
+			it("supports --format=json for machine-readable CI output", () => {
+				expect(findNoCase("--format=json", fullSource) > 0).toBeTrue(
+					"wheels upgrade check should document/accept --format=json so pipelines can consume the report."
 				);
 			});
 

--- a/vendor/wheels/tests/specs/mapperModernSpec.cfc
+++ b/vendor/wheels/tests/specs/mapperModernSpec.cfc
@@ -1,4 +1,4 @@
-component extends="wheels.Testbox" {
+component extends="wheels.WheelsTest" {
 
 	function beforeAll() {
 		config = {path = "wheels", fileName = "Mapper", method = "$init"}

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/upgrade.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/upgrade.mdx
@@ -19,7 +19,7 @@ import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 ### Synopsis
 
 ``` title="Synopsis"
-wheels upgrade check [--to=<version>]
+wheels upgrade check [--to=<version>] [--format=json]
 ```
 
 Calling `wheels upgrade` with no subcommand (or any subcommand other than `check`) prints usage and exits. The only verb the command currently understands is `check`.
@@ -32,6 +32,8 @@ Calling `wheels upgrade` with no subcommand (or any subcommand other than `check
 2. **Resolves the target version.** If you pass `--to=<version>`, that wins. Otherwise the command hits the GitHub releases API (`api.github.com/repos/wheels-dev/wheels/releases/latest`) and strips the leading `v` from the tag name. If the network call fails, the command prints a yellow notice and exits — it will not invent a target.
 3. **Compares major versions.** If current and target share the same major, the command notes "Same major version — no known breaking changes" for the major-transition checks, then still runs its advisory scan for the same-major patterns below.
 4. **Runs breaking-change checks.** Each check is either a directory existence test or a regex grep across a sub-tree of the project. Major-version transitions add their own checks on top of the advisory scan. Hits are printed as issues (yellow); absences are printed as passed checks (green).
+
+**Exit status:** when breaking findings exist the command throws `Wheels.UpgradeCheckFailed` after the report flushes, exiting non-zero so it can gate CI. Advisory findings never affect the exit code. With `--format=json` the human report is replaced by a single JSON document (`currentVersion`, `targetVersion`, `success`, `breaking`, `advisories`, `passed`, `guide`) — the non-zero exit on breaking findings still applies.
 
 Nothing in the project is modified. No files are written. The command does not stage, commit, or touch git state.
 
@@ -48,6 +50,7 @@ None that the command enforces — but in practice:
 | Flag | Description |
 |---|---|
 | `--to=<version>` | Target version to scan against (e.g. `--to=4.0.0`). When omitted, the command queries GitHub for the latest release tag. If the GitHub call fails and no `--to=` is given, the command aborts. |
+| `--format=json` | Emit a single machine-readable JSON report instead of the human output — for CI pipelines. Breaking findings still exit non-zero. |
 
 That is the complete flag surface. The command does not accept `--force`, `--dry-run`, `--check`, `--backup`, or any apply-style switch — there is nothing to apply.
 
@@ -95,14 +98,15 @@ The checks are hard-coded in the CLI and keyed by the major-version transition:
 
 **2.x → 3.x**
 
-- Existence of `app/plugins/` (legacy plugin directory).
-- `extends="wheels.Test"` anywhere under `tests/` (old BDD base class).
+- Existence of `plugins/` at the project root (legacy plugin directory; skipped on a 2.x → 4.x jump where the 4.x check below covers it).
+- `extends="wheels.Test"` or `extends="wheels.Testbox"` (either quote style) anywhere under `tests/` (old test base classes).
 
 **3.x → 4.x**
 
 - Existence of `plugins/` at the project root (deprecated plugin location).
-- `extends="wheels.Test"` anywhere under `tests/`.
-- `application.wirebox` references anywhere under `app/` — these must move to `service()` / `inject()` on the new DI container.
+- `extends="wheels.Test"` or `extends="wheels.Testbox"` (either quote style) anywhere under `tests/`.
+- `application.wirebox` or `wirebox.system.ioc` references under `app/`, `config/`, and the root `Application.cfc` — these must move to `service()` / `application.wheelsdi`, and `new wirebox.system.ioc.Injector(...)` bootstraps to `new wheels.Injector()` (#1888).
+- `renderPage()` / `renderPageToString()` under `app/` — removed in 4.0; replace with `renderView()` / `renderView(returnAs="string")`, or install `wheels-legacy-adapter` for a soft landing.
 - `new wheels.middleware.Cors()` without `allowOrigins` in `config/` — the 4.0 default changed from wildcard to deny-all (#2039).
 - `new wheels.middleware.RateLimiter` in `config/` — prompts the user to verify `trustProxy` and `proxyStrategy`, whose defaults hardened in 4.0 (#2024, #2088).
 - `allowEnvironmentSwitchViaUrl=true` in `config/` — the production default flipped to `false` (#2076).
@@ -110,6 +114,8 @@ The checks are hard-coded in the CLI and keyed by the major-version transition:
 - Legacy `wheels snippets` in `Makefile`, `package.json`, `.github/workflows/`, and top-level `*.sh` files — renamed to `wheels generate snippets` (#1852).
 - Existence of `tests/specs/functions/` — renamed to `tests/specs/functional/` (#1872).
 - `viteScriptTag`, `viteStyleTag`, or `vitePreloadTag` in `app/views/` — `viteStrictManifest` now defaults to `true` in production, throwing on missing manifest entries (#2133).
+- *(advisory)* `new wheels.middleware.SecurityHeaders` in `config/` — HSTS defaults on in production in 4.0; pass `hsts=false` if your load balancer already sets it (#2081).
+- *(advisory)* `protectsFromForgery` under `app/` — the CSRF cookie now sets `SameSite`; cross-site POSTs from third-party frames will break (#2035).
 
 Each grep scan covers the file types relevant to that check (`.cfc` and `.cfm` for config and view checks; `Makefile`, `package.json`, `.yml`, `.yaml`, and `.sh` for the `wheels snippets` check) and reports `path:lineNumber` for every hit. Directory checks report only the top-level path when the directory exists and is non-empty.
 

--- a/web/sites/guides/src/content/docs/v4-0-0/upgrading/3x-to-4x.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/upgrading/3x-to-4x.mdx
@@ -248,6 +248,8 @@ component extends="wheels.WheelsTest" {
 
 See the [Testing guide](/v4-0-0/testing/) for matchers and the phantom-matcher list.
 
+There is also a `wheels.Testbox` shim — a pure alias of `wheels.WheelsTest` retained for specs written before the rename. It adds no behavior. Deprecated since 4.0 with a removal target of 5.0; `wheels upgrade check` flags `extends="wheels.Testbox"` alongside `wheels.Test`, and both should migrate to `wheels.WheelsTest`.
+
 ### 9. Tests directory renamed: `tests/specs/functions/` → `tests/specs/functional/`
 
 **CHANGELOG:** `Breaking: Tests directory tests/specs/functions/ renamed to tests/specs/functional/` (#1872).


### PR DESCRIPTION
## Summary

Finalizes wave-2 package `cli-upgrade-argspec`: six findings across the `wheels upgrade check` scanner and the CLI ArgSpec positional-binding layer. `upgrade check` can now gate CI (non-zero exit on breaking findings + `--format=json`), the breaker scan covers the canonical eleven 3.x→4.x changes, the `wheels.Testbox` shim is documented/owned with a 5.0 removal target, and ArgSpec correctly binds LuCLI's gap-numbered positionals so flags between positionals no longer drop or reject arguments. Branch is one commit behind `origin/develop` (#2917, dispatch) with zero file overlap; merges clean.

## Findings addressed

- **U1 [High] `wheels upgrade check` exits 0 even when breaking changes are found** @ `cli/lucli/Module.cfc:4576` — throws `Wheels.UpgradeCheckFailed` after the report flushes (mirrors `validate()`'s `Wheels.ValidationFailed`), so breaking findings exit non-zero and gate CI. Adds `--format=json` for a machine-readable report (`jsonMode` @ `:4069`, JSON emission @ `:4515`); advisories never affect the exit code.
- **U4 [Medium] Breaker-scan coverage gaps vs the canonical eleven** @ `cli/lucli/Module.cfc:4172-4220` — WireBox check now matches `wirebox.system.ioc` and scans the root `Application.cfc` + `config/` in addition to `app/` (`:4172-4185`); new breaking grep for removed `renderPage()`/`renderPageToString()` (`:4188-4196`); new advisories for the HSTS default flip (SecurityHeaders, #2081 @ `:4199-4208`) and the CSRF SameSite cookie attribute (protectsFromForgery, #2035 @ `:4210-4220`).
- **U5 [Medium] The `wheels.Testbox` shim is unowned — undocumented, unscanned, silent, load-bearing** @ `vendor/wheels/Testbox.cfc:1-13` — CFC docblock declares deprecation since 4.0 and a 5.0 removal target; `mapperModernSpec` migrated off the shim to `wheels.WheelsTest` (`vendor/wheels/tests/specs/mapperModernSpec.cfc:1`) so the core suite no longer depends on it; the upgrade-check "Old test base class" grep now matches `wheels.Testbox` and single-quoted `extends` forms (`cli/lucli/Module.cfc:4141-4163`); the 3x-to-4x guide documents the shim (`web/sites/guides/src/content/docs/v4-0-0/upgrading/3x-to-4x.mdx`).
- **U7 [Low] Notes (loop-var shadowing, dead plugins check, missing guide links, no adapter regression coverage)** @ `cli/lucli/Module.cfc:4430-4433` — `scanTargets` loop var renamed to `scanTarget` so it no longer shadows the target-version local; dead 2.x→3.x `app/plugins` check fixed to the real root `plugins/` path (`:4136`, deduped on 2.x→4.x jumps where the 4.x entry covers it); breaking-finding output now links the version-appropriate upgrade guide and the `wheels-legacy-adapter` soft landing (`:4539`); new in-repo regression spec for legacy-adapter registry resolution (`cli/lucli/tests/specs/packages/LegacyAdapterResolutionSpec.cfc`).
- **CLI-D5 [Low-Medium] Instance-level `__arguments` set on delegation but never cleared — stale argv replays under the long-running MCP server** @ `cli/lucli/Module.cfc:109-111` — `structuredArgs()` now consumes `__arguments` once (cleared on every call), so a delegation stash can never replay stale argv into a later zero-arg tool call. The only two delegation sites (`generate()` @ `:414-415`, `create()` @ `:1046`) re-stash immediately before `return new()`, so delegation is unaffected.
- **CLI-D1 [High] LuCLI's gap-numbered positionals break fixed-index / stop-at-gap consumers — positionals after a flag silently dropped or wrongly rejected** @ `cli/lucli/services/ArgSpec.cfc:94-99,150,179` — `parse()`/`toArgv()` now bind positionals by collecting and numerically sorting `arg<N>` keys (`$positionalIndices()`, the proven `parseTestArgs` pattern) instead of fixed-index probing / stop-at-gap loops. Fixes `wheels new --port=3000 blog` (app name was ignored, then threw `Wheels.InvalidArguments`) and `wheels g scaffold Post --force title:string body:text` (every column after the flag was silently dropped).

## Findings verified already-fixed

- **CLI-D1 sub-item 3 — the `getArgs()` `arg1`-gate dropping all args on named-only invocations for the 8 dispatcher commands** (generate/migrate/start/create/deploy/packages/db/browser): already fixed on `origin/develop` before this branch by the ArgSpec `toArgv` migration (#2872). Evidence: `git grep 'toArgv(structuredArgs' origin/develop -- cli/lucli/Module.cfc` hits the dispatcher sites (develop `Module.cfc:364, 458, 740, 1019, 2055`, …). This branch builds on that path and fixes the remaining stop-at-gap defect inside `toArgv` itself.
- Staleness spot-check on the addressed findings (confirming they were live, not stale): pre-branch `origin/develop` still had the dead `app/plugins` scan path (`cli/lucli/Module.cfc:4101` on develop) and no `Wheels.UpgradeCheckFailed` throw (`git grep 'Wheels.UpgradeCheckFailed' origin/develop` returned no hits).

## Source

Internal multi-agent framework review 2026-06-09, wave 2 package `cli-upgrade-argspec`.

## Tests

- `vendor/wheels/tests/specs/cli/UpgradeCheckCoverageSpec.cfc` — extended to pin the full canonical-eleven pattern set (WireBox incl. `wirebox.system.ioc`, renderPage grep, HSTS + SameSite advisories), the `Wheels.UpgradeCheckFailed` exit-code throw, and the `--format=json` plumbing. Red pre-fix.
- `cli/lucli/tests/specs/services/ArgSpecSpec.cfc` — gap-numbered positional binding for `parse()`/`toArgv()` (flag-between-positionals collections). Red pre-fix.
- `cli/lucli/tests/specs/commands/CommandArgParsingSpec.cfc` + `cli/lucli/tests/_fixtures/commands/ModuleArgvProbe.cfc` — end-to-end flag-between-positionals repro through the module dispatch path and `__arguments` consume-once behavior. Red pre-fix.
- `cli/lucli/tests/specs/packages/LegacyAdapterResolutionSpec.cfc` — new regression coverage for `wheels-legacy-adapter` registry resolution.
- Local verification (Lucee 7 + SQLite, worktree docker single-bundle recipe): core `cli` specs 78/78, `mapperModernSpec` 27/27, CLI suite 774 pass with only the pre-existing environment-dependent SSH/live-server failures. Full engine × DB matrix deferred to CI (runs per PR).

## Cross-engine notes

- ArgSpec changes are pure struct/array CFML using the collect-and-sort pattern already proven cross-engine in `parseTestArgs()`; behavior-identical for gap-free collections, so the ~12 existing `toArgv`/`parse` call sites are unaffected on every engine.
- `mapperModernSpec` base-class swap is alias-to-alias (`wheels.Testbox` extends `wheels.WheelsTest`) — zero behavior change, keeps the shim deletable at 5.0 without crashing the bundle.
- Specs follow the documented gotchas: WheelsTest BDD, no inline closures as constructor named args, `##` escaped in string literals, no `local.X`-in-catch persistence reliance, no reserved-scope parameter names.

## Changelog

Entry deliberately omitted; consolidated at campaign end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
