### PR TITLE
fix(di): singleton locking and keying, SemVer space parsing, lazy provider boot

### DIFF
--- a/vendor/wheels/Bindings.cfc
+++ b/vendor/wheels/Bindings.cfc
@@ -49,9 +49,11 @@ component {
 		// Database adapters (no default — adapter is selected per datasource at runtime)
 		// Bind per-project: bind("DatabaseModelAdapterInterface").to("wheels.databaseAdapters.H2.H2Model")
 
-		// DI subsystem
-		arguments.injector
-			.bind("InjectorInterface").to("wheels.Injector");
+		// Note: there is intentionally NO "InjectorInterface" binding. The live
+		// container self-registers at application.wheelsdi during init(), and a
+		// path binding here could never resolve (Injector.init() requires a
+		// binderPath that no auto-wire mapping supplies) — and if it ever did,
+		// the fresh instance would clobber application.wheelsdi.
 	}
 
 }

--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -3064,6 +3064,32 @@ return local.$wheels;
 	}
 
 	/**
+	 * Internal function. Normalizes mixin-collision records to a single
+	 * shared shape: {target, method, firstProvider, secondProvider,
+	 * acknowledged, source}. Plugins.cfc emits legacy-shaped records
+	 * ({existingPlugin, overridingPlugin}) while PackageLoader.cfc and the
+	 * cross-system merge in $loadPackages emit the shared shape directly;
+	 * all of them end up in the same application.wheels.mixinCollisions
+	 * array, which /wheels/plugins and the development debug footer consume
+	 * unconditionally — a mixed-shape array crashes those surfaces with a
+	 * "key doesn't exist" error.
+	 */
+	public array function $normalizeMixinCollisions(required array collisions) {
+		local.rv = [];
+		for (local.c in arguments.collisions) {
+			ArrayAppend(local.rv, {
+				target = local.c.target,
+				method = local.c.method,
+				firstProvider = StructKeyExists(local.c, "firstProvider") ? local.c.firstProvider : local.c.existingPlugin,
+				secondProvider = StructKeyExists(local.c, "secondProvider") ? local.c.secondProvider : local.c.overridingPlugin,
+				acknowledged = StructKeyExists(local.c, "acknowledged") ? local.c.acknowledged : false,
+				source = StructKeyExists(local.c, "source") ? local.c.source : "plugin"
+			});
+		}
+		return local.rv;
+	}
+
+	/**
 	 * Internal function.
 	 */
 	public void function $loadPlugins() {
@@ -3085,7 +3111,14 @@ return local.$wheels;
 		application[local.appKey].incompatiblePlugins = application[local.appKey].PluginObj.getIncompatiblePlugins();
 		application[local.appKey].dependantPlugins = application[local.appKey].PluginObj.getDependantPlugins();
 		application[local.appKey].versionMismatchPlugins = application[local.appKey].PluginObj.getVersionMismatchPlugins();
-		application[local.appKey].mixinCollisions = application[local.appKey].PluginObj.getMixinCollisions();
+		// Plugins.cfc emits legacy-shaped collision records ({existingPlugin,
+		// overridingPlugin}); normalize them to the shared shape at the merge
+		// point so package- and cross-system records (which already use
+		// {firstProvider, secondProvider}) can live in the same array without
+		// crashing the consumers (/wheels/plugins and the debug footer).
+		application[local.appKey].mixinCollisions = $normalizeMixinCollisions(
+			application[local.appKey].PluginObj.getMixinCollisions()
+		);
 		application[local.appKey].mixins = application[local.appKey].PluginObj.getMixins();
 		application[local.appKey].pluginMiddleware = application[local.appKey].PluginObj.getPluginMiddleware();
 		// Invoke register(container) on ServiceProviderInterface plugins before activation
@@ -3181,8 +3214,13 @@ return local.$wheels;
 			ArrayAppend(application[local.appKey].pluginMiddleware, local.mw);
 		}
 
