### PR TITLE
perf(events): fix $wheelsHeaders memo guard and reuse stored httpRequestData headers

### DIFF
--- a/changelog.d/eventmethods-headers-memo.performance.md
+++ b/changelog.d/eventmethods-headers-memo.performance.md
@@ -1,0 +1,1 @@
+- `$runOnRequestStart` no longer re-materializes `GetHTTPRequestData()` on every request: the `request.$wheelsHeaders` memo guard checked a misspelled singular key, and headers are now reused from the `request.wheels.httpRequestData` snapshot taken at request start (#2961)

--- a/vendor/wheels/events/EventMethods.cfc
+++ b/vendor/wheels/events/EventMethods.cfc
@@ -170,9 +170,7 @@ component extends="wheels.Global" implements="wheels.interfaces.events.EventHand
 		}
 
 		// Copy HTTP headers.
-		if (!StructKeyExists(request, "$wheelsHeader")) {
-			request.$wheelsHeaders = GetHTTPRequestData().headers;
-		}
+		$initializeRequestHeaders();
 
 		// Soft-reload of app/global/*.cfm when bare ?reload=true is hit in dev
 		// and any tracked include has a newer mtime. The password-gated
@@ -290,6 +288,21 @@ component extends="wheels.Global" implements="wheels.interfaces.events.EventHand
 			&& request.CGI.request_method eq "OPTIONS"
 		) {
 			abort;
+		}
+	}
+
+	/**
+	 * Internal function. Memoizes HTTP request headers in request.$wheelsHeaders.
+	 * Reuses the GetHTTPRequestData() result stored by $initializeRequestScope()
+	 * so the request body is not materialized a second time per request.
+	 */
+	public void function $initializeRequestHeaders() {
+		if (!StructKeyExists(request, "$wheelsHeaders")) {
+			if (StructKeyExists(request, "wheels") && StructKeyExists(request.wheels, "httpRequestData")) {
+				request.$wheelsHeaders = request.wheels.httpRequestData.headers;
+			} else {
+				request.$wheelsHeaders = GetHTTPRequestData().headers;
+			}
 		}
 	}
 

--- a/vendor/wheels/tests/specs/events/requestHeadersMemoSpec.cfc
+++ b/vendor/wheels/tests/specs/events/requestHeadersMemoSpec.cfc
@@ -1,0 +1,114 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+		describe("EventMethods request-header memoization (issue 2961 DC6)", () => {
+			// $runOnRequestStart memoizes HTTP headers into request.$wheelsHeaders
+			// (consumed by csrf.cfc and Dispatch.cfc). The guard used to check a
+			// misspelled singular key ($wheelsHeader) that is never written, so the
+			// memo never hit and GetHTTPRequestData() — which materializes the
+			// request body — ran a second time per request even though
+			// $initializeRequestScope() already stored the full result in
+			// request.wheels.httpRequestData. These specs run inside the live test
+			// request, so each one snapshots and restores the request-scope keys it
+			// touches (request.$wheelsHeaders / request.wheels.httpRequestData are
+			// live state consumed by the csrf specs later in the same request).
+
+			it("preserves an already-memoized request.$wheelsHeaders", () => {
+				var em = CreateObject("component", "wheels.events.EventMethods");
+				var hadHeaders = StructKeyExists(request, "$wheelsHeaders");
+				var priorHeaders = hadHeaders ? request.$wheelsHeaders : {};
+
+				try {
+					request.$wheelsHeaders = {"X-Memo-Sentinel" = "kept"};
+
+					em.$initializeRequestHeaders();
+
+					expect(StructKeyExists(request.$wheelsHeaders, "X-Memo-Sentinel")).toBeTrue(
+						"an already-memoized request.$wheelsHeaders must not be overwritten"
+					);
+				} finally {
+					if (hadHeaders) {
+						request.$wheelsHeaders = priorHeaders;
+					} else {
+						StructDelete(request, "$wheelsHeaders");
+					}
+				}
+			});
+
+			it("reuses request.wheels.httpRequestData.headers instead of calling GetHTTPRequestData() again", () => {
+				var em = CreateObject("component", "wheels.events.EventMethods");
+				var hadHeaders = StructKeyExists(request, "$wheelsHeaders");
+				var priorHeaders = hadHeaders ? request.$wheelsHeaders : {};
+				var hadHttpData = StructKeyExists(request, "wheels") && StructKeyExists(request.wheels, "httpRequestData");
+				var priorHttpData = hadHttpData ? request.wheels.httpRequestData : {};
+
+				try {
+					StructDelete(request, "$wheelsHeaders");
+
+					// Overwriting this from the test suite is a documented seam,
+					// see the comment in $initializeRequestScope() in Global.cfc.
+					request.wheels.httpRequestData = {
+						headers = {"X-From-Stored" = "yes"},
+						content = "",
+						method = "GET",
+						protocol = "HTTP/1.1"
+					};
+
+					em.$initializeRequestHeaders();
+
+					expect(StructKeyExists(request, "$wheelsHeaders")).toBeTrue(
+						"the helper must populate request.$wheelsHeaders when it is absent"
+					);
+					expect(StructKeyExists(request.$wheelsHeaders, "X-From-Stored")).toBeTrue(
+						"headers must come from the request.wheels.httpRequestData snapshot, not a fresh GetHTTPRequestData() call"
+					);
+				} finally {
+					if (hadHttpData) {
+						request.wheels.httpRequestData = priorHttpData;
+					} else {
+						StructDelete(request.wheels, "httpRequestData");
+					}
+					if (hadHeaders) {
+						request.$wheelsHeaders = priorHeaders;
+					} else {
+						StructDelete(request, "$wheelsHeaders");
+					}
+				}
+			});
+
+			it("falls back to GetHTTPRequestData() when request.wheels.httpRequestData is absent", () => {
+				var em = CreateObject("component", "wheels.events.EventMethods");
+				var hadHeaders = StructKeyExists(request, "$wheelsHeaders");
+				var priorHeaders = hadHeaders ? request.$wheelsHeaders : {};
+				var hadHttpData = StructKeyExists(request, "wheels") && StructKeyExists(request.wheels, "httpRequestData");
+				var priorHttpData = hadHttpData ? request.wheels.httpRequestData : {};
+
+				try {
+					StructDelete(request, "$wheelsHeaders");
+					StructDelete(request.wheels, "httpRequestData");
+
+					em.$initializeRequestHeaders();
+
+					expect(StructKeyExists(request, "$wheelsHeaders")).toBeTrue(
+						"the helper must fall back to GetHTTPRequestData() when the request-start snapshot is missing"
+					);
+					expect(IsStruct(request.$wheelsHeaders)).toBeTrue(
+						"the fallback must still store a headers struct"
+					);
+				} finally {
+					if (hadHttpData) {
+						request.wheels.httpRequestData = priorHttpData;
+					} else {
+						StructDelete(request.wheels, "httpRequestData");
+					}
+					if (hadHeaders) {
+						request.$wheelsHeaders = priorHeaders;
+					} else {
+						StructDelete(request, "$wheelsHeaders");
+					}
+				}
+			});
+		});
+	}
+
+}


