### PR TITLE
docs(web/guides): fix caching guide cache categories, finder-cache store, and invalidation claims

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/caching.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/caching.mdx
@@ -43,7 +43,7 @@ component extends="Controller" {
 Rules:
 
 - `caches()` accepts either `action="name"` or `actions="one,two,three"` — same argument, aliased.
-- `time` defaults to 60 minutes (`defaultCacheTime`). Pass a number to override.
+- `time` defaults to 60 minutes. Pass a number to override. (The separate `defaultCacheTime` setting governs `cache=true` on finders and `renderView()`/`renderPartial()` — `caches()` carries its own hardcoded 60, so `set(defaultCacheTime=15)` won't change it.)
 - Caches are **skipped automatically** when the request has a flash message or a non-empty `form` scope. Wheels assumes a flash or form submission means the user just did something — serving them yesterday's HTML would be wrong.
 - Omit `action` entirely (`caches()`) and every action in the controller is cacheable.
 
@@ -142,7 +142,9 @@ Query caching is ideal when:
 
 ## Where cache entries live
 
-Wheels keeps cache entries in `application.wheels.cache` — an in-memory struct on the CFML application scope, split into categories (`action`, `partial`, `query`, `image`, `main`). Reads are struct lookups; writes are struct writes. No external service required.
+Wheels keeps cache entries in `application.wheels.cache` — an in-memory struct on the CFML application scope, split into categories (`action`, `page`, `partial`, `sql`, `image`, `main`, plus a legacy `query` category that nothing writes to). Reads are struct lookups; writes are struct writes. No external service required.
+
+One exception: `findAll(cache=N)` / `findByKey(cache=N)` results do **not** live in this struct. Cached finder results are stored in the CFML engine's native query cache (via `cachedWithin`); only the generated SQL shell lands in the `sql` category.
 
 | Property | Default | Meaning |
 | --- | --- | --- |
@@ -197,7 +199,7 @@ For caches keyed by query arguments (the automatic `findAll(cache=N)` flavor), i
    ```
 
    Now the model callback can call `$removeFromCache(key="posts-listing")` surgically.
-3. **Clear the whole category.** `$clearCache(category="query")` is a blunt instrument but fast to reason about when in doubt.
+3. **Bust the engine's query cache with a reload.** `$clearCache(category="query")` does **not** invalidate finder caches — as noted above, `findAll(cache=N)` results live in the CFML engine's native query cache, not in `application.wheels.cache`. The blunt instruments that actually work are `?reload=true&password=...` (which rotates the cache-key comment Wheels embeds in every cached query's SQL, invalidating all engine-cached results) or an application restart.
 
 ## Per-user keys
 
@@ -240,7 +242,7 @@ Configure edge caching at the deploy layer, not in Wheels. The [Deployment](/v4-
 
 Three ways to confirm what you're seeing:
 
-1. **Disable caching temporarily** — `set(cacheActions=false)` in `config/environments/development.cfm` is the default; flipping it on in development reproduces production behavior when you're investigating a stale-read bug.
+1. **Disable caching temporarily** — `cacheActions=false` is already the development default (the framework sets it; no config file needed). Flipping it on with `set(cacheActions=true)` in `config/development/settings.cfm` reproduces production behavior when you're investigating a stale-read bug.
 2. **Pass `time=0`** to force re-rendering while you leave the `caches()` declaration in place:
 
    ```cfm {test:compile} title="app/controllers/Posts.cfc (debugging)"
@@ -251,7 +253,7 @@ Three ways to confirm what you're seeing:
        }
    }
    ```
-3. **Clear caches on reload.** `?reload=true&password=...` flushes query and template caches automatically (`clearQueryCacheOnReload`, `clearTemplateCacheOnReload`). Combine with a custom admin action that calls `application.wo.$clearCache()` when you need to purge the full cache without a restart.
+3. **Clear caches on reload.** `?reload=true&password=...` flushes query and template caches automatically (`clearQueryCacheOnReload`, `clearTemplateCacheOnReload`). Combine with a custom admin action that calls `application.wo.$clearCache()` when you need to purge the full cache without a restart. Note: when `reloadPassword` is empty, `?reload=true` currently restarts the app with no password at all — set a non-empty `reloadPassword` anywhere that matters (see [#3062](https://github.com/wheels-dev/wheels/issues/3062)).
 
 ## Related guides
 


### PR DESCRIPTION
Audit-driven corrections to the Caching guide (`digging-deeper/caching.mdx`). Four claims in the page were verified wrong against framework source (and live probes on Lucee 7); each fix below cites the source of truth.

## Corrections

1. **`caches()` time default is a hardcoded 60, not `defaultCacheTime`.**
   The page attributed the 60-minute default to `defaultCacheTime`. In fact `caches()` carries its own literal default — `application.$wheels.functions.caches = {time = 60, static = false}` (`vendor/wheels/events/init/functions.cfm:25`). `defaultCacheTime` governs `cache=true` finders and `renderView()`/`renderPartial()` fallbacks (`vendor/wheels/Global.cfc:808-828`, `vendor/wheels/controller/rendering.cfc:453,479`, `vendor/wheels/model/read.cfc:339-341`), so `set(defaultCacheTime=15)` would not change `caches()`. The bullet now says so.

2. **Real cache-struct categories; finder results don't live in `application.wheels.cache`.**
   The page listed 5 categories (`action`, `partial`, `query`, `image`, `main`). The struct is actually initialized with 7 — `sql`, `image`, `main`, `action`, `page`, `partial`, `query` (`vendor/wheels/events/onapplicationstart.cfc:123-131`) — and nothing in the framework ever writes the `query` category (writers: `read.cfc:288` → `sql`, `view/assets.cfc:154` → `image`, `controller/processing.cfc:57` + `rendering.cfc:52` → `action`, `rendering.cfc:547` → `partial`). Added the explicit caveat that `findAll(cache=N)`/`findByKey(cache=N)` results are stored in the CFML engine's native query cache via `cachedWithin` (`vendor/wheels/model/read.cfc:341`), with only the SQL shell in the `sql` category.

3. **Invalidation Option 3 rewritten — `$clearCache(category="query")` is a no-op for finder caches.**
   Live-verified: stale finder results survived `$clearCache(category="query")` because they live in the engine's query cache, not the Wheels struct. The working blunt instruments are `?reload=true&password=...` — which rotates the cache-key SQL comment embedded in every cached query (`vendor/wheels/databaseAdapters/Base.cfc:813-817`), invalidating all engine-cached results — or an application restart. The option now says exactly that.

4. **Per-environment config path corrected.**
   `config/environments/development.cfm` is never read; per-environment overrides load from `config/<environment>/settings.cfm` (`vendor/wheels/events/onapplicationstart.cfc:326-328`). Also clarified that `cacheActions=false` is the framework-set development default (`vendor/wheels/events/init/caching.cfm:10`) — no config file involved.

5. **Current reload-password behavior noted (open issue).**
   Since the page recommends `?reload=true&password=...` for cache busting, added a note that an empty `reloadPassword` currently allows anonymous `?reload=true` restarts, per the open contract-drift issue.

Refs #3062

## Verification

- `pnpm verify:docs src/content/docs/v4-0-0/digging-deeper/caching.mdx` — 10 tagged blocks, 10 passed, exit 0.
- All source citations re-checked against current `develop` in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
