### PR TITLE
docs(web/guides): correct migrations and seeding guides to verified 4.0.x behavior

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/basics/migrations.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/basics/migrations.mdx
@@ -39,10 +39,10 @@ wheels --version
 <Aside type="caution" title="Write commands require a project-bound server">
 `wheels migrate latest`, `migrate up`, `migrate down`, `migrate forget`, `migrate pretend`, `migrate rename-system-tables`, `wheels seed`, and `wheels db reset` (which runs migrate + seed) only connect to a server whose port is explicitly configured for this project — via the `port` field in `lucee.json` (created by `wheels new`, or set manually) or the `PORT` variable in `.env`. They refuse the common-port fallback (8080, etc.) to prevent silently targeting a sibling app's server when you work on multiple projects. If you see `Wheels.ServerNotRunning`, run `wheels start` in this project's directory first.
 
-`wheels migrate info` and `wheels migrate doctor` are read-only and still probe common ports as a fallback, so they work without an explicit port config.
+`wheels migrate info` and `wheels migrate doctor` are read-only, but they currently go through the same project-bound check — there is no common-port fallback for them either, so they too need the explicit port config ([#3080](https://github.com/wheels-dev/wheels/issues/3080) tracks whether the read-side fallback comes back).
 </Aside>
 
-The runner wraps each migration in a transaction so a failing `up()` or `down()` rolls back cleanly on databases that support transactional DDL — but that support varies, so read the caution below before relying on it.
+The runner wraps each migration in a transaction so a failing `up()` or `down()` rolls back cleanly on databases that support transactional DDL — but that support varies, so read the caution below before relying on it. One more caveat for scripts and CI: a failed migration is loud in the command output but the CLI currently still exits `0`, so don't gate a pipeline on the exit code alone ([#3081](https://github.com/wheels-dev/wheels/issues/3081)).
 
 <Aside type="caution" title="DDL auto-commit on MySQL and Oracle">
 On MySQL and Oracle, DDL statements (`CREATE TABLE`, `ALTER TABLE`, `DROP TABLE`, …) implicitly commit the surrounding transaction. A multi-statement migration that fails midway on those databases leaves the statements that already ran committed — partial schema the transaction wrapper cannot undo. PostgreSQL, SQL Server, and SQLite support transactional DDL, so the all-or-nothing guarantee holds there. On MySQL/Oracle, prefer small single-purpose migrations, and if one does die halfway, use `wheels migrate doctor` and the reconciliation subcommands below to get the tracking table and schema back in line.
@@ -66,7 +66,7 @@ The generator scaffolds a CFC with `up()` and `down()` stubs and drops it in `ap
 wheels generate migration CreatePosts
 ```
 
-That produces a file named like `20260420143000_create_posts_table.cfc`. The prefix is `YYYYMMDDHHMMSS` — generated from the clock at creation time — and the runner applies migrations in filename order, so the timestamp is what puts your change after everyone else's. Never rename or reorder migration files after they've been committed: the history in `wheels_migrator_versions` keys on the timestamp prefix, and a renamed file looks like a brand-new migration to the runner.
+That produces a file named like `20260420143000_CreatePosts.cfc` — the name you typed is used verbatim. The prefix is `YYYYMMDDHHMMSS` — generated from your local clock at creation time — and the runner applies migrations in filename order, so the timestamp is what puts your change after everyone else's. Never rename or reorder migration files after they've been committed: the history in `wheels_migrator_versions` keys on the timestamp prefix, and a renamed file looks like a brand-new migration to the runner.
 
 ## Writing a migration — full example
 
@@ -94,7 +94,7 @@ Three things to note:
 
 1. `createTable("posts")` returns a table-builder object. Every column method — `t.string`, `t.integer`, `t.datetime` — mutates that builder. Nothing hits the database until `t.create()`.
 2. `t.timestamps()` creates `createdAt`, `updatedAt`, **and** a soft-delete column (`deletedAt`). Don't also add those columns by hand — you'll get duplicate-column errors. See [Models and the ORM](/v4-0-0/basics/models-and-the-orm/) for how Wheels populates them automatically on save.
-3. The column-builder methods use `columnNames` (plural) and `allowNull` — not `columnName` and `null`. A single call can create several same-typed columns at once: `t.string(columnNames="firstName,lastName", limit=60)`.
+3. The column-builder methods use `columnNames` (plural) and `allowNull`. Every helper also accepts `columnName` (singular) as an alias, but `columnNames` is the preferred form; the nullable flag is always `allowNull` — `null` is never accepted. A single call can create several same-typed columns at once: `t.string(columnNames="firstName,lastName", limit=60)`.
 
 ## Column types
 
@@ -105,7 +105,7 @@ These are the column-builder methods defined on `TableDefinition`. Every one tak
 | `t.string(columnNames=, limit=, allowNull=, default=)` | VARCHAR | `limit` defaults to 255 |
 | `t.char(columnNames=, limit=)` | CHAR | fixed-width string |
 | `t.text(columnNames=, size=)` | TEXT / MEDIUMTEXT / LONGTEXT | `size` is MySQL-only |
-| `t.integer(columnNames=, limit=, allowNull=, default=)` | INT | `limit=8` maps to BIGINT on MySQL |
+| `t.integer(columnNames=, limit=, allowNull=, default=)` | INT | `limit` is a display width, not a size bump — for BIGINT use `t.bigInteger()` |
 | `t.bigInteger(columnNames=)` | BIGINT | |
 | `t.float(columnNames=)` | FLOAT | |
 | `t.decimal(columnNames=, precision=, scale=)` | DECIMAL | use for money |
@@ -232,12 +232,12 @@ component extends="wheels.migrator.Migration" hint="Remove deprecated teaser" {
 
 Real seed data — users, roles, reference lookups — belongs in `app/db/seeds.cfm` where it runs idempotently via `seedOnce()`. See [Seeding](/v4-0-0/basics/seeding/) for that path. Don't use migrations for seed data in long-lived projects: a `INSERT` in a migration runs exactly once, so editing the inserted row later means writing another migration to update it, and fresh clones of the repo end up with whatever the most recent migration wrote.
 
-That said, you'll occasionally want a migration to backfill data for a schema change — for example, populating a new column from an existing one. When you do, use inline SQL with `NOW()` for timestamps. Parameter binding in `execute()` is unreliable across databases, and database-specific date functions (`CURRENT_TIMESTAMP`, `GETDATE()`, `SYSDATETIME()`) don't port. `NOW()` works across MySQL, PostgreSQL, SQL Server, H2, and SQLite.
+That said, you'll occasionally want a migration to backfill data for a schema change — for example, populating a new column from an existing one. When you do, use inline SQL: `execute()` takes a single SQL string and nothing else — there is no parameters argument, so there's no binding to reach for. For timestamps, use `CURRENT_TIMESTAMP`, which works across MySQL, PostgreSQL, SQL Server, H2, and SQLite. `NOW()` does not port: SQLite — the default database for `wheels new` apps — fails with `no such function: NOW`, and SQL Server has no native `NOW()` either. Other database-specific date functions (`GETDATE()`, `SYSDATETIME()`) don't port at all.
 
 ```cfm {test:compile}
 component extends="wheels.migrator.Migration" hint="Seed admin role" {
     function up() {
-        execute("INSERT INTO roles (name, createdAt, updatedAt) VALUES ('admin', NOW(), NOW())");
+        execute("INSERT INTO roles (name, createdAt, updatedAt) VALUES ('admin', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)");
     }
 
     function down() {
@@ -273,7 +273,7 @@ The throw is the honest signal: "you can't walk past this point backward." If yo
 
 ## Filename format
 
-Generated migration files are named `<YYYYMMDDHHMMSS>_<snake_case_name>.cfc` — a 14-digit UTC-ish timestamp, an underscore, then the name you passed to `wheels generate migration`. The timestamp determines the order the runner applies them. Don't hand-edit the prefix; if you need to reorder after a merge conflict, regenerate the file and move your body into it.
+Generated migration files are named `<YYYYMMDDHHMMSS>_<NameAsTyped>.cfc` — a 14-digit timestamp from your local clock, an underscore, then the name you passed to `wheels generate migration`, written exactly as you typed it (no snake_casing, no added suffix). The snake_case shape you may also see in `app/migrator/migrations/` — `20260420143000_create_posts_table.cfc` — comes from the *model* generator: `wheels g model Post` scaffolds a `create_posts_table` migration alongside the model. The timestamp determines the order the runner applies them. Don't hand-edit the prefix; if you need to reorder after a merge conflict, regenerate the file and move your body into it.
 
 ## Related guides
 

--- a/web/sites/guides/src/content/docs/v4-0-0/basics/seeding.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/basics/seeding.mdx
@@ -58,6 +58,8 @@ Run it with `wheels seed`. The seeder opens a transaction, includes `app/db/seed
 
 Under the hood, it calls `model("<ModelName>").findOne(where="<uniqueProperty>='<value>'")` first. If the record exists, the call increments `totalSkipped` and returns silently. If not, it calls `model(...).new(properties).save()` and increments `totalCreated`. Re-running is always safe: no duplicates, no errors, no surprises.
 
+There's a third outcome: when `save()` fails validation, the entry is recorded as failed and the whole run rolls back — as of 4.0.4, with `success=false` and a non-zero exit so the failure is visible. (On 4.0.3 the run also rolled back, but silently, while still reporting the created counts.)
+
 The `properties` struct is what gets persisted on creation, so include every non-nullable column the model needs — not just the unique ones. The `uniqueProperties` list is only the subset used for the lookup.
 
 ## Environment-specific seeds
@@ -93,10 +95,11 @@ The commands you'll actually use day-to-day:
 
 - `wheels seed` — run convention seeds, auto-detecting the current environment
 - `wheels seed --environment=production` — run seeds for a specific environment regardless of where the app thinks it's running
-- `wheels generate seed` — scaffold `app/db/seeds.cfm` if it doesn't already exist
-- `wheels generate seed --all` — scaffold `seeds.cfm` plus `seeds/development.cfm` and `seeds/production.cfm` stubs
+- `wheels generate snippets seed-data` — write `seeds.cfm` and `seeds-development.cfm` starter templates to `app/snippets/`; copy them into place (`app/db/seeds.cfm` and `app/db/seeds/development.cfm`) to activate them
 
-There's also `wheels seed --generate`, which bypasses your seed files and generates random fake records for every model. It's legacy behaviour from before `seedOnce()` existed and rarely what you want — prefer explicit `seedOnce()` calls where you control the data.
+There is no `wheels generate seed` command — it errors with `Unknown generator type: seed`. The snippets generator above is the scaffold path.
+
+You may also see references to `wheels seed --generate`, a legacy flag from before `seedOnce()` existed that bypasses your seed files and generates random fake records for every model. It's currently non-functional: every model errors internally, zero rows are created, and the command still reports success ([#3082](https://github.com/wheels-dev/wheels/issues/3082)). Don't use it — write explicit `seedOnce()` calls where you control the data.
 
 ## Multiple `seedOnce` calls in one file
 


### PR DESCRIPTION
Guide-behavioral-audit batch 2, work item **p1-14-migrations**. Fixes the docs-affected findings in `basics/migrations.mdx` and `basics/seeding.mdx`. Every correction documents verified current behavior (CLI 4.0.3 + develop source) and cites the tracking issue where the underlying behavior is broken-but-unfixed.

## Corrections

### basics/migrations.mdx

1. **`migrate info` / `migrate doctor` port fallback** (claim `mig-08`, both) — the aside claimed read-only commands "still probe common ports as a fallback". Verified false on 4.0.3 and develop: both route through `requireProjectConfig=true` (Module.cfc:3796-3804) and refuse with `Wheels.ServerNotRunning` even when the server runs on 8080. Rewritten to current behavior, citing [#3080](https://github.com/wheels-dev/wheels/issues/3080).
2. **Exit codes** (evidence from `mig-09`/`mig-28`, group note) — added a one-sentence caution that a failed migration currently still exits `0`, so pipelines should not gate on `$?` alone ([#3081](https://github.com/wheels-dev/wheels/issues/3081)).
3. **Generator filename** (claim `mig-11`, docs-wrong) — `wheels generate migration CreatePosts` produces `<ts>_CreatePosts.cfc` verbatim (Module.cfc:3094), never snake_cased or `_table`-suffixed; timestamp is the local clock, not "UTC-ish". Fixed the example and the Filename format section, with a contrast note that the snake_case shape comes from the model generator (`wheels g model Post` → `<ts>_create_posts_table.cfc`).
4. **`limit=8` → BIGINT row** (claim `mig-17`, docs-wrong) — no such mapping exists anywhere (MySQL `integer`→INT; `Abstract.typeToSQL` appends `(limit)` as a display width). Row now points at `t.bigInteger()`.
5. **`columnName` alias** (sketch item 4) — softened "not `columnName` and `null`": singular `columnName` IS accepted via `$combineArguments` on every helper; `null` remains never-accepted (`allowNull`).
6. **Seed-data SQL** (claims `mig-26`/`mig-27`, docs-wrong) — the guide's own `NOW()` example fails on SQLite (`no such function: NOW`), the default `wheels new` database, and SQL Server has no native `NOW()`; no adapter rewrites it. Example and prose now use `CURRENT_TIMESTAMP` (works on MySQL/PG/MSSQL/H2/SQLite). "Parameter binding in execute() is unreliable" corrected to the real contract: `execute(required string sql)` has no parameters argument at all (Migration.cfc:460).

### basics/seeding.mdx

7. **`wheels generate seed` bullets** (claims `seed-08`/`seed-09`, docs-wrong) — both bullets removed: the command errors with `Unknown generator type: seed` on 4.0.3 and develop (no `seed` case in the generate() switch), and no `--all` variant exists. Replaced with the verified scaffold path `wheels generate snippets seed-data` plus an explicit "no such command" note.
8. **`wheels seed --generate`** (claim `seed-10`, code-broken) — paragraph rewritten: the flag is currently non-functional (every model errors, zero rows created, success still reported), citing [#3082](https://github.com/wheels-dev/wheels/issues/3082).
9. **seedOnce third outcome** (sketch item 8, evidence `seed-11`) — documented the validation-failure path: entry recorded as failed and the run rolls back; as of 4.0.4 with `success=false` and a non-zero exit (#2987), while 4.0.3 rolled back silently and still reported created counts.

## Verification

- `pnpm verify:docs src/content/docs/v4-0-0/basics/migrations.mdx src/content/docs/v4-0-0/basics/seeding.mdx` → 13 tagged blocks, 13 passed, exit 0
- Evidence source: guide-behavioral-audit raw output for p1-14-migrations (wheels CLI 4.0.3 + Lucee 7 + SQLite; develop@ddeec99bf source reads)

Note: repo CLAUDE.md anti-pattern #5 repeats the NOW()/binding errors; the worktree's CLAUDE.md was already updated on develop for the generate-seed/snippets facts, and the CLAUDE.md NOW() fix is left to the campaign's collateral sweep (out of this PR's scoped files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
