### PR TITLE
test(wheelstest): cover the empty-server_name localhost guard in base-URL CGI detection

### DIFF
--- a/vendor/wheels/tests/specs/wheelstest/BrowserTestBaseUrlResolutionSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserTestBaseUrlResolutionSpec.cfc
@@ -69,6 +69,16 @@ component extends="wheels.WheelsTest" {
                 expect(bt.$detectBaseUrlFromCgi({})).toBe("");
             });
 
+            it("$detectBaseUrlFromCgi falls back to localhost when server_name is empty or missing", () => {
+                // Without this guard a blank cgi.server_name would build
+                // "http://:8585" and silently point browser specs at an
+                // unreachable origin.
+                var bt = new wheels.wheelstest.BrowserTest();
+                var fakeCgi = {server_port: "8585", server_name: "", https: "off"};
+                expect(bt.$detectBaseUrlFromCgi(fakeCgi)).toBe("http://localhost:8585");
+                expect(bt.$detectBaseUrlFromCgi({server_port: "8585"})).toBe("http://localhost:8585");
+            });
+
             it("JVM system property is honored when this.baseUrl is empty", () => {
                 var bt = new wheels.wheelstest.BrowserTest();
                 bt.baseUrl = "";

--- a/vendor/wheels/tests/specs/wheelstest/WheelsTestBaseUrlResolutionSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/WheelsTestBaseUrlResolutionSpec.cfc
@@ -39,6 +39,15 @@ component extends="wheels.WheelsTest" {
                 expect($detectTestBaseUrlFromCgi({})).toBe("");
             });
 
+            it("falls back to localhost when server_name is empty or missing", () => {
+                // Without this guard a blank cgi.server_name would build
+                // "http://:8585" and point the HTTP test client at an
+                // unreachable origin.
+                var fakeCgi = {server_port: "8585", server_name: "", https: "off"};
+                expect($detectTestBaseUrlFromCgi(fakeCgi)).toBe("http://localhost:8585");
+                expect($detectTestBaseUrlFromCgi({server_port: "8585"})).toBe("http://localhost:8585");
+            });
+
             it("honors this.testClientBaseUrl as the highest-precedence override", () => {
                 try {
                     this.testClientBaseUrl = "http://override.example:9999";


### PR DESCRIPTION
## Background: the wrong-server browser-suite bug

A downstream app (wheels-publishing-admin) moved from port 8080 to 8585 on 2026-05-11. Its vendored framework still resolved the browser-test base URL with a hard-coded `http://localhost:8080` fallback whenever `WHEELS_BROWSER_TEST_BASE_URL` was unset, so its browser specs were silently pointed at whatever happened to occupy 8080 — a *different* Wheels app. The suite kept "running" for a month (until 2026-06-10) producing meaningless results: failures looked like flaky timeouts, passes asserted against the wrong server.

Investigating an upstream fix, we found the bug was already root-fixed on `develop` by #2783 (closes #2779, merged 2026-05-22 — eleven days after the downstream port move): `BrowserTest.$resolveBaseUrl()` and `WheelsTest.$getTestBaseUrl()` now resolve through a layered lookup whose request-derived layer (`$detectBaseUrlFromCgi` / `$detectTestBaseUrlFromCgi`) builds the URL from `cgi.server_name`/`cgi.server_port` — TestBox runs inside an HTTP request to the app under test, so those are always correct. The downstream app just needs the newer framework.

## What this PR adds

One regression gap remained: the **empty-`server_name` → `localhost` guard** inside both CGI detectors was the only branch of the detection logic with no spec. If a refactor ever dropped the `len()` ternary, a blank `cgi.server_name` would build `http://:8585` and silently point specs at an unreachable origin — the same wrong-origin failure mode #2779 fixed.

This adds one spec to each of the existing pure-logic spec pairs (`BrowserTestBaseUrlResolutionSpec`, `WheelsTestBaseUrlResolutionSpec` — same call-with-a-fake-`cgi`-struct pattern those files already use, in the spirit of the `TestDirectoryResolver`-style extraction-for-testability convention):

- `$detectBaseUrlFromCgi` falls back to `localhost` when `server_name` is empty or missing
- `$detectTestBaseUrlFromCgi` falls back to `localhost` when `server_name` is empty or missing

## Verification

- **Specs are load-bearing (mutation check):** temporarily removing the guard (`var host = arguments.cgiScope.server_name ?: "";`) fails exactly these two specs — `Expected [http://localhost:8585] but received [http://:8585]` — with the other 159 wheelstest specs green. Mutation was never committed.
- **GREEN on pristine code:** `PORT=9192 bash tools/test-local.sh wheels.tests.specs.wheelstest` → 161 passed, 0 failed, 0 errors (Lucee 7 + SQLite).
- Cross-engine safe: matches the existing spec files' style; no inline-closure constructor args, no `local`-in-catch, plain struct literals only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)