### PR TITLE
docs(web/guides): correct 20 audited testing-guide claims (batch 2)

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/testing/browser-tests.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/testing/browser-tests.mdx
@@ -38,7 +38,7 @@ wheels browser setup
 
 The installer resolves seven JARs from Maven Central (Playwright client, driver, driver-bundle, transitive deps) and caches them under a per-project install directory. Subsequent runs skip the download when hashes match. Pass `--force` to re-download. Chromium is the only engine the browser DSL wires today — Firefox and WebKit are not yet selectable.
 
-If Playwright isn't installed when a spec runs, `BrowserTest.beforeAll` catches the missing-JAR error, sets `this.browserTestSkipped = true`, and the suite stays green. That's the safety net for CI cold starts and fresh dev machines — but every `it` in a browser spec still needs to check the flag.
+If Playwright isn't installed when a spec runs, `BrowserTest.beforeAll` catches the missing-JAR error, sets `this.browserTestSkipped = true`, and the suite stays green. That's the safety net for CI cold starts and fresh dev machines. Inside `browserDescribe()` blocks the skip is automatic — its `aroundEach` returns early when the flag is set, so specs don't need a hand-written guard. Only `it` blocks inside a plain `describe()` need to check `this.browserTestSkipped` themselves.
 
 ## A minimal browser spec
 
