### PR TITLE
test(router): cover nested named capture groups in constraint normalization

### DIFF
--- a/vendor/wheels/tests/specs/mapperModernSpec.cfc
+++ b/vendor/wheels/tests/specs/mapperModernSpec.cfc
@@ -394,6 +394,11 @@ component extends="wheels.WheelsTest" {
 				// Named capturing group opener is replaced wholesale with `(?:`.
 				expect(local.mapper.$nonCapturingConstraint("(?<yr>20\d{2})")).toBe("(?:20\d{2})")
 
+				// Nested named groups: the scanner must resume right after the outer
+				// `>` and re-detect the inner opener at the very next character.
+				expect(local.mapper.$nonCapturingConstraint("(?<outer>(?<inner>\d{2})\-\d{2})"))
+					.toBe("(?:(?:\d{2})\-\d{2})")
+
 				// Lookbehinds start with `(?<` too but are NOT capturing groups —
 				// the rewrite must leave them untouched.
 				expect(local.mapper.$nonCapturingConstraint("\w+(?<!tmp)")).toBe("\w+(?<!tmp)")


### PR DESCRIPTION
## Summary

Salvages the one non-duplicative test case from #2982 (otherwise superseded by #2989): a regression spec pinning that `Mapper.cfc::$nonCapturingConstraint` correctly rewrites **nested** Java named capture groups — after consuming the outer `(?<outer>` opener, the scanner must resume immediately after the `>` and re-detect the inner `(?<inner>` opener at the very next character.

```
(?<outer>(?<inner>\d{2})\-\d{2})  →  (?:(?:\d{2})\-\d{2})
```

This case was not covered by the specs that shipped with #2989; the surrounding single-group, lookbehind, and `\k<name>` backref cases already are.

## Why a separate PR

#2982 (bot branch `fix/bot-2976-*`) became test-only after develop's #2989 superseded its implementation, and the Bot PR TDD Gate hard-blocks test-only diffs on `fix/bot-*` branches. This re-files just the surviving test on a regular branch.

## Test plan

- [x] Exact spec content validated on the equivalent tree (develop + this test) via the prebuilt Lucee 7 + SQLite docker image: `wheels.tests.specs.mapperModernSpec` → 35 pass / 0 fail / 0 error; full `wheels.tests.specs.mapper` directory → 94 pass / 0 fail / 0 error
- [ ] CI cross-engine matrix on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)