### PR TITLE
feat(controller): dev-mode warning when config() override skips super.config()

### DIFF
--- a/changelog.d/csrf-config-super-warning.added.md
+++ b/changelog.d/csrf-config-super-warning.added.md
@@ -1,0 +1,1 @@
+- Development-mode warning (debug bar + wheels log) when a controller overrides `config()` without calling `super.config()`, which silently drops the base controller's `protectsFromForgery()` CSRF wiring and other inherited setup such as filters and verifies ([#2960](https://github.com/wheels-dev/wheels/issues/2960))

--- a/vendor/wheels/Controller.cfc
+++ b/vendor/wheels/Controller.cfc
@@ -59,6 +59,7 @@ component output="false" displayName="Controller" extends="wheels.Global"{
 		// Call the developer's "config" function if it exists.
 		if (StructKeyExists(variables, "config")) {
 			config();
+			$warnIfConfigSkipsSuper();
 		}
 
 		return this;
@@ -125,6 +126,239 @@ component output="false" displayName="Controller" extends="wheels.Global"{
 	 */
 	public void function $setControllerClassData() {
 		variables.$class = application.wheels.controllers[arguments.name].$getControllerClassData();
+	}
+
+	/**
+	 * Internal function. Called once per controller class at init time (after the
+	 * developer's config() has run). In the development environment it registers a
+	 * warning when the controller overrides config() without calling super.config(),
+	 * which silently drops the parent controller's setup: protectsFromForgery() CSRF
+	 * protection, filters, verifies, injected services, etc. The warning is surfaced
+	 * in the debug bar and the standard wheels log. Best-effort by design (mirrors
+	 * $deprecated() in Global.cfc): any failure here must never break controller
+	 * initialization.
+	 */
+	public void function $warnIfConfigSkipsSuper() {
+		try {
+			if ($get("environment") != "development") {
+				return;
+			}
+			if (!$configOverrideSkipsSuper()) {
+				return;
+			}
+			local.appKey = $appKey();
+			if (!StructKeyExists(application, local.appKey)) {
+				return;
+			}
+			local.message = "Controller '#variables.$class.name#' overrides config() without calling super.config(). Setup in its parent controller's config() (including protectsFromForgery() CSRF protection, filters, and verifies) will not run for this controller. Add super.config() as the first line of its config().";
+			// One app-wide lock serializes the lazy creation of the registry array and
+			// the dedup check / registration (mirrors $deprecated() in Global.cfc).
+			lock name="wheels_config_warning_registry" type="exclusive" timeout="5" {
+				if (!StructKeyExists(application[local.appKey], "controllerConfigWarnings")) {
+					application[local.appKey].controllerConfigWarnings = [];
+				}
+				for (local.existing in application[local.appKey].controllerConfigWarnings) {
+					if (local.existing.controller == variables.$class.name) {
+						return;
+					}
+				}
+				ArrayAppend(
+					application[local.appKey].controllerConfigWarnings,
+					{controller = variables.$class.name, message = local.message}
+				);
+				// Log if-and-only-if the registration above just succeeded; the registry
+				// enforces the warn-once policy for the log too.
+				try {
+					WriteLog(type = "warning", text = "[Wheels] " & local.message, file = "wheels");
+				} catch (any e) {
+					// Logging is best-effort; the registry entry above already records the warning.
+				}
+			}
+		} catch (any e) {
+			// Best-effort by design (including lock timeouts); never let this advisory
+			// break controller initialization.
+		}
+	}
+
+	/**
+	 * Internal function. Returns true when this controller class overrides config()
+	 * (shadowing a config() declared by an ancestor below wheels.Controller) without
+	 * its source calling super.config(). Pure detection; returns false whenever the
+	 * situation cannot be verified (never warn on uncertainty).
+	 */
+	public boolean function $configOverrideSkipsSuper() {
+		// Walk the inheritance chain from the leaf up to (but excluding) the
+		// framework's wheels.Controller, collecting each component's metadata node.
+		// The boundary match is belt-and-braces: no framework ancestor declares a
+		// config() function, so walking past a differently-named boundary is benign.
+		local.nodes = [];
+		local.node = GetMetaData(this);
+		while (IsStruct(local.node)) {
+			if (
+				StructKeyExists(local.node, "name")
+				&& ReFindNoCase("(^|\.)wheels\.Controller$", local.node.name)
+			) {
+				break;
+			}
+			ArrayAppend(local.nodes, local.node);
+			if (!StructKeyExists(local.node, "extends")) {
+				break;
+			}
+			local.node = local.node.extends;
+		}
+
+		// Find the leaf-most node that declares config(): that is the implementation
+		// that actually executed at class init.
+		local.declarerIndex = 0;
+		local.iEnd = ArrayLen(local.nodes);
+		for (local.i = 1; local.i <= local.iEnd; local.i++) {
+			if ($nodeDeclaresConfig(local.nodes[local.i])) {
+				local.declarerIndex = local.i;
+				break;
+			}
+		}
+
+		// No user-level config() declared anywhere (e.g. mixin-injected): nothing to check.
+		if (local.declarerIndex == 0) {
+			return false;
+		}
+
+		// Unless an ancestor of the declarer also declares config(), nothing was
+		// shadowed (the base-controller case: its config() simply has no parent
+		// config() to call up to).
+		local.shadowed = false;
+		for (local.i = local.declarerIndex + 1; local.i <= local.iEnd; local.i++) {
+			if ($nodeDeclaresConfig(local.nodes[local.i])) {
+				local.shadowed = true;
+				break;
+			}
+		}
+		if (!local.shadowed) {
+			return false;
+		}
+
+		// Cannot verify the source: never warn on uncertainty.
+		local.declarer = local.nodes[local.declarerIndex];
+		if (!StructKeyExists(local.declarer, "path") || !FileExists(local.declarer.path)) {
+			return false;
+		}
+		return !$sourceCallsSuperConfig(local.declarer.path);
+	}
+
+	/**
+	 * Internal function. Returns true when the given component metadata node declares
+	 * its own (non-inherited) config() function.
+	 */
+	public boolean function $nodeDeclaresConfig(required struct node) {
+		if (StructKeyExists(arguments.node, "functions") && IsArray(arguments.node.functions)) {
+			local.iEnd = ArrayLen(arguments.node.functions);
+			for (local.i = 1; local.i <= local.iEnd; local.i++) {
+				if (
+					StructKeyExists(arguments.node.functions[local.i], "name")
+					&& arguments.node.functions[local.i].name == "config"
+				) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Internal function. Comment-aware scan of a component source file for a
+	 * super.config() call. Strips line comments, block comments, and tag comments
+	 * line by line before matching, so a commented-out super.config() is correctly
+	 * reported as not calling it.
+	 *
+	 * Known accepted limitation: a literal comment-opener sequence inside a quoted
+	 * string before a same-line super.config() call strips the call from view and
+	 * yields a false positive warning. The commented-out super.config() case (the
+	 * realistic footgun) is detected correctly.
+	 *
+	 * NOTE: deliberately a line-by-line scanner. A global non-greedy regex comment
+	 * stripper is known to hang Lucee 7 on large files.
+	 */
+	public boolean function $sourceCallsSuperConfig(required string filePath) {
+		// Build the tag-comment markers without a literal angle bracket so engine
+		// tag scanners never mistake this source file for containing an unclosed tag.
+		local.tagOpen = Chr(60) & "!---";
+		local.tagClose = "---" & Chr(62);
+		local.lines = ListToArray(FileRead(arguments.filePath), Chr(10), false);
+		local.inBlock = false;
+		local.blockCloser = "";
+		local.iEnd = ArrayLen(local.lines);
+		for (local.i = 1; local.i <= local.iEnd; local.i++) {
+			local.remaining = local.lines[local.i];
+			local.code = "";
+			// Bounded loop: every iteration consumes at least one comment marker.
+			local.guard = 0;
+			while (Len(local.remaining) && local.guard < 1000) {
+				local.guard++;
+				if (local.inBlock) {
+					local.closePos = Find(local.blockCloser, local.remaining);
+					if (local.closePos == 0) {
+						// Comment continues on the next line.
+						local.remaining = "";
+					} else {
+						local.remaining = Mid(
+							local.remaining,
+							local.closePos + Len(local.blockCloser),
+							Len(local.remaining)
+						);
+						local.inBlock = false;
+					}
+				} else {
+					// Earliest comment opener wins; 0 means not present on this line.
+					local.linePos = Find("//", local.remaining);
+					local.blockPos = Find("/*", local.remaining);
+					local.tagPos = Find(local.tagOpen, local.remaining);
+					local.firstPos = 0;
+					local.marker = "";
+					if (local.linePos > 0) {
+						local.firstPos = local.linePos;
+						local.marker = "line";
+					}
+					if (local.blockPos > 0 && (local.firstPos == 0 || local.blockPos < local.firstPos)) {
+						local.firstPos = local.blockPos;
+						local.marker = "block";
+					}
+					if (local.tagPos > 0 && (local.firstPos == 0 || local.tagPos < local.firstPos)) {
+						local.firstPos = local.tagPos;
+						local.marker = "tag";
+					}
+					if (local.firstPos == 0) {
+						local.code &= local.remaining;
+						local.remaining = "";
+					} else {
+						if (local.firstPos > 1) {
+							local.code &= Left(local.remaining, local.firstPos - 1);
+						}
+						if (local.marker == "line") {
+							// The rest of the line is a comment.
+							local.remaining = "";
+						} else {
+							local.inBlock = true;
+							if (local.marker == "block") {
+								local.blockCloser = "*/";
+								local.openerLen = 2;
+							} else {
+								local.blockCloser = local.tagClose;
+								local.openerLen = Len(local.tagOpen);
+							}
+							local.remaining = Mid(
+								local.remaining,
+								local.firstPos + local.openerLen,
+								Len(local.remaining)
+							);
+						}
+					}
+				}
+			}
+			if (ReFindNoCase("super\s*\.\s*config\s*\(", local.code)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	if (

--- a/vendor/wheels/events/onrequestend/debug.cfm
+++ b/vendor/wheels/events/onrequestend/debug.cfm
@@ -432,6 +432,20 @@ OR (StructKeyExists(url, "format") AND ListFindNoCase("json,xml,csv,pdf", url.fo
 				</div>
 			</div>
 		</cfif>
+		<!---
+			Controller configuration warnings collected via $warnIfConfigSkipsSuper()
+			(controllers overriding config() without calling super.config()).
+		--->
+		<cfif StructKeyExists(application.wheels, "controllerConfigWarnings") AND ArrayLen(application.wheels.controllerConfigWarnings)>
+			<div class="wdb-section">
+				<div class="wdb-section-title" style="color:##f9e2af;">Configuration Warnings</div>
+				<div style="color:##f9e2af;font-size:12px;">
+					<cfloop array="#application.wheels.controllerConfigWarnings#" index="local.cw">
+						<p>#EncodeForHTML(local.cw.message)#</p>
+					</cfloop>
+				</div>
+			</div>
+		</cfif>
 	</div>
 </div>
 

--- a/vendor/wheels/tests/_assets/controllers/configchain/Base.cfc
+++ b/vendor/wheels/tests/_assets/controllers/configchain/Base.cfc
@@ -1,0 +1,11 @@
+component extends="wheels.Controller" {
+
+	function config() {
+		protectsFromForgery();
+	}
+
+	function index() {
+		renderText("index");
+	}
+
+}

--- a/vendor/wheels/tests/_assets/controllers/configchain/CommentedSuper.cfc
+++ b/vendor/wheels/tests/_assets/controllers/configchain/CommentedSuper.cfc
@@ -1,0 +1,11 @@
+component extends="wheels.tests._assets.controllers.configchain.Base" {
+
+	function config() {
+		// super.config();
+	}
+
+	function index() {
+		renderText("index");
+	}
+
+}

--- a/vendor/wheels/tests/_assets/controllers/configchain/InheritsOnly.cfc
+++ b/vendor/wheels/tests/_assets/controllers/configchain/InheritsOnly.cfc
@@ -1,0 +1,7 @@
+component extends="wheels.tests._assets.controllers.configchain.Base" {
+
+	function index() {
+		renderText("index");
+	}
+
+}

--- a/vendor/wheels/tests/_assets/controllers/configchain/NoSuper.cfc
+++ b/vendor/wheels/tests/_assets/controllers/configchain/NoSuper.cfc
@@ -1,0 +1,11 @@
+component extends="wheels.tests._assets.controllers.configchain.Base" {
+
+	function config() {
+		// intentionally does not call the parent configuration
+	}
+
+	function index() {
+		renderText("index");
+	}
+
+}

--- a/vendor/wheels/tests/_assets/controllers/configchain/NoSuperWiring.cfc
+++ b/vendor/wheels/tests/_assets/controllers/configchain/NoSuperWiring.cfc
@@ -1,0 +1,11 @@
+component extends="wheels.tests._assets.controllers.configchain.Base" {
+
+	function config() {
+		// intentionally does not call the parent configuration
+	}
+
+	function index() {
+		renderText("index");
+	}
+
+}

--- a/vendor/wheels/tests/_assets/controllers/configchain/WithSuper.cfc
+++ b/vendor/wheels/tests/_assets/controllers/configchain/WithSuper.cfc
@@ -1,0 +1,11 @@
+component extends="wheels.tests._assets.controllers.configchain.Base" {
+
+	function config() {
+		super.config();
+	}
+
+	function index() {
+		renderText("index");
+	}
+
+}

--- a/vendor/wheels/tests/specs/controller/configSuperWarningSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/configSuperWarningSpec.cfc
@@ -1,0 +1,102 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("config() override without super.config() detection", () => {
+
+			it("flags a controller that overrides config() without calling super.config()", () => {
+				local.c = application.wo.controller(
+					name = "configchain.NoSuper",
+					params = {controller = "configchain.NoSuper", action = "index"}
+				);
+				expect(local.c.$configOverrideSkipsSuper()).toBeTrue();
+			});
+
+			it("does not flag a controller whose config() calls super.config()", () => {
+				local.c = application.wo.controller(
+					name = "configchain.WithSuper",
+					params = {controller = "configchain.WithSuper", action = "index"}
+				);
+				expect(local.c.$configOverrideSkipsSuper()).toBeFalse();
+			});
+
+			it("flags a controller whose super.config() call is commented out", () => {
+				local.c = application.wo.controller(
+					name = "configchain.CommentedSuper",
+					params = {controller = "configchain.CommentedSuper", action = "index"}
+				);
+				expect(local.c.$configOverrideSkipsSuper()).toBeTrue();
+			});
+
+			it("does not flag a controller that inherits config() without overriding it", () => {
+				local.c = application.wo.controller(
+					name = "configchain.InheritsOnly",
+					params = {controller = "configchain.InheritsOnly", action = "index"}
+				);
+				expect(local.c.$configOverrideSkipsSuper()).toBeFalse();
+			});
+
+			it("does not flag a controller whose config() has no ancestor config() to shadow", () => {
+				// The Test asset controller declares config() but its parent (the asset
+				// base Controller.cfc) declares none, so nothing is shadowed.
+				local.c = application.wo.controller(
+					name = "Test",
+					params = {controller = "Test", action = "test"}
+				);
+				expect(local.c.$configOverrideSkipsSuper()).toBeFalse();
+			});
+
+		});
+
+		describe("config() override warning registration", () => {
+
+			beforeEach(() => {
+				variables.origEnv = application.wheels.environment;
+				StructDelete(application.wheels, "controllerConfigWarnings");
+				StructDelete(application.wheels.controllers, "configchain.NoSuperWiring");
+			});
+
+			afterEach(() => {
+				application.wheels.environment = variables.origEnv;
+				StructDelete(application.wheels, "controllerConfigWarnings");
+				StructDelete(application.wheels.controllers, "configchain.NoSuperWiring");
+			});
+
+			it("registers a development-mode warning at controller class init", () => {
+				application.wheels.environment = "development";
+				application.wo.controller(
+					name = "configchain.NoSuperWiring",
+					params = {controller = "configchain.NoSuperWiring", action = "index"}
+				);
+				expect(StructKeyExists(application.wheels, "controllerConfigWarnings")).toBeTrue();
+				expect(ArrayLen(application.wheels.controllerConfigWarnings)).toBe(1);
+				expect(application.wheels.controllerConfigWarnings[1].controller).toBe("configchain.NoSuperWiring");
+			});
+
+			it("dedupes repeated warnings for the same controller", () => {
+				application.wheels.environment = "development";
+				local.c = application.wo.controller(
+					name = "configchain.NoSuperWiring",
+					params = {controller = "configchain.NoSuperWiring", action = "index"}
+				);
+				local.c.$warnIfConfigSkipsSuper();
+				local.c.$warnIfConfigSkipsSuper();
+				expect(ArrayLen(application.wheels.controllerConfigWarnings)).toBe(1);
+			});
+
+			it("does not register a warning outside the development environment", () => {
+				application.wheels.environment = "production";
+				application.wo.controller(
+					name = "configchain.NoSuperWiring",
+					params = {controller = "configchain.NoSuperWiring", action = "index"}
+				);
+				local.registered = StructKeyExists(application.wheels, "controllerConfigWarnings")
+					&& ArrayLen(application.wheels.controllerConfigWarnings) > 0;
+				expect(local.registered).toBeFalse();
+			});
+
+		});
+
+	}
+
+}


### PR DESCRIPTION
## What

Development-mode warning when a controller overrides `config()` without calling `super.config()` — the footgun that silently drops the base controller's `protectsFromForgery()` CSRF wiring (and any inherited filters, verifies, and `inject()` calls). This is the detect-and-warn slice of #2960 only; the framework CSRF code itself is correct and untouched, and the default-on CSRF redesign stays deferred to the design discussion on the issue.

## How

- `vendor/wheels/Controller.cfc` — `$initControllerClass()` now calls `$warnIfConfigSkipsSuper()` right after the developer's `config()` (once per controller class per application lifetime).
  - `$configOverrideSkipsSuper()` — pure detection: walks `GetMetaData(this)` up to (but excluding) `wheels.Controller`, finds the leaf-most node declaring `config()`, and only proceeds when an ancestor below the framework boundary also declares `config()` (i.e. something was actually shadowed). Returns `false` on any uncertainty (no metadata `path`, missing file, mixin-injected config).
  - `$sourceCallsSuperConfig()` — comment-aware line-by-line scan for `super.config(` that strips `//`, `/* */`, and tag comments first, so a commented-out `super.config();` is correctly flagged. Deliberately NOT a global non-greedy regex stripper (known Lucee 7 hang on large files). Tag-comment markers are built via `Chr(60)` concat so engine tag scanners never see a literal opener.
  - `$warnIfConfigSkipsSuper()` — development-environment gate, registry in `application.wheels.controllerConfigWarnings` with per-controller dedup under an exclusive lock, one-time `WriteLog` to the `wheels` log. Entire body is best-effort try/catch mirroring `$deprecated()` in Global.cfc — can never break controller init.
- `vendor/wheels/events/onrequestend/debug.cfm` — new "Configuration Warnings" debug-bar section, sibling of the existing Deprecations block with identical structure/escaping.
- Fixtures `vendor/wheels/tests/_assets/controllers/configchain/` (Base / NoSuper / WithSuper / CommentedSuper / InheritsOnly / NoSuperWiring) + spec `vendor/wheels/tests/specs/controller/configSuperWarningSpec.cfc` (8 specs: 5 detection, 3 registration/dedup/env-gate).
- Changelog fragment `changelog.d/csrf-config-super-warning.added.md`.

One deviation from the scout plan, verified against the code: the docker suite runs in the `development` environment (config/environment.cfm), not `testing`, so the non-development spec explicitly sets `application.wheels.environment = "production"` (restored in `afterEach`) instead of relying on the ambient env.

## Test evidence (TDD: spec written first, failed for the right reason — `$configOverrideSkipsSuper` not found — then implemented)

| Run | Engine | DB | Result |
|---|---|---|---|
| Full suite baseline (develop) | Lucee 7 | sqlite | 4293 pass / 12 fail / 0 error |
| Full suite final (this branch) | Lucee 7 | sqlite | **4301 pass / 12 fail / 0 error** (+8 = the new specs; identical pre-existing failures) |
| Controller area | Lucee 7 | sqlite | 486 pass / 0 fail / 0 error |
| Controller area | Adobe 2023 | sqlite | 486 pass / 0 fail / 0 error |
| New spec bundle | Adobe 2023 | sqlite | 8 pass / 0 fail / 0 error |
| New spec bundle | BoxLang | sqlite | 8 pass / 0 fail / 0 error |
| Controller area | BoxLang | sqlite | 485 pass / 1 fail / 0 error |

Pre-existing failures, unrelated and present on develop:
- Lucee 7 full suite: the 12 failures are all `internal.testClientSpec` (TestClient self-HTTP requests that cannot resolve under the docker port mapping of this local harness; green in CI).
- BoxLang controller area: `miscellaneousSpec :: sendmail separates text and html bodies` — re-ran the same bundle with develop's `Controller.cfc`/`debug.cfm` checked out: still fails (40 pass / 1 fail), confirming pre-existing.

Hand-testing note: in the demo app only the base `app/controllers/Controller.cfc` declares `config()`, so the debug bar shows no warning by default; the debug-bar section was not hand-tested in a browser (it is structurally identical to the adjacent Deprecations block and the registry payload it renders is spec-covered).

## Scope guardrails honored

No changes to `vendor/wheels/controller/csrf.cfc`, `vendor/wheels/events/init/security.cfm`, generated controller templates, or CSRF defaults. No new settings.

Refs #2960

🤖 Generated with [Claude Code](https://claude.com/claude-code)