### PR TITLE
docs(contributing): DCO sign-off is review-enforced, not a required status check

### DIFF
--- a/.claude/commands/_shared-rails.md
+++ b/.claude/commands/_shared-rails.md
@@ -53,9 +53,12 @@ they are honored. Violating them is a bug — fix the prompt, not the rails.
   matching the configured git author identity. Use `git commit -s` (the
   caller workflow's `git config` for `user.name` / `user.email` makes this
   the right value automatically) or append the trailer manually before the
-  `Co-authored-by:` lines. The [DCO GitHub App](https://github.com/apps/dco)
-  is a required status check on every PR and will block merges if any
-  commit is missing the trailer. See
+  `Co-authored-by:` lines. Note: sign-off is project policy verified during
+  code review — there is NO DCO status check on this repo, and no check will
+  fail for a missing trailer. When reviewing someone else's PR, treat a
+  missing sign-off as a fix-before-merge review request (suggest
+  `git rebase --signoff develop`), never as a failing or required CI check.
+  See
   [`CONTRIBUTING.md` § DCO](../../CONTRIBUTING.md#developer-certificate-of-origin-dco)
   for the contributor-facing explanation.
 - **Branch naming** for bot-authored work: `fix/bot-<issue>-<slug>` or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,11 +78,18 @@ git push --force-with-lease
 
 ### Enforcement
 
-The [DCO GitHub App](https://github.com/apps/dco) runs as a required status check on every PR. It verifies that every commit in the PR carries a valid `Signed-off-by:` trailer and blocks merge if any are missing. The app comments on the PR with a fixup suggestion when it finds an unsigned commit.
+Sign-off is required project policy, but it is currently verified during **code review**, not by an automated status check. The [DCO GitHub App](https://github.com/apps/dco) is **not** installed on this repository, and the develop branch's only merge-blocking status check is `Bot PR TDD Gate`. The other CI jobs that run on every PR (commit-message linting, the Lucee test suite, the wheels-bot reviewers) do not verify sign-offs either.
+
+In practice:
+
+- Sign every commit with `git commit -s`. Reviewers (human and bot) check for the `Signed-off-by:` trailer and will ask you to add any missing sign-offs (see [Forgot to sign off?](#forgot-to-sign-off)) before merge.
+- A missing sign-off surfaces as a review request to fix, **not** as a failing check on the PR.
+
+If automated DCO enforcement is added later (installing the DCO App and adding its context to the required status checks), this section will be updated to match.
 
 ### Grandfathering
 
-The DCO is enforced on **new PRs only**. Commits authored before DCO adoption are grandfathered and do not need to be retroactively signed.
+The DCO applies to **new PRs only**. Commits authored before DCO adoption are grandfathered and do not need to be retroactively signed.
 
 ---
 


### PR DESCRIPTION
## What

Docs-only fix for the DCO documentation drift reported in #3000.

- **`CONTRIBUTING.md` § Enforcement** — rewritten. It claimed the [DCO GitHub App](https://github.com/apps/dco) "runs as a required status check on every PR" and blocks merge. It does not: the app is not installed on this repository, and the develop ruleset's only required status check is `Bot PR TDD Gate` (verified: `gh api repos/wheels-dev/wheels/rules/branches/develop` lists exactly that one context; no DCO check appears on #2995/#2996/#2998). The section now describes the actual policy: sign every commit with `git commit -s`; the trailer is verified during code review (human and bot); a missing sign-off surfaces as a fix-before-merge review request, never as a failing check.
- **`CONTRIBUTING.md` § Grandfathering** — "The DCO is enforced on **new PRs only**" → "The DCO applies to **new PRs only**" for consistency (the rest is unchanged).
- **`.claude/commands/_shared-rails.md`** — the bot-rails DCO bullet carried the same false claim and is read by `review-pr.md`; it is exactly how Reviewer A false-escalated the unsigned commit on #2998 into a check-blocked "blocker". The bullet now states there is no DCO status check and instructs reviewers to treat a missing sign-off as a review request (suggesting `git rebase --signoff develop`). The bot's own sign-off requirement for commits it authors is unchanged.

## Why

Contributors and bot reviewers were both reasoning from documentation that does not match the repo. This takes option 2 from the issue ("make the docs honest").

## Follow-up: automated enforcement (deliberately NOT in this PR)

This PR intentionally adds **no** CI workflow and **no** required status check. Automated DCO enforcement remains available as a separate maintainer decision, either of:

- [ ] Install https://github.com/apps/dco on the repo and add its context to the develop ruleset's required status checks (org/repo-admin action), then update § Enforcement to match; **or**
- [ ] Add a small non-required CI job that checks `Signed-off-by:` trailers on PR commits and reports (without blocking).

## Test evidence

Markdown-only diff (`CONTRIBUTING.md`, `.claude/commands/_shared-rails.md`) — neither file is on any CFML load path. Full core suite run anyway on Lucee 7 + SQLite (docker `wheels-test-lucee7:v1.0.0`):

- Final (with this diff): **4293 pass / 12 fail / 0 error** (4323 specs, 18 skipped)
- All 12 failures are in `wheels.tests.specs.internal.testClientSpec` (TestClient loopback HTTP in the port-mapped container). Verified pre-existing: with this diff stashed (pristine develop @ `345b30dcb`), the same bundle yields the identical **41 pass / 12 fail / 0 error** — zero new failures from this change.
- Verification greps per plan: no remaining markdown claims that DCO "is/runs as a required status check" repo-wide (the only `apps/dco` mentions left are the corrected sections and a historical `CHANGELOG.md` release entry, which is not edited per project policy).

Fixes #3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)