### PR TITLE
docs(web/guides): align deploy config-reference + architecture with verified CLI behavior

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/deployment/architecture.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/deployment/architecture.mdx
@@ -48,7 +48,7 @@ The values above are what the code is written against, but three rows don't hold
 
 - **Audit log** — `/tmp/kamal-audit.log` is never written; the audit `record()` command builder has no call sites.
 - **Docker network** — containers are run with `--network kamal`, but `docker network create kamal` is never issued, so on a host not previously managed by Ruby Kamal the network doesn't exist.
-- **Proxy config dir** — the path is built as `/home/<user>/.config/kamal-proxy/`, which resolves to `/home/root` for the default `root` SSH user; root's home is actually `/root`, where Ruby Kamal puts it.
+- **Proxy config dir** — the path is built as `/home/<user>/.config/kamal-proxy/`, which resolves to `/home/root` for the default `root` SSH user; root's home is actually `/root` — and Ruby Kamal mounts a named Docker volume (`kamal-proxy-config`) rather than a host home path, so the bind mount diverges from Kamal either way.
 </Aside>
 
 Two choices in that table warrant commentary.

--- a/web/sites/guides/src/content/docs/v4-0-0/deployment/architecture.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/deployment/architecture.mdx
@@ -43,6 +43,14 @@ The design bet: a server managed by Ruby Kamal can be taken over by `wheels depl
 | Hook env prefix | `KAMAL_*` |
 | Secret file | `.kamal/secrets`, `.kamal/secrets.<destination>` |
 
+<Aside type="caution" title="Three rows are still aspirational">
+The values above are what the code is written against, but three rows don't hold on a live host yet ([#2957](https://github.com/wheels-dev/wheels/issues/2957)):
+
+- **Audit log** — `/tmp/kamal-audit.log` is never written; the audit `record()` command builder has no call sites.
+- **Docker network** — containers are run with `--network kamal`, but `docker network create kamal` is never issued, so on a host not previously managed by Ruby Kamal the network doesn't exist.
+- **Proxy config dir** — the path is built as `/home/<user>/.config/kamal-proxy/`, which resolves to `/home/root` for the default `root` SSH user; root's home is actually `/root`, where Ruby Kamal puts it.
+</Aside>
+
 Two choices in that table warrant commentary.
 
 **Why `KAMAL_*` and not `WHEELS_*`.** Every hook script ever written for Ruby Kamal reads environment variables named `KAMAL_SERVICE`, `KAMAL_VERSION`, and so on. Renaming to `WHEELS_*` would be slightly more consistent with the rest of the Wheels CLI — and it would break every user's existing hook scripts for zero benefit.
@@ -78,10 +86,9 @@ image: ${REGISTRY}/${APP_NAME}
 
 The interpolator (`ConfigLoader.$interpolate`) walks the parsed YAML tree and resolves each `${VAR}` token through this lookup chain:
 
-1. CLI `--env` overrides (test/CI shims).
-2. `.kamal/secrets`, then `.kamal/secrets.<destination>` overlay if `--destination` is set.
-3. `System.getenv(VAR)` on the machine running `wheels deploy`.
-4. Empty string for unset vars (matching Kamal's behavior).
+1. `.kamal/secrets`, then `.kamal/secrets.<destination>` overlay if `--destination` is set. Known defect: this leg resolves the secrets file relative to `deploy.yml`'s own directory — `config/.kamal/secrets` for the standard layout — so the project-root `.kamal/secrets` the rest of the CLI uses is never consulted ([#3084](https://github.com/wheels-dev/wheels/issues/3084)).
+2. `System.getenv(VAR)` on the machine running `wheels deploy`.
+3. Empty string for unset vars (matching Kamal's behavior).
 
 Only uppercase-and-underscore tokens are expanded — the regex is `\$\{([A-Z_][A-Z0-9_]*)\}`. That keeps shell-style `${service}` placeholders elsewhere in the config from being captured by accident, the same rule Kamal applies.
 
@@ -90,7 +97,7 @@ No conditionals, no method calls, no computed expressions. If your existing conf
 We considered preserving ERB by shelling out to a system Ruby. The problem is that it turns a single-binary install into a "works if you also have Ruby" story, and every user without Ruby installed gets a cryptic error on their first deploy. Naming the divergence up front — and keeping Kamal's `${VAR}` syntax untouched — is the honest trade-off.
 
 <Aside type="note" title="Mustache is used elsewhere — not in deploy.yml at runtime">
-The `cli/lucli/services/deploy/lib/Mustache.cfc` wrapper is a thin facade over jmustache, but it is **not** applied to `deploy.yml` at runtime. It's used by `wheels deploy init` to render the initial scaffolding templates (`config/deploy.yml` and `.kamal/secrets`) when a project doesn't have one yet. Once those files exist, `${VAR}` is the only interpolation that runs.
+The `cli/lucli/services/deploy/lib/Mustache.cfc` wrapper is a thin facade over jmustache, but it is **not** applied to `deploy.yml` at runtime. It's used by `wheels deploy init` to render the initial scaffolding templates (`config/deploy.yml`, `.kamal/secrets`, `Dockerfile`, and `.dockerignore`) when a project doesn't have them yet. Once those files exist, `${VAR}` is the only interpolation that runs.
 </Aside>
 
 ## Commands-are-strings invariant
@@ -136,7 +143,7 @@ The separation of `cli/` (user-facing orchestration) from `commands/` (pure comm
 
 - **snakeyaml** — YAML parsing for `config/deploy.yml`
 - **sshj** (with BouncyCastle transitives) — SSH transport
-- **jmustache** — template rendering for the `wheels deploy init` scaffolding (`deploy.yml.mustache`, `secrets.mustache`); not applied to `deploy.yml` at runtime
+- **jmustache** — template rendering for the `wheels deploy init` scaffolding (`deploy.yml.mustache`, `secrets.mustache`, `Dockerfile.mustache`, `dockerignore.mustache`); not applied to `deploy.yml` at runtime
 
 These JARs load through a dedicated `URLClassLoader` isolated from the main JVM classpath. That isolation matters because CFML engines (Lucee, Adobe CF) ship their own copies of some transitive dependencies (older BouncyCastle versions, in particular). Without isolation, class-resolution order would be nondeterministic and you'd get obscure `NoSuchMethodError` failures depending on load order.
 

--- a/web/sites/guides/src/content/docs/v4-0-0/deployment/config-reference.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/deployment/config-reference.mdx
@@ -8,7 +8,7 @@ sidebar:
 
 import { Aside } from '@astrojs/starlight/components';
 
-This is the complete `deploy.yml` schema. `wheels deploy` loads `config/deploy.yml` on every invocation, validates it against this schema, and hands it to every subcommand. Unknown top-level keys fail fast with a line-scoped error; required keys that are missing fail with a pointer to the file.
+This is the complete `deploy.yml` schema. `wheels deploy` loads `config/deploy.yml` on every invocation, validates it against this schema, and hands it to every subcommand. Unknown top-level keys and missing required keys fail fast with an error prefixed by the config file's absolute path (messages are not line-scoped).
 
 <Aside type="note" title="You should already know">
 You've read [Your First Deploy](/v4-0-0/deployment/first-deploy/) and understand the shape of a working deploy. This page is the dry reference — no narrative, just the schema.
@@ -16,7 +16,7 @@ You've read [Your First Deploy](/v4-0-0/deployment/first-deploy/) and understand
 
 ## Required keys
 
-Three keys are required. Omitting any of them stops the loader with `deploy.yml: missing required key: '<name>'`.
+Three keys are required. Omitting any of them stops the loader with `<path to deploy.yml>: missing required key: '<name>'`.
 
 | Key | Type | Purpose |
 |-----|------|---------|
@@ -34,6 +34,10 @@ healthcheck, hooks, accessories, volumes, labels, logging,
 retain_containers, minimum_version, asset_path, require_destination,
 allow_empty_roles, run_directory, readiness_delay
 ```
