### PR TITLE
docs(web/guides): correct start-here guide drift from the 2026-06 behavioral audit

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/cfml-engines.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/cfml-engines.mdx
@@ -68,7 +68,7 @@ Two routes, depending on what you already have installed.
 If you already have Adobe CF installed (e.g. the dev edition from [coldfusion.adobe.com](https://www.adobe.com/products/coldfusion-family.html)), point its web root at your Wheels app's `public/` directory and configure the datasource through the CF Administrator. The framework requires no engine-specific setup beyond having a registered datasource.
 
 <Aside type="note">
-The `wheels start`, `wheels stop`, `wheels reload`, and `wheels test` commands all assume the Lucee Express bundled with the CLI. On Adobe CF you'll use `box server start/stop/restart` instead, and reload via `?reload=true&password=<your-password>` directly. Generators (`wheels generate ...`) are pure file-system operations and work the same regardless of engine.
+The `wheels start`, `wheels stop`, `wheels reload`, and `wheels test` commands all assume the Lucee Express bundled with the CLI. On Adobe CF you'll use `box server start/stop/restart` instead, and reload via `?reload=true&password=<your-password>` directly. Generators (`wheels generate ...`) are pure file-system operations and work the same regardless of engine — with one exception: `wheels generate admin` introspects your database schema through a running server bound to the project, and refuses to run without one.
 </Aside>
 
 ## Running Wheels on BoxLang
@@ -82,7 +82,7 @@ box server start cfengine=boxlang@latest port=8080
 ```
 
 <Aside type="note">
-The `wheels start`, `wheels stop`, `wheels reload`, and `wheels test` commands all assume the Lucee Express bundled with the CLI — they do not interact with BoxLang. BoxLang developers manage their server through CommandBox (`box server start/stop/restart`) and reload via `?reload=true&password=<your-password>` directly. Generators (`wheels generate ...`) are pure file-system operations and work the same regardless of engine.
+The `wheels start`, `wheels stop`, `wheels reload`, and `wheels test` commands all assume the Lucee Express bundled with the CLI — they do not interact with BoxLang. BoxLang developers manage their server through CommandBox (`box server start/stop/restart`) and reload via `?reload=true&password=<your-password>` directly. Generators (`wheels generate ...`) are pure file-system operations and work the same regardless of engine — with one exception: `wheels generate admin` introspects your database schema through a running server bound to the project, and refuses to run without one.
 </Aside>
 
 Wheels' BoxLang compatibility is verified per release in the same CI matrix as Lucee and Adobe CF. Cross-engine gotchas worth knowing about live in [`.ai/wheels/cross-engine-compatibility.md`](https://github.com/wheels-dev/wheels/blob/develop/.ai/wheels/cross-engine-compatibility.md) — most are about minor differences in struct/array semantics under closures.

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/index.mdx
@@ -15,6 +15,7 @@ The entry path for new Wheels developers. Follow it top to bottom.
   <LinkCard title="Why Wheels?" href="/v4-0-0/start-here/why-wheels/" />
   <LinkCard title="Installing Wheels" href="/v4-0-0/start-here/installing/" />
   <LinkCard title="Your First 15 Minutes" href="/v4-0-0/start-here/first-15-minutes/" />
+  <LinkCard title="Release Channels" href="/v4-0-0/start-here/release-channels/" />
   <LinkCard title="Tutorial: Build a Blog" href="/v4-0-0/start-here/tutorial/" />
   <LinkCard title="CFML Engines" href="/v4-0-0/start-here/cfml-engines/" />
 </CardGrid>

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/installing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/installing.mdx
@@ -105,10 +105,6 @@ The two are mutually exclusive — both expose the `wheels` binary. You install 
 
    You should see a `Wheels Version: <version>` line followed by ASCII art. A `Lucee Version: <version>` line may also appear once Lucee Express has been downloaded (typically on first `wheels start`). Any non-empty version output means the CLI is wired up correctly.
 
-   <Aside type="note" title="Multiple version surfaces during 4.0-SNAPSHOT">
-   During the 4.0 pre-release, three places report a Wheels version: the package-manager formula (e.g. `brew info wheels`), `wheels --version` (CLI runtime), and the dev-mode debug bar shown on every rendered page (framework). They may currently disagree — the framework still reports `0.0.0-dev` even when the CLI reports a real version. This is tracked and will converge before 4.0 GA. If your CLI version output is non-empty and roughly matches the formula, your install is fine.
-   </Aside>
-
 </Steps>
 
 </TabItem>
@@ -154,10 +150,6 @@ The legacy `wheels` package on chocolatey.org is the CommandBox-based v1.x relea
    ```
 
    You should see a `Wheels Version: <version>` line followed by ASCII art. A `Lucee Version: <version>` line may also appear once Lucee Express has been downloaded (typically on first `wheels start`). Any non-empty version output means the CLI is wired up correctly.
-
-   <Aside type="note" title="Multiple version surfaces during 4.0-SNAPSHOT">
-   During the 4.0 pre-release, three places report a Wheels version: the package-manager formula (e.g. `brew info wheels`), `wheels --version` (CLI runtime), and the dev-mode debug bar shown on every rendered page (framework). They may currently disagree — the framework still reports `0.0.0-dev` even when the CLI reports a real version. This is tracked and will converge before 4.0 GA. If your CLI version output is non-empty and roughly matches the formula, your install is fine.
-   </Aside>
 
 </Steps>
 
@@ -216,10 +208,6 @@ The apt and yum repos are GPG-signed with the Wheels Distribution key (fingerpri
    ```
 
    You should see a `Wheels Version: <version>` line followed by ASCII art. A `Lucee Version: <version>` line may also appear once Lucee Express has been downloaded (typically on first `wheels start`). Any non-empty version output means the CLI is wired up correctly.
-
-   <Aside type="note" title="Multiple version surfaces during 4.0-SNAPSHOT">
-   During the 4.0 pre-release, three places report a Wheels version: the package-manager formula (e.g. `brew info wheels`), `wheels --version` (CLI runtime), and the dev-mode debug bar shown on every rendered page (framework). They may currently disagree — the framework still reports `0.0.0-dev` even when the CLI reports a real version. This is tracked and will converge before 4.0 GA. If your CLI version output is non-empty and roughly matches the formula, your install is fine.
-   </Aside>
 
 </Steps>
 

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/release-channels.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/release-channels.mdx
@@ -42,7 +42,7 @@ Wheels 4.0.0-snapshot.1787 (bleeding-edge)
 Java 21.0.11
 ```
 
-Note the command is `wheels version` (no dashes). The flag form `wheels --version` prints a `Wheels Version: <version>` line plus ASCII art, with **no** channel parenthetical.
+Note the command is `wheels version` (no dashes). The flag form `wheels --version` varies by install method — Homebrew stable and manual JAR installs print a `Wheels Version: <version>` banner plus ASCII art with no channel, while the apt/yum and Homebrew bleeding-edge package wrappers print a one-line `wheels <version> (<channel>)`. `wheels version` is the form that reports the channel reliably everywhere.
 
 If you see `(development)` instead, you're running from a dev checkout (cloned source repo) rather than an installed package — which is its own thing and not covered here.
 

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/release-channels.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/release-channels.mdx
@@ -20,25 +20,29 @@ Wheels ships on two parallel channels. Pick the one that matches how much churn 
 | Source repo | [`wheels-dev/wheels`](https://github.com/wheels-dev/wheels) | [`wheels-dev/wheels-snapshots`](https://github.com/wheels-dev/wheels-snapshots) |
 | Best for | Production apps, teams that want predictability | Framework contributors, early adopters, validating fixes before they GA |
 | Version string shape | `4.0.0`, `4.1.0` | `4.0.1-snapshot.1700` |
-| `wheels --version` reports | `(stable)` | `(bleeding-edge)` |
+| `wheels version` reports | `(stable)` | `(bleeding-edge)` |
 
 ## How to tell which channel you're on
 
 ```bash title="your shell"
-wheels --version
+wheels version
 ```
 
 The output's parenthetical tells you the channel:
 
 ```
-Wheels Version: 4.0.0 (stable)
+Wheels 4.0.3 (stable)
+Java 21.0.11
 ```
 
 …or:
 
 ```
-Wheels Version: 4.0.0-snapshot.1787 (bleeding-edge)
+Wheels 4.0.0-snapshot.1787 (bleeding-edge)
+Java 21.0.11
 ```
+
+Note the command is `wheels version` (no dashes). The flag form `wheels --version` prints a `Wheels Version: <version>` line plus ASCII art, with **no** channel parenthetical.
 
 If you see `(development)` instead, you're running from a dev checkout (cloned source repo) rather than an installed package — which is its own thing and not covered here.
 

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/welcome.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/welcome.mdx
@@ -22,7 +22,7 @@ A two-minute orientation before you write any code.
 
 ## What Wheels is
 
-Wheels is a full-stack web framework for CFML. It runs on Lucee (open source) and Adobe ColdFusion (commercial). It gives you an ActiveRecord-style ORM, a request pipeline with middleware, a convention-driven file layout, and a scaffold generator that writes working code from a model name. You spend your time on the interesting parts of your app.
+Wheels is a full-stack web framework for CFML. It runs on Lucee (open source), Adobe ColdFusion (commercial), and BoxLang. It gives you an ActiveRecord-style ORM, a request pipeline with middleware, a convention-driven file layout, and a scaffold generator that writes working code from a model name. You spend your time on the interesting parts of your app.
 
 The `wheels` CLI is the only tool you need. It creates apps, runs migrations, generates scaffolds, starts the dev server, runs tests, and ships your code. Under the hood it wraps a Java-based CFML runtime; you rarely think about that.
 

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/why-wheels.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/why-wheels.mdx
@@ -43,7 +43,7 @@ Closest conceptual neighbor. Both descended from the same Rails-era design.
 | View layer | ERB / Haml / etc. | `.cfm` templates (inline expressions via `#...#`) |
 | Hotwire | Bundled (Turbo Drive / Frames / Streams) | Via `wheels-hotwire` package (opt-in activation) |
 | Testing | Minitest / RSpec | WheelsTest (BDD, `describe`/`it`) |
-| Jobs | Active Job + Sidekiq/etc. | Built-in job queue (`wheels jobs work`) |
+| Jobs | Active Job + Sidekiq/etc. | Built-in DB-backed job queue (`wheels.Job` / `processQueue()`); worker CLI tracked in [#3090](https://github.com/wheels-dev/wheels/issues/3090) |
 
 If you know Rails, the tutorial will feel familiar in pacing and idioms. The differences that bite most often:
 


### PR DESCRIPTION
Final-wave docs fixes from the 2026-06 guide behavioral audit — manifest group 1 (start-here, non-tutorial). Six findings, six files, all under `web/sites/guides/src/content/docs/v4-0-0/start-here/`. Every fix describes verified current behavior of the released 4.0.3 CLI / framework.

## Fixes

| Claim | File | Fix |
|---|---|---|
| index-01 | `index.mdx` | The section grid listed 6 of 7 pages — added the missing **Release Channels** LinkCard (placed per sidebar order 5). |
| welcome-01 | `welcome.mdx` | "Runs on Lucee and Adobe ColdFusion" omitted **BoxLang**, contradicting `cfml-engines.mdx` (Production-supported: Yes) and the CI compat matrix (`compat-matrix.yml` engines incl. `boxlang`). |
| whywheels-01 | `why-wheels.mdx` | The Rails-comparison Jobs row cited `wheels jobs work`, which does not exist (`Module.cfc` has no `jobs` function; released 4.0.3 errors "has no function with name [jobs]"). Now describes the real surface — built-in DB-backed queue via `wheels.Job` / `processQueue()` — and cites #3090 for the worker CLI. |
| installing-03 | `installing.mdx` | Removed the 3 identical "Multiple version surfaces during 4.0-SNAPSHOT" asides ("will converge before 4.0 GA") — 4.0 GA shipped 2026-06-09; the pre-release framing is stale. The surrounding "any non-empty version output means the CLI is wired up" guidance stands on its own. |
| rc-01 | `release-channels.mdx` | The channel parenthetical comes from `wheels version`, not `wheels --version`. Verified against the released CLI: `wheels --version` → `Wheels Version: 4.0.3` + ASCII art, **no** channel; `wheels version` → `Wheels 4.0.3 (stable)` + `Java 21.0.11`. Fixed the at-a-glance row, the "How to tell" command + samples, and added a note distinguishing the two forms. |
| engines-04 | `cfml-engines.mdx` | "Generators are pure file-system operations" now carries the one exception: `wheels generate admin` introspects the project schema through a running project-bound server and refuses to run without one (`Module.cfc` write-side guard / `$requireRunningServer(requireProjectConfig=true)`). Applied to both the Adobe CF and BoxLang asides. |

## Verification

- `pnpm verify:docs` run per touched page from `web/sites/guides` — all exit 0 (installing.mdx's `{test:cli}` block: 1 passed).
- `wheels version` / `wheels --version` output shapes re-confirmed live against brew wheels 4.0.3 before documenting.

Evidence source: P2 audit manifest (`/tmp/p2-docs-manifest.md`, group 1) + verifier evidence in the audit task output; catalog at `docs/superpowers/audits/2026-06-guide-audit-findings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)