### PR TITLE
docs(web/guides): correct debug-panel guide against live framework behavior

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/debug-panel.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/debug-panel.mdx
@@ -32,13 +32,15 @@ This means AJAX-driven partial updates, Turbo Streams, API endpoints, and CSV ex
 
 ## Enabling and disabling
 
-The bar respects the `showDebugInformation` application setting. By default, Wheels sets this to `true` only in the `development` environment and `false` in every other environment (`testing`, `maintenance`, and `production`). You can override it explicitly in `config/environment.cfm`:
+The bar respects the `showDebugInformation` application setting. By default, Wheels sets this to `true` only in the `development` environment and `false` in every other environment (`testing`, `maintenance`, and `production`). You can override it explicitly in `config/settings.cfm` (or an environment-specific file such as `config/production/settings.cfm`):
 
-```cfm title="config/environment.cfm"
+```cfm {test:compile} title="config/settings.cfm"
 <cfset set(showDebugInformation=true)>
 ```
 
 Setting `showDebugInformation=false` removes the bar entirely — no HTML is injected into responses.
+
+Do not put this override in `config/environment.cfm`. That file only selects the environment: it is included before the framework's own defaults are applied, so any other `set()` call placed there is silently overwritten.
 
 <Aside type="caution">
   Never enable the debug bar in production. It renders internal state — your data source name, environment, CFML engine version, and parameter values — that you do not want visible to end users.
@@ -46,7 +48,7 @@ Setting `showDebugInformation=false` removes the bar entirely — no HTML is inj
 
 ## The debug bar
 
-When active, the bar appears as a slim strip pinned to the bottom of the browser window. Tabs are arranged from left to right: a Wheels logo (doubles as the Request tab toggle), then Request, Timing, Params, Environment, and optionally Tools. The right side shows the current git branch (when Wheels detects a `.git` directory), the framework version, and a one-click reload link when no reload password is configured.
+When active, the bar appears as a slim strip pinned to the bottom of the browser window. Tabs are arranged from left to right: a Wheels logo (doubles as the Request tab toggle), then Request, Timing, Params, Environment, and optionally Tools. The right side shows the current git branch (when the web root — `public/` — contains a `.git` directory), the framework version, and a one-click reload link when no reload password is configured.
 
 ![The collapsed Wheels debug bar pinned to the bottom of a browser window: Wheels logo, Posts.index controller.action, timing badge, Params, Development environment, and Tools tabs, with Wheels 4.0.0-SNAPSHOT version on the right](/v4-0-0/digging-deeper/debug-panel-screenshots/01-collapsed-bar.png)
 
@@ -81,11 +83,11 @@ The Timing tab label shows the total request duration in milliseconds, color-cod
 - **Yellow** — 100–499 ms
 - **Red** — 500 ms or more
 
-Opening the panel shows a horizontal bar chart breaking down where time was spent. Each phase (model, queries, template rendering, etc.) is sorted by duration descending and rendered as a proportional colored bar showing both the raw milliseconds and the percentage of total time.
+Opening the panel shows a horizontal bar chart breaking down where time was spent. Each framework phase (`setup`, `requestStart`, `beforeFilters`, `action`, `afterFilters`, `view`, `requestEnd`) that recorded time is sorted by duration descending and rendered as a proportional colored bar — the bar's width represents the phase's share of total time, and the raw milliseconds are printed inside it. No percentage figure is displayed.
 
 ![Timing panel showing "Execution Timing — 9ms total" in the header with horizontal bar chart for action and view phases, color-coded and sorted by duration](/v4-0-0/digging-deeper/debug-panel-screenshots/03-timing-panel.png)
 
-The chart is most useful for spotting query-heavy actions: if `queries` or `model` accounts for 80%+ of total time, look at the SQL being generated (the Routes admin page lists query counts per action if you need more detail).
+The chart is most useful for spotting where a slow request spends its time: if `action` dominates the total, look at the model calls and SQL your action triggers; if `view` dominates, look at the rendering work in your templates and partials.
 
 ## Params tab
 
@@ -103,19 +105,25 @@ This is the fastest way to confirm that form fields, query string values, and ne
 
 ## Environment tab
 
-The Environment tab label shows the current environment name (Development, Testing, etc.) with a color-coded dot matching the timing badge palette. The panel is divided into subsections based on what is enabled.
+The Environment tab label shows the current environment name (Development, Testing, etc.) with a color-coded dot: green for `development`, orange for `testing`, yellow for `maintenance`, and red for `production`. The panel is divided into subsections based on what is enabled.
 
 ### Application
 
-Always shown. Lists the environment, the git branch (when the app root contains a `.git` directory), the Wheels version, the CFML engine and version, and the host name (when available).
+Always shown. Lists the environment, the git branch (when the **web root** — `public/` — contains a `.git` directory; in a standard app layout the `.git` directory lives at the project root, so the row does not appear), the Wheels version, the CFML engine and version, and the host name (when available).
 
-When no reload password is set, the environment name is followed by quick-switch links that reload the app in a different environment mode. This is useful during development to test environment-specific code paths without editing config files.
+When no reload password is set, the environment name is followed by quick-switch links. These links are currently dead: switching environments via the URL requires a configured `reloadPassword` plus a matching `password` parameter, which is exactly the state in which the links do not render — so clicking one only restarts the app in the same environment. See [#3060](https://github.com/wheels-dev/wheels/issues/3060).
+
+To actually switch environments at runtime, set a `reloadPassword` in `config/settings.cfm` and request `?reload=<environment>&password=<your password>`. The switch is additionally gated by the `allowEnvironmentSwitchViaUrl` setting: an explicit boolean you set is honored in every environment, and when unset it defaults to `false` in `production`, `testing`, and `maintenance` and `true` everywhere else. Switching to the environment you are already in is a no-op, and after a successful switch the redirect strips the reload parameters from the URL.
+
+<Aside type="caution">
+  When no `reloadPassword` is configured, any visitor can currently restart the application with `?reload=true` — the bar's reload link is just that URL. This contract is being tightened; see [#3062](https://github.com/wheels-dev/wheels/issues/3062).
+</Aside>
 
 ![Environment & Configuration panel showing Application section with Environment (Development with green dot), Wheels Version, CFML Engine (Lucee 7.0.0.395), Host Name; Packages section listing wheels-basecoat; and Plugins (Legacy) "No plugins installed."](/v4-0-0/digging-deeper/debug-panel-screenshots/05-environment-panel.png)
 
 ### Packages
 
-Shown when `enablePackagesComponent` is `true` (the default in Wheels 4.0+). Displays two tables.
+Shown when `enablePackagesComponent` is `true` (the default in Wheels 4.0+).
 
 **Installed packages** lists every package found in `vendor/` and loaded by `PackageLoader.cfc`:
 
@@ -127,17 +135,9 @@ Shown when `enablePackagesComponent` is `true` (the default in Wheels 4.0+). Dis
 
 If any package failed to load (manifest error, missing dependency, CFC exception), a red error list appears below the installed table with the package name and the exception message.
 
-**Available from registry** pulls the same 24-hour cached registry index used by the `wheels packages` CLI and shows what is available to install:
-
-| Column | Description |
-|---|---|
-| Package | Name, linked to the package homepage when available |
-| Latest | Latest compatible version |
-| Description | Registry description |
-
 ![Packages section of the Environment panel — Installed table showing wheels-basecoat 3.0.0-rc.1 with version and description columns](/v4-0-0/digging-deeper/debug-panel-screenshots/05-environment-panel.png)
 
-This lets you discover first-party packages such as `wheels-hotwire`, `wheels-sentry`, or `wheels-i18n` without leaving the app. The table reflects the same 24-hour cache as `wheels packages list`; run `wheels packages registry refresh` from the CLI if you need up-to-the-minute data.
+To browse what is available to install — and discover first-party packages such as `wheels-hotwire`, `wheels-sentry`, or `wheels-i18n` — open the Packages tool page at `/wheels/packages` (linked from the Tools tab) or run `wheels packages list` from the CLI. Both read the same 24-hour cached registry index; run `wheels packages registry refresh` if you need up-to-the-minute data.
 
 ### Plugins (legacy)
 
@@ -169,9 +169,9 @@ Shown when `enablePublicComponent` is `true` (the default in development). Opens
 
 ## Configuration reference
 
-All settings are applied in `config/settings.cfm` or an environment-specific file under `config/`:
+All settings are applied in `config/settings.cfm` or an environment-specific file under `config/` (not `config/environment.cfm`, which only selects the environment — see [Enabling and disabling](#enabling-and-disabling)):
 
-```cfm title="config/environment.cfm"
+```cfm {test:compile} title="config/settings.cfm"
 <cfset set(showDebugInformation=true)>
 <cfset set(enablePackagesComponent=true)>
 <cfset set(enablePluginsComponent=true)>
@@ -181,7 +181,7 @@ All settings are applied in `config/settings.cfm` or an environment-specific fil
 ```
 
 :::note
