### PR TITLE
docs(web/guides): correct reload-password behavior claims in security-hardening guide

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/deployment/security-hardening.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/deployment/security-hardening.mdx
@@ -128,8 +128,8 @@ component extends="wheels.Controller" {
 
 1. **View** — add a hidden token field to any `POST`/`PUT`/`PATCH`/`DELETE` form with `authenticityTokenField()` (view helper in `vendor/wheels/view/csrf.cfc`, line 26). Form helpers like `startFormTag()` insert it automatically for non-GET forms.
 2. **View (AJAX)** — add `csrfMetaTags()` to your layout `<head>` (line 10 of the same file). It emits two `<meta>` tags your JavaScript reads to send the token as an `X-CSRF-Token` header.
-3. **Controller pipeline** — before each action runs, `$runCsrfProtection(action)` (`vendor/wheels/controller/csrf.cfc` line 37) checks the `only`/`except` filters, calls `$verifyAuthenticityToken()` (line 63), and throws, aborts, or ignores per the `with` setting.
-4. **Verification** — `$isVerifiedRequest()` (line 82) short-circuits on GET/HEAD/OPTIONS; otherwise it matches `params.authenticityToken` against the session-stored token (`CsrfVerifyToken`) or the cookie-stored token depending on `application.wheels.csrfStore` (session by default, see `vendor/wheels/events/init/security.cfm` line 3).
+3. **Controller pipeline** — before each action runs, `$runCsrfProtection(action)` (`vendor/wheels/controller/csrf.cfc` line 37) checks the `only`/`except` filters, calls `$verifyAuthenticityToken()` (line 59), and throws, aborts, or ignores per the `with` setting.
+4. **Verification** — `$isVerifiedRequest()` (line 78) short-circuits on GET/HEAD/OPTIONS; otherwise it matches `params.authenticityToken` against the session-stored token (`CsrfVerifyToken`) or the cookie-stored token depending on `application.wheels.csrfStore` (session by default, see `vendor/wheels/events/init/security.cfm` line 3).
 
 ### Disable per-action for API endpoints
 
@@ -152,7 +152,9 @@ For an entire JSON API under `/api`, inherit from a controller that calls `prote
 
 ## Reload password
 
-`reloadPassword` gates `?reload=true` and environment switches via URL (`?reload=production`). If it's empty, both are disabled and Wheels logs a security warning on boot (`vendor/wheels/events/onapplicationstart.cfc` line 287-290). If it's set, attempts log to `wheels_security.log` with the source IP (line 189, 197) and rate-limit by IP (line 135).
+`reloadPassword` gates `?reload=true` and environment switches via URL (`?reload=production`). If it's empty, URL environment switching is disabled — but plain `?reload=true` currently remains open to **any** anonymous client, so always set a password. The security warning Wheels logs on boot (`vendor/wheels/events/onapplicationstart.cfc` lines 371-374) claims both are disabled; that overstatement and the open gate are tracked in [#3062](https://github.com/wheels-dev/wheels/issues/3062).
+
+If it's set, rejected and accepted attempts log to `wheels_security.log` with the trusted client IP (lines 219 and 227 of the same file), and failed attempts rate-limit by IP — 5 failures in 5 minutes locks the source out (lines 160-178). One scoping caveat: that code runs during application startup, so it only fires on requests that themselves trigger a cold start. A wrong-password `?reload=true` against an already-running app is served normally with no log entry and no rate-limit count.
 
 ```cfm {test:compile} title="config/settings.cfm"
 <cfscript>
@@ -165,7 +167,7 @@ Rotate it in every environment. The scaffolded template already reads this from 
 
 ### What it protects (and what it doesn't)
 
-The reload password defends a single threat: **a remote attacker who can reach your app over HTTP** otherwise being able to call `/?reload=true` and clobber app state, or `/?reload=production` and switch environments at will. With the password set, those URLs return 403 unless the attacker also knows the secret.
+The reload password defends a single threat: **a remote attacker who can reach your app over HTTP** otherwise being able to call `/?reload=true` and clobber app state, or `/?reload=production` and switch environments at will. With the password set, a request with a missing or wrong password is served normally (HTTP 200) without reloading — no `403` is returned, and nothing in the response reveals that the attempt was noticed (the gate in `public/Application.cfc` simply falls through to normal request serving; the only `403`s on this surface live on the CLI command gate in `vendor/wheels/Public.cfc`).
 
 What it explicitly does **not** gate:
 


### PR DESCRIPTION
Guide behavioral audit follow-up for `web/sites/guides/src/content/docs/v4-0-0/deployment/security-hardening.mdx`. Each correction was live-verified against current develop (post #3036/#3037/#3038/#3057/#3058) and re-cited against today's source.

## Corrections

1. **"If it's empty, both are disabled" — false.** With `set(reloadPassword="")`, plain `?reload=true` from any anonymous client still fires `applicationStop()` — the warm-reload gate in `public/Application.cfc` lines 268-288 explicitly passes when the password has no length; only the environment-switch leg (`vendor/wheels/events/onapplicationstart.cfc` line 188) requires a non-empty password. The guide now states that empty disables URL environment switching only, that plain reload stays open, and links the tracking issue #3062 (the boot warning at `onapplicationstart.cfc` 371-374 repeats the same false "disabled" claim).

2. **"those URLs return 403 unless the attacker also knows the secret" — false.** A missing/wrong password is served normally (HTTP 200, no reload, no 403) — the gate in `public/Application.cfc` lines 268-288 simply falls through to normal request serving. The only 403s on this surface are the CLI command gate in `vendor/wheels/Public.cfc` lines 90-111. Sentence replaced accordingly.

3. **Logging/rate-limit claim overstated + stale line cites.** Rejected attempts log at `vendor/wheels/events/onapplicationstart.cfc` line 219, accepted at line 227, IP rate-limit (5 failures / 5 min) at lines 160-178 — the guide cited 189/197/135. More importantly, that code only runs on application cold start: a wrong-password `?reload=true` against a warm app produces no `wheels_security.log` entry and no rate-limit count. The guide now scopes the claim and updates the cites. Boot-warning cite updated 287-290 → 371-374.

4. **CSRF line cites refreshed.** `$verifyAuthenticityToken()` is at `vendor/wheels/controller/csrf.cfc` line 59 (guide said 63); `$isVerifiedRequest()` at line 78 (guide said 82). `$runCsrfProtection()` line 37 and the view-helper cites (`csrfMetaTags` 10, `authenticityTokenField` 26) were verified still correct and left unchanged.

No change needed for `?reload=production` switching itself: #3058 (merged today) fixed the `$location` crash, so switching into production/maintenance now sticks.

## Verification

- `pnpm verify:docs src/content/docs/v4-0-0/deployment/security-hardening.mdx` → 11 tagged blocks, 11 passed, exit 0.

Refs #3062

🤖 Generated with [Claude Code](https://claude.com/claude-code)