+
+<Aside type="caution" title="Allowlisted ≠ implemented">
+The validator accepts every key above, but a number of them are parsed and then **never read by the runtime**: `boot`, `logging`, `retain_containers`, `minimum_version`, `asset_path`, `require_destination`, `allow_empty_roles`, `run_directory`, `readiness_delay`, `hooks.path`, plus several sub-keys under `builder`, `ssh`, `proxy`, and role maps. Setting them has no effect today. Each one is flagged in its section below; the umbrella issue is [#3088](https://github.com/wheels-dev/wheels/issues/3088).
+</Aside>
 
 ## `service`
 
@@ -80,7 +84,7 @@ servers:
     - 192.0.2.11
 ```
 
-Any number of roles. The `web` role is special — it's the only one the proxy routes public traffic to. Other roles (`job`, `worker`, `sidekiq`) are started and stopped like `web` but don't receive a `kamal-proxy deploy` call.
+Any number of roles. The `web` role is the one meant to receive public traffic through the proxy; other roles (`job`, `worker`, `sidekiq`) are started and stopped like `web`. Known defect: the current CLI issues the `kamal-proxy deploy` cutover call for *every* role, not just `web`, so non-web roles also get registered with the proxy ([#2957](https://github.com/wheels-dev/wheels/issues/2957)).
 
 ### Roles with options
 
@@ -101,12 +105,12 @@ servers:
 ```
 
 - `hosts:` — required when using the map shape.
-- `env:` — merges over the top-level `env:`. See [`env`](#env).
-- `options:` — additional `docker run` flags (`memory`, `cpus`, `user`, `publish`, etc.).
-- `labels:` — extra labels attached to the container, on top of the four Wheels adds (`service`, `role`, `destination`, `version`).
 - `cmd:` — overrides the container entrypoint for this role. Useful when one image runs as `web` under one command and as `job` under another.
+- `env:` — parsed but **currently ignored**: only the top-level `env:` is applied to containers; per-role overrides never reach `docker run` ([#3088](https://github.com/wheels-dev/wheels/issues/3088)).
+- `options:` — parsed but **currently ignored**: no extra `docker run` flags (`memory`, `cpus`, etc.) are emitted ([#3088](https://github.com/wheels-dev/wheels/issues/3088)).
+- `labels:` — parsed but **currently ignored**: containers only get the four labels Wheels adds (`service`, `role`, `destination`, `version`) ([#3088](https://github.com/wheels-dev/wheels/issues/3088)).
 
-Host strings accept `user@host`, `host:port`, and `user@host:port`. IPv6 literals must be bracketed (`[::1]:22`). Multiple colons without brackets are rejected.
+Host strings accept `user@host`, `host:port`, and `user@host:port`. IPv6 literals must be bracketed (`[::1]:22`). Multiple colons without brackets are meant to be rejected, but the validator currently under-counts adjacent colons, so malformed strings like `'::1:22'` slip through ([#3086](https://github.com/wheels-dev/wheels/issues/3086)) — always bracket IPv6 literals yourself.
 
 ## `registry`
 
@@ -144,34 +148,28 @@ builder:
 
 - `context:` — build context. Default `.`.
 - `dockerfile:` — path relative to context. Default `Dockerfile`.
-- `arch:` — target architectures. Single-arch defaults to whatever the host running the build is. Multi-arch requires `docker buildx` (which `wheels deploy build create` sets up for you).
-- `args:` — map of `--build-arg` values.
-- `remote:` — SSH URL of a remote builder. Faster than local QEMU emulation when you're on an arm64 Mac building amd64 images.
+- `arch:` — parsed but **currently ignored**: no `--platform` flag is emitted, so builds target whatever the host running the build is ([#3088](https://github.com/wheels-dev/wheels/issues/3088)). `wheels deploy build create` does set up a `docker buildx` builder.
+- `args:` — parsed but **currently ignored**: no `--build-arg` flags are emitted ([#3088](https://github.com/wheels-dev/wheels/issues/3088)).
+- `remote:` — parsed but **currently ignored**: the build always runs locally; no remote builder endpoint is used ([#3088](https://github.com/wheels-dev/wheels/issues/3088)).
 
 ## `env`
 
-Environment variables for app containers, split into `clear` (baked into `deploy.yml`, safe under git) and `secret` (resolved from `.kamal/secrets` at deploy time).
+Environment variables for app containers. `clear` values are baked into `deploy.yml` (safe under git) and passed to `docker run -e` at deploy time.
 
 ```yaml title="config/deploy.yml (illustrative — do not type)"
 env:
   clear:
     WHEELS_ENV: production
     WHEELS_LOG_TO_STDOUT: "1"
-  secret:
-    - DATABASE_URL
-    - WHEELS_RELOAD_PASSWORD
 ```
 
-Per-role overrides merge over the top level.
-
-| Layer | Wins over |
-|-------|-----------|
-| role `clear` | role `secret`, top-level `clear`, top-level `secret` |
-| role `secret` | top-level `clear`, top-level `secret` |
-| top-level `clear` | top-level `secret` |
-| top-level `secret` | — |
-
 Changes to `env` take effect on next deploy only; running containers keep their original values.
+
+<Aside type="caution" title="env.secret is not yet supported">
+Kamal's `env.secret` list (secret keys resolved from `.kamal/secrets` and delivered to the container) is **not implemented**. On the released 4.0.3 CLI, `secret:` entries are silently dropped — the variables never reach the container. On current develop builds the loader fails fast with `Wheels.Deploy.EnvSecretUnsupported` instead of dropping them. Track secret delivery in [#2956](https://github.com/wheels-dev/wheels/issues/2956).
+
+Per-role `env:` overrides are also not implemented — only the top-level `env.clear` map reaches `docker run` ([#3088](https://github.com/wheels-dev/wheels/issues/3088)).
+</Aside>
 
 ## `ssh`
 
@@ -187,13 +185,13 @@ ssh:
   keys_only: false
 ```
 
-- `user:` — SSH user. Defaults to the current local user. If not root, `wheels deploy` wraps root-requiring commands with `sudo -n`.
+- `user:` — SSH user. Defaults to `root`. If not root, `wheels deploy` wraps root-requiring commands with `sudo -n`.
 - `port:` — TCP port. Default 22.
-- `proxy:` — bastion host. Maps to OpenSSH's `ProxyJump`; every connection first hops through this host.
+- `proxy:` — parsed but **currently ignored**: `ProxyJump`-style bastion hops are not implemented; every connection goes direct ([#3088](https://github.com/wheels-dev/wheels/issues/3088)).
 - `keys:` — array of private key file paths. The first entry is passed to the SSH pool. Tilde (`~/`) is expanded against the JVM `user.home` because sshj reads key files via `java.io.File` and does not expand the shell shortcut. Omit to fall back to `ssh-agent`.
-- `keys_only:` — if true, disables agent-based auth and requires explicit `keys:`.
+- `keys_only:` — parsed but **currently ignored** ([#3088](https://github.com/wheels-dev/wheels/issues/3088)).
 
-SSH config picks up your usual `~/.ssh/config`, `~/.ssh/known_hosts`, and `ssh-agent` — you don't re-declare that here.
+Host key verification reads your `~/.ssh/known_hosts`. Your `~/.ssh/config` is **not** read — the bundled sshj client doesn't parse OpenSSH client config, so per-host users, identities, and `ProxyJump` directives there have no effect. Declare connection settings in this `ssh:` block instead.
 
 ## `proxy`
 
@@ -214,11 +212,15 @@ proxy:
 ```
 
 - `host:` — the public hostname. Used for TLS SNI and Let's Encrypt issuance.
-- `app_port:` — port the app listens on inside the container. Default 3000. Wheels apps typically bind whatever `wheels start` binds; make sure the `Dockerfile` EXPOSE matches.
+- `app_port:` — port the app listens on inside the container. The config default is `80`, and `wheels deploy init` scaffolds `8080`.
 - `ssl:` — if true, `kamal-proxy` requests a Let's Encrypt cert for `host` on first boot. Set false if you terminate TLS in front of the proxy.
-- `healthcheck:` — new container must return 2xx at `healthcheck.path` within `healthcheck.timeout` seconds or the proxy refuses to cut traffic over.
-- `forward_headers:` — if true, `X-Forwarded-For`, `X-Forwarded-Proto`, and related headers pass through. Turn on when the app trusts them.
-- `buffering:` — enable request/response buffering. Useful for slow clients on fast backends.
+- `healthcheck:` — new container must return 2xx at `healthcheck.path` within `healthcheck.timeout` seconds (defaults: `/up`, 30) or the proxy refuses to cut traffic over.
+- `forward_headers:` — parsed but **currently ignored**; not forwarded to the proxy ([#3088](https://github.com/wheels-dev/wheels/issues/3088)).
+- `buffering:` — parsed but **currently ignored** ([#3088](https://github.com/wheels-dev/wheels/issues/3088)).
+
+<Aside type="caution" title="app_port is currently ignored — the proxy target is hardcoded to 3000">
+`wheels deploy` and `wheels deploy rollback` currently hardcode the `kamal-proxy deploy` target to `<container>:3000`, regardless of `app_port` — and regardless of the `8080` the init template writes. Until [#3089](https://github.com/wheels-dev/wheels/issues/3089) is fixed, your container must listen on port 3000 for the traffic cutover to work.
+</Aside>
 
 ## `accessories`
 
@@ -245,6 +247,8 @@ accessories:
       - config/init.sql:/docker-entrypoint-initdb.d/init.sql
 ```
 
+Two caveats on the example shapes: `files:` is accepted but **never uploaded** — no copy step or docker flag is emitted ([#3088](https://github.com/wheels-dev/wheels/issues/3088)) — and accessory `env.secret` entries are subject to the same not-yet-implemented secret delivery as the top-level [`env`](#env) key ([#2956](https://github.com/wheels-dev/wheels/issues/2956)).
+
 See [Accessories](/v4-0-0/deployment/accessories/) for the full walk-through.
 
 ## `volumes`, `labels`
@@ -263,7 +267,7 @@ Role-level `volumes` and `labels` merge over these.
 
 ## `hooks`
 
-Path override for the `.kamal/hooks/` directory. Rarely used; the default is fine.
+Path override for the `.kamal/hooks/` directory. **Currently ignored**: the key passes validation but is never read — hook scripts are always loaded from `.kamal/hooks/` ([#3088](https://github.com/wheels-dev/wheels/issues/3088)).
 
 ```yaml title="config/deploy.yml (illustrative — do not type)"
 hooks:
@@ -278,22 +282,19 @@ Legacy top-level healthcheck config (pre-kamal-proxy). New deploys should config
 
 ## `boot`
 
-Controls the rolling boot sequence.
+In Kamal, controls the rolling boot sequence (`limit:` for parallelism, `wait:` for pauses between hosts). **Currently ignored**: `wheels deploy` never reads `boot.limit` or `boot.wait` — it always deploys hosts one at a time, sequentially, with no pause ([#3088](https://github.com/wheels-dev/wheels/issues/3088); the rolling-boot orchestration work is tracked under [#2957](https://github.com/wheels-dev/wheels/issues/2957)).
 
-```yaml title="config/deploy.yml (illustrative — do not type)"
+```yaml title="config/deploy.yml (accepted but currently ignored)"
 boot:
   limit: 25%
   wait: 2
 ```
 
-- `limit:` — how many hosts boot in parallel. Default 1 (strict sequential). Set to `25%` or an absolute number to parallelize.
-- `wait:` — seconds to pause between each host's completion and the next host's start. Default 0.
-
 ## `logging`
 
-Docker logging driver and options. Passed through to `docker run --log-driver` / `--log-opt`.
+In Kamal, the Docker logging driver and options, passed through as `docker run --log-driver` / `--log-opt`. **Currently ignored**: no logging flags are ever emitted ([#3088](https://github.com/wheels-dev/wheels/issues/3088)).
 
-```yaml title="config/deploy.yml (illustrative — do not type)"
+```yaml title="config/deploy.yml (accepted but currently ignored)"
 logging:
   driver: json-file
   options:
@@ -303,68 +304,47 @@ logging:
 
 ## `retain_containers`
 
-How many old containers to keep on each host for rollback. Default 5. Older ones are pruned during `wheels deploy prune all`.
+In Kamal, how many old containers to keep on each host for rollback. **The config key is currently ignored** ([#3088](https://github.com/wheels-dev/wheels/issues/3088)): `wheels deploy prune all` always keeps the 5 most recent containers unless you pass `--keep=<n>` on the command line.
 
-```yaml title="config/deploy.yml (illustrative — do not type)"
+```yaml title="config/deploy.yml (accepted but currently ignored — use prune --keep=<n> instead)"
 retain_containers: 10
 ```
 
 ## `minimum_version`
 
-Require the CLI to be at least this version. Causes a fail-fast error if the installed `wheels` CLI is older.
-
-```yaml title="config/deploy.yml (illustrative — do not type)"
-minimum_version: "4.0.0"
-```
+In Kamal, requires the CLI to be at least this version. **Currently ignored**: no version gate runs, even with an impossible value like `"99.0.0"` ([#3088](https://github.com/wheels-dev/wheels/issues/3088)).
 
 ## `asset_path`
 
-Path inside the container for long-lived static assets. Used by the asset-swap path for zero-downtime JS/CSS rotation.
-
-```yaml title="config/deploy.yml (illustrative — do not type)"
-asset_path: /app/public/assets
-```
+In Kamal, the in-container path used for zero-downtime JS/CSS asset rotation. **Currently ignored** ([#3088](https://github.com/wheels-dev/wheels/issues/3088)).
 
 ## `require_destination`
 
-If true, every command must pass `--destination=<name>`. Guards against deploying the wrong environment by default.
-
-```yaml title="config/deploy.yml (illustrative — do not type)"
-require_destination: true
-```
+In Kamal, forces every command to pass `--destination=<name>`. **Currently ignored** — commands run fine without a destination regardless of this key ([#3088](https://github.com/wheels-dev/wheels/issues/3088)).
 
 ## `allow_empty_roles`
 
-If true, a role with an empty `hosts:` list doesn't fail validation. Useful when a role is temporarily scaled to zero.
-
-```yaml title="config/deploy.yml (illustrative — do not type)"
-allow_empty_roles: true
-```
+In Kamal, lets a role with an empty `hosts:` list pass validation. **Currently ignored** ([#3088](https://github.com/wheels-dev/wheels/issues/3088)).
 
 ## `run_directory`
 
-Working directory inside the container. Default is the image's configured `WORKDIR`. Override when the image ships without one.
-
-```yaml title="config/deploy.yml (illustrative — do not type)"
-run_directory: /app
-```
+In Kamal, the working directory inside the container. **Currently ignored** — the image's configured `WORKDIR` is always used ([#3088](https://github.com/wheels-dev/wheels/issues/3088)).
 
 ## `readiness_delay`
 
-Seconds to wait after `docker run` before asking the proxy to cut over. Default 0. Set when your app needs a head start before the health check starts succeeding (database migrations running in-container on boot, for example).
-
-```yaml title="config/deploy.yml (illustrative — do not type)"
-readiness_delay: 5
-```
+In Kamal, seconds to wait after `docker run` before asking the proxy to cut over. **Currently ignored** ([#3088](https://github.com/wheels-dev/wheels/issues/3088)).
 
 ## Variable interpolation
 
-`deploy.yml` supports a single, deliberately small interpolation form: `${UPPER_SNAKE}` env-var tokens. This is the same syntax Ruby Kamal supports natively, with the same lookup order:
+`deploy.yml` supports a single, deliberately small interpolation form: `${UPPER_SNAKE}` env-var tokens. This is the same syntax Ruby Kamal supports natively. Lookup order:
 
-1. CLI `--env` overrides (test/CI shims).
-2. `.kamal/secrets` (and `.kamal/secrets.<destination>` when `--destination` is set).
-3. `System.getenv(VAR)` on the machine running `wheels deploy`.
-4. Empty string for unset vars.
+1. `.kamal/secrets` (and `.kamal/secrets.<destination>` when `--destination` is set).
+2. `System.getenv(VAR)` on the machine running `wheels deploy`.
+3. Empty string for unset vars.
+
+<Aside type="caution" title="Secrets are read from config/.kamal/secrets here">
+The interpolator resolves the secrets file relative to `deploy.yml`'s **own directory** — so for the standard `config/deploy.yml` layout it reads `config/.kamal/secrets`, and the project-root `.kamal/secrets` the rest of the CLI uses is never consulted. Until [#3084](https://github.com/wheels-dev/wheels/issues/3084) is fixed, `${VAR}` tokens only resolve from `config/.kamal/secrets` or the process environment.
+</Aside>
 
 ```yaml title="config/deploy.yml (illustrative — do not type)"
 service: ${APP_NAME}
@@ -401,10 +381,13 @@ proxy:
   host: staging.example.com
 ```
 
+One caveat: the `wheels deploy config` inspection verb currently ignores `--destination` and always prints the base file ([#3085](https://github.com/wheels-dev/wheels/issues/3085)). To see an overlay applied, use a verb that does resolve it, e.g. `wheels deploy details --destination=staging --dry-run`.
+
 ## Validation errors
 
-Three classes of error, all emitted as `deploy.yml: <message>`:
+Errors are emitted as `<absolute path to deploy.yml>: <message>` — the prefix is the full file path, and messages are never line-scoped:
 
 - `missing required key: '<name>'` — one of `service`, `image`, `servers` is absent.
 - `unknown top-level key: '<name>'` — typo or unsupported key. Cross-check against the allowlist above.
-- `invalid host: '<string>'` — host string has more than one colon without IPv6 brackets.
+- `invalid host: '<string>'` — host string has more than one colon without IPv6 brackets. (Known gap: adjacent colons are under-counted, so strings like `'::1:22'` currently pass — [#3086](https://github.com/wheels-dev/wheels/issues/3086).)
+- `invalid <kind> name: '<name>' (must match [a-zA-Z0-9][a-zA-Z0-9_.-]*)` — a service, role, or accessory name contains shell-unsafe characters. Develop builds only (added after 4.0.3 by [#3008](https://github.com/wheels-dev/wheels/pull/3008) for [#2956](https://github.com/wheels-dev/wheels/issues/2956)).


### PR DESCRIPTION
## Summary

Guide-behavioral-audit batch 2, work item **p1-16-deploy** — the `deployment/config-reference.mdx` and `deployment/architecture.mdx` slice (claims `cfg-01`–`cfg-16`, `arch-02`–`arch-06`). Every correction below describes **current** CLI behavior, verified live against the released 4.0.3 CLI and develop source, and links the tracking issue for anything broken-but-unfixed — no aspirational behavior is documented.

## config-reference.mdx

| Correction | Evidence | Issue |
|---|---|---|
| Umbrella aside + per-key flags for every accepted-but-ignored key: `boot.*`, `logging.*`, `retain_containers`, `minimum_version`, `asset_path`, `require_destination`, `allow_empty_roles`, `run_directory`, `readiness_delay`, `hooks.path`, `builder.arch/args/remote`, `ssh.proxy/keys_only`, `proxy.forward_headers/buffering`, role `env:`/`options:`/`labels:`, accessory `files:` | cfg-04, cfg-06, cfg-08–cfg-14, acc-03 — zero readers outside the Validator allowlist; spot checks (e.g. `minimum_version: "99.0.0"` passes, `retain_containers: 10` still prunes to 5, role env/options absent from `docker run`) | #3088 |
| `env`: removed the per-role precedence table (machinery doesn't exist); `env.secret` callout — silently dropped on 4.0.3, hard-fails `Wheels.Deploy.EnvSecretUnsupported` on develop | cfg-07, sec-08 | #2956, #3088 |
| `proxy`: `app_port` default is **80** (not 3000), init template writes 8080, and deploy/rollback hardcode the proxy target to `:3000` ignoring `app_port` (verified `DeployMainCli.cfc:97/148`) | cfg-09 | #3089 |
| `ssh`: `user` defaults to **root** (not the local user, `Ssh.cfc:18-20`); `~/.ssh/config` is **not** read (sshj doesn't parse OpenSSH client config; `known_hosts` is honored) | cfg-08 | — |
| `servers`: every role currently receives the `kamal-proxy deploy` cutover call, not just `web` (observed for a `job` role in dry-run) | cfg-04 | #2957 |
| Host validation: documented the colon-under-count gap (`'::1:22'` passes, `Validator.cfc:72`) | cfg-03 | #3086 |
| Interpolation: removed the nonexistent "CLI `--env` overrides" lookup step (no such flag in `DeployArgsParser`); noted `${VAR}` secrets resolve from `config/.kamal/secrets` (relative to deploy.yml's directory), not the project root | arch-04 | #3084 |
| Destination overlays: `wheels deploy config` ignores `--destination`; pointed readers at `details --destination=... --dry-run` | arch-03, cfg-15 | #3085 |
| Validation errors: prefix is the absolute config path (never line-scoped, intro + required-keys wording too); added the fourth `invalid <kind> name:` class shipped on develop | cfg-01, cfg-02, cfg-16 | #3008 / #2956 |

## architecture.mdx

| Correction | Evidence | Issue |
|---|---|---|
| Byte-compat table: caution aside for the three aspirational rows — audit log never written (`record()` has no call sites), `docker network create kamal` never issued, proxy config dir resolves to `/home/root` for the default root user | arch-02 (DEP-6, DEP-5c, DEP-11c) | #2957 |
| Interpolation chain: same `--env` removal + `config/.kamal/secrets` resolution note | arch-04 | #3084 |
| `wheels deploy init` scaffolding renders four templates (`deploy.yml`, `secrets`, `Dockerfile`, `dockerignore` — verified in `cli/lucli/templates/deploy/init/`), not two | arch-06, fd-01 | — |

## Verification

- `pnpm verify:docs src/content/docs/v4-0-0/deployment/config-reference.mdx src/content/docs/v4-0-0/deployment/architecture.mdx` → `1 passed, 0 failed`, exit 0
- All cited defaults/hardcodes re-checked against worktree source (`Ssh.cfc`, `Proxy.cfc`, `Validator.cfc`, `DeployMainCli.cfc`, init templates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)