### PR TITLE
fix(bot): use Refs not Fixes on staged propose-fix PRs

### DIFF
--- a/.claude/commands/propose-fix.md
+++ b/.claude/commands/propose-fix.md
@@ -146,7 +146,13 @@ is enforced by code, so don't skip steps.
 11. **Open the draft PR.** Use `gh pr create --draft --base develop`. The
     PR body must:
     - Open with one paragraph naming what changed and why
-    - Include `Fixes #<issue-number>`
+    - Include `Fixes #<issue-number>` — **but only when the PR ships the
+      issue's complete scope.** If the PR is a stage, a partial fix, or
+      defers any of the issue's acceptance criteria to follow-ups, write
+      `Refs #<issue-number>` instead so the merge does not auto-close the
+      tracking issue. (Three multi-stage issues were silently orphaned
+      this way during the 2026-06 remediation campaign — #2897, #2959,
+      #2963 — each auto-closed by its Stage-1 PR.)
     - **If a research comment was used**: include
       `Recommended path from research: <link to research comment>`
     - Fill the `.github/pull_request_template.md` checklist honestly:


### PR DESCRIPTION
## Summary

`propose-fix.md` step 11 unconditionally required `Fixes #<issue-number>` in PR bodies. When the bot ships a stage or partial fix, the merge auto-closes the multi-stage tracking issue — this orphaned #2897, #2959, and #2963 during the 2026-06 remediation campaign (each closed by its Stage-1 PR, remainders untracked until the coverage audit caught them; all three since reopened).

## Fix

The instruction now requires `Refs #<issue-number>` whenever the PR ships less than the issue's complete scope, with the three orphaned issues cited as the cautionary example.

## Tests

Prompt-only change to `.claude/commands/propose-fix.md`; no executable code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)