### PR TITLE
fix(migrator): quote char defaults like string/text, restore adapter cache in spec

### DIFF
--- a/vendor/wheels/databaseAdapters/Abstract.cfc
+++ b/vendor/wheels/databaseAdapters/Abstract.cfc
@@ -126,7 +126,7 @@ component extends="wheels.migrator.Base"{
 		}
 		if (
 			StructKeyExists(arguments.options, 'type') && ListFindNoCase(
-				"binary,date,datetime,time,timestamp,text,string",
+				"binary,char,date,datetime,time,timestamp,text,string",
 				arguments.options.type
 			)
 		) {

--- a/vendor/wheels/tests/specs/migrator/adapterQuoteEscapingSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/adapterQuoteEscapingSpec.cfc
@@ -25,6 +25,10 @@ component extends="wheels.WheelsTest" {
 				expect(variables.adapter.quote(value = "O'Brien's", options = {type: "string"})).toBe("'O''Brien''s'");
 			});
 
+			it("escapes every embedded single quote for char types", () => {
+				expect(variables.adapter.quote(value = "O'Brien", options = {type: "char"})).toBe("'O''Brien'");
+			});
+
 			it("escapes every embedded single quote for text types", () => {
 				expect(variables.adapter.quote(value = "it's a 'quoted' default", options = {type: "text"})).toBe(
 					"'it''s a ''quoted'' default'"

--- a/vendor/wheels/tests/specs/model/adapterMemoizationSpec.cfc
+++ b/vendor/wheels/tests/specs/model/adapterMemoizationSpec.cfc
@@ -8,6 +8,22 @@
  */
 component extends="wheels.WheelsTest" {
 
+	function beforeAll() {
+		// Snapshot the shared cache so a mid-spec assertion failure can't leave
+		// the rest of the suite running against a cold (or half-built) cache.
+		if (StructKeyExists(application.wheels, "adapterCache")) {
+			variables.$priorAdapterCache = Duplicate(application.wheels.adapterCache);
+		}
+	}
+
+	function afterAll() {
+		if (StructKeyExists(variables, "$priorAdapterCache")) {
+			application.wheels.adapterCache = variables.$priorAdapterCache;
+		} else {
+			StructDelete(application.wheels, "adapterCache");
+		}
+	}
+
 	function run() {
 
 		g = application.wo;


### PR DESCRIPTION
## Summary

Follow-up to #2921, carrying the two wheels-bot Reviewer A suggestions that were still open when that PR merged (the blocking spec-semicolon point was already fixed on the branch in `4eddb04c3` and merged):

- **`Abstract.quote()` — add `char` to the string-family type list** @ `vendor/wheels/databaseAdapters/Abstract.cfc:129` — `char` was already string-family in the sibling `addColumnOptions` empty-default branch (line 87, `string,text,char`) but absent from `quote()`'s list, so a `char` column with `default="O'Brien"` emitted the value **unquoted and unescaped** (`DEFAULT O'Brien`). Pre-existing gap, narrowed but not closed by #2921; now closed. `Abstract.quote()` is the only `quote()` implementation (no adapter overrides), so this covers every engine.
- **`adapterMemoizationSpec` — snapshot/restore `application.wheels.adapterCache`** via `beforeAll`/`afterAll` so a mid-spec assertion failure can't leave later suites running against a cold cache. `Model.cfc::$assignAdapter()` lazily rebuilds the struct, so restoring either the snapshot or deleting the key is safe.

## Tests

- New assertion in `vendor/wheels/tests/specs/migrator/adapterQuoteEscapingSpec.cfc`: `quote(value="O'Brien", options={type: "char"})` → `'O''Brien'`.
- Verified locally on Lucee 7 + SQLite against the develop tip: migrator suite 290 passed, model suite 871 passed, 0 failures/errors.

## Source

wheels-bot Reviewer A on #2921 (review 4465418255, 2026-06-10T07:13Z), Correctness + Tests sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)