### PR TITLE
docs(web/blog): correct double-converted updatedAt in 4.0.3 post frontmatter

### DIFF
--- a/web/content/blog/posts/wheels-4-0-3-released.md
+++ b/web/content/blog/posts/wheels-4-0-3-released.md
@@ -2,7 +2,7 @@
 title: 'Wheels 4.0.3: rebuilt CLI argument parsing, honest exit codes, and wrong-database guardrails'
 slug: wheels-4-0-3-released
 publishedAt: '2026-06-10T00:00:00.000Z'
-updatedAt: '2026-06-10T11:47:37.000Z'
+updatedAt: '2026-06-10T20:56:50.000Z'
 author: Peter Amiri
 tags:
   - wheels-4


### PR DESCRIPTION
One-line frontmatter fix: the publishing admin's exporter double-converted the ORM-UTC `updatedAt` (local→UTC applied to an already-UTC value), so the live 4.0.3 post shows an updated time ~7 hours in the future. Re-exported with the fixed exporter (wheels-publishing-admin#7, BUGS.md #3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)