### PR DESCRIPTION
## What

Fixes section C (DC6) of the #2961 roll-up: the request-header memo in `$runOnRequestStart` (`vendor/wheels/events/EventMethods.cfc`) guarded on a misspelled **singular** key — `request.$wheelsHeader` — that is never written anywhere, while the assignment writes the plural `request.$wheelsHeaders`. The memo therefore never hit, and `GetHTTPRequestData()` (which materializes the request body) ran a **second** time on every request even though `$initializeRequestScope()` (`vendor/wheels/Global.cfc`) already stores the full result in `request.wheels.httpRequestData` before `$runOnRequestStart` runs.

## How

- Extracted the block into a public `$initializeRequestHeaders()` helper (public + `$`-prefix per cross-engine invariant 7).
- The helper now guards on the correct plural key `request.$wheelsHeaders`, reuses `request.wheels.httpRequestData.headers`, and falls back to a direct `GetHTTPRequestData()` call only when the request-start snapshot is absent (defensive path for non-standard Application.cfc flows).
- The key stays spelled `$wheelsHeaders` — `csrf.cfc` and the csrf specs consume it under that name.
- New spec `vendor/wheels/tests/specs/events/requestHeadersMemoSpec.cfc` (TDD: first two `it`s were red against the old code, green after the fix):
  1. an already-memoized `request.$wheelsHeaders` is preserved,
  2. headers come from the stored `request.wheels.httpRequestData` snapshot, not a fresh `GetHTTPRequestData()` call,
  3. fallback still populates the headers struct when the snapshot is absent.
  Each `it` snapshots and restores the live request-scope keys in `finally` (they are consumed by the csrf specs later in the same suite request).
- Changelog fragment: `changelog.d/eventmethods-headers-memo.performance.md`.

Out of scope (sibling work items of the same roll-up): rendering coercion (C2/C13/C16/C17), MSSQL/Oracle adapters (DA1/DA5/DA14), public route-tester helpers (SEC-8/P14, already merged in #2995).

## Test evidence

Docker-staged engines, `db=sqlite`, full core suite via `/wheels/core/tests`:

| Run | Engine | Scope | Pass | Fail | Error |
|---|---|---|---|---|---|
| Baseline (untouched develop) | Lucee 7 | full suite | 4293 | 12 | 0 |
| Final (with fix) | Lucee 7 | full suite | 4296 | 12 | 0 |
| Final | Lucee 7 | events area | 39 | 0 | 0 |
| Final | Lucee 7 | csrf cookieSpec + sessionSpec | 96 | 0 | 0 |
| Final | Adobe 2023 | events area | 39 | 0 | 0 |
| Final | Adobe 2023 | csrf cookieSpec + sessionSpec | 96 | 0 | 0 |

Pass count is baseline + exactly the 3 new specs; the failing-spec set is byte-identical between baseline and final. The 12 pre-existing failures are all in `wheels.tests.specs.internal.testClientSpec` (TestClient loopback HTTP requests cannot resolve from inside the dir-mounted docker container — an environment artifact present on untouched develop, unrelated to this change).

Red phase verified: spec `it`s 1 and 2 failed against the buggy guard with the expected messages; `it` 3 passed (fallback behavior), guarding against regressions.

Refs #2961

🤖 Generated with [Claude Code](https://claude.com/claude-code)