### PR TITLE
ci: point docs-verify at the live v4-0-0 tree, untag illustrative blocks

### DIFF
--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -4,10 +4,10 @@ on:
   pull_request:
     branches: [develop]
     paths:
-      - 'web/sites/guides/src/content/docs/v4-0-0-snapshot/**'
+      - 'web/sites/guides/src/content/docs/v4-0-0/**'
       - 'web/sites/guides/scripts/verify-docs/**'
       - 'web/sites/guides/package.json'
-      - 'web/sites/guides/src/sidebars/v4-0-0-snapshot.json'
+      - 'web/sites/guides/src/sidebars/v4-0-0.json'
       - '.github/workflows/docs-verify.yml'
 
 jobs:

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -45,6 +45,12 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
 
       - name: Install Wheels CLI
+        env:
+          # Homebrew 5.x's Linux sandbox needs a rootless bwrap, which
+          # ubuntu-latest runners don't provide (and 24.04's unprivileged
+          # userns restrictions make it unreliable even when installed).
+          # The ephemeral runner is already isolation enough for CI.
+          HOMEBREW_NO_SANDBOX_LINUX: "1"
         run: |
           brew tap wheels-dev/wheels || true
           # Homebrew 5.1+ refuses to load formulae from untrusted third-party

--- a/.github/workflows/docs-verify.yml
+++ b/.github/workflows/docs-verify.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Install Wheels CLI
         run: |
           brew tap wheels-dev/wheels || true
+          # Homebrew 5.1+ refuses to load formulae from untrusted third-party
+          # taps; trust must be granted explicitly (no-op on older brew).
+          brew trust wheels-dev/wheels || true
           brew install wheels
 
       - name: Patch wheels wrapper JAVA_HOME for Linux

--- a/web/sites/guides/src/content/docs/v4-0-0/contributing/coding-standards.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/contributing/coding-standards.mdx
@@ -78,7 +78,7 @@ These come directly from `.ai/wheels/cross-engine-compatibility.md` and are the 
 
 Both engines resolve `obj.map()` as the built-in struct member function, not your CFC's `map()` method. The DI container exposes `mapInstance()` as the engine-safe alias.
 
-```cfm title="illustrative — do not type" {test:compile}
+```cfm title="illustrative — do not type"
 // WRONG — triggers struct.map(callback) on Lucee/Adobe
 arguments.container.map("myService").to("path").asSingleton();
 
@@ -90,7 +90,7 @@ arguments.container.mapInstance("myService").to("path").asSingleton();
 
 Adobe's `application` scope is Java-backed and loses function members across requests. Pass a plain struct context instead of mutating `application` directly.
 
-```cfm title="illustrative — do not type" {test:compile}
+```cfm title="illustrative — do not type"
 // WRONG — works on Lucee, breaks on Adobe
 application.registerMiddleware = function() { return true; };
 
@@ -103,7 +103,7 @@ context.registerMiddleware = function() { return true; };
 
 A closure binds `this` to where it is defined, not where it is assigned. Test code that dynamically attaches methods to a controller will call back into the spec, not the controller.
 
-```cfm title="illustrative — do not type" {test:compile}
+```cfm title="illustrative — do not type"
 // WRONG — this.renderText() runs on the test spec
 _controller.myAction = function() {
     this.renderText("hello");
@@ -120,7 +120,7 @@ _controller.myAction = function() {
 
 Split the lookup and the call.
 
-```cfm title="illustrative — do not type" {test:compile}
+```cfm title="illustrative — do not type"
 // WRONG — crashes Adobe CF 2021/2023 parser inside closures
 var result = obj["dynamicMethod"]();
 
@@ -133,7 +133,7 @@ var result = fn();
 
 `{arr: myArray}` duplicates the array on Adobe. Closures that append to the copy never touch the original. Reference through a parent struct.
 
-```cfm title="illustrative — do not type" {test:compile}
+```cfm title="illustrative — do not type"
 // WRONG — Adobe copies myArray into the struct
 var config = {arr: myArray};
 

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/authentication-patterns.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/authentication-patterns.mdx
@@ -209,7 +209,7 @@ The callback receives the extracted token string and returns a principal struct 
 
 ### Static token map (tests, seeded keys)
 
-```cfm {test:compile} title="illustrative — static tokens"
+```cfm title="illustrative — static tokens"
 var tokenStrategy = new wheels.auth.TokenStrategy(tokens={
     "dev-key-alice": {id: 1, role: "admin"},
     "dev-key-bob":   {id: 2, role: "reader"}


### PR DESCRIPTION
## What

Two quick wins from the verify:docs triage (P0 Task 4 of the guide-behavioral-audit campaign; full report in `docs/superpowers/audits/2026-06-verify-docs-triage.md` — currently untracked):

1. **`docs-verify.yml` could never fire on live-tree edits**: its `paths:` filters still referenced `v4-0-0-snapshot/**`, deleted at the GA rename (`4a62207ed`, 2026-05-12). Both filters now point at the live `v4-0-0` tree and its real sidebar file. The verify step keeps `continue-on-error: true` deliberately — the compile driver currently fails 312/317 live blocks on missing framework *context*, not content (#3041); this PR buys advisory visibility, gating comes with the harness fix.
2. **Six blocks violated the docs' own tagging policy** (`writing-docs.mdx`: anything that can't compile gets the illustrative title INSTEAD of a test tag): `contributing/coding-standards.mdx` ×5 and `digging-deeper/authentication-patterns.mdx` ×1 carried both `title="illustrative…"` and `{test:compile}`. Tags removed; a repo-wide grep confirms no other illustrative-tagged combinations remain.

## Triage headline (context)

370 tagged blocks on the live tree → 58 pass / 312 fail, **all 312 harness-defect bucket, zero verified broken doc claims**. The known brew-CLI compile-fallback caveat inverted with wheels 4.0.3 (proper exit codes flipped the driver into bare-engine execution). Real content bugs may still hide behind the broken driver — #3041 is the gating item; #3042 covers the cli-fixture target mismatch.

Refs #3041

🤖 Generated with [Claude Code](https://claude.com/claude-code)