### PR TITLE
test(router): add regression spec pinning root() without to= to GET default

### DIFF
--- a/vendor/wheels/tests/specs/mapper/RootSpec.cfc
+++ b/vendor/wheels/tests/specs/mapper/RootSpec.cfc
@@ -62,6 +62,15 @@ component extends="wheels.WheelsTest" {
                expect(r[1].methods).toBe("post");
 			});
 
+            it("Root without to= defaults to GET", function(){
+               m.$draw()
+               .root()
+               .end();
+               r = m.getRoutes();
+               expect(r[1]).toHaveKey("methods");
+               expect(r[1].methods).toBe("get");
+			});
+
 		});
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to #2944 (`mapper-matching-constraints` review package, squash-merged to develop as `b95cd97fe`). Lands the one stranded commit from the review branch: a 9-line additive regression spec pinning `root()` without `to=` to the GET default. The spec was committed to `peter/review-w2-review-mapper-matching-constraints` two minutes after the squash-merge and never reached develop. Per final-review guidance, the stale branch is NOT re-merged — the spec is re-authored onto a fresh branch cut from `origin/develop`.

## Findings addressed

- Round-1 reviewer consensus (Reviewers A + B): no spec covered the no-`to=` branch of `root()` after the GET-default was lifted into a single top-level guard @ `vendor/wheels/mapper/matching.cfc:169-173`. New `it("Root without to= defaults to GET")` @ `vendor/wheels/tests/specs/mapper/RootSpec.cfc:65-73` calls `m.$draw().root().end()` and asserts `r[1].methods == "get"`.

## Findings verified already-fixed

All six package findings (routing:2, 3, 6, 7, 9, 10) already landed on develop via #2944 / `b95cd97fe` — verified byte-identical fix content on `Dispatch.cfc`, `matching.cfc`, and `Mapper.cfc` during final review. The remaining develop-vs-branch deltas (`Mapper.cfc` `$init` staticRoutes lines, `mapperModernSpec` base class) are develop moving ahead after the branch's last develop merge, not regressions; nothing else from the branch is missing.

## Source

Internal multi-agent framework review 2026-06-09, wave 2 package `mapper-matching-constraints` (finalize phase).

## Tests

- `vendor/wheels/tests/specs/mapper/RootSpec.cfc` — new `it("Root without to= defaults to GET")`, mirroring the adjacent `to=`-passing GET-default and explicit-`method` sibling specs in the same `describe` block.
- Local verification skipped: Docker daemon unavailable in this environment, so the worktree single-bundle recipe could not run. Deferred to CI, which runs the full engine x DB matrix per PR. The spec exercises the exact guard merged in #2944 (`!StructKeyExists(arguments, "method") && !StructKeyExists(arguments, "methods")` fires for the zero-arg call), and `root()`'s only parameters (`to`, `mapFormat`) are optional.

## Cross-engine notes

Pure additive test code; no framework changes. No `#` characters in spec strings (no `##` escaping needed), no inline closures as constructor named args, no reserved-scope parameter names, no outer-`local` capture (uses the suite-level `m`/`r` variables exactly like every sibling spec in the file). HEAD requests are unaffected by the guard under test because `$findMatchingRoute` maps HEAD to GET before the verb check (`Dispatch.cfc:145`).

## Changelog

Entry deliberately omitted; consolidated at campaign end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
