### PR TITLE
docs(web/guides): correct environments guide load order, WHEELS_ENV detection, and env-switch docs

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/core-concepts/environments-and-configuration.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/core-concepts/environments-and-configuration.mdx
@@ -14,30 +14,33 @@ Wheels ships with three named environments, a small stack of configuration files
 - Where configuration lives and the order files load in
 - How `set()` writes into the settings struct and how overrides cascade
 - How the active environment is chosen at boot
+- How to switch environments at runtime — and what gates it
 - Where secrets belong — and where they don't
 
 ## The three environments
 
-| Environment | When it's used | Typical settings |
-|-------------|----------------|------------------|
+| Environment | When it's used | Framework defaults |
+|-------------|----------------|--------------------|
 | `development` | Local dev server | Verbose errors, hot reload, debug helpers visible |
-| `testing` | Test suite runs | Clean DB reset per spec, shorter timeouts, deterministic time |
-| `production` | Real users | Errors hidden, caches warmed, log rotation, HTTPS enforced |
+| `testing` | Test suite runs | Debug UI off, `/wheels/*` public component disabled, caching on, URL environment switching blocked by default |
+| `production` | Real users | Errors hidden, caching on, debug UI and `/wheels/*` public component disabled |
 
 A fourth value, `maintenance`, is supported for planned downtime. Most apps never need it.
 
+These are the defaults the framework itself flips per environment. Operational concerns like log rotation and HTTPS enforcement are not framework settings — handle those in your web server, or use the `SecurityHeaders` middleware for transport-security headers.
+
 ## Where settings live
 
-Configuration loads from a small set of files in `config/`. The framework reads them in order at application start and on every `wheels reload`:
+Configuration loads from a small set of files in `config/`. The framework reads them in order at application start and on every reload (`?reload=true&password=...`):
 
-- `config/app.cfm` — init-time hooks for the `this` scope of `Application.cfc` (app name, session timeout). Runs once per app start.
+- `config/app.cfm` — hooks for the `this` scope of `Application.cfc` (app name, session timeout). It's included from the `Application.cfc` pseudo-constructor, so it *executes on every request* — its `this`-scope effects apply at application start, but don't put side effects in it that aren't safe to run per request.
+- `config/environment.cfm` — sets the active environment name. This runs *first* at application start: the framework derives its environment-dependent defaults (error verbosity, caching, debug UI) from this value before any other config file loads.
 - `config/settings.cfm` — shared defaults that apply to every environment. Middleware list, datasource name, reload password.
-- `config/environment.cfm` — reads the active environment name, typically from `WHEELS_ENV` with a sane default.
 - `config/<environment>/settings.cfm` — per-environment overrides. `config/development/settings.cfm`, `config/testing/settings.cfm`, `config/production/settings.cfm`. Loaded *after* the shared file, so these win.
 - `config/services.cfm` — DI container registrations. See [The Dependency Injection Container](/v4-0-0/core-concepts/dependency-injection/).
 - `config/routes.cfm` — route definitions. See [How Routing Works](/v4-0-0/core-concepts/how-routing-works/).
 
-The per-environment override directory is only read for the environment you're in. `config/production/settings.cfm` never runs in development, which is exactly what you want when production is where the caching and HTTPS enforcement belong.
+The per-environment override directory is only read for the environment you're in. `config/production/settings.cfm` never runs in development, which is exactly what you want when production is where the extra caching belongs.
 
 ## The `set()` pattern
 
@@ -46,8 +49,11 @@ Every framework setting is written with one function: `set(key=value)`. It write
 ```cfm title="illustrative — config/settings.cfm"
 set(dataSourceName = "myapp_dev");
 set(reloadPassword = env("WHEELS_RELOAD_PASSWORD", ""));
-set(environment = env("WHEELS_ENV", "development"));
 ```
