### PR TITLE
fix(events): honor explicit set(allowEnvironmentSwitchViaUrl=true) in production-like envs

### DIFF
--- a/changelog.d/3031-envswitch-explicit-override.fixed.md
+++ b/changelog.d/3031-envswitch-explicit-override.fixed.md
@@ -1,0 +1,1 @@
+- Explicit `set(allowEnvironmentSwitchViaUrl=true)` in `config/settings.cfm` is now honored in production-like environments (production, testing, maintenance). It used to be indistinguishable from the framework default and was silently discarded, making the documented override impossible (#3031)

--- a/vendor/wheels/events/onapplicationstart.cfc
+++ b/vendor/wheels/events/onapplicationstart.cfc
@@ -1,5 +1,10 @@
 component {
 
+	// Boot-time sentinel meaning "the developer has not explicitly set
+	// allowEnvironmentSwitchViaUrl". Must never escape $init(): the setting is
+	// resolved back to a real boolean by $resolveAllowEnvironmentSwitchViaUrl()
+	// right after the config/settings.cfm includes (issue #3031).
+	variables.$envSwitchUnset = "__wheels_unset__";
 
 	public void function $init(struct keys = {}) {
 
@@ -140,8 +145,14 @@ component {
 		application.$wheels.rootcomponentPath = local.paths.rootcomponentPath;
 		application.$wheels.wheelsComponentPath = local.paths.wheelsComponentPath;
 
-		// Check old environment to see whether we're allowed to switch configuration
-		application.$wheels.allowEnvironmentSwitchViaUrl = true;
+		// Check old environment to see whether we're allowed to switch configuration.
+		// The setting boots as a non-boolean sentinel (NOT `true`) so that an explicit
+		// set(allowEnvironmentSwitchViaUrl=true) in config/settings.cfm is distinguishable
+		// from "the developer never set it" — see $resolveAllowEnvironmentSwitchViaUrl()
+		// below, which runs right after the settings includes and always resolves the
+		// setting back to a real boolean (issue #3031). The sentinel only ever exists
+		// between here and that resolution point within a single application start.
+		application.$wheels.allowEnvironmentSwitchViaUrl = variables.$envSwitchUnset;
 		if (StructKeyExists(local, "allowEnvironmentSwitchViaUrl") && !local.allowEnvironmentSwitchViaUrl) {
 			application.$wheels.allowEnvironmentSwitchViaUrl = false;
 		}
@@ -218,8 +229,15 @@ component {
 			}
 		}
 
-		// If we're not allowed to switch, override and replace with the old environment
-		if (!application.$wheels.allowEnvironmentSwitchViaUrl && StructKeyExists(local, "oldEnvironment")) {
+		// If we're not allowed to switch, override and replace with the old environment.
+		// At this point the setting can still be the boot sentinel (= "not explicitly
+		// set", which historically meant `true` here), so only an explicit or
+		// carried-over boolean false blocks the switch.
+		if (
+			IsBoolean(application.$wheels.allowEnvironmentSwitchViaUrl)
+			&& !application.$wheels.allowEnvironmentSwitchViaUrl
+			&& StructKeyExists(local, "oldEnvironment")
+		) {
 			application.$wheels.environment = local.oldEnvironment;
 		}
 
@@ -298,14 +316,12 @@ component {
 		application.$wheels.initialized = true;
 
 		// Load general developer settings first, then override with environment specific ones.
-		// Track the initial default so we can detect if the developer explicitly overrides it.
 		// $includeConfig captures any output the file produces and warns via the application
 		// log if non-empty — usually the signal that a config/*.cfm file is missing its
 		// cfscript wrapper, in which case the engine parses cfscript-style code as markup
 		// and the registrations silently never run. (Note: Lucee 7's tag scanner reads
 		// CFC comments before compilation and treats literal cf-tags as unclosed errors,
 		// so this comment deliberately avoids putting the angle-bracketed form inline.)
-		local.envSwitchDefault = application.$wheels.allowEnvironmentSwitchViaUrl;
 		application.wo.$includeConfig(template = "/config/settings.cfm");
 		if (FileExists(ExpandPath("/config/#application.$wheels.environment#/settings.cfm"))) {
 			application.wo.$includeConfig(template = "/config/#application.$wheels.environment#/settings.cfm");
@@ -341,15 +357,16 @@ component {
 			application.$wheels.subpath = local.configuredSubpath;
 		}
 
-		// In production-like environments, disable URL-based environment switching by default.
-		// Developers can override by explicitly calling set(allowEnvironmentSwitchViaUrl=true) in settings.cfm.
-		if (
-			ListFindNoCase("production,testing,maintenance", application.$wheels.environment)
-			&& application.$wheels.allowEnvironmentSwitchViaUrl == local.envSwitchDefault
-			&& local.envSwitchDefault
-		) {
-			application.$wheels.allowEnvironmentSwitchViaUrl = false;
-		}
+		// Resolve allowEnvironmentSwitchViaUrl to a real boolean now that the developer's
+		// settings have loaded. If it is still the boot sentinel the framework default
+		// applies: disabled in production-like environments, enabled everywhere else.
+		// An explicit boolean from config/settings.cfm — including explicit `true`, which
+		// used to be indistinguishable from the default and silently discarded — is
+		// honored as-is in every environment (issue #3031).
+		application.$wheels.allowEnvironmentSwitchViaUrl = $resolveAllowEnvironmentSwitchViaUrl(
+			settingValue = application.$wheels.allowEnvironmentSwitchViaUrl,
+			environment = application.$wheels.environment
+		);
 
 		// Warn if reloadPassword is empty — URL-based reload and environment switching are disabled.
 		if (!Len(application.$wheels.reloadPassword)) {
@@ -470,5 +487,24 @@ component {
 			}
 			$location(url = local.url, addToken = false);
 		}
+	}
+
+	/**
+	 * Resolves the allowEnvironmentSwitchViaUrl setting to a real boolean after the
+	 * config/settings.cfm includes have run. Any explicit boolean the developer set is
+	 * honored as-is in every environment — this is what makes the documented production
+	 * override set(allowEnvironmentSwitchViaUrl=true) actually work (issue #3031).
+	 * A non-boolean value means the developer never touched the setting (it still holds
+	 * the boot sentinel), so the framework default applies: disabled in production-like
+	 * environments, enabled everywhere else.
+	 */
+	public boolean function $resolveAllowEnvironmentSwitchViaUrl(
+		required any settingValue,
+		required string environment
+	) {
+		if (IsBoolean(arguments.settingValue)) {
+			return arguments.settingValue;
+		}
+		return !ListFindNoCase("production,testing,maintenance", arguments.environment);
 	}
 }

--- a/vendor/wheels/tests/specs/events/EnvironmentSwitchResolutionSpec.cfc
+++ b/vendor/wheels/tests/specs/events/EnvironmentSwitchResolutionSpec.cfc
@@ -1,0 +1,95 @@
+/**
+ * Issue 3031: explicit set(allowEnvironmentSwitchViaUrl=true) used to be
+ * indistinguishable from the framework default (also true), so the documented
+ * production override was always silently discarded. The setting now boots as
+ * a non-boolean sentinel and $resolveAllowEnvironmentSwitchViaUrl() resolves
+ * it to a real boolean right after the config/settings.cfm includes: an
+ * explicit boolean is honored in every environment, the sentinel falls back
+ * to the framework default (disabled in production-like environments,
+ * enabled everywhere else).
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("allowEnvironmentSwitchViaUrl resolution (issue 3031)", () => {
+
+			// "__wheels_unset__" stands in for the boot sentinel below: the helper's
+			// contract is "explicit boolean -> honored, anything else -> default".
+
+			it("disables switching in production-like environments when the developer never set it", () => {
+				local.events = CreateObject("component", "wheels.events.onapplicationstart");
+				for (local.environmentName in ["production", "testing", "maintenance"]) {
+					local.resolved = local.events.$resolveAllowEnvironmentSwitchViaUrl(
+						settingValue = "__wheels_unset__",
+						environment = local.environmentName
+					);
+					expect(local.resolved).toBeFalse("expected unset to resolve to false in #local.environmentName#");
+				}
+			});
+
+			it("honors explicit set(allowEnvironmentSwitchViaUrl=true) in production-like environments", () => {
+				local.events = CreateObject("component", "wheels.events.onapplicationstart");
+				for (local.environmentName in ["production", "testing", "maintenance"]) {
+					local.resolved = local.events.$resolveAllowEnvironmentSwitchViaUrl(
+						settingValue = true,
+						environment = local.environmentName
+					);
+					expect(local.resolved).toBeTrue("expected explicit true to be honored in #local.environmentName#");
+				}
+			});
+
+			it("honors explicit set(allowEnvironmentSwitchViaUrl=false) in production-like environments", () => {
+				local.events = CreateObject("component", "wheels.events.onapplicationstart");
+				local.resolved = local.events.$resolveAllowEnvironmentSwitchViaUrl(
+					settingValue = false,
+					environment = "production"
+				);
+				expect(local.resolved).toBeFalse();
+			});
+
+			it("enables switching in development when the developer never set it", () => {
+				local.events = CreateObject("component", "wheels.events.onapplicationstart");
+				local.resolved = local.events.$resolveAllowEnvironmentSwitchViaUrl(
+					settingValue = "__wheels_unset__",
+					environment = "development"
+				);
+				expect(local.resolved).toBeTrue();
+			});
+
+			it("honors explicit set(allowEnvironmentSwitchViaUrl=false) in development", () => {
+				local.events = CreateObject("component", "wheels.events.onapplicationstart");
+				local.resolved = local.events.$resolveAllowEnvironmentSwitchViaUrl(
+					settingValue = false,
+					environment = "development"
+				);
+				expect(local.resolved).toBeFalse();
+			});
+
+			it("always resolves to a real boolean", () => {
+				local.events = CreateObject("component", "wheels.events.onapplicationstart");
+				local.cases = [
+					{settingValue: "__wheels_unset__", environment: "production"},
+					{settingValue: true, environment: "production"},
+					{settingValue: false, environment: "production"},
+					{settingValue: "__wheels_unset__", environment: "development"},
+					{settingValue: false, environment: "development"}
+				];
+				for (local.testCase in local.cases) {
+					local.resolved = local.events.$resolveAllowEnvironmentSwitchViaUrl(
+						settingValue = local.testCase.settingValue,
+						environment = local.testCase.environment
+					);
+					expect(IsBoolean(local.resolved)).toBeTrue(
+						"expected a boolean for #local.testCase.environment# / #local.testCase.settingValue#"
+					);
+				}
+			});
+
+			it("leaves the running application's setting as a real boolean after app start", () => {
+				expect(IsBoolean(application.wheels.allowEnvironmentSwitchViaUrl)).toBeTrue();
+			});
+
+		});
+	}
+}


### PR DESCRIPTION
## What

`set(allowEnvironmentSwitchViaUrl=true)` in `config/settings.cfm` — the documented override for URL-based environment switching in production-like environments — is now actually honored. Previously the framework default was also `true` and the hardening guard in `vendor/wheels/events/onapplicationstart.cfc` detected explicitness by comparing the post-settings value against that default, so explicit-true was indistinguishable from unset and silently discarded in `production`, `testing`, and `maintenance` (compounding #3023 symptom 1: switching into a prod-like environment was a one-way trapdoor).

## How

- The setting boots as a non-boolean sentinel (`__wheels_unset__`) instead of `true`. The cross-reload carryover (which only ever forces `false`) is unchanged.
- After the `config/settings.cfm` includes, a new public helper `$resolveAllowEnvironmentSwitchViaUrl(settingValue, environment)` resolves the setting back to a **real boolean**:
  - explicit boolean from settings → honored as-is in every environment (the fix);
  - still the sentinel → framework default: `false` in production-like environments, `true` everywhere else (both prior behaviors preserved).
- The pre-settings env-revert reader (`onapplicationstart.cfc:222`) gains an `IsBoolean` guard: the sentinel there keeps the historical `true` (allow) semantics; only an explicit/carried-over boolean `false` blocks the switch.
- The sentinel never escapes a single app start — downstream readers (cross-reload carryover, env revert, `/wheels/info`) only ever see a boolean.

Sibling PRs untouched per scope: `public/Application.cfc` redirect-strip (#3030) and Dispatch (#3029).

## Acceptance matrix (from #3031)

| Environment | Setting | Resolved |
|---|---|---|
| production/testing/maintenance | unset | `false` (hardening preserved) |
| production/testing/maintenance | explicit `true` | `true` (**the fix**) |
| production/testing/maintenance | explicit `false` | `false` |
| development | unset | `true` |
| development | explicit `false` | `false` |

Value is a real boolean in all cases.

## Test evidence (Lucee 7 + SQLite, docker harness)

- **Baseline (unmodified develop)**: 4374 pass / 12 fail / 0 error — the 12 are the known pre-existing `internal.testClientSpec` container artifacts.
- **RED (spec)**: new `events/EnvironmentSwitchResolutionSpec` on unmodified code → HTTP 417, 1 pass / 6 errors (helper absent).
- **RED (live)**: staged `environment=testing` + `set(allowEnvironmentSwitchViaUrl=true)`, probe via `app/events/onapplicationstart.cfm` hook (runs post-resolution), double reload for fresh templates, on unmodified code: `{"environment":"testing","allowEnvironmentSwitchViaUrl":false}` — explicit true silently discarded.
- **GREEN (live, post-fix)**: testing + explicit true → `true`; testing + unset → `false`; testing + explicit false → `false`; development + unset → `true`; `isBoolean: true` in every probe.
- **GREEN (spec)**: 7/7 pass (HTTP 200).
- **Full suite post-fix**: 4381 pass / 12 fail / 0 error (baseline + 7 new specs; only the tolerated `testClientSpec` artifacts remain).

All staged configs and the temporary probe hook were restored before commit.

Fixes #3031

🤖 Generated with [Claude Code](https://claude.com/claude-code)