-		// Invoke ServiceProvider register/boot if DI container exists
-		if (IsDefined("application.wheelsdi") && ArrayLen(application[local.appKey].PackageLoaderObj.getServiceProviders())) {
+		// Invoke ServiceProvider register/boot if DI container exists. The
+		// gate asks the loader (not just getServiceProviders()) because lazy
+		// service-hinted packages aren't instantiated yet at this point —
+		// $invokeServiceProviderRegister pulls them into the lifecycle, so a
+		// vendor tree containing only lazy service packages still needs the
+		// lifecycle invoked.
+		if (IsDefined("application.wheelsdi") && application[local.appKey].PackageLoaderObj.$hasServiceProviderWork()) {
 			application[local.appKey].PackageLoaderObj.$invokeServiceProviderRegister(application.wheelsdi);
 			application[local.appKey].PackageLoaderObj.$invokeServiceProviderBoot(application[local.appKey]);
 			// Re-sync the application-scope copy so register()/boot() failure

--- a/vendor/wheels/Injector.cfc
+++ b/vendor/wheels/Injector.cfc
@@ -22,11 +22,26 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 		// Storage for alias → component path mappings
 		variables.mappings = {};
 
-		// Singleton cache: component path → instance
+		// Singleton cache: mapping name → instance. Keyed by the same value
+		// as variables.singletonFlags so the flag and the cache can never
+		// disagree (previously the cache was keyed by component path, so a
+		// singleton resolved via a second alias was never cached and two
+		// singleton aliases to one path silently shared an instance).
 		variables.singletons = {};
 
 		// Track which mappings are singletons
 		variables.singletonFlags = {};
+
+		// Memoized init() parameter names per component path. getMetaData +
+		// the function scan in $resolveInitArguments run once per component,
+		// not on every transient resolution. Only parameter NAMES are cached;
+		// they are matched against the live mappings on each resolution.
+		variables.initParamCache = {};
+
+		// Unique per-container prefix for the singleton construction lock so
+		// separate Injector instances (e.g. tests) never contend with each
+		// other or with the application container.
+		variables.lockNamePrefix = "wheelsDISingleton_" & CreateUUID() & "_";
 
 		// Track which mappings are request-scoped
 		variables.requestScopedFlags = {};
@@ -78,6 +93,18 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 	public Injector function to(required string componentPath) {
 		if (!len(variables.currentMapping)) {
 			throw(type="Wheels.Injector", message="to() called without a preceding map() call.");
+		}
+		// Re-binding an alias to a DIFFERENT component path invalidates any
+		// cached singleton instance for that alias — the cache is keyed by
+		// alias, so without this the stale instance of the old component
+		// would keep being served. Re-registering the same path (the
+		// dev-mode reload pattern) keeps the cached instance.
+		if (
+			structKeyExists(variables.singletons, variables.currentMapping)
+			&& structKeyExists(variables.mappings, variables.currentMapping)
+			&& variables.mappings[variables.currentMapping] != arguments.componentPath
+		) {
+			structDelete(variables.singletons, variables.currentMapping);
 		}
 		variables.mappings[variables.currentMapping] = arguments.componentPath;
 		variables.lastMappedName = variables.currentMapping;
@@ -133,19 +160,54 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 		// Resolve the component path
 		local.componentPath = resolveMapping(arguments.name);
 
-		// Check singleton cache
-		if (structKeyExists(variables.singletonFlags, arguments.name) && structKeyExists(variables.singletons, local.componentPath)) {
-			return variables.singletons[local.componentPath];
+		// Singleton: the cache is keyed by the mapping name — the same key
+		// the asSingleton() flag uses — so the flag and the cache can never
+		// disagree. A double-checked named lock ensures concurrent first
+		// resolutions construct exactly once instead of racing and orphaning
+		// one of the two constructed instances.
+		if (structKeyExists(variables.singletonFlags, arguments.name)) {
+			if (!structKeyExists(variables.singletons, arguments.name)) {
+				lock name="#variables.lockNamePrefix##lCase(arguments.name)#" type="exclusive" timeout="30" {
+					if (!structKeyExists(variables.singletons, arguments.name)) {
+						variables.singletons[arguments.name] = $constructInstance(
+							arguments.name,
+							local.componentPath,
+							arguments.initArguments
+						);
+					}
+				}
+			}
+			return variables.singletons[arguments.name];
 		}
 
-		// Check request-scope cache
+		// Request-scoped: cached per request in request.$wheelsDICache. A
+		// request runs on a single thread, so no lock is needed here.
 		if (structKeyExists(variables.requestScopedFlags, arguments.name)) {
 			local.requestCache = $getRequestCache();
-			if (structKeyExists(local.requestCache, arguments.name)) {
-				return local.requestCache[arguments.name];
+			if (!structKeyExists(local.requestCache, arguments.name)) {
+				local.requestCache[arguments.name] = $constructInstance(
+					arguments.name,
+					local.componentPath,
+					arguments.initArguments
+				);
 			}
+			return local.requestCache[arguments.name];
 		}
 
+		// Transient: a fresh instance per call.
+		return $constructInstance(arguments.name, local.componentPath, arguments.initArguments);
+	}
+
+	/**
+	 * Creates, initializes (with auto-wiring when no explicit initArguments
+	 * are passed), and finalizes a component instance. Shared by the
+	 * singleton, request-scoped, and transient paths of getInstance().
+	 */
+	private any function $constructInstance(
+		required string name,
+		required string componentPath,
+		required struct initArguments
+	) {
 		// Circular dependency guard. The resolving struct is request-scoped —
 		// it tracks "what this thread is currently resolving" — so concurrent
 		// requests don't trip each other's guard. Application-scoping it (the
@@ -166,7 +228,7 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 
 		try {
 			// Create the component instance
-			local.instance = createObject("component", local.componentPath);
+			local.instance = createObject("component", arguments.componentPath);
 
 			// Call init() if it exists
 			if (structKeyExists(local.instance, "init")) {
@@ -174,7 +236,7 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 					local.instance.init(argumentCollection = arguments.initArguments);
 				} else {
 					// Auto-wire: resolve init() arguments from container mappings
-					local.autoArgs = $resolveInitArguments(local.instance);
+					local.autoArgs = $resolveInitArguments(local.instance, arguments.componentPath);
 					if (!structIsEmpty(local.autoArgs)) {
 						local.instance.init(argumentCollection = local.autoArgs);
 					} else {
@@ -186,17 +248,6 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 			// Call onDIcomplete() lifecycle callback if present
 			if (structKeyExists(local.instance, "onDIcomplete")) {
 				local.instance.onDIcomplete();
-			}
-
-			// Cache singletons
-			if (structKeyExists(variables.singletonFlags, arguments.name)) {
-				variables.singletons[local.componentPath] = local.instance;
-			}
-
-			// Cache in request scope
-			if (structKeyExists(variables.requestScopedFlags, arguments.name)) {
-				local.requestCache = $getRequestCache();
-				local.requestCache[arguments.name] = local.instance;
 			}
 		} finally {
 			// Clean up resolving guard. Even on success this runs to keep the
@@ -285,38 +336,65 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 	 * Inspect the init() method of an instance and auto-resolve parameters
 	 * whose names match registered container mappings.
 	 *
+	 * The init() parameter names are memoized per component path so
+	 * getMetaData and the function scan run once per component rather than
+	 * on every transient resolution. Only the parameter NAMES are cached —
+	 * they are matched against the live mappings on each call, so mappings
+	 * registered after a component's first resolution are still honored.
+	 *
+	 * The scan walks the extends chain so an inherited init() participates
+	 * in constructor auto-wiring just like one declared on the component
+	 * itself.
+	 *
 	 * @instance The component instance to inspect
+	 * @componentPath The resolved dotted component path (memoization key)
 	 */
-	private struct function $resolveInitArguments(required any instance) {
+	private struct function $resolveInitArguments(required any instance, required string componentPath) {
 		local.args = {};
-		local.meta = getMetaData(arguments.instance);
 
-		// Find the init() function in the metadata
-		if (!structKeyExists(local.meta, "functions")) {
-			return local.args;
-		}
-
-		local.initMeta = {};
-		for (local.fn in local.meta.functions) {
-			if (local.fn.name == "init") {
-				local.initMeta = local.fn;
-				break;
-			}
-		}
-
-		// No init() or no parameters
-		if (structIsEmpty(local.initMeta) || !structKeyExists(local.initMeta, "parameters")) {
-			return local.args;
+		if (!structKeyExists(variables.initParamCache, arguments.componentPath)) {
+			variables.initParamCache[arguments.componentPath] = $scanInitParameterNames(getMetaData(arguments.instance));
 		}
 
 		// Match parameter names against container mappings
-		for (local.param in local.initMeta.parameters) {
-			if (containsInstance(local.param.name)) {
-				local.args[local.param.name] = getInstance(local.param.name);
+		for (local.paramName in variables.initParamCache[arguments.componentPath]) {
+			if (containsInstance(local.paramName)) {
+				local.args[local.paramName] = getInstance(local.paramName);
 			}
 		}
 
 		return local.args;
+	}
+
+	/**
+	 * Walks component metadata — including the extends chain — for the
+	 * first init() declaration and returns its parameter names as an array.
+	 * Returns an empty array when no init() (or no parameters) is found.
+	 */
+	private array function $scanInitParameterNames(required struct meta) {
+		local.names = [];
+		local.current = arguments.meta;
+
+		while (isStruct(local.current)) {
+			if (structKeyExists(local.current, "functions")) {
+				for (local.fn in local.current.functions) {
+					if (local.fn.name == "init") {
+						if (structKeyExists(local.fn, "parameters")) {
+							for (local.param in local.fn.parameters) {
+								arrayAppend(local.names, local.param.name);
+							}
+						}
+						return local.names;
+					}
+				}
+			}
+			if (!structKeyExists(local.current, "extends") || !isStruct(local.current.extends)) {
+				break;
+			}
+			local.current = local.current.extends;
+		}
+
+		return local.names;
 	}
 
 }

--- a/vendor/wheels/ModuleGraph.cfc
+++ b/vendor/wheels/ModuleGraph.cfc
@@ -69,19 +69,27 @@ component output="false" {
 		local.sortResult = $topologicalSort(local.validNodes, local.adjacency);
 
 		if (ArrayLen(local.sortResult.cycle) > 0) {
-			// Report cycle errors for all packages in the cycle
-			for (local.node in local.sortResult.cycle) {
+			// Kahn's algorithm leaves both true cycle members AND their
+			// downstream dependents unprocessed. Distinguish them so a package
+			// that merely requires a cycled package is reported as a casualty
+			// of the cycle, not mislabeled as a circular dependency itself.
+			// (Unprocessed nodes were never added to sortResult.order, so no
+			// removal from the load order is needed.)
+			local.classified = $classifyCycleNodes(local.sortResult.cycle, local.adjacency);
+			for (local.node in local.classified.members) {
 				ArrayAppend(local.result.errors, {
 					package = local.node,
-					message = "Circular dependency detected: " & ArrayToList(local.sortResult.cycle, " -> ")
+					message = "Circular dependency detected: " & ArrayToList(
+						$findCyclePath(local.node, local.adjacency, local.classified.memberSet),
+						" -> "
+					)
 				});
 			}
-			// Remove cycled packages from load order
-			for (local.node in local.sortResult.cycle) {
-				local.idx = ArrayFind(local.sortResult.order, local.node);
-				if (local.idx > 0) {
-					ArrayDeleteAt(local.sortResult.order, local.idx);
-				}
+			for (local.node in local.classified.dependents) {
+				ArrayAppend(local.result.errors, {
+					package = local.node,
+					message = "Cannot load: depends on package(s) involved in a circular dependency (#ArrayToList(local.classified.members, ", ")#)"
+				});
 			}
 		}
 
@@ -99,7 +107,20 @@ component output="false" {
 	private struct function $processReplacements(required struct manifests, required struct nameToDir) {
 		local.excluded = {};
 
-		for (local.dirName in arguments.manifests) {
+		// Process packages in sorted directory-name order so the outcome is
+		// deterministic regardless of struct iteration order, and skip the
+		// replaces declarations of packages that have already been excluded —
+		// an excluded package never loads, so its declarations must not apply.
+		// This also resolves mutual replaces (A replaces B AND B replaces A):
+		// the first package in sorted order wins and the other is excluded,
+		// instead of both being silently removed from the load order.
+		local.sortedDirs = StructKeyArray(arguments.manifests);
+		ArraySort(local.sortedDirs, "textnocase");
+
+		for (local.dirName in local.sortedDirs) {
+			if (StructKeyExists(local.excluded, local.dirName)) {
+				continue;
+			}
 			local.m = arguments.manifests[local.dirName];
 			if (!StructKeyExists(local.m, "replaces") || !IsStruct(local.m.replaces)) {
 				continue;
@@ -142,6 +163,9 @@ component output="false" {
 	 * Edges point from dependency to dependent: if A requires B, edge is B -> A.
 	 * This means packages with no incoming edges (no dependencies) are processed first.
 	 *
+	 * In-degrees are computed by $topologicalSort (restricted to the valid
+	 * nodes), so this function intentionally does not track them.
+	 *
 	 * @return  Struct with: adjacency (struct of arrays), validNodes (array), errors (array)
 	 */
 	private struct function $buildAdjacencyList(
@@ -151,8 +175,6 @@ component output="false" {
 	) {
 		// adjacency: dirName -> array of dirNames that depend on it
 		local.adjacency = {};
-		// inDegree: dirName -> count of dependencies
-		local.inDegree = {};
 		local.validNodes = [];
 		local.errors = [];
 		local.failedNodes = {};
@@ -160,7 +182,6 @@ component output="false" {
 		// Initialize all active packages as nodes
 		for (local.dirName in arguments.activeManifests) {
 			local.adjacency[local.dirName] = [];
-			local.inDegree[local.dirName] = 0;
 		}
 
 		// Process requires
@@ -222,7 +243,6 @@ component output="false" {
 
 				// Add edge: reqDir -> dirName (dependency loads before dependent)
 				ArrayAppend(local.adjacency[local.reqDir], local.dirName);
-				local.inDegree[local.dirName] = local.inDegree[local.dirName] + 1;
 			}
 		}
 
@@ -259,7 +279,6 @@ component output="false" {
 
 				// Soft edge: sugDir -> dirName
 				ArrayAppend(local.adjacency[local.sugDir], local.dirName);
-				local.inDegree[local.dirName] = local.inDegree[local.dirName] + 1;
 			}
 		}
 
@@ -272,10 +291,136 @@ component output="false" {
 
 		return {
 			adjacency = local.adjacency,
-			inDegree = local.inDegree,
 			validNodes = local.validNodes,
 			errors = local.errors
 		};
+	}
+
+	/**
+	 * Splits the unprocessed nodes left over from Kahn's algorithm into true
+	 * cycle members (nodes that can reach themselves following edges within
+	 * the unprocessed set) and downstream dependents (nodes that merely
+	 * depend, directly or transitively, on a cycle member and therefore never
+	 * reached in-degree zero).
+	 *
+	 * @cycleNodes  Array of unprocessed node names from $topologicalSort
+	 * @adjacency   Struct of node -> array of dependent nodes
+	 * @return      Struct with: members (sorted array), dependents (sorted array), memberSet (struct)
+	 */
+	private struct function $classifyCycleNodes(required array cycleNodes, required struct adjacency) {
+		local.unprocessedSet = {};
+		for (local.node in arguments.cycleNodes) {
+			local.unprocessedSet[local.node] = true;
+		}
+
+		local.members = [];
+		local.dependents = [];
+		local.memberSet = {};
+
+		for (local.node in arguments.cycleNodes) {
+			if ($canReachSelf(local.node, arguments.adjacency, local.unprocessedSet)) {
+				ArrayAppend(local.members, local.node);
+				local.memberSet[local.node] = true;
+			} else {
+				ArrayAppend(local.dependents, local.node);
+			}
+		}
+
+		ArraySort(local.members, "textnocase");
+		ArraySort(local.dependents, "textnocase");
+
+		return {
+			members = local.members,
+			dependents = local.dependents,
+			memberSet = local.memberSet
+		};
+	}
+
+	/**
+	 * Returns true when the given node can reach itself following adjacency
+	 * edges restricted to the allowed node set — i.e. the node is part of a
+	 * dependency cycle. Iterative DFS.
+	 */
+	private boolean function $canReachSelf(
+		required string startNode,
+		required struct adjacency,
+		required struct allowedSet
+	) {
+		local.stack = [];
+		local.visited = {};
+
+		if (StructKeyExists(arguments.adjacency, arguments.startNode)) {
+			for (local.next in arguments.adjacency[arguments.startNode]) {
+				if (StructKeyExists(arguments.allowedSet, local.next)) {
+					ArrayAppend(local.stack, local.next);
+				}
+			}
+		}
+
+		while (ArrayLen(local.stack) > 0) {
+			local.current = local.stack[ArrayLen(local.stack)];
+			ArrayDeleteAt(local.stack, ArrayLen(local.stack));
+			if (local.current == arguments.startNode) {
+				return true;
+			}
+			if (StructKeyExists(local.visited, local.current)) {
+				continue;
+			}
+			local.visited[local.current] = true;
+			if (StructKeyExists(arguments.adjacency, local.current)) {
+				for (local.next in arguments.adjacency[local.current]) {
+					if (StructKeyExists(arguments.allowedSet, local.next)) {
+						ArrayAppend(local.stack, local.next);
+					}
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Finds an actual cycle path starting and ending at the given node,
+	 * following edges restricted to verified cycle members. Returns an array
+	 * like ["a", "b", "a"] suitable for rendering as "a -> b -> a". Falls
+	 * back to a single-element array if no path is found (which cannot happen
+	 * for a node $classifyCycleNodes verified as a cycle member).
+	 *
+	 * Iterative DFS; each stack frame carries the path taken to reach it so
+	 * no arrays are mutated across function boundaries (Adobe CF passes
+	 * arrays by value).
+	 */
+	private array function $findCyclePath(
+		required string startNode,
+		required struct adjacency,
+		required struct memberSet
+	) {
+		local.stack = [{node = arguments.startNode, path = [arguments.startNode]}];
+		local.visited = {};
+
+		while (ArrayLen(local.stack) > 0) {
+			local.frame = local.stack[ArrayLen(local.stack)];
+			ArrayDeleteAt(local.stack, ArrayLen(local.stack));
+			if (!StructKeyExists(arguments.adjacency, local.frame.node)) {
+				continue;
+			}
+			for (local.next in arguments.adjacency[local.frame.node]) {
+				if (local.next == arguments.startNode) {
+					local.completed = Duplicate(local.frame.path);
+					ArrayAppend(local.completed, local.next);
+					return local.completed;
+				}
+				if (!StructKeyExists(arguments.memberSet, local.next) || StructKeyExists(local.visited, local.next)) {
+					continue;
+				}
+				local.visited[local.next] = true;
+				local.nextPath = Duplicate(local.frame.path);
+				ArrayAppend(local.nextPath, local.next);
+				ArrayAppend(local.stack, {node = local.next, path = local.nextPath});
+			}
+		}
+
+		return [arguments.startNode];
 	}
 
 	/**
@@ -350,7 +495,9 @@ component output="false" {
 			}
 		}
 
-		// Any remaining nodes with in-degree > 0 are in a cycle
+		// Any remaining nodes with in-degree > 0 are either true cycle members
+		// or downstream dependents of one — resolve() classifies them via
+		// $classifyCycleNodes before reporting.
 		local.cycle = [];
 		if (local.processed < ArrayLen(arguments.validNodes)) {
 			for (local.node in arguments.validNodes) {

--- a/vendor/wheels/PackageLoader.cfc
+++ b/vendor/wheels/PackageLoader.cfc
@@ -42,6 +42,13 @@ component output="false" {
 		variables.loadOrder = [];
 		variables.lazyPackages = {};
 		variables.mixinCollisions = [];
+		// ServiceProvider lifecycle state. The container/app references are
+		// captured when Global.cfc invokes the lifecycle so a lazy provider
+		// instantiated AFTER boot can still have register()/boot() invoked
+		// (see $instantiateLazyPackage).
+		variables.lifecycleContainer = "";
+		variables.lifecycleApp = {};
+		variables.lifecycleBooted = false;
 		// Per-package CFML mapping registry: alias → absolute package directory.
 		// Populated during load so each installed package gets a static, identifier-
 		// safe alias usable in `new <alias>.Sibling()` even when the on-disk dir
@@ -672,6 +679,33 @@ component output="false" {
 			type = "information",
 			file = "wheels"
 		);
+
+		// A ServiceProvider instantiated after the boot lifecycle already ran
+		// would otherwise never have register()/boot() invoked — its services
+		// would be silently missing with no failedPackages entry. Invoke the
+		// lifecycle now using the references captured at boot. Boot-time
+		// instantiation (from $invokeServiceProviderRegister) does not hit
+		// this branch because lifecycleBooted is still false there; those
+		// providers run through the normal register/boot loops instead.
+		if (variables.lifecycleBooted && ArrayFind(variables.serviceProviders, arguments.dirName) > 0) {
+			try {
+				variables.packages[arguments.dirName].register(variables.lifecycleContainer);
+				variables.packages[arguments.dirName].boot(variables.lifecycleApp);
+			} catch (any e) {
+				WriteLog(
+					text = "[Wheels] Package '#arguments.dirName#' ServiceProvider lifecycle failed on lazy instantiation: #e.message#",
+					type = "error",
+					file = "wheels"
+				);
+				ArrayAppend(variables.failedPackages, {
+					name = arguments.dirName,
+					error = "ServiceProvider lifecycle failed on lazy instantiation: " & e.message,
+					detail = StructKeyExists(e, "detail") ? e.detail : ""
+				});
+				$rollbackPackage(arguments.dirName);
+				Rethrow;
+			}
+		}
 	}
 
 	/**
@@ -849,6 +883,41 @@ component output="false" {
 	}
 
 	/**
+	 * Returns true when a manifest declares service entries under
+	 * provides.services. Used to pull lazy service-only packages into the
+	 * ServiceProvider lifecycle at boot — such a package exists to register
+	 * services, which must happen during register()/boot() or the services
+	 * are silently missing.
+	 */
+	private boolean function $hintsServices(required struct manifest) {
+		return StructKeyExists(arguments.manifest, "provides")
+			&& IsStruct(arguments.manifest.provides)
+			&& StructKeyExists(arguments.manifest.provides, "services")
+			&& IsArray(arguments.manifest.provides.services)
+			&& ArrayLen(arguments.manifest.provides.services) > 0;
+	}
+
+	/**
+	 * Returns true when the ServiceProvider lifecycle has work to do: either
+	 * eagerly loaded packages already registered as providers, or lazy
+	 * packages whose manifest hints services (these are instantiated into
+	 * the lifecycle by $invokeServiceProviderRegister). Global.cfc uses this
+	 * as the gate for invoking the lifecycle so a vendor tree containing
+	 * ONLY lazy service-only packages still gets register()/boot() invoked.
+	 */
+	public boolean function $hasServiceProviderWork() {
+		if (ArrayLen(variables.serviceProviders) > 0) {
+			return true;
+		}
+		for (local.lazyKey in variables.lazyPackages) {
+			if ($hintsServices(variables.lazyPackages[local.lazyKey].manifest)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Invokes register(container) on all packages that implement ServiceProviderInterface.
 	 * Also triggers instantiation of lazy ServiceProvider packages.
 	 *
@@ -863,6 +932,38 @@ component output="false" {
 	 * happens before this lifecycle invoke.
 	 */
 	public void function $invokeServiceProviderRegister(required any container) {
+		// Capture the container so a lazy provider instantiated after boot
+		// can still have its lifecycle invoked (see $instantiateLazyPackage).
+		variables.lifecycleContainer = arguments.container;
+
+		// Lazy packages whose manifest hints services join the lifecycle
+		// here: lazy loading defers CFC instantiation past discovery and
+		// mixin collection, but a package that exists to register services
+		// must be live before the register() phase runs — otherwise its
+		// services are silently missing (no failedPackages entry, just a
+		// Wheels.DI.ServiceNotFound on some later request).
+		local.lazyKeys = StructKeyArray(variables.lazyPackages);
+		for (local.lazyKey in local.lazyKeys) {
+			if (!$hintsServices(variables.lazyPackages[local.lazyKey].manifest)) {
+				continue;
+			}
+			try {
+				$instantiateLazyPackage(local.lazyKey);
+			} catch (any e) {
+				WriteLog(
+					text = "[Wheels] Package '#local.lazyKey#' failed to instantiate for the ServiceProvider lifecycle: #e.message#",
+					type = "error",
+					file = "wheels"
+				);
+				ArrayAppend(variables.failedPackages, {
+					name = local.lazyKey,
+					error = "Lazy ServiceProvider instantiation failed: " & e.message,
+					detail = StructKeyExists(e, "detail") ? e.detail : ""
+				});
+				$rollbackPackage(local.lazyKey);
+			}
+		}
+
 		// Iterate a snapshot: $rollbackPackage deletes from
 		// variables.serviceProviders, and mutating the array mid-iteration
 		// would skip the provider after a failing one.
@@ -896,6 +997,12 @@ component output="false" {
 	 * Injector has no per-package tracking.
 	 */
 	public void function $invokeServiceProviderBoot(required struct app) {
+		// Capture the app reference and mark the lifecycle complete so a lazy
+		// provider instantiated after this point can have register()/boot()
+		// invoked late (see $instantiateLazyPackage).
+		variables.lifecycleApp = arguments.app;
+		variables.lifecycleBooted = true;
+
 		// Iterate a snapshot: $rollbackPackage deletes from variables.serviceProviders.
 		local.providerKeys = Duplicate(variables.serviceProviders);
 		for (local.pkgKey in local.providerKeys) {

--- a/vendor/wheels/SemVer.cfc
+++ b/vendor/wheels/SemVer.cfc
@@ -88,9 +88,25 @@ component output="false" {
 			local.operator = Left(local.c, 1);
 			local.targetStr = Trim(Mid(local.c, 2, Len(local.c) - 1));
 		} else if (Left(local.c, 1) == "^") {
-			return $satisfiesCaret(local.ver, Trim(Mid(local.c, 2, Len(local.c) - 1)));
+			local.caretTarget = Trim(Mid(local.c, 2, Len(local.c) - 1));
+			if (!Len(local.caretTarget)) {
+				// Operator with no target is malformed — fail closed.
+				return false;
+			}
+			return $satisfiesCaret(local.ver, local.caretTarget);
 		} else if (Left(local.c, 1) == "~") {
-			return $satisfiesTilde(local.ver, Trim(Mid(local.c, 2, Len(local.c) - 1)));
+			local.tildeTarget = Trim(Mid(local.c, 2, Len(local.c) - 1));
+			if (!Len(local.tildeTarget)) {
+				// Operator with no target is malformed — fail closed.
+				return false;
+			}
+			return $satisfiesTilde(local.ver, local.tildeTarget);
+		}
+		// An operator with an empty target (e.g. a bare ">=") is malformed —
+		// fail closed instead of parsing the empty target as 0.0.0, which
+		// would make the constraint match almost everything.
+		if (Len(local.operator) && !Len(local.targetStr)) {
+			return false;
 		}
 		// Default: exact match
 		if (!Len(local.operator)) {
@@ -117,7 +133,9 @@ component output="false" {
 	/**
 	 * Evaluates whether a version satisfies ALL constraints in a space-separated string.
 	 * Each constraint is ANDed: ">=1.0.0 <2.0.0" means version must satisfy both.
-	 * Wildcard "*" always returns true.
+	 * A space between an operator and its target is tolerated: ">= 1.0.0" is
+	 * read as ">=1.0.0", not as two separate constraints. Wildcard "*" always
+	 * returns true.
 	 *
 	 * @version The version to check (string or parsed struct)
 	 * @constraints Space-separated constraint expressions
@@ -130,7 +148,26 @@ component output="false" {
 		}
 		local.ver = IsStruct(arguments.version) ? arguments.version : this.parse(arguments.version);
 		local.parts = ListToArray(local.c, " ");
-		for (local.part in local.parts) {
+		// Merge an operator-only token with the following token so constraints
+		// written with a space after the operator (">= 1.0.0", "^ 1.2.3") keep
+		// their range semantics. Without this, ">= 1.0.0" split into ">="
+		// (empty target) AND "1.0.0" (exact match) — silently turning a range
+		// constraint into an exact match. A trailing operator with no target
+		// falls through to satisfies(), which fails closed on it.
+		local.merged = [];
+		local.i = 1;
+		local.partCount = ArrayLen(local.parts);
+		while (local.i <= local.partCount) {
+			local.token = local.parts[local.i];
+			if (local.i < local.partCount && REFind("^(>=|<=|[><=^~])$", local.token)) {
+				local.token &= local.parts[local.i + 1];
+				local.i += 2;
+			} else {
+				local.i += 1;
+			}
+			ArrayAppend(local.merged, local.token);
+		}
+		for (local.part in local.merged) {
 			if (!this.satisfies(local.ver, local.part)) {
 				return false;
 			}

--- a/vendor/wheels/events/onrequestend/debug.cfm
+++ b/vendor/wheels/events/onrequestend/debug.cfm
@@ -402,7 +402,7 @@ OR (StructKeyExists(url, "format") AND ListFindNoCase("json,xml,csv,pdf", url.fo
 						</cfif>
 						<cfif isDefined("application.wheels.mixinCollisions") AND arrayLen(application.wheels.mixinCollisions)>
 							<cfloop array="#application.wheels.mixinCollisions#" index="local.ci">
-								<p>Method <strong>#local.ci.method#</strong> on <strong>#local.ci.target#</strong>: <strong>#local.ci.existingPlugin#</strong> overridden by <strong>#local.ci.overridingPlugin#</strong></p>
+								<p>Method <strong>#local.ci.method#</strong> on <strong>#local.ci.target#</strong>: <strong>#local.ci.firstProvider#</strong> overridden by <strong>#local.ci.secondProvider#</strong></p>
 							</cfloop>
 						</cfif>
 					</div>

--- a/vendor/wheels/public/views/plugins.cfm
+++ b/vendor/wheels/public/views/plugins.cfm
@@ -86,7 +86,7 @@ if (request.wheels.params.format == "json") {
 							<cfloop list="#application.wheels.versionMismatchPlugins#" index="local.mm">Plugin <strong>#ListGetAt(local.mm, 1, "|")#</strong> requires <strong>#ListGetAt(local.mm, 2, "|")#</strong> #ListGetAt(local.mm, 3, "|")# but version <strong>#ListGetAt(local.mm, 4, "|")#</strong> is loaded<br></cfloop>
 						</cfif>
 						<cfif isDefined("application.wheels.mixinCollisions") AND arrayLen(application.wheels.mixinCollisions)>
-							<cfloop array="#application.wheels.mixinCollisions#" index="local.c">Method <strong>#local.c.method#</strong> on <strong>#local.c.target#</strong>: provided by <strong>#local.c.existingPlugin#</strong>, overridden by <strong>#local.c.overridingPlugin#</strong><br></cfloop>
+							<cfloop array="#application.wheels.mixinCollisions#" index="local.c">Method <strong>#local.c.method#</strong> on <strong>#local.c.target#</strong>: provided by <strong>#local.c.firstProvider#</strong>, overridden by <strong>#local.c.secondProvider#</strong><br></cfloop>
 						</cfif>
 			</div>
 		</cfif>

--- a/vendor/wheels/tests/_assets/di/InheritedDependentService.cfc
+++ b/vendor/wheels/tests/_assets/di/InheritedDependentService.cfc
@@ -1,0 +1,12 @@
+/**
+ * Extends DependentService WITHOUT declaring its own init() so the container
+ * must walk the extends chain in the metadata to find the inherited
+ * init(simpleService) signature for constructor auto-wiring.
+ */
+component extends="wheels.tests._assets.di.DependentService" {
+
+	public string function shout() {
+		return UCase(delegateGreet());
+	}
+
+}

--- a/vendor/wheels/tests/_assets/di/OptionalDependentService.cfc
+++ b/vendor/wheels/tests/_assets/di/OptionalDependentService.cfc
@@ -1,0 +1,18 @@
+/**
+ * A test service with an OPTIONAL init() dependency. Used to verify that the
+ * memoized init-parameter metadata is matched against the live mappings on
+ * every resolution: a mapping registered after the component's first
+ * resolution must still be injected on subsequent resolutions.
+ */
+component {
+
+	public any function init(any simpleService = "") {
+		variables.simpleService = arguments.simpleService;
+		return this;
+	}
+
+	public boolean function hasDependency() {
+		return IsObject(variables.simpleService);
+	}
+
+}

--- a/vendor/wheels/tests/_assets/di/SimpleService.cfc
+++ b/vendor/wheels/tests/_assets/di/SimpleService.cfc
@@ -16,4 +16,15 @@ component {
 		return "hello";
 	}
 
+	// Marker accessors so specs can verify instance identity (shared vs
+	// distinct instances) without relying on engine-specific object-equality
+	// semantics or external property assignment.
+	public void function setMarker(required string value) {
+		variables.marker = arguments.value;
+	}
+
+	public string function getMarker() {
+		return structKeyExists(variables, "marker") ? variables.marker : "";
+	}
+
 }

--- a/vendor/wheels/tests/_assets/packages_lazy_sp/lazylate/Lazylate.cfc
+++ b/vendor/wheels/tests/_assets/packages_lazy_sp/lazylate/Lazylate.cfc
@@ -1,0 +1,24 @@
+/**
+ * Test fixture: lazy ServiceProvider package with NO provides.services hint.
+ * It stays lazy through the boot lifecycle; when getPackage() instantiates it
+ * after boot, the loader must invoke register()/boot() late so its services
+ * are not silently missing.
+ */
+component implements="wheels.ServiceProviderInterface" {
+
+	public any function init() {
+		this.version = "1.0.0";
+		this.registerCalled = false;
+		this.bootCalled = false;
+		return this;
+	}
+
+	public void function register(required any container) {
+		this.registerCalled = true;
+	}
+
+	public void function boot(required struct app) {
+		this.bootCalled = true;
+	}
+
+}

--- a/vendor/wheels/tests/_assets/packages_lazy_sp/lazylate/package.json
+++ b/vendor/wheels/tests/_assets/packages_lazy_sp/lazylate/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "wheels-lazylate",
+	"version": "1.0.0",
+	"description": "Test fixture: lazy ServiceProvider WITHOUT a services hint — stays lazy through boot; register()/boot() must run on late instantiation.",
+	"lazy": true,
+	"provides": {
+		"mixins": "none"
+	}
+}

--- a/vendor/wheels/tests/_assets/packages_lazy_sp/lazysvc/Lazysvc.cfc
+++ b/vendor/wheels/tests/_assets/packages_lazy_sp/lazysvc/Lazysvc.cfc
@@ -1,0 +1,24 @@
+/**
+ * Test fixture: lazy service-only ServiceProvider package. Declares
+ * provides.services in its manifest, so the loader must instantiate it into
+ * the ServiceProvider lifecycle at boot — otherwise the services it exists
+ * to register would silently never register.
+ */
+component implements="wheels.ServiceProviderInterface" {
+
+	public any function init() {
+		this.version = "1.0.0";
+		this.registerCalled = false;
+		this.bootCalled = false;
+		return this;
+	}
+
+	public void function register(required any container) {
+		this.registerCalled = true;
+	}
+
+	public void function boot(required struct app) {
+		this.bootCalled = true;
+	}
+
+}

--- a/vendor/wheels/tests/_assets/packages_lazy_sp/lazysvc/package.json
+++ b/vendor/wheels/tests/_assets/packages_lazy_sp/lazysvc/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "wheels-lazysvc",
+	"version": "1.0.0",
+	"description": "Test fixture: lazy service-only ServiceProvider — must be pulled into the register()/boot() lifecycle at boot.",
+	"lazy": true,
+	"provides": {
+		"mixins": "none",
+		"services": ["lazyGreeter"]
+	}
+}

--- a/vendor/wheels/tests/specs/di/InjectorSpec.cfc
+++ b/vendor/wheels/tests/specs/di/InjectorSpec.cfc
@@ -55,6 +55,53 @@ component extends="wheels.WheelsTest" {
 					expect(first).toBe(second);
 				});
 
+				it("keys the singleton cache by mapping name, so two singleton aliases to one path get distinct instances", () => {
+					di.map("singletonAliasA").to("wheels.tests._assets.di.SimpleService").asSingleton();
+					di.map("singletonAliasB").to("wheels.tests._assets.di.SimpleService").asSingleton();
+					var a1 = di.getInstance("singletonAliasA");
+					// Mark the cached instance so reference identity can be
+					// verified without relying on object-equality semantics.
+					a1.setMarker("aliasA");
+					var a2 = di.getInstance("singletonAliasA");
+					expect(a2.getMarker()).toBe("aliasA");
+					// Each singleton MAPPING gets its own instance — previously
+					// the cache was keyed by component path, so both aliases
+					// silently shared one instance.
+					var b = di.getInstance("singletonAliasB");
+					expect(b.getMarker()).toBe("");
+				});
+
+				it("does not give a transient alias the singleton instance of a shared component path", () => {
+					di.map("sharedSingleton").to("wheels.tests._assets.di.SimpleService").asSingleton();
+					di.map("sharedTransient").to("wheels.tests._assets.di.SimpleService");
+					var s1 = di.getInstance("sharedSingleton");
+					s1.setMarker("singleton");
+					var s2 = di.getInstance("sharedSingleton");
+					expect(s2.getMarker()).toBe("singleton");
+					var t = di.getInstance("sharedTransient");
+					expect(t.getMarker()).toBe("");
+				});
+
+				it("invalidates a cached singleton when the alias is re-bound to a different component path", () => {
+					di.map("rebindable").to("wheels.tests._assets.di.SimpleService").asSingleton();
+					var before = di.getInstance("rebindable");
+					expect(before.greet()).toBe("hello");
+					// Re-bind to a different implementation: the stale cached
+					// instance must not keep being served.
+					di.map("rebindable").to("wheels.tests._assets.di.OptionalDependentService").asSingleton();
+					var after = di.getInstance("rebindable");
+					expect(structKeyExists(after, "hasDependency")).toBeTrue();
+				});
+
+				it("keeps the cached singleton when the alias is re-registered with the same path (dev-reload pattern)", () => {
+					di.map("stableSingleton").to("wheels.tests._assets.di.SimpleService").asSingleton();
+					var before = di.getInstance("stableSingleton");
+					before.setMarker("stable");
+					di.map("stableSingleton").to("wheels.tests._assets.di.SimpleService").asSingleton();
+					var after = di.getInstance("stableSingleton");
+					expect(after.getMarker()).toBe("stable");
+				});
+
 				it("creates new transient instances each call", () => {
 					di.map("simpleService").to("wheels.tests._assets.di.SimpleService");
 					var first = di.getInstance("simpleService");
@@ -169,6 +216,40 @@ component extends="wheels.WheelsTest" {
 					var manual = new wheels.tests._assets.di.SimpleService();
 					var svc = di.getInstance(name="dependentService", initArguments={simpleService: manual});
 					expect(svc.getSimpleService()).toBe(manual);
+				});
+
+				it("auto-wires an inherited init() found via the extends chain", () => {
+					// InheritedDependentService declares no init() of its own;
+					// the inherited init(simpleService) lives under the extends
+					// node of the metadata. Previously only top-level functions
+					// were scanned, so resolution called bare init() and threw
+					// a missing-required-argument error.
+					di.map("simpleService").to("wheels.tests._assets.di.SimpleService");
+					di.map("inheritedDependentService").to("wheels.tests._assets.di.InheritedDependentService");
+					var svc = di.getInstance("inheritedDependentService");
+					expect(svc.delegateGreet()).toBe("hello");
+					expect(svc.shout()).toBe("HELLO");
+				});
+
+				it("memoized init metadata still auto-wires on repeated transient resolutions", () => {
+					di.map("simpleService").to("wheels.tests._assets.di.SimpleService");
+					di.map("dependentService").to("wheels.tests._assets.di.DependentService");
+					var first = di.getInstance("dependentService");
+					var second = di.getInstance("dependentService");
+					expect(first.delegateGreet()).toBe("hello");
+					expect(second.delegateGreet()).toBe("hello");
+				});
+
+				it("matches cached init() parameter names against live mappings (late registration)", () => {
+					// Only the parameter NAMES are memoized — a mapping
+					// registered after the component's first resolution must
+					// still be injected on the next resolution.
+					di.map("optionalDependentService").to("wheels.tests._assets.di.OptionalDependentService");
+					var before = di.getInstance("optionalDependentService");
+					expect(before.hasDependency()).toBeFalse();
+					di.map("simpleService").to("wheels.tests._assets.di.SimpleService");
+					var after = di.getInstance("optionalDependentService");
+					expect(after.hasDependency()).toBeTrue();
 				});
 
 				it("throws on circular dependency", () => {

--- a/vendor/wheels/tests/specs/global/mixinCollisionShapeSpec.cfc
+++ b/vendor/wheels/tests/specs/global/mixinCollisionShapeSpec.cfc
@@ -1,0 +1,88 @@
+/**
+ * Mixin-collision records reach application.wheels.mixinCollisions from three
+ * producers: Plugins.cfc (legacy shape: existingPlugin/overridingPlugin),
+ * PackageLoader.cfc, and the cross-system merge in Global.cfc::$loadPackages
+ * (shared shape: firstProvider/secondProvider). The debug surfaces
+ * (/wheels/plugins, the dev debug footer) consume the array unconditionally,
+ * so every record must be normalized to ONE shape at the merge point —
+ * previously a package-sourced record crashed both surfaces with
+ * "key [EXISTINGPLUGIN] doesn't exist".
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("$normalizeMixinCollisions", () => {
+
+			it("maps legacy plugin-shaped records to the shared shape", () => {
+				var normalized = application.wo.$normalizeMixinCollisions([
+					{
+						method = "$collidingHelper",
+						target = "controller",
+						existingPlugin = "PluginA",
+						overridingPlugin = "PluginB"
+					}
+				]);
+
+				expect(ArrayLen(normalized)).toBe(1);
+				expect(normalized[1].target).toBe("controller");
+				expect(normalized[1].method).toBe("$collidingHelper");
+				expect(normalized[1].firstProvider).toBe("PluginA");
+				expect(normalized[1].secondProvider).toBe("PluginB");
+				expect(normalized[1].acknowledged).toBeFalse();
+				expect(normalized[1].source).toBe("plugin");
+			});
+
+			it("passes already-shared-shape records through unchanged", () => {
+				var normalized = application.wo.$normalizeMixinCollisions([
+					{
+						method = "$pkgHelper",
+						target = "model",
+						firstProvider = "wheels-pkgA",
+						secondProvider = "wheels-pkgB",
+						acknowledged = true,
+						source = "package"
+					}
+				]);
+
+				expect(normalized[1].firstProvider).toBe("wheels-pkgA");
+				expect(normalized[1].secondProvider).toBe("wheels-pkgB");
+				expect(normalized[1].acknowledged).toBeTrue();
+				expect(normalized[1].source).toBe("package");
+			});
+
+			it("normalizes mixed-shape arrays so every record exposes the shared keys", () => {
+				var normalized = application.wo.$normalizeMixinCollisions([
+					{
+						method = "$one",
+						target = "controller",
+						existingPlugin = "PluginA",
+						overridingPlugin = "PluginB"
+					},
+					{
+						method = "$two",
+						target = "controller",
+						firstProvider = "wheels-pkgA",
+						secondProvider = "wheels-pkgB",
+						acknowledged = false,
+						source = "cross"
+					}
+				]);
+
+				for (var rec in normalized) {
+					expect(rec).toHaveKey("firstProvider");
+					expect(rec).toHaveKey("secondProvider");
+					expect(rec).toHaveKey("acknowledged");
+					expect(rec).toHaveKey("source");
+				}
+			});
+
+			it("returns an empty array for no collisions", () => {
+				expect(application.wo.$normalizeMixinCollisions([])).toHaveLength(0);
+			});
+
+		});
+
+	}
+
+}

--- a/vendor/wheels/tests/specs/interfaces/InjectorInterfaceSpec.cfc
+++ b/vendor/wheels/tests/specs/interfaces/InjectorInterfaceSpec.cfc
@@ -57,14 +57,22 @@ component extends="wheels.WheelsTest" {
 						"ViewContentInterface",
 						"RouteMapperInterface",
 						"RouteResolverInterface",
-						"EventHandlerInterface",
-						"InjectorInterface"
+						"EventHandlerInterface"
 					];
 					for (var name in bindings) {
 						expect(di.containsInstance(name)).toBeTrue(
 							"Missing DI binding: #name#"
 						);
 					}
+				});
+
+				it("does not register a dead InjectorInterface binding", () => {
+					// The live container self-registers at application.wheelsdi.
+					// A path binding for InjectorInterface could never resolve
+					// (init() requires a binderPath no auto-wire mapping supplies)
+					// and, if it ever did, would clobber the live container.
+					var di = new wheels.Injector(binderPath="wheels.Bindings");
+					expect(di.containsInstance("InjectorInterface")).toBeFalse();
 				});
 
 				it("all interface bindings resolve to real components", () => {
@@ -87,8 +95,7 @@ component extends="wheels.WheelsTest" {
 						"ViewContentInterface",
 						"RouteMapperInterface",
 						"RouteResolverInterface",
-						"EventHandlerInterface",
-						"InjectorInterface"
+						"EventHandlerInterface"
 					];
 					for (var name in bindings) {
 						if (di.containsInstance(name)) {

--- a/vendor/wheels/tests/specs/packages/LazyServiceProviderSpec.cfc
+++ b/vendor/wheels/tests/specs/packages/LazyServiceProviderSpec.cfc
@@ -1,0 +1,102 @@
+/**
+ * Lazy ServiceProvider lifecycle coverage.
+ *
+ * A "service-only" lazy package (the documented lazy use case) previously
+ * never had register()/boot() invoked: variables.serviceProviders was only
+ * populated by eager instantiation, and late instantiation appended to the
+ * array without ever running the lifecycle — so the package's services were
+ * silently missing, surfacing later as Wheels.DI.ServiceNotFound with no
+ * failedPackages entry.
+ *
+ * Fixtures live in /wheels/tests/_assets/packages_lazy_sp:
+ * - lazysvc:  lazy + provides.services hint — must join the lifecycle at boot.
+ * - lazylate: lazy, no services hint — stays lazy through boot; register()/
+ *             boot() must run when getPackage() instantiates it afterwards.
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("Lazy ServiceProvider packages", () => {
+
+			beforeEach(() => {
+				lazyFixturesPath = ExpandPath("/wheels/tests/_assets/packages_lazy_sp");
+				lazyFixturesPrefix = "wheels.tests._assets.packages_lazy_sp";
+			});
+
+			it("reports lifecycle work when only lazy packages are present", () => {
+				var loader = new wheels.PackageLoader(
+					vendorPath = lazyFixturesPath,
+					componentPrefix = lazyFixturesPrefix
+				);
+
+				// Nothing is instantiated at discovery time...
+				expect(loader.getPackages()).notToHaveKey("lazysvc");
+				expect(loader.getPackages()).notToHaveKey("lazylate");
+				expect(ArrayLen(loader.getServiceProviders())).toBe(0);
+
+				// ...but the loader knows the lifecycle still has work to do,
+				// so Global.cfc's gate invokes register()/boot().
+				expect(loader.$hasServiceProviderWork()).toBeTrue();
+			});
+
+			it("invokes register() and boot() on a lazy package that hints services", () => {
+				var loader = new wheels.PackageLoader(
+					vendorPath = lazyFixturesPath,
+					componentPrefix = lazyFixturesPrefix
+				);
+				var fakeContainer = CreateObject(
+					"component",
+					"wheels.tests._assets.plugins.serviceprovider.FakeContainer"
+				).init();
+
+				loader.$invokeServiceProviderRegister(fakeContainer);
+				loader.$invokeServiceProviderBoot({});
+
+				var pkgs = loader.getPackages();
+				expect(pkgs).toHaveKey("lazysvc");
+				expect(pkgs.lazysvc.registerCalled).toBeTrue();
+				expect(pkgs.lazysvc.bootCalled).toBeTrue();
+			});
+
+			it("leaves a lazy provider without a services hint un-instantiated through boot", () => {
+				var loader = new wheels.PackageLoader(
+					vendorPath = lazyFixturesPath,
+					componentPrefix = lazyFixturesPrefix
+				);
+				var fakeContainer = CreateObject(
+					"component",
+					"wheels.tests._assets.plugins.serviceprovider.FakeContainer"
+				).init();
+
+				loader.$invokeServiceProviderRegister(fakeContainer);
+				loader.$invokeServiceProviderBoot({});
+
+				// Unhinted lazy packages keep their laziness.
+				expect(loader.getPackages()).notToHaveKey("lazylate");
+				expect(loader.isPackageLoaded("lazylate")).toBeTrue();
+			});
+
+			it("invokes register()/boot() when an unhinted lazy provider is instantiated after boot", () => {
+				var loader = new wheels.PackageLoader(
+					vendorPath = lazyFixturesPath,
+					componentPrefix = lazyFixturesPrefix
+				);
+				var fakeContainer = CreateObject(
+					"component",
+					"wheels.tests._assets.plugins.serviceprovider.FakeContainer"
+				).init();
+
+				loader.$invokeServiceProviderRegister(fakeContainer);
+				loader.$invokeServiceProviderBoot({});
+
+				var pkg = loader.getPackage("lazylate");
+				expect(pkg.registerCalled).toBeTrue();
+				expect(pkg.bootCalled).toBeTrue();
+			});
+
+		});
+
+	}
+
+}

--- a/vendor/wheels/tests/specs/packages/ModuleGraphSpec.cfc
+++ b/vendor/wheels/tests/specs/packages/ModuleGraphSpec.cfc
@@ -223,6 +223,130 @@ component extends="wheels.WheelsTest" {
 					expect(ArrayFind(result.loadOrder, "cycleB")).toBe(0);
 				});
 
+				it("does not label a downstream dependent of a cycle as circular itself", () => {
+					var manifests = {
+						"cycleA": {
+							name: "wheels-cycleA", version: "1.0.0",
+							requires: {"wheels-cycleB": ">=1.0.0"}
+						},
+						"cycleB": {
+							name: "wheels-cycleB", version: "1.0.0",
+							requires: {"wheels-cycleA": ">=1.0.0"}
+						},
+						"downstream": {
+							name: "wheels-downstream", version: "1.0.0",
+							requires: {"wheels-cycleA": ">=1.0.0"}
+						}
+					};
+					var result = graph.resolve(manifests);
+
+					// downstream cannot load (its dependency is cycled)...
+					expect(ArrayFind(result.loadOrder, "downstream")).toBe(0);
+
+					var downstreamMessage = "";
+					var cycleMessages = [];
+					for (var err in result.errors) {
+						if (err.package == "downstream") {
+							downstreamMessage = err.message;
+						}
+						if (err.package == "cycleA" || err.package == "cycleB") {
+							ArrayAppend(cycleMessages, err.message);
+						}
+					}
+
+					// ...but its error must say it depends on a cycle, not
+					// that it IS one (previously it got the same fabricated
+					// "Circular dependency detected" message).
+					expect(Len(downstreamMessage)).toBeGT(0);
+					expect(downstreamMessage).notToInclude("Circular dependency detected");
+					expect(downstreamMessage).toInclude("circular dependency");
+					expect(downstreamMessage).toInclude("cycleA");
+					expect(downstreamMessage).toInclude("cycleB");
+
+					// The true cycle members still get the circular error.
+					expect(ArrayLen(cycleMessages)).toBe(2);
+					for (var msg in cycleMessages) {
+						expect(msg).toInclude("Circular dependency detected");
+					}
+				});
+
+				it("reports an actual closed cycle path in the arrow chain", () => {
+					var manifests = {
+						"cycleA": {
+							name: "wheels-cycleA", version: "1.0.0",
+							requires: {"wheels-cycleB": ">=1.0.0"}
+						},
+						"cycleB": {
+							name: "wheels-cycleB", version: "1.0.0",
+							requires: {"wheels-cycleA": ">=1.0.0"}
+						}
+					};
+					var result = graph.resolve(manifests);
+
+					var chainMessage = "";
+					for (var err in result.errors) {
+						if (err.package == "cycleA") {
+							chainMessage = err.message;
+						}
+					}
+					expect(Len(chainMessage)).toBeGT(0);
+
+					// The arrow chain must be a real closed loop (first node ==
+					// last node), not just an unordered listing of leftover
+					// nodes from the topological sort.
+					var arrowChain = Trim(ListLast(chainMessage, ":"));
+					var chainNodes = ListToArray(arrowChain, " ->");
+					expect(ArrayLen(chainNodes)).toBeGTE(3);
+					expect(chainNodes[1]).toBe(chainNodes[ArrayLen(chainNodes)]);
+				});
+
+			});
+
+			describe("resolve() with mutual replaces", () => {
+
+				it("keeps exactly one of two mutually-replacing packages", () => {
+					var manifests = {
+						"alpha": {
+							name: "wheels-alpha", version: "1.0.0",
+							replaces: {"wheels-beta": "*"}
+						},
+						"beta": {
+							name: "wheels-beta", version: "1.0.0",
+							replaces: {"wheels-alpha": "*"}
+						}
+					};
+					var result = graph.resolve(manifests);
+
+					// Previously BOTH packages were excluded with no error.
+					// Now the first package in sorted order wins; the other is
+					// excluded — exactly one survives, deterministically.
+					expect(ArrayFind(result.loadOrder, "alpha")).toBeGT(0);
+					expect(result.excluded).toHaveKey("beta");
+					expect(result.excluded).notToHaveKey("alpha");
+				});
+
+				it("ignores replaces declared by an already-excluded package", () => {
+					var manifests = {
+						"aaa": {
+							name: "wheels-aaa", version: "1.0.0",
+							replaces: {"wheels-bbb": "*"}
+						},
+						"bbb": {
+							name: "wheels-bbb", version: "1.0.0",
+							replaces: {"wheels-ccc": "*"}
+						},
+						"ccc": {name: "wheels-ccc", version: "1.0.0"}
+					};
+					var result = graph.resolve(manifests);
+
+					// aaa excludes bbb; bbb never loads, so its replaces
+					// declaration against ccc must not apply.
+					expect(result.excluded).toHaveKey("bbb");
+					expect(result.excluded).notToHaveKey("ccc");
+					expect(ArrayFind(result.loadOrder, "aaa")).toBeGT(0);
+					expect(ArrayFind(result.loadOrder, "ccc")).toBeGT(0);
+				});
+
 			});
 
 		});

--- a/vendor/wheels/tests/specs/semverSpec.cfc
+++ b/vendor/wheels/tests/specs/semverSpec.cfc
@@ -192,6 +192,47 @@ component extends="wheels.WheelsTest" {
 			})
 		})
 
+		describe("SemVer constraints with a space after the operator", function() {
+
+			beforeEach(function() {
+				semver = CreateObject("component", "wheels.SemVer")
+			})
+
+			it("treats '>= X' as a range constraint, not an exact match", function() {
+				// Previously '>= 1.0.0' split into '>=' (empty target, always
+				// true) AND '1.0.0' (exact match) — silently '=1.0.0'.
+				expect(semver.satisfiesAll("1.5.0", ">= 1.0.0")).toBeTrue()
+				expect(semver.satisfiesAll("1.0.0", ">= 1.0.0")).toBeTrue()
+				expect(semver.satisfiesAll("0.9.0", ">= 1.0.0")).toBeFalse()
+			})
+
+			it("treats '^ X' as a caret range", function() {
+				// Previously '^ 1.2.3' was unsatisfiable.
+				expect(semver.satisfiesAll("1.5.0", "^ 1.2.3")).toBeTrue()
+				expect(semver.satisfiesAll("1.2.3", "^ 1.2.3")).toBeTrue()
+				expect(semver.satisfiesAll("2.0.0", "^ 1.2.3")).toBeFalse()
+			})
+
+			it("treats '~ X' as a tilde range", function() {
+				expect(semver.satisfiesAll("1.2.5", "~ 1.2.3")).toBeTrue()
+				expect(semver.satisfiesAll("1.3.0", "~ 1.2.3")).toBeFalse()
+			})
+
+			it("handles spaced operators inside compound constraints", function() {
+				expect(semver.satisfiesAll("1.5.0", ">= 1.0.0 < 2.0.0")).toBeTrue()
+				expect(semver.satisfiesAll("2.1.0", ">= 1.0.0 < 2.0.0")).toBeFalse()
+				expect(semver.satisfiesAll("1.5.0", ">=1.0.0 < 2.0.0")).toBeTrue()
+			})
+
+			it("fails closed on an operator with no target", function() {
+				expect(semver.satisfies("1.0.0", ">=")).toBeFalse()
+				expect(semver.satisfies("1.0.0", "^")).toBeFalse()
+				expect(semver.satisfies("1.0.0", "~")).toBeFalse()
+				expect(semver.satisfiesAll("1.0.0", ">=")).toBeFalse()
+				expect(semver.satisfiesAll("1.0.0", ">=1.0.0 <")).toBeFalse()
+			})
+		})
+
 		describe("SemVer format", function() {
 
 			beforeEach(function() {


### PR DESCRIPTION
## Summary

Fixes the eight findings of the **di-container** package from the 2026-06-09 framework review: singleton-cache keying/locking and init-param memoization in the DI container, SemVer space-separated operator parsing, lazy-package ServiceProvider lifecycle participation, mixin-collision record-shape normalization, module-graph cycle diagnostics and deterministic mutual `replaces`, and removal of a dead `InjectorInterface` binding.

## Findings addressed

- **DI3 — singleton cache keyed by component path while `asSingleton()` flags are keyed by mapping name** @ `vendor/wheels/Injector.cfc:121-206`. Cache re-keyed by mapping name (same key as the flags, so two aliases to one path get distinct instances), singleton construction wrapped in a double-checked named lock with a per-container UUID prefix (`Injector.cfc:170`), and construction extracted into `$constructInstance` (`Injector.cfc:206`) shared by singleton/request-scoped/transient paths. `to()` invalidates a cached instance only when the alias re-binds to a *different* path (dev-reload keeps it).
- **DI13 — `init()` metadata scanned on every transient resolution and inherited `init()` ignored** @ `vendor/wheels/Injector.cfc:356-374`. Init-param *names* are memoized per component path, and `$scanInitParameterNames` walks the `extends` chain so an inherited `init()` participates in constructor auto-wiring as advertised. Late-registered mappings are still honored (names, not resolved instances, are cached).
- **DI2 — space-separated SemVer operators degrade to exact match / unsatisfiable** @ `vendor/wheels/SemVer.cfc:93-156`. `satisfiesAll` merges an operator-only token (`^(>=|<=|[><=^~])$`) with the following token (`SemVer.cfc:151`), so `">= 1.0.0"` keeps range semantics; an operator with an empty target now fails closed across all seven operators including the `^`/`~` early-returns (`SemVer.cfc:93-106`).
- **DI9 — lazy packages never join the ServiceProvider lifecycle** @ `vendor/wheels/PackageLoader.cfc:908-951` + `vendor/wheels/Global.cfc:3220-3224`. Service-hinted lazy packages are instantiated in `$invokeServiceProviderRegister` *before* the provider snapshot, joining both register and boot loops; an unhinted lazy provider instantiated post-boot gets `register()`/`boot()` invoked late via the captured lifecycle context, with failures routed to `failedPackages` + `$rollbackPackage`. The `$loadPackages` gate now asks `$hasServiceProviderWork()` so a vendor tree with only lazy service packages still runs the lifecycle.
- **DI1 — mixin-collision records have two incompatible shapes** @ `vendor/wheels/Global.cfc:3077` (`$normalizeMixinCollisions`), `vendor/wheels/public/views/plugins.cfm:89`, `vendor/wheels/events/onrequestend/debug.cfm:404`. Plugin-shaped records (`{existingPlugin, overridingPlugin}`) are normalized to the shared `{firstProvider, secondProvider, acknowledged, source}` shape at the merge point; both debug surfaces now read one shape. `Plugins.cfc`'s own `getMixinCollisions()` API keeps the legacy shape (pinned by `pluginsModernSpec`).
- **DI6 — cycle diagnostics conflate true cycle members with downstream dependents** @ `vendor/wheels/ModuleGraph.cfc:310` (`$classifyCycleNodes`, self-reachability DFS within the unprocessed set) and `vendor/wheels/ModuleGraph.cfc:393` (`$findCyclePath`). Members get a real closed arrow chain (first == last asserted in spec); dependents get a distinct "depends on package(s) involved in a circular dependency" message. The dead `inDegree` bookkeeping was dropped from `$buildAdjacencyList` (`$topologicalSort` recomputes it locally; no other consumer).
- **DI11 — mutual `replaces` non-deterministically removes both packages** @ `vendor/wheels/ModuleGraph.cfc:107` (`$processReplacements`). Declarations are processed in sorted directory order and declarations from already-excluded packages are skipped, so mutual replaces deterministically keep the lexicographically-first package.
- **DI5 — dead `InjectorInterface` binding that could never resolve** @ `vendor/wheels/Bindings.cfc:52`. Removed with an explanatory comment; grep confirms zero resolvers of `"InjectorInterface"` anywhere in `vendor/` or `cli/`.

## Findings verified already-fixed

None — all eight findings were still present on `origin/develop` (spot-checked during review: the path-keyed singleton cache, the unmerged `satisfiesAll` tokenization, and the `Bindings.cfc` `InjectorInterface` binding were all confirmed in the pre-image).

## Source

Internal multi-agent framework review, 2026-06-09 — wave 2, package **di-container**.

## Tests

New/updated specs (WheelsTest BDD, red-verified against pre-fix code):

- `vendor/wheels/tests/specs/di/InjectorSpec.cfc` — singleton cache keyed by mapping name (fails pre-fix); inherited-`init()` auto-wiring (errors pre-fix); late-registered mapping still honored after memoization. Fixtures under `vendor/wheels/tests/_assets/di/`.
- `vendor/wheels/tests/specs/semverSpec.cfc` — 5 specs fail pre-fix (space-separated operators, fail-closed empty targets).
- `vendor/wheels/tests/specs/packages/ModuleGraphSpec.cfc` — 4 specs fail pre-fix (member vs dependent classification, closed cycle path, deterministic mutual replaces).
- `vendor/wheels/tests/specs/packages/LazyServiceProviderSpec.cfc` — 2 fail + 1 error pre-fix (`$hasServiceProviderWork` missing). Fixtures under `vendor/wheels/tests/_assets/packages_lazy_sp/`.
- `vendor/wheels/tests/specs/global/mixinCollisionShapeSpec.cfc` — pins the normalized record shape.
- `vendor/wheels/tests/specs/interfaces/InjectorInterfaceSpec.cfc` — updated to assert the binding's absence.

Local verification: implementation run green on Lucee 7 + SQLite. Reviewer independently re-traced red-on-develop for every claimed red spec (counts matched exactly). Full engine × DB matrix deferred to CI, which is the real gate for Adobe/BoxLang coverage.

## Cross-engine notes

- The script-syntax named lock in `Injector.cfc` follows existing prior art (`Global.cfc:31`, `TenantMigrator`).
- `$findCyclePath` explicitly `Duplicate()`s path arrays before struct-literal insertion (Adobe CF copies arrays by value in struct literals — invariant 6), with a docstring noting why.
- No `local.X` reads after `catch` bodies (BoxLang invariant 11), no `Left(str, 0)` (Lucee 7), no `arguments` passed as `attributeCollection`.
- The new `Global.cfc` helper follows the public `$`-prefix mixin convention (invariant 7).
- `/wheels/plugins` JSON debug payload key rename (`existingPlugin` → `firstProvider`) is a dev-surface contract change; the old shape crashed on any package-sourced record, so nothing functional could have depended on it.

## Changelog

Entry deliberately omitted; consolidated at campaign end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
