### PR TITLE
fix(cli): belongsTo scaffold views, API test signatures, cross-engine migration catches

### DIFF
--- a/app/snippets/DBMigrate.txt
+++ b/app/snippets/DBMigrate.txt
@@ -1,16 +1,17 @@
 component extends="wheels.migrator.Migration" hint="|DBMigrateHINT|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				|DBMigrateUP|
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				throw(errorCode="1", detail=local.exception.detail, message=local.exception.message, type="any");
+				throw(errorCode="1", detail=state.exception.detail, message=state.exception.message, type="any");
 			} else {
 				transaction action="commit";
 			}
@@ -18,16 +19,17 @@ component extends="wheels.migrator.Migration" hint="|DBMigrateHINT|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 		  try {
 				|DBMigrateDOWN|
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				throw(errorCode="1", detail=local.exception.detail, message=local.exception.message, type="any");
+				throw(errorCode="1", detail=state.exception.detail, message=state.exception.message, type="any");
 			} else {
 				transaction action="commit";
 			}

--- a/app/snippets/dbmigrate/blank.txt
+++ b/app/snippets/dbmigrate/blank.txt
@@ -1,16 +1,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				// your code goes here
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -18,16 +19,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				// your code goes here
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/app/snippets/dbmigrate/change-column.txt
+++ b/app/snippets/dbmigrate/change-column.txt
@@ -20,16 +20,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				changeColumn(table = '|tableName|', columnType = '', columnName = 'columnName', default = '', allowNull = true);
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -37,16 +38,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				changeColumn(table = '|tableName|', columnName = 'columnName');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/app/snippets/dbmigrate/change-table.txt
+++ b/app/snippets/dbmigrate/change-table.txt
@@ -13,17 +13,18 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				t = changeTable('|tableName|');
 				t.change();
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -31,16 +32,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				removeColumn(table = '|tableName|', columnName = 'columnName');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/app/snippets/dbmigrate/create-column.txt
+++ b/app/snippets/dbmigrate/create-column.txt
@@ -19,16 +19,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				addColumn(table = '|tableName|', columnType = '|columnType|', columnName = '|columnName|' |arguments|);
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -36,16 +37,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				removeColumn(table = '|tableName|', columnName = '|columnName|');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/app/snippets/dbmigrate/create-index.txt
+++ b/app/snippets/dbmigrate/create-index.txt
@@ -14,16 +14,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				addIndex(table = '|tableName|', columnNames = 'columnName', unique = true);
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -31,16 +32,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				removeIndex(table = '|tableName|', indexName = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/app/snippets/dbmigrate/create-record.txt
+++ b/app/snippets/dbmigrate/create-record.txt
@@ -12,16 +12,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				addRecord(table = '|tableName|', field = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -29,16 +30,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				removeRecord(table = '|tableName|', where = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/app/snippets/dbmigrate/create-table.txt
+++ b/app/snippets/dbmigrate/create-table.txt
@@ -29,18 +29,19 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				t = createTable(name = '|tableName|', force='|force|', id='|id|', primaryKey='|primaryKey|');
 				t.timestamps();
 				t.create();
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -48,16 +49,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				dropTable('|tableName|');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/app/snippets/dbmigrate/execute.txt
+++ b/app/snippets/dbmigrate/execute.txt
@@ -1,16 +1,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				execute('');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -18,16 +19,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				execute('');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/app/snippets/dbmigrate/remove-column.txt
+++ b/app/snippets/dbmigrate/remove-column.txt
@@ -13,16 +13,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				removeColumn(table = '|tableName|', columnName = 'columnName');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -30,16 +31,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				addColumn(table = '|tableName|', columnType = '', columnName = 'columnName', default = '', allowNull = true);
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/app/snippets/dbmigrate/remove-index.txt
+++ b/app/snippets/dbmigrate/remove-index.txt
@@ -12,16 +12,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				removeIndex(table = '|tableName|', indexName = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -29,16 +30,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				addIndex(table = '|tableName|', columnNames = 'columnName', unique = true);
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/app/snippets/dbmigrate/remove-record.txt
+++ b/app/snippets/dbmigrate/remove-record.txt
@@ -12,16 +12,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				removeRecord(table = '|tableName|', where = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -29,16 +30,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				addRecord(table = '|tableName|', field = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/app/snippets/dbmigrate/remove-table.txt
+++ b/app/snippets/dbmigrate/remove-table.txt
@@ -11,16 +11,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				dropTable(name = '|tableName|');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -28,18 +29,19 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				t = createTable(name = '|tableName|');
 				t.timestamps();
 				t.create();
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/app/snippets/dbmigrate/rename-column.txt
+++ b/app/snippets/dbmigrate/rename-column.txt
@@ -13,16 +13,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				renameColumn(table = '|tableName|', columnName = 'columnName', newColumnName = 'newColumnName');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -30,16 +31,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				renameColumn(table = '|tableName|', columnName = 'columnName', newColumnName = 'newColumnName');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/app/snippets/dbmigrate/rename-table.txt
+++ b/app/snippets/dbmigrate/rename-table.txt
@@ -12,16 +12,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				renameTable(oldName = '', newName = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -29,16 +30,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				renameTable(oldName = '', newName = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/app/snippets/dbmigrate/update-record.txt
+++ b/app/snippets/dbmigrate/update-record.txt
@@ -13,16 +13,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				updateRecord(table = '|tableName|', where = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -30,16 +31,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				updateRecord(table = '|tableName|', where = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/cli/lucli/services/Scaffold.cfc
+++ b/cli/lucli/services/Scaffold.cfc
@@ -572,6 +572,13 @@ component {
 		var nl = chr(10);
 		var t = chr(9);
 
+		// processRequest() takes a params STRUCT (with the route NAME inside it,
+		// not a URL path) and needs returnAs="struct" for the result to expose
+		// `status`. Routes added by updateApiRoutes() live in .namespace("api"),
+		// which prefixes child route names: apiProducts / apiProduct.
+		var collectionRoute = "api" & variables.helpers.capitalize(plural);
+		var memberRoute = "api" & variables.helpers.capitalize(singular);
+
 		var c = 'component extends="wheels.WheelsTest" {' & nl & nl;
 		c &= t & 'function run() {' & nl;
 		c &= t & t & 'describe("API #arguments.controllerName# Controller", () => {' & nl & nl;
@@ -579,24 +586,24 @@ component {
 		c &= t & t & t & t & '// Setup test data' & nl;
 		c &= t & t & t & '})' & nl & nl;
 		c &= t & t & t & 'it("GET /api/#plural# returns JSON list", () => {' & nl;
-		c &= t & t & t & t & 'result = processRequest(route="/api/#plural#", method="get", params={format: "json"});' & nl;
+		c &= t & t & t & t & 'result = processRequest(params={route: "#collectionRoute#", format: "json"}, method="get", returnAs="struct");' & nl;
 		c &= t & t & t & t & 'expect(result).toHaveKey("status");' & nl;
 		c &= t & t & t & t & 'expect(result.status).toBe(200);' & nl;
 		c &= t & t & t & '})' & nl & nl;
 		c &= t & t & t & 'it("GET /api/#plural#/:key returns JSON record", () => {' & nl;
-		c &= t & t & t & t & 'result = processRequest(route="/api/#plural#/1", method="get", params={format: "json"});' & nl;
+		c &= t & t & t & t & 'result = processRequest(params={route: "#memberRoute#", key: 1, format: "json"}, method="get", returnAs="struct");' & nl;
 		c &= t & t & t & t & 'expect(result).toHaveKey("status");' & nl;
 		c &= t & t & t & '})' & nl & nl;
 		c &= t & t & t & 'it("POST /api/#plural# creates record", () => {' & nl;
-		c &= t & t & t & t & 'result = processRequest(route="/api/#plural#", method="post", params={format: "json", #singular#: {}});' & nl;
+		c &= t & t & t & t & 'result = processRequest(params={route: "#collectionRoute#", format: "json", #singular#: {}}, method="post", returnAs="struct");' & nl;
 		c &= t & t & t & t & 'expect(result).toHaveKey("status");' & nl;
 		c &= t & t & t & '})' & nl & nl;
 		c &= t & t & t & 'it("PUT /api/#plural#/:key updates record", () => {' & nl;
-		c &= t & t & t & t & 'result = processRequest(route="/api/#plural#/1", method="put", params={format: "json", #singular#: {}});' & nl;
+		c &= t & t & t & t & 'result = processRequest(params={route: "#memberRoute#", key: 1, format: "json", #singular#: {}}, method="put", returnAs="struct");' & nl;
 		c &= t & t & t & t & 'expect(result).toHaveKey("status");' & nl;
 		c &= t & t & t & '})' & nl & nl;
 		c &= t & t & t & 'it("DELETE /api/#plural#/:key deletes record", () => {' & nl;
-		c &= t & t & t & t & 'result = processRequest(route="/api/#plural#/1", method="delete", params={format: "json"});' & nl;
+		c &= t & t & t & t & 'result = processRequest(params={route: "#memberRoute#", key: 1, format: "json"}, method="delete", returnAs="struct");' & nl;
 		c &= t & t & t & t & 'expect(result).toHaveKey("status");' & nl;
 		c &= t & t & t & '})' & nl & nl;
 		c &= t & t & '})' & nl;
@@ -635,8 +642,13 @@ component {
 		var t = chr(9);
 		var c = "";
 
+		// Failure tracking uses a struct field (state.exception), NOT local.X:
+		// `local.X = ...` inside a catch body does not persist on BoxLang
+		// (Cross-Engine Invariant #11), which silently turned failed
+		// migrations into committed "successes".
 		c &= 'component extends="wheels.migrator.Migration" hint="Migration: #arguments.className#" {' & nl & nl;
 		c &= t & 'function up() {' & nl;
+		c &= t & t & 'var state = {};' & nl;
 		c &= t & t & 'transaction {' & nl;
 		c &= t & t & t & 'try {' & nl;
 		c &= t & t & t & t & "t = createTable(name='#arguments.tableName#', force='false', id='true', primaryKey='#arguments.primaryKey#');" & nl;
@@ -662,11 +674,11 @@ component {
 		c &= t & t & t & t & "t.timestamps();" & nl;
 		c &= t & t & t & t & "t.create();" & nl;
 		c &= t & t & t & '} catch (any e) {' & nl;
-		c &= t & t & t & t & 'local.exception = e;' & nl;
+		c &= t & t & t & t & 'state.exception = e;' & nl;
 		c &= t & t & t & '}' & nl & nl;
-		c &= t & t & t & 'if (StructKeyExists(local, "exception")) {' & nl;
+		c &= t & t & t & 'if (StructKeyExists(state, "exception")) {' & nl;
 		c &= t & t & t & t & 'transaction action="rollback";' & nl;
-		c &= t & t & t & t & 'Throw(errorCode="1", detail=local.exception.detail, message=local.exception.message, type="any");' & nl;
+		c &= t & t & t & t & 'Throw(errorCode="1", detail=state.exception.detail, message=state.exception.message, type="any");' & nl;
 		c &= t & t & t & '} else {' & nl;
 		c &= t & t & t & t & 'transaction action="commit";' & nl;
 		c &= t & t & t & '}' & nl;
@@ -674,15 +686,16 @@ component {
 		c &= t & '}' & nl & nl;
 
 		c &= t & 'function down() {' & nl;
+		c &= t & t & 'var state = {};' & nl;
 		c &= t & t & 'transaction {' & nl;
 		c &= t & t & t & 'try {' & nl;
 		c &= t & t & t & t & "dropTable('#arguments.tableName#');" & nl;
 		c &= t & t & t & '} catch (any e) {' & nl;
-		c &= t & t & t & t & 'local.exception = e;' & nl;
+		c &= t & t & t & t & 'state.exception = e;' & nl;
 		c &= t & t & t & '}' & nl & nl;
-		c &= t & t & t & 'if (StructKeyExists(local, "exception")) {' & nl;
+		c &= t & t & t & 'if (StructKeyExists(state, "exception")) {' & nl;
 		c &= t & t & t & t & 'transaction action="rollback";' & nl;
-		c &= t & t & t & t & 'Throw(errorCode="1", detail=local.exception.detail, message=local.exception.message, type="any");' & nl;
+		c &= t & t & t & t & 'Throw(errorCode="1", detail=state.exception.detail, message=state.exception.message, type="any");' & nl;
 		c &= t & t & t & '} else {' & nl;
 		c &= t & t & t & t & 'transaction action="commit";' & nl;
 		c &= t & t & t & '}' & nl;

--- a/cli/lucli/services/Templates.cfc
+++ b/cli/lucli/services/Templates.cfc
@@ -548,7 +548,7 @@ component {
 			var label = variables.helpers.capitalize(prop.name);
 			if (arrayFindNoCase(foreignKeys, prop.name)) {
 				// findAll() returns a flat query — association objects are not
-				// reachable inside <cfloop query>, so posts.author.name throws.
+				// reachable inside a query-driven cfloop, so posts.author.name throws.
 				// Keep the friendly label but render the raw FK column value.
 				label = variables.helpers.capitalize(left(prop.name, len(prop.name) - 2));
 			}
@@ -581,7 +581,7 @@ component {
 		var cells = [];
 
 		// findAll() returns a flat query — association objects are not reachable
-		// inside <cfloop query>, so FK columns render their raw value (e.g.
+		// inside a query-driven cfloop, so FK columns render their raw value (e.g.
 		// authorId); the table header still shows the association label.
 		for (var prop in arguments.properties) {
 			var cellCode = '<td>' & chr(10);

--- a/cli/lucli/services/Templates.cfc
+++ b/cli/lucli/services/Templates.cfc
@@ -547,12 +547,12 @@ component {
 		for (var prop in arguments.properties) {
 			var label = variables.helpers.capitalize(prop.name);
 			if (arrayFindNoCase(foreignKeys, prop.name)) {
-				var assocName = left(prop.name, len(prop.name) - 2);
-				label = variables.helpers.capitalize(assocName);
-				arrayAppend(blocks, '<p>' & label & ': ##|ObjectNamePlural|.' & assocName & '.name##</p>');
-			} else {
-				arrayAppend(blocks, '<p>' & label & ': ##|ObjectNamePlural|.' & prop.name & '##</p>');
+				// findAll() returns a flat query — association objects are not
+				// reachable inside <cfloop query>, so posts.author.name throws.
+				// Keep the friendly label but render the raw FK column value.
+				label = variables.helpers.capitalize(left(prop.name, len(prop.name) - 2));
 			}
+			arrayAppend(blocks, '<p>' & label & ': ##|ObjectNamePlural|.' & prop.name & '##</p>');
 		}
 		return arrayToList(blocks, chr(10) & chr(9) & chr(9));
 	}
@@ -579,16 +579,13 @@ component {
 	 */
 	private string function generateIndexTableBody(required array properties, string belongsTo = "") {
 		var cells = [];
-		var foreignKeys = buildForeignKeyList(arguments.belongsTo);
 
+		// findAll() returns a flat query — association objects are not reachable
+		// inside <cfloop query>, so FK columns render their raw value (e.g.
+		// authorId); the table header still shows the association label.
 		for (var prop in arguments.properties) {
 			var cellCode = '<td>' & chr(10);
-			if (arrayFindNoCase(foreignKeys, prop.name)) {
-				var assocName = left(prop.name, len(prop.name) - 2);
-				cellCode &= chr(9) & chr(9) & chr(9) & chr(9) & chr(9) & chr(9) & chr(9) & '##|ObjectNamePlural|.' & assocName & '.name##' & chr(10);
-			} else {
-				cellCode &= chr(9) & chr(9) & chr(9) & chr(9) & chr(9) & chr(9) & chr(9) & '##|ObjectNamePlural|.#prop.name###' & chr(10);
-			}
+			cellCode &= chr(9) & chr(9) & chr(9) & chr(9) & chr(9) & chr(9) & chr(9) & '##|ObjectNamePlural|.#prop.name###' & chr(10);
 			cellCode &= chr(9) & chr(9) & chr(9) & chr(9) & chr(9) & chr(9) & '</td>';
 			arrayAppend(cells, cellCode);
 		}
@@ -635,10 +632,16 @@ component {
 
 		var includeParam = 'include="' & arrayToList(includeList) & '"';
 
-		processed = replace(processed, '=model("|ObjectNameSingular|").findAll();', '=model("|ObjectNameSingular|").findAll(#includeParam#);', 'all');
-		processed = replace(processed, '=model("|ObjectNameSingular|").findByKey(params.key);', '=model("|ObjectNameSingular|").findByKey(params.key, #includeParam#);', 'all');
+		// CRUD controller template (CRUDContent.txt) uses the capitalized
+		// |ObjectNameSingularC| placeholder inside model() and no spaces around
+		// the assignment `=`. findByKey must be all-named (key=...) — Wheels
+		// rejects mixing the positional key with the named include at runtime.
+		processed = replace(processed, '=model("|ObjectNameSingularC|").findAll();', '=model("|ObjectNameSingularC|").findAll(#includeParam#);', 'all');
+		processed = replace(processed, '=model("|ObjectNameSingularC|").findByKey(params.key);', '=model("|ObjectNameSingularC|").findByKey(key=params.key, #includeParam#);', 'all');
+		// API controller template (ApiControllerContent.txt) assigns into the
+		// `local.` scope with spaces around `=` and the lowercase placeholder.
 		processed = replace(processed, 'local.|ObjectNamePlural| = model("|ObjectNameSingular|").findAll();', 'local.|ObjectNamePlural| = model("|ObjectNameSingular|").findAll(#includeParam#);', 'all');
-		processed = replace(processed, 'local.|ObjectNameSingular| = model("|ObjectNameSingular|").findByKey(params.key);', 'local.|ObjectNameSingular| = model("|ObjectNameSingular|").findByKey(params.key, #includeParam#);', 'all');
+		processed = replace(processed, 'local.|ObjectNameSingular| = model("|ObjectNameSingular|").findByKey(params.key);', 'local.|ObjectNameSingular| = model("|ObjectNameSingular|").findByKey(key=params.key, #includeParam#);', 'all');
 
 		return processed;
 	}

--- a/cli/lucli/templates/app/app/snippets/DBMigrate.txt
+++ b/cli/lucli/templates/app/app/snippets/DBMigrate.txt
@@ -1,16 +1,17 @@
 component extends="wheels.migrator.Migration" hint="|DBMigrateHINT|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				|DBMigrateUP|
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				throw(errorCode="1", detail=local.exception.detail, message=local.exception.message, type="any");
+				throw(errorCode="1", detail=state.exception.detail, message=state.exception.message, type="any");
 			} else {
 				transaction action="commit";
 			}
@@ -18,16 +19,17 @@ component extends="wheels.migrator.Migration" hint="|DBMigrateHINT|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 		  try {
 				|DBMigrateDOWN|
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				throw(errorCode="1", detail=local.exception.detail, message=local.exception.message, type="any");
+				throw(errorCode="1", detail=state.exception.detail, message=state.exception.message, type="any");
 			} else {
 				transaction action="commit";
 			}

--- a/cli/lucli/templates/migrations/remove_table.txt
+++ b/cli/lucli/templates/migrations/remove_table.txt
@@ -1,20 +1,22 @@
 component extends="wheels.migrator.Migration" hint="Migration: {{className}}" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				dropTable(tableName="{{tableName}}");
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				throw(object=local.exception);
+				throw(object=state.exception);
 			}
 		}
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				// Re-create the table manually if needed
@@ -22,11 +24,11 @@ component extends="wheels.migrator.Migration" hint="Migration: {{className}}" {
 				// t.timestamps();
 				// t.create();
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				throw(object=local.exception);
+				throw(object=state.exception);
 			}
 		}
 	}

--- a/cli/lucli/templates/snippets/auth-sessions-controller.txt
+++ b/cli/lucli/templates/snippets/auth-sessions-controller.txt
@@ -18,7 +18,9 @@ component extends="Controller" {
 	 * Process login
 	 */
 	function create() {
-		var user = model("User").findOne(where="username='#params.username#'");
+		// Use the injection-safe query builder — never interpolate user input
+		// into a where string (a quote in the username would rewrite the SQL).
+		var user = model("User").where("username", params.username).first();
 		if (IsObject(user) && user.authenticate(params.password)) {
 			session.currentUserId = user.key();
 			flashInsert(success="Logged in successfully.");

--- a/cli/lucli/templates/snippets/soft-delete-migration.txt
+++ b/cli/lucli/templates/snippets/soft-delete-migration.txt
@@ -2,7 +2,7 @@ component extends="wheels.migrator.Migration" {
 
 	function up() {
 		// Add to your table: change "tablename" below
-		addColumn(table="tablename", columnType="datetime", columnName="deletedAt", null=true, default="NULL");
+		addColumn(table="tablename", columnType="datetime", columnName="deletedAt", allowNull=true, default="NULL");
 		addIndex(table="tablename", columnNames="deletedAt");
 	}
 

--- a/cli/lucli/templates/snippets/soft-delete-mixin.txt
+++ b/cli/lucli/templates/snippets/soft-delete-mixin.txt
@@ -1,7 +1,7 @@
 <!---
 	Soft Delete Pattern
 	Requires: deletedAt (datetime, nullable) column on the table.
-	Migration: t.datetime(columnNames="deletedAt", null=true, default="NULL");
+	Migration: t.datetime(columnNames="deletedAt", allowNull=true, default="NULL");
 
 	Usage in your model config():
 		beforeDelete("softDelete");

--- a/cli/lucli/tests/specs/services/ScaffoldSpec.cfc
+++ b/cli/lucli/tests/specs/services/ScaffoldSpec.cfc
@@ -445,6 +445,105 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 
 			});
 
+			describe("belongsTo scaffolding (CLI-D2)", () => {
+
+				it("injects include= into the CRUD controller finders with all-named findByKey", () => {
+					var result = scaffold.generateScaffold(
+						name = "Review",
+						properties = [{name: "body", type: "text"}],
+						belongsTo = "Author",
+						force = true
+					);
+					expect(result.success).toBeTrue();
+					var content = fileRead(tempRoot & "/app/controllers/Reviews.cfc");
+					expect(content).toInclude('findAll(include="author")');
+					expect(content).toInclude('findByKey(key=params.key, include="author")');
+					// The mixed positional+named form is rejected at runtime by
+					// Lucee/Adobe — it must never be generated.
+					expect(content).notToInclude('findByKey(params.key, include=');
+					expect(content).notToInclude("findByKey(params.key)");
+				});
+
+				it("index.cfm renders the raw FK column, not query.assoc.name", () => {
+					scaffold.generateScaffold(
+						name = "Review",
+						properties = [{name: "body", type: "text"}],
+						belongsTo = "Author",
+						force = true
+					);
+					var content = fileRead(tempRoot & "/app/views/reviews/index.cfm");
+					// findAll() queries are flat — reviews.author.name throws at runtime.
+					expect(content).notToInclude(".author.name");
+					expect(content).toInclude("##reviews.authorId##");
+				});
+
+				it("show.cfm association display is backed by the injected include", () => {
+					scaffold.generateScaffold(
+						name = "Review",
+						properties = [{name: "body", type: "text"}],
+						belongsTo = "Author",
+						force = true
+					);
+					var showContent = fileRead(tempRoot & "/app/views/reviews/show.cfm");
+					var controllerContent = fileRead(tempRoot & "/app/controllers/Reviews.cfc");
+					// show.cfm walks review.author.* — valid only because the
+					// controller fetches with include="author".
+					expect(showContent).toInclude("review.author.name");
+					expect(controllerContent).toInclude('findByKey(key=params.key, include="author")');
+				});
+
+				it("injects include= into the API controller with all-named findByKey", () => {
+					var result = scaffold.generateApiResource(
+						name = "Memo",
+						properties = [{name: "subject", type: "string"}],
+						belongsTo = "Author",
+						force = true
+					);
+					expect(result.success).toBeTrue();
+					var content = fileRead(tempRoot & "/app/controllers/api/Memos.cfc");
+					expect(content).toInclude('findAll(include="author")');
+					expect(content).toInclude('findByKey(key=params.key, include="author")');
+					expect(content).notToInclude('findByKey(params.key, include=');
+				});
+
+			});
+
+			describe("generateApiTest() (CLI-D3)", () => {
+
+				it("emits processRequest calls matching the real framework signature", () => {
+					var result = scaffold.generateApiTest("Widgets", "Widget");
+					expect(result.success).toBeTrue();
+					var content = fileRead(result.path);
+					// Route NAME inside the params struct + returnAs="struct"
+					// (the old route="/api/widgets" URL-path form never matched
+					// processRequest(required struct params, ...)).
+					expect(content).toInclude('params={route: "apiWidgets", format: "json"}');
+					expect(content).toInclude('route: "apiWidget"');
+					expect(content).toInclude('returnAs="struct"');
+					expect(content).notToInclude('processRequest(route=');
+				});
+
+			});
+
+			describe("generated migration failure tracking (CLI-D4)", () => {
+
+				it("uses the struct-field catch pattern instead of local.X (BoxLang-safe)", () => {
+					var path = scaffold.createMigrationWithProperties(
+						name = "Ledger",
+						properties = [{name: "total", type: "decimal"}]
+					);
+					var content = fileRead(path);
+					// `local.X = ...` inside catch is discarded on BoxLang
+					// (Cross-Engine Invariant #11): a failed migration would
+					// take the commit branch and be recorded as applied.
+					expect(content).toInclude("var state = {};");
+					expect(content).toInclude("state.exception = e;");
+					expect(content).toInclude('StructKeyExists(state, "exception")');
+					expect(content).notToInclude("local.exception");
+				});
+
+			});
+
 		});
 
 	}

--- a/cli/lucli/tests/specs/services/TemplatesSpec.cfc
+++ b/cli/lucli/tests/specs/services/TemplatesSpec.cfc
@@ -139,6 +139,71 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 
 			});
 
+			describe("shipped migration templates (CLI-D4)", () => {
+
+				// `local.X = ...` inside a catch body does not persist on BoxLang
+				// (Cross-Engine Invariant #11): the old local.exception idiom made
+				// a failed migration take the COMMIT branch and get recorded as
+				// applied. Every shipped template must use the struct-field pattern.
+				it("never use local.X-in-catch failure tracking", () => {
+					var templateFiles = [];
+					var templateDirs = [
+						{path: expandPath("/cli/src/templates/dbmigrate"), filter: "*.txt"},
+						{path: expandPath("/vendor/wheels/migrator/templates"), filter: "*.cfc"},
+						{path: expandPath("/cli/lucli/templates/migrations"), filter: "*.txt"},
+						{path: expandPath("/app/snippets/dbmigrate"), filter: "*.txt"}
+					];
+					for (var dirSpec in templateDirs) {
+						if (directoryExists(dirSpec.path)) {
+							templateFiles.append(directoryList(dirSpec.path, false, "path", dirSpec.filter), true);
+						}
+					}
+					var singleFiles = [
+						expandPath("/cli/src/templates/DBMigrate.txt"),
+						expandPath("/cli/lucli/templates/app/app/snippets/DBMigrate.txt"),
+						expandPath("/app/snippets/DBMigrate.txt")
+					];
+					for (var singleFile in singleFiles) {
+						if (fileExists(singleFile)) {
+							templateFiles.append(singleFile);
+						}
+					}
+					expect(arrayLen(templateFiles)).toBeGTE(30);
+
+					for (var templateFile in templateFiles) {
+						var content = fileRead(templateFile);
+						expect(content).notToInclude("local.exception", "local.X-in-catch found in #templateFile#");
+						expect(content).notToInclude('StructKeyExists(local, "exception")', "local.X-in-catch found in #templateFile#");
+						if (find("state.exception", content)) {
+							expect(content).toInclude("var state = {};", "state struct never declared in #templateFile#");
+						}
+					}
+				});
+
+			});
+
+			describe("shipped snippets (CLI-D6/D7)", () => {
+
+				it("auth sessions snippet uses the injection-safe builder, not where-string interpolation", () => {
+					var content = fileRead(expandPath("/cli/lucli/templates/snippets/auth-sessions-controller.txt"));
+					expect(content).toInclude('.where("username", params.username).first()');
+					// Interpolating params into a where string lets a quoted
+					// username rewrite the WHERE clause (condition injection).
+					expect(content).notToInclude("findOne(where=");
+				});
+
+				it("soft-delete snippets pass allowNull (null= is silently ignored by the migrator)", () => {
+					var migration = fileRead(expandPath("/cli/lucli/templates/snippets/soft-delete-migration.txt"));
+					expect(migration).toInclude("allowNull=true");
+					expect(migration).notToInclude(", null=true");
+
+					var mixin = fileRead(expandPath("/cli/lucli/templates/snippets/soft-delete-mixin.txt"));
+					expect(mixin).toInclude("allowNull=true");
+					expect(mixin).notToInclude(", null=true");
+				});
+
+			});
+
 		});
 
 	}

--- a/cli/src/templates/DBMigrate.txt
+++ b/cli/src/templates/DBMigrate.txt
@@ -1,16 +1,17 @@
 component extends="wheels.migrator.Migration" hint="|DBMigrateHINT|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				|DBMigrateUP|
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				throw(errorCode="1", detail=local.exception.detail, message=local.exception.message, type="any");
+				throw(errorCode="1", detail=state.exception.detail, message=state.exception.message, type="any");
 			} else {
 				transaction action="commit";
 			}
@@ -18,16 +19,17 @@ component extends="wheels.migrator.Migration" hint="|DBMigrateHINT|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 		  try {
 				|DBMigrateDOWN|
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				throw(errorCode="1", detail=local.exception.detail, message=local.exception.message, type="any");
+				throw(errorCode="1", detail=state.exception.detail, message=state.exception.message, type="any");
 			} else {
 				transaction action="commit";
 			}

--- a/cli/src/templates/dbmigrate/blank.txt
+++ b/cli/src/templates/dbmigrate/blank.txt
@@ -1,16 +1,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				// your code goes here
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -18,16 +19,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				// your code goes here
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/cli/src/templates/dbmigrate/change-column.txt
+++ b/cli/src/templates/dbmigrate/change-column.txt
@@ -20,16 +20,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				changeColumn(table = '|tableName|', columnType = '', columnName = 'columnName', default = '', allowNull = true);
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -37,16 +38,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				changeColumn(table = '|tableName|', columnName = 'columnName');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/cli/src/templates/dbmigrate/change-table.txt
+++ b/cli/src/templates/dbmigrate/change-table.txt
@@ -13,17 +13,18 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				t = changeTable('|tableName|');
 				t.change();
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -31,16 +32,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				removeColumn(table = '|tableName|', columnName = 'columnName');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/cli/src/templates/dbmigrate/create-column.txt
+++ b/cli/src/templates/dbmigrate/create-column.txt
@@ -19,16 +19,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				addColumn(table = '|tableName|', columnType = '|columnType|', columnName = '|columnName|' |arguments|);
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -36,16 +37,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				removeColumn(table = '|tableName|', columnName = '|columnName|');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/cli/src/templates/dbmigrate/create-index.txt
+++ b/cli/src/templates/dbmigrate/create-index.txt
@@ -14,16 +14,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				addIndex(table = '|tableName|', columnNames = 'columnName', unique = true);
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -31,16 +32,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				removeIndex(table = '|tableName|', indexName = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/cli/src/templates/dbmigrate/create-record.txt
+++ b/cli/src/templates/dbmigrate/create-record.txt
@@ -12,16 +12,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				addRecord(table = '|tableName|', field = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -29,16 +30,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				removeRecord(table = '|tableName|', where = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/cli/src/templates/dbmigrate/create-table.txt
+++ b/cli/src/templates/dbmigrate/create-table.txt
@@ -29,18 +29,19 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				t = createTable(name = '|tableName|', force='|force|', id='|id|', primaryKey='|primaryKey|');
 				t.timestamps();
 				t.create();
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -48,16 +49,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				dropTable('|tableName|');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/cli/src/templates/dbmigrate/execute.txt
+++ b/cli/src/templates/dbmigrate/execute.txt
@@ -1,16 +1,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				execute('');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -18,16 +19,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				execute('');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/cli/src/templates/dbmigrate/remove-column.txt
+++ b/cli/src/templates/dbmigrate/remove-column.txt
@@ -13,16 +13,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				removeColumn(table = '|tableName|', columnName = 'columnName');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -30,16 +31,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				addColumn(table = '|tableName|', columnType = '', columnName = 'columnName', default = '', allowNull = true);
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/cli/src/templates/dbmigrate/remove-index.txt
+++ b/cli/src/templates/dbmigrate/remove-index.txt
@@ -12,16 +12,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				removeIndex(table = '|tableName|', indexName = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -29,16 +30,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				addIndex(table = '|tableName|', columnNames = 'columnName', unique = true);
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/cli/src/templates/dbmigrate/remove-record.txt
+++ b/cli/src/templates/dbmigrate/remove-record.txt
@@ -12,16 +12,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				removeRecord(table = '|tableName|', where = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -29,16 +30,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				addRecord(table = '|tableName|', field = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/cli/src/templates/dbmigrate/remove-table.txt
+++ b/cli/src/templates/dbmigrate/remove-table.txt
@@ -11,16 +11,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				dropTable(name = '|tableName|');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -28,18 +29,19 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				t = createTable(name = '|tableName|');
 				t.timestamps();
 				t.create();
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/cli/src/templates/dbmigrate/rename-column.txt
+++ b/cli/src/templates/dbmigrate/rename-column.txt
@@ -13,16 +13,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				renameColumn(table = '|tableName|', columnName = 'columnName', newColumnName = 'newColumnName');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -30,16 +31,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				renameColumn(table = '|tableName|', columnName = 'columnName', newColumnName = 'newColumnName');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/cli/src/templates/dbmigrate/rename-table.txt
+++ b/cli/src/templates/dbmigrate/rename-table.txt
@@ -12,16 +12,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				renameTable(oldName = '', newName = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -29,16 +30,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				renameTable(oldName = '', newName = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/cli/src/templates/dbmigrate/update-record.txt
+++ b/cli/src/templates/dbmigrate/update-record.txt
@@ -13,16 +13,17 @@
 component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				updateRecord(table = '|tableName|', where = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -30,16 +31,17 @@ component extends="|DBMigrateExtends|" hint="|DBMigrateDescription|" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				updateRecord(table = '|tableName|', where = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/vendor/wheels/migrator/templates/blank.cfc
+++ b/vendor/wheels/migrator/templates/blank.cfc
@@ -1,16 +1,17 @@
 component extends="[extends]" hint="[description]" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				// your code goes here
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -18,16 +19,17 @@ component extends="[extends]" hint="[description]" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				// your code goes here
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/vendor/wheels/migrator/templates/change-column.cfc
+++ b/vendor/wheels/migrator/templates/change-column.cfc
@@ -20,16 +20,17 @@
 component extends="[extends]" hint="[description]" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				changeColumn(table = 'tableName', columnType = '', columnName = 'columnName', default = '', allowNull = true);
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -37,16 +38,17 @@ component extends="[extends]" hint="[description]" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				changeColumn(table = 'tableName', columnName = 'columnName');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/vendor/wheels/migrator/templates/change-table.cfc
+++ b/vendor/wheels/migrator/templates/change-table.cfc
@@ -13,17 +13,18 @@
 component extends="[extends]" hint="[description]" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				t = changeTable('tableName');
 				t.change();
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -31,16 +32,17 @@ component extends="[extends]" hint="[description]" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				removeColumn(table = 'tableName', columnName = 'columnName');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/vendor/wheels/migrator/templates/create-column.cfc
+++ b/vendor/wheels/migrator/templates/create-column.cfc
@@ -19,16 +19,17 @@
 component extends="[extends]" hint="[description]" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				addColumn(table = 'tableName', columnType = '', columnName = 'columnName', default = '', allowNull = true);
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -36,16 +37,17 @@ component extends="[extends]" hint="[description]" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				removeColumn(table = 'tableName', columnName = 'columnName');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/vendor/wheels/migrator/templates/create-index.cfc
+++ b/vendor/wheels/migrator/templates/create-index.cfc
@@ -14,16 +14,17 @@
 component extends="[extends]" hint="[description]" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				addIndex(table = 'tableName', columnNames = 'columnName', unique = true);
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -31,16 +32,17 @@ component extends="[extends]" hint="[description]" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				removeIndex(table = 'tableName', indexName = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/vendor/wheels/migrator/templates/create-record.cfc
+++ b/vendor/wheels/migrator/templates/create-record.cfc
@@ -12,16 +12,17 @@
 component extends="[extends]" hint="[description]" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				addRecord(table = 'tableName', field = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -29,16 +30,17 @@ component extends="[extends]" hint="[description]" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				removeRecord(table = 'tableName', where = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/vendor/wheels/migrator/templates/create-table.cfc
+++ b/vendor/wheels/migrator/templates/create-table.cfc
@@ -29,18 +29,19 @@
 component extends="[extends]" hint="[description]" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				t = createTable(name = 'tableName');
 				t.timestamps();
 				t.create();
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -48,16 +49,17 @@ component extends="[extends]" hint="[description]" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				dropTable('tableName');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/vendor/wheels/migrator/templates/execute.cfc
+++ b/vendor/wheels/migrator/templates/execute.cfc
@@ -1,16 +1,17 @@
 component extends="[extends]" hint="[description]" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				execute('');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -18,16 +19,17 @@ component extends="[extends]" hint="[description]" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				execute('');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/vendor/wheels/migrator/templates/remove-column.cfc
+++ b/vendor/wheels/migrator/templates/remove-column.cfc
@@ -13,16 +13,17 @@
 component extends="[extends]" hint="[description]" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				removeColumn(table = 'tableName', columnName = 'columnName');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -30,16 +31,17 @@ component extends="[extends]" hint="[description]" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				addColumn(table = 'tableName', columnType = '', columnName = 'columnName', default = '', allowNull = true);
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/vendor/wheels/migrator/templates/remove-index.cfc
+++ b/vendor/wheels/migrator/templates/remove-index.cfc
@@ -12,16 +12,17 @@
 component extends="[extends]" hint="[description]" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				removeIndex(table = 'tableName', indexName = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -29,16 +30,17 @@ component extends="[extends]" hint="[description]" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				addIndex(table = 'tableName', columnNames = 'columnName', unique = true);
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/vendor/wheels/migrator/templates/remove-record.cfc
+++ b/vendor/wheels/migrator/templates/remove-record.cfc
@@ -12,16 +12,17 @@
 component extends="[extends]" hint="[description]" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				removeRecord(table = 'tableName', where = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -29,16 +30,17 @@ component extends="[extends]" hint="[description]" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				addRecord(table = 'tableName', field = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/vendor/wheels/migrator/templates/remove-table.cfc
+++ b/vendor/wheels/migrator/templates/remove-table.cfc
@@ -11,16 +11,17 @@
 component extends="[extends]" hint="[description]" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				dropTable(name = 'tableName');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -28,18 +29,19 @@ component extends="[extends]" hint="[description]" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				t = createTable(name = 'tableName');
 				t.timestamps();
 				t.create();
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/vendor/wheels/migrator/templates/rename-column.cfc
+++ b/vendor/wheels/migrator/templates/rename-column.cfc
@@ -13,16 +13,17 @@
 component extends="[extends]" hint="[description]" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				renameColumn(table = 'tableName', columnName = 'columnName', newColumnName = 'newColumnName');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -30,16 +31,17 @@ component extends="[extends]" hint="[description]" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				renameColumn(table = 'tableName', columnName = 'columnName', newColumnName = 'newColumnName');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/vendor/wheels/migrator/templates/rename-table.cfc
+++ b/vendor/wheels/migrator/templates/rename-table.cfc
@@ -12,16 +12,17 @@
 component extends="[extends]" hint="[description]" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				renameTable(oldName = '', newName = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -29,16 +30,17 @@ component extends="[extends]" hint="[description]" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				renameTable(oldName = '', newName = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/vendor/wheels/migrator/templates/update-record.cfc
+++ b/vendor/wheels/migrator/templates/update-record.cfc
@@ -13,16 +13,17 @@
 component extends="[extends]" hint="[description]" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				updateRecord(table = 'tableName', where = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}
@@ -30,16 +31,17 @@ component extends="[extends]" hint="[description]" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				updateRecord(table = 'tableName', where = '');
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (StructKeyExists(local, "exception")) {
+			if (StructKeyExists(state, "exception")) {
 				transaction action="rollback";
-				Throw(errorCode = "1", detail = local.exception.detail, message = local.exception.message, type = "any");
+				Throw(errorCode = "1", detail = state.exception.detail, message = state.exception.message, type = "any");
 			} else {
 				transaction action="commit";
 			}

--- a/vendor/wheels/public/docs/reference/migration/announce.txt
+++ b/vendor/wheels/public/docs/reference/migration/announce.txt
@@ -27,7 +27,7 @@ function up() {
 	var state = {};
 	transaction {
 		try {
-			addColumn(table="users", columnType="string", columnName="apiKey", limit=64, null=true);
+			addColumn(table="users", columnType="string", columnName="apiKey", limit=64, allowNull=true);
 			announce("Added apiKey column to users");
 
 			addIndex(table="users", columnNames="apiKey", unique=true);

--- a/vendor/wheels/public/docs/reference/migration/announce.txt
+++ b/vendor/wheels/public/docs/reference/migration/announce.txt
@@ -1,5 +1,6 @@
 // 1. Log a custom message during a migration's up() step
 function up() {
+	var state = {};
 	transaction {
 		try {
 			createTable(name="articles", force=true) {
@@ -9,12 +10,12 @@ function up() {
 			};
 			announce("Created articles table");
 		} catch (any e) {
-			local.exception = e;
+			state.exception = e;
 		}
 
-		if (StructKeyExists(local, "exception")) {
+		if (StructKeyExists(state, "exception")) {
 			transaction action="rollback";
-			throw(errorCode="1", detail=local.exception.detail, message=local.exception.message, type="any");
+			throw(errorCode="1", detail=state.exception.detail, message=state.exception.message, type="any");
 		} else {
 			transaction action="commit";
 		}
@@ -23,6 +24,7 @@ function up() {
 
 // 2. Announce multiple steps to provide granular feedback
 function up() {
+	var state = {};
 	transaction {
 		try {
 			addColumn(table="users", columnType="string", columnName="apiKey", limit=64, null=true);
@@ -31,12 +33,12 @@ function up() {
 			addIndex(table="users", columnNames="apiKey", unique=true);
 			announce("Added unique index on users.apiKey");
 		} catch (any e) {
-			local.exception = e;
+			state.exception = e;
 		}
 
-		if (StructKeyExists(local, "exception")) {
+		if (StructKeyExists(state, "exception")) {
 			transaction action="rollback";
-			throw(errorCode="1", detail=local.exception.detail, message=local.exception.message, type="any");
+			throw(errorCode="1", detail=state.exception.detail, message=state.exception.message, type="any");
 		} else {
 			transaction action="commit";
 		}

--- a/vendor/wheels/public/docs/reference/migration/down.txt
+++ b/vendor/wheels/public/docs/reference/migration/down.txt
@@ -51,6 +51,7 @@ function down() {
 component extends="[extends]" hint="Add status column to orders" {
 
 	function up() {
+		var state = {};
 		transaction {
 			try {
 				addColumn(table="orders", columnType="string", columnName="status", limit=50, default="pending");
@@ -73,6 +74,7 @@ component extends="[extends]" hint="Add status column to orders" {
 	}
 
 	function down() {
+		var state = {};
 		transaction {
 			try {
 				removeColumn(table="orders", columnName="status");

--- a/vendor/wheels/public/docs/reference/migration/down.txt
+++ b/vendor/wheels/public/docs/reference/migration/down.txt
@@ -1,19 +1,20 @@
 // 1. Reverse a table creation by dropping the table
 // Called automatically when rolling back this migration
 function down() {
+	var state = {};
 	transaction {
 		try {
 			dropTable("employees");
 		} catch (any e) {
-			local.exception = e;
+			state.exception = e;
 		}
 
-		if (structKeyExists(local, "exception")) {
+		if (structKeyExists(state, "exception")) {
 			transaction action="rollback";
 			throw(
 				errorCode = "1",
-				detail    = local.exception.detail,
-				message   = local.exception.message,
+				detail    = state.exception.detail,
+				message   = state.exception.message,
 				type      = "any"
 			);
 		} else {
@@ -24,19 +25,20 @@ function down() {
 
 // 2. Reverse an addColumn() call by removing the column
 function down() {
+	var state = {};
 	transaction {
 		try {
 			removeColumn(table="users", columnName="biography");
 		} catch (any e) {
-			local.exception = e;
+			state.exception = e;
 		}
 
-		if (structKeyExists(local, "exception")) {
+		if (structKeyExists(state, "exception")) {
 			transaction action="rollback";
 			throw(
 				errorCode = "1",
-				detail    = local.exception.detail,
-				message   = local.exception.message,
+				detail    = state.exception.detail,
+				message   = state.exception.message,
 				type      = "any"
 			);
 		} else {
@@ -53,15 +55,15 @@ component extends="[extends]" hint="Add status column to orders" {
 			try {
 				addColumn(table="orders", columnType="string", columnName="status", limit=50, default="pending");
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (structKeyExists(local, "exception")) {
+			if (structKeyExists(state, "exception")) {
 				transaction action="rollback";
 				throw(
 					errorCode = "1",
-					detail    = local.exception.detail,
-					message   = local.exception.message,
+					detail    = state.exception.detail,
+					message   = state.exception.message,
 					type      = "any"
 				);
 			} else {
@@ -75,15 +77,15 @@ component extends="[extends]" hint="Add status column to orders" {
 			try {
 				removeColumn(table="orders", columnName="status");
 			} catch (any e) {
-				local.exception = e;
+				state.exception = e;
 			}
 
-			if (structKeyExists(local, "exception")) {
+			if (structKeyExists(state, "exception")) {
 				transaction action="rollback";
 				throw(
 					errorCode = "1",
-					detail    = local.exception.detail,
-					message   = local.exception.message,
+					detail    = state.exception.detail,
+					message   = state.exception.message,
 					type      = "any"
 				);
 			} else {

--- a/vendor/wheels/public/docs/reference/migration/up.txt
+++ b/vendor/wheels/public/docs/reference/migration/up.txt
@@ -1,5 +1,6 @@
 // 1. Create a new table (typical migration forward)
 function up() {
+	var state = {};
 	transaction {
 		try {
 			t = createTable(name="posts");
@@ -9,15 +10,15 @@ function up() {
 			t.timestamps();
 			t.create();
 		} catch (any e) {
-			local.exception = e;
+			state.exception = e;
 		}
 
-		if (structKeyExists(local, "exception")) {
+		if (structKeyExists(state, "exception")) {
 			transaction action="rollback";
 			throw(
 				errorCode = "1",
-				detail    = local.exception.detail,
-				message   = local.exception.message,
+				detail    = state.exception.detail,
+				message   = state.exception.message,
 				type      = "any"
 			);
 		} else {
@@ -28,19 +29,20 @@ function up() {
 
 // 2. Add a column to an existing table
 function up() {
+	var state = {};
 	transaction {
 		try {
 			addColumn(table="users", columnType="string", columnName="avatarUrl", limit=500, allowNull=true);
 		} catch (any e) {
-			local.exception = e;
+			state.exception = e;
 		}
 
-		if (structKeyExists(local, "exception")) {
+		if (structKeyExists(state, "exception")) {
 			transaction action="rollback";
 			throw(
 				errorCode = "1",
-				detail    = local.exception.detail,
-				message   = local.exception.message,
+				detail    = state.exception.detail,
+				message   = state.exception.message,
 				type      = "any"
 			);
 		} else {
@@ -51,20 +53,21 @@ function up() {
 
 // 3. Run raw SQL and seed initial data in the same migration
 function up() {
+	var state = {};
 	transaction {
 		try {
 			execute("ALTER TABLE products ADD COLUMN sku VARCHAR(50)");
 			addRecord(table="settings", key="maintenance_mode", value="false");
 		} catch (any e) {
-			local.exception = e;
+			state.exception = e;
 		}
 
-		if (structKeyExists(local, "exception")) {
+		if (structKeyExists(state, "exception")) {
 			transaction action="rollback";
 			throw(
 				errorCode = "1",
-				detail    = local.exception.detail,
-				message   = local.exception.message,
+				detail    = state.exception.detail,
+				message   = state.exception.message,
 				type      = "any"
 			);
 		} else {


### PR DESCRIPTION
## Summary

Wave-2 remediation for the **cli-scaffold-templates** package: five findings in the CLI scaffold/snippet generators whose emitted code crashed at runtime (`--belongsTo` views, API test files), silently mis-recorded failed migrations on BoxLang, or taught unsafe/no-op idioms (auth where-string interpolation, `null=` instead of `allowNull=`). All emitted-code paths now produce engine-portable, convention-correct output, with regression specs guarding every shipped template location.

## Findings addressed

- **CLI-D2 [High] `--belongsTo` scaffolds emit views that crash at runtime; `include=` injection dead for CRUD and invalid for API** @ `cli/lucli/services/Templates.cfc:624-641` — `addControllerIncludes()` replace targets now match the real `|ObjectNameSingularC|` template text in `cli/src/templates/CRUDContent.txt` (lines 7, 14, 40, 47, 59) and the wheels-new app-template copy; the `findByKey` injection is all-named (`findByKey(key=params.key, include=...)`) for both CRUD and API templates instead of the mixed positional+named form Lucee/Adobe reject (Anti-Pattern #1). Index views (`generateIndexArticleBody`/`generateIndexTableBody` @ `Templates.cfc:543-596`) now render the raw FK column (`authorId`, which `generateScaffold`/`generateApiResource` append) instead of `posts.author.name` on a flat query; show.cfm's `post.author.name` (`generateShowViewProperties` @ `Templates.cfc:598`) is now backed by an include that actually arrives.
- **CLI-D3 [Medium-High] Generated API tests can never pass — nonexistent `processRequest()` signature** @ `cli/lucli/services/Scaffold.cfc:557-606` — `generateApiTest()` now emits `processRequest(params={route: "apiXs", ...}, method=..., returnAs="struct")`, matching the framework signature (`vendor/wheels/Global.cfc:3428`) and the namespaced route names registered by `updateApiRoutes()` (mapper namespace prefix convention, `vendor/wheels/mapper/scoping.cfc:53`); `$findRoute` disambiguates member routes by method.
- **CLI-D4 [Medium] Generated migrations use the `local.X`-in-catch idiom broken on BoxLang (Cross-Engine Invariant #11)** — a failed migration took the COMMIT branch and was recorded as applied. Replaced with the struct-field pattern (`var state = {}; state.exception = e`) in the generator (`cli/lucli/services/Scaffold.cfc:645-698`), all 15 `cli/src/templates/dbmigrate/*.txt`, all 15 `vendor/wheels/migrator/templates/*.cfc`, `cli/src/templates/DBMigrate.txt`, the wheels-new app template (`cli/lucli/templates/app/app/snippets/DBMigrate.txt`) and demo-app copies (`app/snippets/dbmigrate/*`), the Destroy `remove_table` template (`cli/lucli/templates/migrations/remove_table.txt`), and the in-framework migration reference docs (`vendor/wheels/public/docs/reference/migration/{up,down,announce}.txt`).
- **CLI-D6 [Low, security-adjacent] Auth snippet interpolates user input into a finder `where` string** @ `cli/lucli/templates/snippets/auth-sessions-controller.txt:23` — login lookup now uses the injection-safe query builder: `model("User").where("username", params.username).first()` (values pass through adapter `$quoteValue` + `$validateValueShape`; `IsObject` check preserves findOne's false-on-miss semantics).
- **CLI-D7 [Low] Soft-delete snippet passes the no-op `null=` argument** @ `cli/lucli/templates/snippets/soft-delete-migration.txt:5` and `cli/lucli/templates/snippets/soft-delete-mixin.txt:4` — `addColumn()`/`t.datetime()` take `allowNull`, not `null`; both now pass `allowNull=true`.

## Findings verified already-fixed

None in this package — all five findings reproduced against `origin/develop`. staleRefs were line-number drift only, both confirmed accurate on develop: the CLI-D2 stale replace targets sit at `cli/lucli/services/Templates.cfc:638-641` on develop, and the CLI-D3 broken `processRequest` emission at `cli/lucli/services/Scaffold.cfc:582-599` on develop.

## Source

Internal multi-agent framework review 2026-06-09, wave 2, package **cli-scaffold-templates** (CLI-D2, CLI-D3, CLI-D4, CLI-D6, CLI-D7; refs followups 13, 14, 15, 17).

## Tests

- `cli/lucli/tests/specs/services/ScaffoldSpec.cfc` — new describes: **belongsTo scaffolding (CLI-D2)** (include injection for CRUD + API, index/show view output, raw-FK rendering), **generateApiTest() (CLI-D3)** (params-struct route name + `returnAs="struct"` signature), **generated migration failure tracking (CLI-D4)** (struct-field catch pattern).
- `cli/lucli/tests/specs/services/TemplatesSpec.cfc` — content guards over every shipped migration-template location (cli/src, vendor/wheels/migrator, app template, demo-app snippets) plus the fixed auth/soft-delete snippets.
- Every new assertion fails against the pre-fix code (regression-detecting by construction); the spec temp project copies from the webroot, so template resolution falls through to the fixed `cli/src/templates` copies.
- Local run deferred to CI: the new specs live in the CLI suite (pr.yml `cli` job is the gate). The worktree-safe docker single-bundle recipe covers core bundles only, and no core spec executes the migrator template files (they are generator input text, not framework code paths), so a bounded local core run would not exercise anything this PR changes.

## Cross-engine notes

- CLI-D4 **is** a cross-engine fix: catch-body `local.X` writes are discarded on BoxLang (Invariant #11), so generated migrations silently committed on failure there. The struct-field pattern is the documented prior art (`TenantResolverSpec`), applied uniformly across generator, all template copies, and reference docs so newly generated migrations are portable across Lucee 5/6/7, Adobe 2018-2025, and BoxLang.
- CLI-D2's all-named `findByKey(key=params.key, include=...)` removes a mixed positional+named call (Anti-Pattern #1) that Lucee/Adobe reject at runtime in generated API controllers.
- No reserved-scope parameter names, no inline closures as constructor named args, no `attributeCollection` usage introduced; new specs use the shared-struct closure pattern.

## Changelog

Entry deliberately omitted; consolidated at campaign end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)