+
+One exception: don't `set(environment=...)` here. Environment selection belongs in `config/environment.cfm` only — by the time `settings.cfm` runs, the framework has already derived its environment-dependent defaults, so setting the environment this late produces a half-switched app (the environment reports `production` while verbose error details, development caching flags, and `allowMigrationDown` persist from the boot-time value).
+
+Also note that a blank `reloadPassword` currently permits *anonymous* `?reload=true` restarts — the password check is skipped entirely when no password is configured ([#3062](https://github.com/wheels-dev/wheels/issues/3062)). Set a real reload password in every environment.
 
 Settings cascade: framework defaults load first, then `config/settings.cfm`, then `config/<environment>/settings.cfm`. Later writes win. A value you set in the shared file is the default for every environment; the environment-specific file only needs to name the keys it changes.
 
@@ -55,7 +61,36 @@ One development-only default worth noting: `reloadOnGlobalChange` (defaults `tru
 
 ## Environment detection
 
-The active environment is set by `config/environment.cfm`, which typically reads `WHEELS_ENV` from the environment variables with a default of `development`. The `wheels` CLI respects the same variable, and `.env` files loaded at boot get merged into the lookup. Override in CI or production by exporting `WHEELS_ENV=production` before the app starts — a deploy script, a Dockerfile `ENV`, or a systemd unit is the usual place.
+The active environment is whatever `config/environment.cfm` sets — and the scaffold hard-codes it:
+
+```cfm title="illustrative — config/environment.cfm (as generated)"
+set(environment = "development");
+```
+
+Exporting `WHEELS_ENV` does **not** change the environment on a stock app: nothing in the generated `environment.cfm` reads it, and the `wheels` CLI ignores the variable entirely. In a generated app, the exported value's only built-in effect is selecting which `.env.<name>` overlay file loads at boot.
+
+To drive the environment from a variable, two edits are required:
+
+1. Change `config/environment.cfm` to read it:
+
+   ```cfm title="illustrative — config/environment.cfm"
+   set(environment = env("WHEELS_ENV", "development"));
+   ```
+
+2. Remove the `WHEELS_ENV=development` line the scaffold writes into `.env`. `env()` checks `.env` *before* OS environment variables, so that line shadows any exported `WHEELS_ENV=production` until it's gone.
+
+With both edits in place, export `WHEELS_ENV=production` before the app starts — a deploy script, a Dockerfile `ENV`, or a systemd unit is the usual place.
+
+## Switching environments at runtime
+
+A running app can switch environments without a redeploy: request `?reload=<environment>&password=<reloadPassword>` (for example `?reload=testing&password=...`). The framework restarts the application, carries the switch parameters through the restart redirect, and boots into the requested environment — including switches into `production` or `maintenance`, after which the redirect strips the parameters. Requesting the environment you're already in is a no-op; for a plain same-environment restart use `?reload=true&password=<reloadPassword>`, which strips the reload parameters from the redirect.
+
+The gate is `allowEnvironmentSwitchViaUrl`. Any explicit boolean you `set()` is honored in every environment. If you never touch it, the default is `false` in `production`, `testing`, and `maintenance`, and `true` everywhere else. Leave it disabled in production.
+
+Two caveats, tracked as open issues:
+
+- The debug bar's environment quick-switch links are currently broken ([#3060](https://github.com/wheels-dev/wheels/issues/3060)) — use the URL form above.
+- The `wheels reload` CLI command can report success even when the reload didn't take effect ([#3059](https://github.com/wheels-dev/wheels/issues/3059)) — verify with the URL form.
 
 ## Secrets handling
 


### PR DESCRIPTION
Audit-driven corrections to `web/sites/guides/src/content/docs/v4-0-0/core-concepts/environments-and-configuration.mdx`. Each change is cite-checked against framework source (and live audit probes on lucee7/adobe2023); no editorial rewrites beyond the established findings.

## Corrections

1. **Config load order reordered** — the guide listed `settings.cfm` before `environment.cfm`. Actual order: `config/app.cfm` (Application.cfc pseudo-constructor) → `config/environment.cfm` → framework defaults → `config/settings.cfm` → `config/<env>/settings.cfm` → `services.cfm` → `routes.cfm`.
   Evidence: `vendor/wheels/events/onapplicationstart.cfc:204` (environment.cfm), `:245-313` (framework defaults), `:325-328` (settings.cfm + per-env settings), `:380-386` (services), `:429` (routes); `public/Application.cfc:105` (app.cfm include).

2. **`config/app.cfm` "runs once per app start" removed** — it is included from the `Application.cfc` pseudo-constructor and executes on **every request**; only its `this`-scope effects apply at app start. Evidence: `public/Application.cfc:105`; live probe showed 2 executions per plain GET on adobe2023 with zero reloads.

3. **`WHEELS_ENV` detection claim fixed** — the scaffold hard-codes `set(environment = "development")` and neither `environment.cfm` nor the `wheels` CLI reads `WHEELS_ENV`. Documented the two required edits: read it via `env("WHEELS_ENV", "development")` in `environment.cfm` AND remove the scaffold `.env`'s `WHEELS_ENV=development` line (`env()` checks `.env` before OS env, so it shadows exports). Evidence: `config/environment.cfm:9`, `cli/lucli/templates/app/config/environment.cfm:9`, `cli/lucli/templates/app/_env:4`; `grep -rn WHEELS_ENV cli/lucli` hits only generated-app templates; live `WHEELS_ENV=production wheels info` output byte-identical to plain `wheels info`.

4. **Removed `set(environment = ...)` from the illustrative `settings.cfm` block** and added a warning — setting the environment there yields a half-switched app (environment reports `production` while verbose errors, dev caching flags, and `allowMigrationDown` persist, since boot-derived flags are computed at `onapplicationstart.cfc:245-313`, before `settings.cfm` at `:325`). Live probe confirmed verbose error leakage (`boom-marker` visible at HTTP 500 while environment=production).

5. **Environments table rows replaced with real framework defaults** — testing row claimed "Clean DB reset per spec, shorter timeouts, deterministic time" (no such code paths exist); production row claimed "caches warmed, log rotation, HTTPS enforced" (caching is merely *enabled* outside development, `vendor/wheels/events/init/caching.cfm:15-21`; log rotation/HTTPS are not framework settings anywhere in `vendor/wheels`). Now lists: debug UI off, `/wheels/*` public component disabled, caching on, URL env-switch blocked by default — with a note pointing log rotation/HTTPS to the web server / `SecurityHeaders` middleware.

6. **New "Switching environments at runtime" section** (previous docs gap) — documents `?reload=<environment>&password=<reloadPassword>` (params preserved through the restart redirect, #3036), `?reload=<current-env>` as a no-op vs `?reload=true` for a plain restart, switches into `production`/`maintenance` sticking with params stripped afterward (#3058), and the `allowEnvironmentSwitchViaUrl` gate: explicit boolean honored in every environment; unset defaults to `false` in production/testing/maintenance and `true` elsewhere (#3038, `vendor/wheels/events/onapplicationstart.cfc:501-509` + `$resolveAllowEnvironmentSwitchViaUrl`).

7. **Open-issue caveats cited instead of papered over**:
   - Blank `reloadPassword` currently permits anonymous `?reload=true` restarts (`public/Application.cfc:272-277`) — #3062.
   - Debug-bar environment quick-switch links broken — #3060.
   - `wheels reload` CLI can report false success — #3059.

## Verification

- `pnpm verify:docs src/content/docs/v4-0-0/core-concepts/environments-and-configuration.mdx` → exit 0 (all code blocks on this page are `title="illustrative — ..."` config fragments per the writing-docs tagging policy; none are tagged `{test:*}`).

Refs #3036, #3038, #3058, #3059, #3060, #3062

🤖 Generated with [Claude Code](https://claude.com/claude-code)