-Setting `enablePublicComponent=true` outside the `development` environment shows the Tools tab, but every Tools link (`/wheels/info`, `/wheels/routes`, the test runners, migrator, packages, …) returns **404**: since Wheels 4.0.3 those handlers are gated by a development-only allowlist, regardless of this setting. Only `environment="development"` can reach them.
+Setting `enablePublicComponent=true` outside the `development` environment shows the Tools tab, but every Tools link (`/wheels/info`, `/wheels/routes`, the test runners, migrator, packages, …) returns **404**: since Wheels 4.0.4 ([#2903](https://github.com/wheels-dev/wheels/pull/2903)) those handlers are gated by a development-only allowlist, regardless of this setting. Only `environment="development"` can reach them.
 :::
 
 | Setting | Default | Effect |
@@ -192,6 +192,18 @@ Setting `enablePublicComponent=true` outside the `development` environment shows
 | `showIncompatiblePlugins` | `true` | Include incompatible-plugin warnings in the Warnings subsection |
 | `enablePublicComponent` | `true` in `development`, `false` elsewhere | Show the Tools tab and its link grid |
 | `enableMigratorComponent` | `true` | Show the Migrator link in the Tools panel |
+
+### IP-based debug access outside development
+
+Three settings let requests from specific source IPs see the debug bar in non-development environments, overriding the "`false` elsewhere" defaults above on a per-request basis:
+
+| Setting | Default | Effect |
+|---|---|---|
+| `allowIPBasedDebugAccess` | `false` | Master switch for the per-request IP override |
+| `debugAccessIPs` | `[]` | Array of allowed client IP addresses (exact match) |
+| `debugAccessTrustProxy` | `false` | When `true`, use the rightmost `X-Forwarded-For` entry as the client IP — only enable this behind a trusted reverse proxy, since the header is otherwise client-controlled |
+
+When `allowIPBasedDebugAccess` is `true` and the request comes from an IP listed in `debugAccessIPs`, Wheels re-enables `showDebugInformation`, `enablePublicComponent`, and `showErrorInformation` for that request only — so the debug bar (including the Tools tab) renders even in `production`. The `/wheels/*` tool pages themselves still return **404** outside `development`: the allowlist described in the note above is environment-based and is not bypassed by the IP override. Requests from any other IP are unaffected.
 
 ## Related guides
 


### PR DESCRIPTION
Cite-checked corrections for the Debug Panel guide from the 2026-06 guide behavioral audit (Lucee 7 / development unless noted). Each fix below lists the framework-source evidence.

## Corrections

1. **Overrides belong in `config/settings.cfm`, not `config/environment.cfm`.** Both code blocks retitled and a warning added: `environment.cfm` is included in the environment-selection block of `vendor/wheels/events/onapplicationstart.cfc` (line ~205) *before* the framework defaults (`events/init/*.cfm`) and `$includeConfig(/config/settings.cfm)` run, so any non-environment `set()` there is clobbered. Verified live: `set(showDebugInformation=false)` in `environment.cfm` left the bar rendering; the same line in `settings.cfm` removed it.
2. **Git branch detection is web-root based.** `vendor/wheels/events/onrequestend/debug.cfm:37-39` checks `GetDirectoryFromPath(GetBaseTemplatePath()) & ".git"` — the web root (`public/`), and requires a directory. In a standard `wheels new` layout (`.git` at project root) the branch never appears. Both "when Wheels detects a `.git` directory" and "when the app root contains a `.git` directory" corrected.
3. **Timing panel: real phase names, no percentage text.** Replaced the invented `(model, queries, template rendering, etc.)` with the actual `$debugPoint()` phases (`setup`, `requestStart`, `beforeFilters`, `action`, `afterFilters`, `view`, `requestEnd` — `vendor/wheels/Dispatch.cfc:342,388`, `controller/processing.cfc:36-127`, `controller/rendering.cfc:31,77`, `EventMethods.cfc:160-308`). The percentage exists only as the bar's CSS width (`debug.cfm:62,252`); no `%` figure is printed. The 80% tip rewritten around `action`/`view` dominating.
4. **Removed the per-action query-count claim.** `/wheels/routes` (`vendor/wheels/public/views/routes.cfm:50-51`) shows tab route counts and Name/Method/Pattern/Controller/Action columns — no query counts exist on the page.
5. **Environment dot colors stated directly.** `debug.cfm:41-49`: development green `#28a745`, testing orange `#fd7e14`, maintenance yellow `#ffc107`, production red `#dc3545` — testing's orange is not in the timing badge palette, so "matching the timing badge palette" was wrong.
6. **Quick-switch links documented as currently dead.** URL environment switching requires a configured `reloadPassword` + matching `password` param (`onapplicationstart.cfc:181-205`, hardening from #2082), but the bar's links render only when *no* password is set (`debug.cfm:304-311`) — clicking one just restarts the same environment. Documented the working flow instead (`?reload=<env>&password=...`), the `allowEnvironmentSwitchViaUrl` gate (`$resolveAllowEnvironmentSwitchViaUrl()`, `onapplicationstart.cfc:516-525`: explicit boolean honored everywhere, unset defaults to false in production/testing/maintenance — #3038), the same-environment no-op and post-switch param stripping (#3036/#3058). Dead links tracked in #3060; the anonymous `?reload=true` restart with an empty password is called out with a caution and tracked in #3062.
7. **Removed the nonexistent "Available from registry" table.** `debug.cfm:328-356` renders only the installed table + failed list; the registry browser lives on the `/wheels/packages` page (`vendor/wheels/public/views/packagelist.cfm`). The discovery/registry-refresh tip now points at that page and the CLI.
8. **"since Wheels 4.0.3" → "since Wheels 4.0.4".** Released 4.0.3's `Public.cfc::$shouldBlockInProduction()` blocked only `production`; the development-only allowlist landed in #2903 (`cb6241c1e`), which is not an ancestor of the v4.0.3 tag.
9. **New section: IP-based debug access outside development.** Documents `allowIPBasedDebugAccess` / `debugAccessIPs` / `debugAccessTrustProxy` (defaults `false` / `[]` / `false`, `vendor/wheels/events/init/security.cfm:53-57`). For allowed IPs in non-development environments, `public/Application.cfc:218-250` re-enables `showDebugInformation`, `enablePublicComponent`, and `showErrorInformation` per request (verified live on Lucee 7 and Adobe 2023 in production), while `/wheels/*` tool pages still 404 outside development.

Both retitled config blocks are now `{test:compile}`-tagged; `pnpm verify:docs src/content/docs/v4-0-0/digging-deeper/debug-panel.mdx` passes (2/2 blocks).

Refs #3060, #3062.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
