### PR TITLE
fix(docs): handle SIGPIPE in changelog-promote.sh so --preview | head exits cleanly

### DIFF
--- a/tools/changelog-promote.sh
+++ b/tools/changelog-promote.sh
@@ -21,7 +21,15 @@ python3 - "$@" <<'PYEOF'
 import datetime
 import pathlib
 import re
+import signal
 import sys
+
+# Piping --preview into head/less closes stdout early; restore the default
+# SIGPIPE action so we exit silently like cat/grep instead of spraying a
+# BrokenPipeError traceback. Safe for the promote path: all file mutations
+# happen before the summary prints.
+if hasattr(signal, "SIGPIPE"):
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
 FRAG_DIR = pathlib.Path("changelog.d")
 CHANGELOG = pathlib.Path("CHANGELOG.md")

--- a/tools/test-changelog-promote.sh
+++ b/tools/test-changelog-promote.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Tests tools/changelog-promote.sh in a hermetic fixture (never reads or
+# mutates the real CHANGELOG.md or changelog.d/). Covers the SIGPIPE fix
+# (#2958): `--preview | head` must exit silently like `cat | head` instead of
+# spraying a BrokenPipeError traceback, plus preview/promote regressions.
+#
+# Dev-run only (like the sibling tools/test-*.sh scripts — not wired into CI):
+#   bash tools/test-changelog-promote.sh
+set -uo pipefail
+
+TOOLS_DIR="$(cd "$(dirname "$0")" && pwd)"
+fail=0
+tmpdirs=()
+cleanup() { for d in "${tmpdirs[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done; }
+trap cleanup EXIT
+
+ok()  { echo "ok:   $1"; }
+bad() { echo "FAIL: $1"; fail=1; }
+
+# Builds a throwaway project root in $tmp. The script under test derives
+# PROJECT_ROOT from its own dirname/.., so the copy operates entirely in $tmp.
+make_fixture() {
+  tmp="$(mktemp -d)"
+  tmpdirs+=("$tmp")
+  mkdir -p "$tmp/tools" "$tmp/changelog.d"
+  cp "$TOOLS_DIR/changelog-promote.sh" "$tmp/tools/"
+  cat >"$tmp/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+## [0.0.1] - 2020-01-01
+
+### Fixed
+
+- baseline bullet (#0)
+EOF
+  # One big fragment: >64KB of preview output guarantees the pipe buffer
+  # overflows after `head -1` exits, so SIGPIPE deterministically fires.
+  local pad i
+  pad="$(printf 'x%.0s' {1..400})"
+  : >"$tmp/changelog.d/big.fixed.md"
+  for i in $(seq 1 300); do
+    printf -- '- padding entry %03d %s (#1)\n' "$i" "$pad" >>"$tmp/changelog.d/big.fixed.md"
+  done
+}
+
+# Test 1: --preview piped into head must not spray a traceback (#2958).
+make_fixture
+"$tmp/tools/changelog-promote.sh" --preview 2>"$tmp/err" | head -1 >"$tmp/out"
+if grep -q "BrokenPipeError" "$tmp/err" || grep -q "Traceback" "$tmp/err"; then
+  bad "--preview | head sprayed a traceback on stderr:"
+  sed 's/^/      /' "$tmp/err"
+else
+  ok "--preview | head leaves stderr clean"
+fi
+if [ "$(head -1 "$tmp/out")" = "### Fixed" ]; then
+  ok "--preview | head -1 prints '### Fixed'"
+else
+  bad "--preview | head -1 printed '$(head -1 "$tmp/out")' (expected '### Fixed')"
+fi
+
+# Test 2: unpiped --preview still exits 0 with empty stderr.
+make_fixture
+"$tmp/tools/changelog-promote.sh" --preview >/dev/null 2>"$tmp/err"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  ok "--preview (unpiped) exits 0"
+else
+  bad "--preview (unpiped) exited $rc"
+fi
+if [ ! -s "$tmp/err" ]; then
+  ok "--preview (unpiped) stderr is empty"
+else
+  bad "--preview (unpiped) wrote to stderr:"
+  sed 's/^/      /' "$tmp/err"
+fi
+
+# Test 3: promote path regression — restoring default SIGPIPE must not change
+# behavior when stdout stays open (all file mutations precede stdout writes).
+make_fixture
+"$tmp/tools/changelog-promote.sh" 1.2.3 2026-01-01 >"$tmp/pout" 2>"$tmp/perr"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  ok "promote exits 0"
+else
+  bad "promote exited $rc:"
+  sed 's/^/      /' "$tmp/perr"
+fi
+if grep -q '## \[1.2.3\] - 2026-01-01' "$tmp/CHANGELOG.md"; then
+  ok "promote wrote the '## [1.2.3] - 2026-01-01' section"
+else
+  bad "CHANGELOG.md is missing the promoted version section"
+fi
+if [ ! -e "$tmp/changelog.d/big.fixed.md" ]; then
+  ok "promote deleted the fragment"
+else
+  bad "promote left the fragment behind"
+fi
+if grep -q 'Removed 1 fragment' "$tmp/pout"; then
+  ok "promote summary reports the removed fragment"
+else
+  bad "promote summary missing 'Removed 1 fragment'"
+fi
+
+exit $fail


### PR DESCRIPTION
## What

`tools/changelog-promote.sh --preview | head` sprayed a `BrokenPipeError` traceback on stderr and exited 120 (reproduced on develop @345b30dcb). Preview output currently runs 400+ lines, so piping into `head`/`less` is normal usage at release cut.

The python heredoc inherits CPython's default ignore-SIGPIPE behavior, so the EPIPE from the closed pipe surfaces as an unhandled exception at `print("\n".join(bullets))` instead of a silent exit.

## Fix

Restore the default SIGPIPE action at the top of the heredoc (guarded by `hasattr(signal, "SIGPIPE")` so the script stays harmless on platforms without it). The script now exits silently like `cat bigfile | head`.

Safe for the promote path: all file mutations (`CHANGELOG.write_text(...)`, fragment unlinks) happen **before** any stdout writes, so a SIGPIPE exit can never interrupt a half-finished promote.

Semantics note: with `SIG_DFL` the process exits via signal (status 141) when the reader closes early — identical to `cat bigfile | head`. Under a plain shell the pipeline status is `head`'s 0; under `pipefail` it is 141. Both are expected, and the script's own `set -euo pipefail` is unaffected because python3 is the final command.

## Tests

New `tools/test-changelog-promote.sh` — hermetic dev-run harness modeled on `tools/test-freshen-decide.sh` (NOT wired into CI, matching its siblings). It copies the script into a throwaway fixture root (the script derives PROJECT_ROOT from its own location), builds a >64KB fragment so the pipe buffer deterministically overflows after `head -1` exits, and covers:

1. `--preview | head` — stderr must contain no `BrokenPipeError`/`Traceback`; piped output starts with `### Fixed` (FAILED before the fix, passes after)
2. `--preview` unpiped — exit 0, empty stderr
3. promote path (`1.2.3 2026-01-01`) — exit 0, version section written, fragment deleted, summary printed

Manual smoke in the repo root: `tools/changelog-promote.sh --preview | head` prints 10 clean lines with empty stderr, `git status --porcelain` confirms the harness never touches real repo files.

## Test evidence (CFML suites)

No CFML is touched (`tools/`-only diff: one bash/python script + one bash test harness), so baseline == final by construction. Full core suite run anyway on Lucee 7 + SQLite (docker `wheels-test-lucee7:v1.0.0`): **HTTP 200, 4305 pass / 0 fail / 0 error (301 bundles, 4323 specs)**.

Harness note: a host-side run through a remapped port (61217→60007) showed 12 `testClientSpec` failures (status 0) — proven to be the known port-remap artifact (TestClient self-requests the request's Host header, unreachable inside the container); the same bundle passes 53/53 from inside the container, and the in-container full suite above is fully green.

changelog: none — internal release tooling.

Refs #2958

🤖 Generated with [Claude Code](https://claude.com/claude-code)