@@ -50,7 +50,6 @@ component extends="wheels.wheelstest.BrowserTest" {
     function run() {
         browserDescribe("Home page", () => {
             it("loads the home page", () => {
-                if (this.browserTestSkipped) return;
                 this.browser
                     .visitUrl("http://localhost:8080/")
                     .assertTitleContains("My App");
@@ -63,7 +62,7 @@ component extends="wheels.wheelstest.BrowserTest" {
 Two things to note in every browser spec:
 
 1. **`extends="wheels.wheelstest.BrowserTest"`** — not `wheels.WheelsTest`. The browser base class adds the Playwright lifecycle hooks on top of BDD.
-2. **`if (this.browserTestSkipped) return;`** — the first line of every `it`. When Playwright JARs aren't installed, or when the CI gate (`WHEELS_CI=true` without `WHEELS_BROWSER_CI_ENABLE=true`) is active, `beforeAll` sets the flag. Without the guard, the spec would crash on the first `this.browser` call instead of staying green.
+2. **Use `browserDescribe()`, not plain `describe()`.** When Playwright JARs aren't installed, or when the CI gate (`WHEELS_CI=true` without `WHEELS_BROWSER_CI_ENABLE=true`) is active, `beforeAll` sets `this.browserTestSkipped` — and `browserDescribe`'s `aroundEach` skips each `it` automatically. If you put browser `it` blocks inside a plain `describe()` instead, you must guard them yourself with `if (this.browserTestSkipped) return;` or they crash on the first `this.browser` call.
 
 ## `browserDescribe` vs `describe`
 
@@ -74,13 +73,11 @@ component extends="wheels.wheelstest.BrowserTest" {
     function run() {
         browserDescribe("Isolated per-it state", () => {
             it("starts with no cookies", () => {
-                if (this.browserTestSkipped) return;
                 this.browser.visitUrl("http://localhost:8080/")
                     .clearCookies()
                     .assertSee("Sign in");
             });
             it("also starts with no cookies", () => {
-                if (this.browserTestSkipped) return;
                 // Fresh context; the previous test's state is gone.
                 this.browser.visitUrl("http://localhost:8080/")
                     .assertSee("Sign in");
@@ -106,7 +103,6 @@ component extends="wheels.wheelstest.BrowserTest" {
     function run() {
         browserDescribe("Navigation", () => {
             it("follows a route and comes back", () => {
-                if (this.browserTestSkipped) return;
                 this.browser
                     .visitRoute(route="posts")
                     .click("a.post-link")
@@ -152,7 +148,6 @@ component extends="wheels.wheelstest.BrowserTest" {
     function run() {
         browserDescribe("Scoped form", () => {
             it("fills the signin form, not the signup form", () => {
-                if (this.browserTestSkipped) return;
                 this.browser
                     .visitUrl("http://localhost:8080/sign-in")
                     .within("form##signin", (scoped) => {
@@ -176,7 +171,7 @@ component extends="wheels.wheelstest.BrowserTest" {
 
 ## The DSL — auth fixtures
 
-`loginAs(identifier)` takes a single string (email, username, or whatever your app uses to identify a user) and navigates to `/_browser/login-as?identifier=...`. That route is mounted automatically in test mode. The default handler writes `session.userId = 1` and `session.userEmail = identifier` — enough for simple apps. If your app stores a richer session shape (e.g. `session.member = { id, email, firstName, lastName }`), add one line to `config/settings.cfm`:
+`loginAs(identifier)` takes a single string (email, username, or whatever your app uses to identify a user) and navigates to `/_browser/login-as?identifier=...`. In your own app that route is mounted when `set(loadBrowserTestFixtures=true)` is on (default `false`) and the environment is `testing` or `development`. The default handler writes `session.userId = 1` and `session.userEmail = identifier` — enough for simple apps. If your app stores a richer session shape (e.g. `session.member = { id, email, firstName, lastName }`), add one line to `config/settings.cfm`:
 
 ```cfm title="config/settings.cfm"
 set(browserLoginAsHandler = "AuthFixture##loginAs");
@@ -189,7 +184,6 @@ component extends="wheels.wheelstest.BrowserTest" {
     function run() {
         browserDescribe("Authenticated dashboard", () => {
             it("shows the user's posts", () => {
-                if (this.browserTestSkipped) return;
                 this.browser
                     .loginAs("alice@example.com")
                     .visitRoute(route="posts")
@@ -212,7 +206,6 @@ component extends="wheels.wheelstest.BrowserTest" {
     function run() {
         browserDescribe("Delete confirmation", () => {
             it("accepts the native confirm dialog", () => {
-                if (this.browserTestSkipped) return;
                 this.browser
                     .visitRoute(route="post", key=42)
                     .acceptDialog()
@@ -276,14 +269,13 @@ These return a value instead of `this`, so they end the chain.
 
 ## Targeting form fields with `data-auto-id`
 
-Wheels form helpers emit two selector hooks on every field — a camelCase `id="postTitle"` for browser URL hashes, and an underscored `data-auto-id="post_title"` for test selectors. The underscored form is stable against rename refactors; use it in browser specs.
+Wheels form helpers emit two selector hooks on every field — a dashed `id="post-title"` for DOM labels and CSS, and an underscored `data-auto-id="post_title"` for test selectors. The underscored form is stable against rename refactors; use it in browser specs.
 
 ```cfm {test:compile} title="tests/specs/browser/NewPostSpec.cfc"
 component extends="wheels.wheelstest.BrowserTest" {
     function run() {
         browserDescribe("Create a post", () => {
             it("submits the new-post form", () => {
-                if (this.browserTestSkipped) return;
                 this.browser
                     .loginAs("alice@example.com")
                     .visitRoute(route="newPost")
@@ -304,10 +296,10 @@ See [View & Form Tests](/v4-0-0/testing/view-and-form-tests/) for the same `data
 
 Most of the DSL is engine-agnostic — Playwright drives a real Chromium regardless of which CFML engine is running your app. The exceptions:
 
-- **Dialogs** — `acceptDialog`, `dismissDialog`, `dialogMessage` use `createDynamicProxy` to register a listener on Playwright's Java-side `Dialog` interface. That API is Lucee-only. On Adobe CF and BoxLang, calls throw `Wheels.DialogSupportMissing`. Wrap dialog-driven specs in an engine check (`if (server.coldfusion.productname != "Lucee") return;`) if you run the suite across engines.
-- **`loginAs`** — relies on the `/_browser/login-as` fixture route, which is mounted automatically in test mode from `vendor/wheels/tests/routes.cfm`. If your app clears or replaces the route table in another spec, `BrowserTest.beforeAll` re-includes the fixture routes so browser specs stay self-contained.
+- **Dialogs** — `acceptDialog`, `dismissDialog`, `dialogMessage` use `createDynamicProxy` to register a listener on Playwright's Java-side `Dialog` interface. That API is Lucee-only. On Adobe CF and BoxLang, calls throw `Wheels.BrowserDialogNotSupported`. Wrap dialog-driven specs in an engine check (`if (server.coldfusion.productname != "Lucee") return;`) if you run the suite across engines.
+- **`loginAs`** — relies on the `/_browser/login-as` fixture route. Nothing restores that route automatically: if another spec clears or replaces the route table (a `$clearRoutes()`-style spec), `loginAs` and every `/_browser/*` request will 404 until the routes reload. Make any spec that manipulates the route table restore it before browser specs run.
 
-See the cross-engine notes in [`CLAUDE.md`](https://github.com/cfwheels/cfwheels/blob/develop/CLAUDE.md) for the full list of Lucee/Adobe/BoxLang divergences.
+See the cross-engine notes in [`CLAUDE.md`](https://github.com/wheels-dev/wheels/blob/develop/CLAUDE.md) for the full list of Lucee/Adobe/BoxLang divergences.
 
 ## Debugging failing specs
 

--- a/web/sites/guides/src/content/docs/v4-0-0/testing/ci-integration.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/testing/ci-integration.mdx
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install LuCLI
         run: |
-          curl -sL "https://github.com/cybersonic/LuCLI/releases/download/v0.3.3/lucli-0.3.3-linux" \
+          curl -sL "https://github.com/cybersonic/LuCLI/releases/download/v0.3.7/lucli-0.3.7-linux" \
             -o /usr/local/bin/lucli
           chmod +x /usr/local/bin/lucli
 
@@ -71,16 +71,17 @@ If you want the raw CLI instead of the bash wrapper, the equivalent is `wheels s
 
 ## Reporter output for CI
 
-The `wheels test` command accepts a `--reporter=<name>` flag, but understanding what it does today avoids a surprise: the LuCLI implementation always requests JSON from the test endpoint and then prints a human-readable summary on success or failure details on failure. The flag is parsed but does not currently select between output formats — you get the same output regardless of `--reporter` value.
+The `wheels test` command accepts a `--reporter=<name>` flag. The CLI always requests JSON from the test endpoint, then formats the result for the reporter you picked:
 
 | Flag | Behaviour today |
 | --- | --- |
 | `--reporter=simple` (default) | Human-readable summary: `N passed (Xs)` on green, plus failure details on red |
-| `--reporter=<anything else>` | Accepted, currently no-op — same human-readable output |
-| `--ci` | Accepted, reserved for CI-specific behaviour — currently a no-op in the output path |
+| `--reporter=json` | Emits the raw JSON result document — pipe it to `jq` or a post-processor |
+| `--reporter=tap` | Emits TAP version 13 (`1..N`, `ok` / `not ok` lines) for TAP-consuming CI tooling |
+| `--ci` | Accepted for forward-compatibility — currently changes nothing; every run already exits non-zero on failure |
 | `--verbose` / `-v` | Adds the full bundle/suite/spec tree to the output |
 
-For machine-readable results, call the test runner URL directly and post-process the JSON. That is exactly what `tools/ci/run-tests.sh` does in this repo: it `curl`s `/wheels/core/tests?db=sqlite&format=json`, parses the totals in Python, and emits a JUnit XML file that `actions/upload-artifact` ingests for the GitHub summary.
+For machine-readable results you can also call the test runner URL directly and post-process the JSON. That is exactly what `tools/ci/run-tests.sh` does in this repo: it `curl`s `/wheels/core/tests?db=sqlite&format=json`, parses the totals in Python, and emits a JUnit XML file that `actions/upload-artifact` ingests for the GitHub summary.
 
 ```bash title="tools/ci/run-tests.sh (excerpt)"
 curl -s -o "$RESULT_FILE" --max-time 600 \
@@ -102,7 +103,7 @@ Browser specs are expensive to run in CI — they need the Playwright JARs (~370
 - **`WHEELS_CI=true`** — mark the environment as CI
 - **`WHEELS_BROWSER_CI_ENABLE=true`** (or `1` or `yes`) — opt browser specs in
 
-If `WHEELS_CI` is set and `WHEELS_BROWSER_CI_ENABLE` is not one of `true,1,yes`, `BrowserTest.cfc` sets `this.browserTestSkipped = true` in `beforeAll`. Every `it` block in a browser spec that begins with `if (this.browserTestSkipped) return;` then exits without running. The suite stays green; the browser tests simply don't count.
+If `WHEELS_CI` is set and `WHEELS_BROWSER_CI_ENABLE` is not one of `true,1,yes`, `BrowserTest.cfc` sets `this.browserTestSkipped = true` in `beforeAll`, and `browserDescribe`'s `aroundEach` skips every `it` automatically. The suite stays green; the browser tests simply don't count.
 
 ```yaml title=".github/workflows/tests.yml (fragment)"
 env:

--- a/web/sites/guides/src/content/docs/v4-0-0/testing/fixtures-and-test-data.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/testing/fixtures-and-test-data.mdx
@@ -32,6 +32,10 @@ The trigger conditions live in `vendor/wheels/tests/runner.cfm`. The runner read
 This is a significant departure from Rails or Laravel, where the framework wraps each test in a transaction and rolls back. Wheels sets `application.wheels.transactionMode = "none"` in `runner.cfm`, so writes during a test run persist across specs. The two mechanisms you have for isolation are: (1) make `populate.cfm` idempotent so re-running it always resets the world, and (2) wrap destructive specs in a manual `transaction { ... }` block that rolls back.
 
 <Aside type="caution">
+  The runner applies these settings (and path swaps like `modelPath`) to the **live** `application.wheels` of the server it runs against — they can leak into normal requests served during and after a test run. Track [#3025](https://github.com/wheels-dev/wheels/issues/3025) for the isolation work; until then, prefer a dedicated test server over running the suite against the instance you're browsing.
+</Aside>
+
+<Aside type="caution">
   `populate.cfm` does not run between specs. A `create()` in `specs/models/PostSpec.cfc` leaves a row visible to `specs/models/CommentSpec.cfc`. Design specs to tolerate shared state, or roll back writes explicitly.
 </Aside>
 
@@ -44,13 +48,17 @@ The canonical pattern is DROP + CREATE + seed, in that order, with the drops in 
 // Runs once per test run. Triggered by runner.cfm whenever url.populate is
 // truthy (default) or when the sentinel table is missing.
 
+function runSql(required string sql) {
+    queryExecute(arguments.sql, {}, {datasource: application.wheels.dataSourceName});
+}
+
 // Drop existing tables (reverse dependency order)
-try { application.wo.execute("DROP TABLE comments"); } catch (any e) {}
-try { application.wo.execute("DROP TABLE posts"); } catch (any e) {}
-try { application.wo.execute("DROP TABLE users"); } catch (any e) {}
+try { runSql("DROP TABLE comments"); } catch (any e) {}
+try { runSql("DROP TABLE posts"); } catch (any e) {}
+try { runSql("DROP TABLE users"); } catch (any e) {}
 
 // Create tables
-application.wo.execute("
+runSql("
     CREATE TABLE users (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         email VARCHAR(100) UNIQUE NOT NULL,
@@ -60,7 +68,7 @@ application.wo.execute("
     )
 ");
 
-application.wo.execute("
+runSql("
     CREATE TABLE posts (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         userId INTEGER NOT NULL,
@@ -72,7 +80,7 @@ application.wo.execute("
     )
 ");
 
-application.wo.execute("
+runSql("
     CREATE TABLE comments (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         postId INTEGER NOT NULL,
@@ -84,20 +92,20 @@ application.wo.execute("
 ");
 
 // Seed known fixtures
-application.wo.execute("
+runSql("
     INSERT INTO users (email, passwordHash, createdAt, updatedAt)
     VALUES ('alice@example.com', 'hash', NOW(), NOW()),
            ('bob@example.com', 'hash', NOW(), NOW())
 ");
 
-application.wo.execute("
+runSql("
     INSERT INTO posts (userId, title, body, status, createdAt, updatedAt)
     VALUES (1, 'Welcome', 'First post', 'published', NOW(), NOW())
 ");
 </cfscript>
 ```
 
-Two things to notice. First, every call goes through `application.wo.execute(...)` rather than a bare `execute(...)`. That's the scope gotcha (covered below) — Wheels' internal functions are not available as globals inside a plain `.cfm` include. Second, the schema uses SQLite-flavoured syntax (`AUTOINCREMENT`, `TEXT`) because SQLite is the inner-loop reference platform for Wheels 4.0 tests.
+Two things to notice. First, every call goes through native `queryExecute(...)` rather than a bare `execute(...)` — there is no global `execute()` in a plain `.cfm` include, and none on `application.wo` either; `execute()` exists only inside migration CFCs. That's the scope gotcha (covered below). Second, the schema uses SQLite-flavoured syntax (`AUTOINCREMENT`, `TEXT`) because SQLite is the inner-loop reference platform for Wheels 4.0 tests.
 
 ## Per-spec isolation — the manual pattern
 
@@ -137,7 +145,7 @@ Sometimes you want a model that exists only during the test run — a stripped-d
 ```cfm {test:compile} title="tests/_assets/models/TestPost.cfc"
 component extends="Model" {
     function config() {
-        tableName("test_posts");
+        table("test_posts");
         setPrimaryKey("id");
     }
 }
@@ -185,10 +193,10 @@ Factories trade a few lines of setup for a shorter, more readable spec body. Whe
 
 ## The scope gotcha
 
-Wheels' internal functions (`model()`, `$dbinfo`, `execute()`, and friends) are not available as bare globals inside plain `.cfm` files that are included from CFCs like `TestRunner.cfc`. If you write `execute("CREATE TABLE ...")` in `populate.cfm`, you'll get a "variable EXECUTE is undefined" error.
+Wheels' internal functions (`model()`, `$dbinfo`, and friends) are not available as bare globals inside plain `.cfm` files that are included from CFCs like `TestRunner.cfc`. If you write `execute("CREATE TABLE ...")` in `populate.cfm`, you'll get a "No matching function [EXECUTE] found" error (Adobe words it as "variable EXECUTE is undefined").
 
 <Aside type="caution">
-  Call framework internals via `application.wo.` (the scope where Wheels stores its callable methods) or use native CFML tags. `application.wo.execute("CREATE TABLE ...")` works; so does `<cfdbinfo>`, `<cfquery>`, and `<cfdump>`. Same rule for `application.wo.model("Post")` if you need to seed through the ORM instead of raw SQL.
+  Call framework internals via `application.wo.` (the scope where Wheels stores its callable methods) or use native CFML. `application.wo.model("Post")` works if you need to seed through the ORM. For raw SQL there is no framework helper at all here — `execute()` exists only on migration CFCs (`wheels.migrator.Migration`), not on `application.wo` — so use native `queryExecute(...)` with an explicit `datasource`, or `<cfquery>`/`<cfdbinfo>`.
 </Aside>
 
 This is the most common first-time-authoring bug in `populate.cfm`. If your tests die at boot with "function not defined" and the stack trace points at your populate, it's this.

--- a/web/sites/guides/src/content/docs/v4-0-0/testing/functional-tests.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/testing/functional-tests.mdx
@@ -43,7 +43,7 @@ component extends="wheels.WheelsTest" {
 
                 $testClient().get("/posts/##post.id##")
                     .assertOk()
-                    .assertHeader("Content-Type", "text/html; charset=UTF-8")
+                    .assertHeader("Content-Type", "text/html;charset=UTF-8")
                     .assertSee("<h1>T</h1>")
                     .assertSee("B");
             });
@@ -52,7 +52,7 @@ component extends="wheels.WheelsTest" {
 }
 ```
 
-The assertion chain reads as a trace of the request. `assertOk` confirms the router matched a real action and no filter short-circuited. `assertHeader` confirms the response came back as HTML, not JSON or a redirect. The two `assertSee` calls confirm the view actually rendered the record. If any layer misbehaves — a route typo, a filter that redirects, a view that swallowed the record — one of these fails and tells you which.
+The assertion chain reads as a trace of the request. `assertOk` confirms the router matched a real action and no filter short-circuited. `assertHeader` confirms the response came back as HTML, not JSON or a redirect — note it's an **exact-match** comparison, and both Lucee and Adobe emit `text/html;charset=UTF-8` with no space after the semicolon, so a `"text/html; charset=UTF-8"` literal fails. The two `assertSee` calls confirm the view actually rendered the record. If any layer misbehaves — a route typo, a filter that redirects, a view that swallowed the record — one of these fails and tells you which.
 
 ## Testing middleware effects
 
@@ -183,7 +183,7 @@ component extends="wheels.WheelsTest" {
 }
 ```
 
-The split assertion sidesteps an apostrophe-encoding gotcha: Wheels HTML-escapes error messages, so `can't` renders as `can&##39;t`. A single `assertSee("can't be empty")` would miss the encoded form. `assertSeeInOrder(["can", "t be empty"])` is an equivalent one-liner when you want to assert the two fragments appear in that order.
+The split assertion sidesteps an apostrophe-encoding gotcha: Wheels HTML-escapes error messages, so `can't` renders as `can&##x27;t` (the hex entity, on both Lucee and Adobe). A single `assertSee("can't be empty")` would miss the encoded form. `assertSeeInOrder(["can", "t be empty"])` is an equivalent one-liner when you want to assert the two fragments appear in that order.
 
 ## When to choose functional over integration
 

--- a/web/sites/guides/src/content/docs/v4-0-0/testing/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/testing/index.mdx
@@ -67,7 +67,7 @@ Wheels used to ship with a homegrown runner called RocketUnit. Specs were CFCs i
 
 ## The reference platform
 
-Wheels 4.0 core tests run against **Lucee 7 + SQLite**. That's the baseline you should assume when reading the test docs. The full matrix — Adobe ColdFusion 2018/2021/2023/2025, BoxLang, and every supported database (MySQL, PostgreSQL, SQL Server, H2, SQLite, CockroachDB) — runs in CI on every PR to the framework. For your own app, pick one engine and one database for fast feedback, then let CI handle the matrix. Cross-engine nuances (Lucee vs. Adobe scope rules, closure semantics, reserved names) surface as asides in the detail pages where they matter.
+Wheels 4.0 core tests run against **Lucee 7 + SQLite**. That's the baseline you should assume when reading the test docs. The full matrix — Lucee 6/7, Adobe ColdFusion 2023/2025, BoxLang, and every supported database (MySQL, PostgreSQL, SQL Server, SQLite, CockroachDB, Oracle) — runs on a weekly schedule (plus manual dispatch) in the framework repo, not on every PR. For your own app, pick one engine and one database for fast feedback, then let a scheduled matrix job handle the rest. Cross-engine nuances (Lucee vs. Adobe scope rules, closure semantics, reserved names) surface as asides in the detail pages where they matter.
 
 ## Running tests
 
@@ -81,9 +81,9 @@ Common invocations:
 
 - `wheels test` — execute the entire suite.
 - `wheels test --filter=models` — a single directory or keyword.
-- `wheels test --ci` — CI mode (browser specs gate on `WHEELS_BROWSER_CI_ENABLE`).
+- `wheels test --ci` — accepted for forward-compatibility, but currently a no-op: failure exit codes are non-zero on every run, with or without the flag. Browser-spec gating is controlled by the *server's* environment (`WHEELS_CI` / `WHEELS_BROWSER_CI_ENABLE`), not by this flag.
 
-The runner also exposes an HTTP endpoint at `/wheels/core/tests` you can hit directly. A URL like `/wheels/core/tests?format=json&directory=tests.specs.model` runs just the model specs and returns JSON. This is useful for dev-loop iteration — keep the server up, change a spec, refresh the URL. See [Running Tests Locally](/v4-0-0/testing/running-tests-locally/) for the full invocation surface including Docker-based cross-engine runs.
+The runner also exposes an HTTP endpoint at `/wheels/app/tests` you can hit directly. A URL like `/wheels/app/tests?format=json&directory=tests.specs.models` runs just the model specs and returns JSON. (The framework's own suite lives at `/wheels/core/tests`, where the directory prefix is `wheels.tests.specs` — e.g. `directory=wheels.tests.specs.model`. A `directory` value the endpoint doesn't recognize is silently ignored and the full suite runs instead; see [#3083](https://github.com/wheels-dev/wheels/issues/3083).) This is useful for dev-loop iteration — keep the server up, change a spec, refresh the URL. See [Running Tests Locally](/v4-0-0/testing/running-tests-locally/) for the full invocation surface including Docker-based cross-engine runs.
 
 ## Setup files that matter
 
@@ -93,14 +93,14 @@ Four files drive your test setup. Knowing what each one does saves a lot of head
 |------|--------------|
 | `tests/TestRunner.cfc` | Sets up shared state. Runs before and after the whole suite. |
 | `tests/populate.cfm` | Seeds test data. Runs **once per test run**, not per spec. |
-| `tests/_assets/models/` | Test-only models, often using `tableName()` to map to test tables. |
+| `tests/_assets/models/` | Test-only models, often using `table()` to map to test tables. |
 | `tests/specs/<category>/` | Where your actual specs live. |
 
-`populate.cfm` typically drops and recreates the test schema — it's idempotent by construction but runs exactly once per `wheels test` invocation (or when you hit the runner URL with `?populate=true`). This is a deliberate departure from Rails/Laravel-style per-spec rollback: the framework default is `transactionMode = "none"`, so writes persist across specs unless you explicitly wrap them in `transaction { ... transaction action="rollback"; }`. [Fixtures & Test Data](/v4-0-0/testing/fixtures-and-test-data/) walks through the real lifecycle and the per-spec isolation pattern.
+`populate.cfm` typically drops and recreates the test schema — it's idempotent by construction and runs by default on every runner-URL hit (pass `?populate=false` to opt out). This is a deliberate departure from Rails/Laravel-style per-spec rollback: the framework default is `transactionMode = "none"`, so writes persist across specs unless you explicitly wrap them in `transaction { ... transaction action="rollback"; }`. [Fixtures & Test Data](/v4-0-0/testing/fixtures-and-test-data/) walks through the real lifecycle and the per-spec isolation pattern.
 
 ## CI integration
 
-The Wheels repo ships with GitHub Actions workflows that run the full engine × database matrix on every PR. Your app's CI doesn't need to be nearly that heavy. A single job that runs `wheels test --ci` against one engine and one database is usually enough. See [CI Integration](/v4-0-0/testing/ci-integration/) for drop-in templates, cross-engine matrix patterns, browser-test gating, and soft-fail database handling.
+The Wheels repo ships with GitHub Actions workflows that run the full engine × database matrix on a weekly schedule. Your app's CI doesn't need to be nearly that heavy. A single job that runs `wheels test` against one engine and one database is usually enough. See [CI Integration](/v4-0-0/testing/ci-integration/) for drop-in templates, cross-engine matrix patterns, browser-test gating, and soft-fail database handling.
 
 ## Where to go next
 

--- a/web/sites/guides/src/content/docs/v4-0-0/testing/model-tests.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/testing/model-tests.mdx
@@ -104,7 +104,7 @@ describe("Post uniqueness", () => {
 });
 ```
 
-`create(...)` builds and saves in one call — it returns the saved object whether the save succeeded or not, so check `.persisted()` if you need to be sure.
+`create(...)` builds and saves in one call — it returns the object whether the save succeeded or not, so check `isPersisted()` (or its inverse, `isNew()`) if you need to be sure.
 
 ## Testing callbacks
 

--- a/web/sites/guides/src/content/docs/v4-0-0/testing/running-tests-locally.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/testing/running-tests-locally.mdx
@@ -15,7 +15,7 @@ The fast path for day-to-day development is Lucee 7 + SQLite, driven by `wheels 
 - The fastest way to run the suite — `wheels test` and `tools/test-local.sh`
 - How to filter by directory or single spec, both from the CLI and the test-runner URL
 - How to drive the Docker cross-engine matrix for pre-merge verification
-- How to target a specific database (SQLite, MySQL, Postgres, MSSQL, H2, CockroachDB)
+- How to target a specific database (SQLite, H2, MySQL, Postgres, SQL Server, CockroachDB, Oracle)
 - The cross-engine gotchas that bite first-time contributors
 - The common failure modes — `JAVA_HOME` unset, port conflicts, missing Playwright JARs
 
@@ -28,7 +28,7 @@ The fast path for day-to-day development is Lucee 7 + SQLite, driven by `wheels 
 Before either path works, you need a handful of tools on `PATH`:
 
 - **Java 21+** — `brew install openjdk@21` on macOS, your distro's OpenJDK package on Linux, Adoptium on Windows.
-- **`JAVA_HOME` set** — LuCLI's preflight refuses to start if this is unset and points you at Adoptium. Set it in your shell profile (`export JAVA_HOME=$(/usr/libexec/java_home -v 21)` on macOS).
+- **`JAVA_HOME` set** — only matters when no Java is otherwise discoverable: the Homebrew install wraps the binary and exports `JAVA_HOME` itself, so brew users never see the preflight refusal. On other install paths, if the CLI can't find a JVM it refuses to start and points you at Adoptium — set `JAVA_HOME` in your shell profile (`export JAVA_HOME=$(/usr/libexec/java_home -v 21)` on macOS).
 - **The `wheels` CLI** — `brew install wheels`, `choco install wheels`, or the install script on Linux. The Wheels CLI is built on the LuCLI runtime; we ship the runtime under the `wheels` brand so you only ever invoke it as `wheels`.
 - **SQLite** — usually pre-installed; `brew install sqlite` if not. Needed for the default test database.
 - **Docker Desktop or Docker Engine** — only if you're running the cross-engine matrix.
@@ -55,18 +55,18 @@ wheels test --reporter=tap
 # Target a specific test database — only meaningful with --core
 wheels test --core --db=mysql
 
-# CI-friendly output (exits non-zero on failures, terse pass/fail summary)
+# Accepted for forward-compat — every run already exits non-zero on failures
 wheels test --ci
 ```
 
-The supported flags today are `--filter=<dir>`, `--reporter=<simple|json|tap>`, `--db=<sqlite|h2|mysql|postgres|sqlserver|oracle|cockroachdb>` (only honoured with `--core`), `--verbose` / `-v`, `--ci`, `--core` (force framework-core mode when the auto-detect doesn't pick it up), `--no-test-db` (don't auto-swap to `<datasource>_test`), and `--base-path=<path>` (URL prefix for subfolder-mounted apps — auto-derived from `WHEELS_SUBPATH` or `set(subpath=...)` when omitted). A positional argument acts as the filter. The CLI always requests JSON from the underlying runner and formats the result for the chosen reporter.
+The supported flags today are `--filter=<dir>`, `--reporter=<simple|json|tap>`, `--db=<sqlite|h2|mysql|postgres|sqlserver|oracle|cockroachdb>` (only honoured with `--core`), `--verbose` / `-v`, `--ci`, `--core` (run the framework's own suite instead of the app suite), `--no-test-db` (don't auto-swap to `<datasource>_test`), and `--base-path=<path>` (URL prefix for subfolder-mounted apps — auto-derived from `WHEELS_SUBPATH` or `set(subpath=...)` when omitted). A positional argument acts as the filter. The CLI always requests JSON from the underlying runner and formats the result for the chosen reporter.
 
 <Aside type="note" title="--db is for --core only">
 The framework's matrix self-tests (`--core`) wire up a `wheelstestdb_<engine>` datasource per supported engine — that's what `--db` selects between. App tests run against the datasource your project is configured for; passing `--db` to an app run prints a warning and is otherwise ignored. To run your app suite against a different engine, set the engine in your shell environment before invoking `wheels test` — see [the testing CLI reference](/v4-0-0/command-line-tools/wheels-commands/testing/#testing-against-different-engines) for the env-var pattern. This matches Rails (`DATABASE_URL`), Laravel (`DB_CONNECTION`), Symfony (`APP_ENV=test`), and Phoenix (`MIX_ENV`) — DB selection is a process-level concern, not a per-invocation flag.
 </Aside>
 
 <Aside type="tip">
-  When `vendor/wheels/tests/` exists (you're hacking on framework core), `wheels test` auto-enables `--core`. Pass `--core` explicitly if you want to force it.
+  `wheels test` always runs the app suite by default — even in the framework repo, where `vendor/wheels/tests/` exists. Pass `--core` explicitly to run the framework suite. (Earlier builds auto-detected core mode from the presence of `vendor/wheels/tests/`; that behavior was removed because it silently ran the wrong suite for user apps.)
 </Aside>
 
 ## LuCLI one-shot: `tools/test-local.sh`
@@ -99,17 +99,17 @@ curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json"
 # Filter by directory
 curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json&directory=wheels.tests.specs.model"
 
-# Filter to a single spec file — fastest iteration loop
-curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json&directory=wheels.tests.specs.model.postSpec"
+# Filter to a single spec file — fastest iteration loop (use testBundles, not directory)
+curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json&testBundles=wheels.tests.specs.model.callbacksSpec"
 
 # Skip populate when iterating on one spec and the schema is already in place
-curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json&populate=false&directory=wheels.tests.specs.model.postSpec"
+curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json&populate=false&testBundles=wheels.tests.specs.model.callbacksSpec"
 
 # Scope to a single installed package's tests (e.g. wheels-sentry, wheels-i18n)
 curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json&directory=vendor.wheels-sentry.tests"
 ```
 
-The `populate=false` query param is the trick that makes tight inner loops possible. Populate drops and recreates every test table — a second or two on SQLite but much slower on networked databases. Once the schema is in place for the run, skipping populate shaves the wait down to just your specs executing.
+`directory=` only filters down to a *directory* — pointing it at a single spec file matches zero bundles and runs nothing. For one file, pass the bundle's dotted path via `testBundles=` instead. Also note the core endpoint only accepts `directory` values starting with `wheels.tests` (or `vendor.<package>.tests`); anything else is silently dropped and the **full** suite runs instead ([#3083](https://github.com/wheels-dev/wheels/issues/3083)) — check the bundle count in the output when a filtered run looks suspiciously slow. The `populate=false` query param is the other trick that makes tight inner loops possible. Populate drops and recreates every test table — a second or two on SQLite but much slower on networked databases. Once the schema is in place for the run, skipping populate shaves the wait down to just your specs executing.
 
 ## Filtering tests
 
@@ -120,7 +120,7 @@ The runner accepts filters at every layer. Pick whichever matches your workflow.
 | By directory (CLI) | `wheels test model` or `wheels test --filter=controller` |
 | By directory (script) | `bash tools/test-local.sh model` |
 | By directory (URL) | `&directory=wheels.tests.specs.model` |
-| By single spec file (URL) | `&directory=wheels.tests.specs.model.postSpec` |
+| By single spec file (URL) | `&testBundles=wheels.tests.specs.model.callbacksSpec` |
 | By installed package (URL) | `&directory=vendor.wheels-sentry.tests` |
 | Skip in source | `xdescribe("...", ...)` / `xit("...", ...)` — built into WheelsTest |
 | Skip the whole populate | `&populate=false` on the URL (schema must already exist) |
@@ -168,7 +168,7 @@ The service names and ports:
 
 ## Testing against specific databases
 
-Each engine ships with H2 and SQLite baked in. Every other database is a separate compose service you bring up alongside the engine. The compose file ships `mysql`, `postgres` (in `docker-compose.db-postgres.yml`), `mssql`, and `h2` overlays — start the ones you need.
+Each engine ships with H2 and SQLite baked in — no container needed for either. Every other database is a separate compose service you bring up alongside the engine: `compose.yml` ships `mysql`, `postgres`, `sqlserver`, `cockroachdb`, and `oracle` services. (The `docker-compose.db-h2.yml` / `db-mysql.yml` / `db-postgres.yml` files at the repo root are dev-stack overlays for the demo app, not test-matrix services.)
 
 ```bash title="your shell — multi-database"
 # Start Lucee 7 + MySQL
@@ -178,7 +178,7 @@ docker compose up -d lucee7 mysql
 curl -sf "http://localhost:60007/wheels/core/tests?db=mysql&format=json"
 ```
 
-Supported `db` values on the URL: `sqlite` (default for the script and local runs), `h2` (default on some engines), `mysql`, `postgres`, `sqlserver`, `oracle`, `cockroachdb`. CockroachDB is currently soft-failed in CI — failures log warnings but don't block the build.
+Supported `db` values on the URL: `sqlite` (default for the script and local runs), `h2` (default on some engines), `mysql`, `postgres`, `sqlserver`, `oracle`, `cockroachdb`. Oracle is currently soft-failed in CI — failures log warnings but don't block the build.
 
 ## Cross-engine gotchas
 
@@ -195,7 +195,7 @@ These are the runtime differences that catch first-time framework contributors. 
 
 These are the errors you'll actually hit. Fix-ups first, diagnosis second.
 
-- **`JAVA_HOME` unset** — LuCLI's preflight refuses to start and prints a pointer to Adoptium. Set `JAVA_HOME` in your shell profile and re-source.
+- **No Java found** — on non-brew installs, the CLI's preflight refuses to start and prints a pointer to Adoptium when it can't locate a JVM; set `JAVA_HOME` in your shell profile and re-source. Homebrew installs are immune — the brew wrapper exports `JAVA_HOME` itself.
 - **Docker daemon not running** — `docker compose up` fails with `Cannot connect to the Docker daemon`. Start Docker Desktop (macOS, Windows) or `systemctl start docker` (Linux).
 - **Port already in use** — `docker compose up` fails with `bind: address already in use` or a local `wheels start` is already on the port. Find the holder with `lsof -i :60007` and stop it.
 - **Playwright JARs missing** — browser specs skip with `this.browserTestSkipped = true` instead of failing, so the suite stays green. Run `wheels browser setup` once to install the JARs and Chromium.

--- a/web/sites/guides/src/content/docs/v4-0-0/testing/view-and-form-tests.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/testing/view-and-form-tests.mdx
@@ -54,7 +54,7 @@ it("shows expected content and hides drafts", () => {
 });
 ```
 
-`assertSee` is a substring match — the text must appear somewhere in the body. `assertDontSee` confirms absence. Both are case-sensitive.
+`assertSee` is a substring match — the text must appear somewhere in the body. `assertDontSee` confirms absence. Both are case-insensitive (as is `assertSeeInOrder`).
 
 ```cfm {test:compile} title="tests/specs/views/PostsIndexSpec.cfc"
 it("renders posts in reverse chronological order", () => {
@@ -159,12 +159,13 @@ it("re-renders the form with inline validation errors", () => {
     $testClient()
         .post("/posts", {"post[title]": "", "post[body]": "Body text"})
         .assertOk()
-        .assertSee("can&##39;t be empty")
+        .assertSee("Title can")
+        .assertSee("t be empty")
         .assertSee("data-auto-id=""post_title""");
 });
 ```
 
-The `&##39;` is the HTML-encoded apostrophe Wheels emits in error messages — `"can't be empty"` becomes `"can&##39;t be empty"` after encoding. Assert on the encoded form, not the raw text, because that's what's in the response body.
+Wheels HTML-encodes the apostrophe in error messages — `"can't be empty"` arrives in the body as `"can&##x27;t be empty"` (the hex entity, on both Lucee and Adobe). Asserting the raw `"can't be empty"` fails because that string isn't in the response. The split assertion above sidesteps the encoding entirely and is the recommended pattern. If you'd rather pin the encoded form exactly, write `assertSee("can&##x27;t be empty")` — the doubled `##` is the CFML escape for a literal `#` in a string.
 
 ## Browser tests vs `assertSee`
 
@@ -178,7 +179,7 @@ If you have a browser test that covers the same flow end-to-end, most view-outpu
 
 - **Static pages** — marketing copy, error pages, the login form. No JavaScript, no state; a substring assertion proves everything the spec needs to prove.
 - **Form-helper regression checks** — the `data-auto-id` attribute must keep emitting, the error-display partial must keep rendering errors. A view spec catches a helper refactor that breaks the convention in milliseconds; a browser spec would take seconds and obscure the root cause.
-- **Error-message presence** — `assertSee("can&##39;t be empty")` after a bad POST is faster than driving a browser through the form.
+- **Error-message presence** — `assertSee("can&##x27;t be empty")` after a bad POST is faster than driving a browser through the form.
 
 Anything that requires a real DOM, real JavaScript, or real user interaction — Turbo Streams landing correctly, modal dialogs opening, a client-side validator firing — belongs in a browser test.
 


### PR DESCRIPTION
Batch 2 of the guide behavioral-audit docs wave — all 20 docs-affected claims for work item **p1-15-testing** (testing/*.mdx). Every correction below was live-verified by the audit (raw evidence in the p1 batch-2 verifier output); broken-but-unfixed behavior is documented as-is with the tracking issue cited.

## index.mdx
- **IDX-10** — full engine x DB matrix runs on a **weekly cron + manual dispatch**, not "on every PR"; engine list corrected to Lucee 6/7, Adobe 2023/2025, BoxLang (`compat-matrix.yml:1-23`). Same fix applied to the CI-integration paragraph lower on the page for consistency with `ci-integration.mdx`.
- **IDX-11** — `wheels test --ci` is accepted for forward-compat but currently changes nothing (`ciMode` parsed, never used; verified byte-identical output and exit codes). Browser gating is the **server** env (`WHEELS_CI`/`WHEELS_BROWSER_CI_ENABLE`), not this flag.
- **IDX-07** — runner-URL example used the wrong directory shape for the core endpoint; rewritten around `/wheels/app/tests?directory=tests.specs.models` with the core form (`directory=wheels.tests.specs.model`) noted. Unrecognized `directory` values silently run the FULL suite — cited [#3083](https://github.com/wheels-dev/wheels/issues/3083).
- **IDX-08** — populate is opt-**out** (`?populate=false`), defaulting true when absent (`runner.cfm:113`); page previously said opt-in via `?populate=true`, contradicting its sibling `fixtures-and-test-data.mdx`.
- Setup-files table: `tableName()` → `table()` (the setter; `tableName()` is a getter no-op, #3079 finding).

## model-tests.mdx
- **MOD-03** — `.persisted()` does not exist (throws); the API is `isPersisted()` / `isNew()` (`miscellaneous.cfc:244/228`).

## view-and-form-tests.mdx
- **VFT-01** — `assertSee`/`assertDontSee`/`assertSeeInOrder` are case-**insensitive** (`FindNoCase`, verified live); page said case-sensitive.
- **VFT-06** — the encoded apostrophe is `&#x27;` (hex) on both Lucee 7 and Adobe 2023, so the `assertSee("can&#39;t be empty")` example failed everywhere probed. Example rewritten to the split-assertion pattern (primary recommendation) with the corrected `&#x27;` literal documented; trailing bullet fixed too.

## functional-tests.mdx
- **FUN-03** — both engines emit `text/html;charset=UTF-8` (no space) and `assertHeader` is exact-match; the `"text/html; charset=UTF-8"` example failed as written. Fixed the literal + added an exact-match note.
- Same `&#39;` → `&#x27;` correction in the split-assertion explanation.

## fixtures-and-test-data.mdx
- **FIX-03** — `application.wo.execute(...)` does not exist ("No matching function [EXECUTE] found", verified live); `execute()` lives only on `wheels.migrator.Migration`. The minimal `populate.cfm` example would crash at boot. Rewritten to native `queryExecute(..., {datasource: application.wheels.dataSourceName})` via a small `runSql()` helper; scope-gotcha section corrected (`application.wo.model()` still works and is kept).
- `tableName("test_posts")` → `table("test_posts")` in the TestPost example (getter no-op; all framework test models use `table()`). This also covers the p1-13 cross-file sketch entry for this file.
- Added an isolation caution: the runner mutates the **live** `application.wheels` (settings/path swaps leak into normal requests) — cites [#3025](https://github.com/wheels-dev/wheels/issues/3025).

## browser-tests.mdx
- **BRW-04** — `browserDescribe()`'s `aroundEach` auto-skips when `browserTestSkipped` is set (`BrowserTest.cfc:140-152`); the hand-written `if (this.browserTestSkipped) return;` guard is only needed inside plain `describe()`. Prose updated and the guard line stripped from all example specs.
- **BRW-08** — dialog error type is `Wheels.BrowserDialogNotSupported`, not `Wheels.DialogSupportMissing`.
- **BRW-15** — form helpers emit a **dashed** `id="post-title"`, not camelCase `id="postTitle"` (matches sibling page).
- **BRW-16** — no `beforeAll` fixture-route re-include exists; replaced with a warning that route-clearing specs must restore the route table.
- **BRW-14** — stale `cfwheels/cfwheels` CLAUDE.md link → `wheels-dev/wheels` (branding rule).
- loginAs: noted app-side mounting requires `set(loadBrowserTestFixtures=true)` (default false) in testing/development.

## running-tests-locally.mdx
- **RUN-03** — `--core` auto-detect is removed (`Module.cfc:738` comment; live `wheels test` at the framework repo root runs the app suite). Aside rewritten: pass `--core` explicitly; `--core` flag description aligned.
- **RUN-06** — single-spec-file filtering via `directory=` matches 0 bundles; the working form is `testBundles=wheels.tests.specs.model.callbacksSpec` (verified live; also replaced the nonexistent `postSpec`). Filter table updated; added the `directory` allowlist silent-fallback note citing [#3083](https://github.com/wheels-dev/wheels/issues/3083).
- **RUN-10** — `compose.yml` ships `mysql`, `postgres`, `sqlserver`, `cockroachdb`, `oracle` services; there is no `mssql` or `h2` service (H2/SQLite are embedded). The `docker-compose.db-*.yml` files are demo-app dev overlays, now noted as such. "You'll learn" DB list aligned.
- **RUN-11** — the soft-fail CI database is **Oracle** (`SOFT_FAIL_DBS="oracle"`), not CockroachDB.
- **RUN-12** — `JAVA_HOME` preflight qualified: the brew wrapper exports `JAVA_HOME` itself, so the refusal can't trigger on brew installs (prereqs + failure-modes sections).
- `--ci` example comment aligned with IDX-11 (non-zero exit applies to every run).

## ci-integration.mdx
- **CI-01** — reporter table was stale: on released 4.0.3, `--reporter=tap` emits TAP v13 and `--reporter=json` emits the raw JSON document (verified live; `Module.cfc` reporter dispatch). Table rewritten; `--ci` row kept with the universal non-zero-exit note.
- Pinned LuCLI bumped v0.3.3 → v0.3.7 to match `pr.yml`'s `LUCLI_VERSION`.
- Browser-gating paragraph aligned with BRW-04 (auto-skip via `browserDescribe`, no per-`it` guard).

## Verification
`pnpm verify:docs` over all 8 changed files: **38 tagged blocks, 38 passed, 0 failed** (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
