### PR TITLE
docs(web/guides): correct eight behavioral-audit findings in the tutorial

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/tutorial/03-crud-scaffold.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/tutorial/03-crud-scaffold.mdx
@@ -270,11 +270,16 @@ The `binding=true` arg turns on **route model binding**. When a request hits `/p
 
 Core Wheels lives in `vendor/wheels/`. Optional features ship as separate packages — standalone repositories maintained under `wheels-dev/` and indexed by the [`wheels-dev/wheels-packages`](https://github.com/wheels-dev/wheels-packages) registry. Installing one means getting its files into `vendor/<name>/`. On app boot, `PackageLoader.cfc` walks `vendor/*/package.json` and wires each package's mixins, services, and middleware into the framework.
 
-Three first-party packages ship today:
+Six first-party packages ship today:
 
-- **`hotwire`** — Turbo Drive for SPA-like page transitions, Turbo Frames for partial updates, Turbo Streams for server-pushed DOM changes. No app code changes needed for Turbo Drive — activation alone makes link clicks feel instant.
-- **`basecoat`** — Tailwind-based UI components for forms, buttons, and layouts.
-- **`sentry`** — error tracking integration.
+- **`wheels-hotwire`** — Turbo Drive for SPA-like page transitions, Turbo Frames for partial updates, Turbo Streams for server-pushed DOM changes. No app code changes needed for Turbo Drive — activation alone makes link clicks feel instant.
+- **`wheels-basecoat`** — shadcn/ui-quality UI components for forms, buttons, and layouts.
+- **`wheels-sentry`** — error tracking integration.
+- **`wheels-i18n`** — internationalization.
+- **`wheels-seo-suite`** — SEO tooling.
+- **`wheels-legacy-adapter`** — 3.x → 4.x compatibility shims.
+
+Browse them all with `wheels packages list`. This tutorial uses the first two.
 
 Conceptually, installing Hotwire looks like this:
 

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/tutorial/04-validations-frames.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/tutorial/04-validations-frames.mdx
@@ -98,7 +98,7 @@ When someone submits the form with a blank title, `post.save()` returns `false` 
 
 A `<turbo-frame>` is an HTML element shipped by the [Hotwire Turbo](https://turbo.hotwired.dev/) library. When a link or form inside a frame is activated, Turbo intercepts the navigation, fetches the response, finds the element with a matching `id` in the returned HTML, and swaps only that frame's contents. The rest of the page stays exactly where it was — no flash, no scroll jump, no lost input in other fields.
 
-For the frame to do anything, Turbo has to be loaded on the page. The `hotwire` package (introduced conceptually in Part 3) handles this automatically when activated. Until you activate it, include Turbo from a CDN.
+For the frame to do anything, Turbo has to be loaded on the page. The `wheels-hotwire` package (introduced in Part 3) handles this when activated. The tutorial sticks with a plain CDN tag so this chapter works without any install step.
 
 <Steps>
 
@@ -110,7 +110,7 @@ For the frame to do anything, Turbo has to be loaded on the page. The `hotwire` 
 
 </Steps>
 
-That one tag gives you Turbo Drive (SPA-like page transitions) globally, plus the Frame and Stream features. Once the `hotwire` package is installable on your CLI, this manual include goes away — the package drops a bundled Turbo build into `public/` and wires the tag for you.
+That one tag gives you Turbo Drive (SPA-like page transitions) globally, plus the Frame and Stream features. If you'd rather let the package manage the script tags, run `wheels packages add wheels-hotwire` and replace the manual include with the package's `#hotwireIncludes()#` helper in the layout — it emits the Turbo (and Stimulus) module tags for you, and the package also brings controller helpers like `renderTurboStream()` and `isHotwireRequest()` that you'll appreciate in Part 5. Either path works for the rest of the tutorial.
 
 ## Wrap the form in a Turbo Frame
 

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/tutorial/06-authentication.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/tutorial/06-authentication.mdx
@@ -160,7 +160,7 @@ Four pieces to notice:
 
 </Steps>
 
-`passwordHash` is 64 chars because that's the width of a SHA-256 hex digest. `passwordSalt` is ~44 chars because `generateSecretKey("AES")` returns a base64-encoded AES key — 48 gives a little headroom. `timestamps()` creates both `createdAt` and `updatedAt` columns.
+`passwordHash` is 64 chars because that's the width of a SHA-256 hex digest. `passwordSalt` is ~44 chars because `generateSecretKey("AES")` returns a base64-encoded AES key — 48 gives a little headroom. `timestamps()` creates three columns: `createdAt`, `updatedAt`, and `deletedAt` (the soft-delete marker).
 
 ### Signup — the Users controller
 
@@ -497,7 +497,7 @@ The `/logout` route is a `DELETE`, so a plain `<a href>` won't reach it — you 
 That's the hand-rolled version. Thirty-ish lines of logic total, no hidden machinery. Now let's see what the framework gives you for free.
 
 <Aside type="caution" title="Scripting smoke tests with curl? Read this first.">
-**CSRF token rotation**: Wheels rotates the CSRF token after each accepted POST. A scraped token is single-use — re-POSTing with the same token fails with `Wheels.InvalidAuthenticityToken`. To script a flow, fetch a fresh form before every write. **Always scrape the token from the layout's `<meta name="csrf-token" content="...">` tag**, not from a form's hidden `authenticityToken` input. The meta tag is in the response on every page render and always carries the current token. Form-helper-emitted hidden inputs work too on signup, but other forms (login, post show with the comments form, the rewritten basecoat views in chapter 8) don't always include the input — scraping the meta tag uniformly avoids the special cases.
+**CSRF token scraping**: with the default session-backed store, Wheels keeps one CSRF token per session — it stays valid across multiple POSTs in the same scripted flow, so you don't need to re-fetch a form before every write. **Always scrape the token from the layout's `<meta name="csrf-token" content="...">` tag**, not from a form's hidden `authenticityToken` input. The meta tag is in the response on every page render and always carries the session's token. Form-helper-emitted hidden inputs work too on signup, but other forms (login, post show with the comments form, the rewritten basecoat views in chapter 8) don't always include the input — scraping the meta tag uniformly avoids the special cases.
 
 **curl bracket-syntax and `@`**: a curl POST body using bracket-nested keys without an `=` separator — for example `--data-urlencode "user[email][badkey]"` — is read by Lucee's form parser as a deeper nested-struct path. The email arrives in your controller as `params.user.email = {"badkey": ""}` (a struct, not a string), and the next assignment via `setProperties()` is rejected with a `Wheels.PropertyIsIncorrectType` error from the model layer. (Don't put a literal `@` inside the bracket key when reproducing this — `--data-urlencode` reads any unescaped `@` as the start of a filename, so curl would error on the example before it ever reached Lucee.) The fix is to keep the `=` separator AND %-encode the brackets and the `@` in the body. The reliable shape is:
 
@@ -557,7 +557,7 @@ if (StructKeyExists(application, "wheelsdi") && application.wheelsdi.containsIns
 
 Don't put this in `config/app.cfm` — that file is for `Application.cfc` `this`-scope settings (`this.name`, `this.datasources`, `this.sessionTimeout`, etc.), not for init code. The DI container isn't initialized when `config/app.cfm` runs, so `application.wheelsdi` doesn't exist yet and the registration silently no-ops.
 
-On a *cold* reload — meaning `wheels stop` followed by `wheels start`, which re-fires `onApplicationStart` — this registers the strategy exactly once. (Plain `wheels reload` does **not** re-run `onApplicationStart`; if you edit init code, restart the server.) The `hasStrategy` check keeps a second cold reload from stacking duplicates.
+Both `wheels reload` and a full `wheels stop && wheels start` re-fire `onApplicationStart` — an authorized reload stops the application and the next request boots it fresh, re-running this file and `config/services.cfm`. Either way, this registers the strategy exactly once, and the `hasStrategy` check keeps repeated restarts from stacking duplicates. (Some CLI messages still claim `wheels reload` skips `onApplicationStart`; that's outdated — tracked in [#3110](https://github.com/wheels-dev/wheels/issues/3110).)
 
 ### Rewrite the Sessions controller
 
@@ -744,7 +744,7 @@ Whether you stopped at 6a or continued to 6b, the user-facing behavior should be
 
 **"The password always mismatches, even for a user I just created."** The `beforeValidation` callback isn't firing, or the form is storing plaintext. Open the database and look at the `users` row directly: `passwordHash` should be exactly 64 uppercase hex characters, `passwordSalt` should be populated with a ~44-char base64 string. If either is blank, check that you named the callback correctly in `config()` (`beforeValidation("hashPassword")` — case-sensitive) and that the form submits `user[password]`, not just `password`.
 
-**"6b: `authenticator` service not found."** Three things to check, in this order. **(1) Does the file have a `<cfscript>` wrapper?** Without it, Lucee treats the body as markup — you'll see the bare `local.di = injector();` lines printed at the top of every page after a cold restart, and the registration code never runs. Compare against `config/settings.cfm` if unsure of the shape. **(2) Did you do a *cold* restart?** `wheels reload` does not re-fire `onApplicationStart`, so it doesn't re-run `config/services.cfm`; you need `wheels stop && wheels start`. **(3) Component path typo?** The `.to(...)` argument must be the exact dotted path — `wheels.auth.Authenticator`, not `Authenticator` — and the `injector()` call has to come first.
+**"6b: `authenticator` service not found."** Three things to check, in this order. **(1) Does the file have a `<cfscript>` wrapper?** Without it, Lucee treats the body as markup — you'll see the bare `local.di = injector();` lines printed at the top of every page after a cold restart, and the registration code never runs. Compare against `config/settings.cfm` if unsure of the shape. **(2) Did the application actually restart?** Both `wheels reload` and `wheels stop && wheels start` re-fire `onApplicationStart` and re-run `config/services.cfm` — but a reload with a wrong or missing reload password silently skips the restart. If in doubt, `wheels stop && wheels start` removes that variable. (CLI messages claiming `wheels reload` never re-fires `onApplicationStart` are outdated — see [#3110](https://github.com/wheels-dev/wheels/issues/3110).) **(3) Component path typo?** The `.to(...)` argument must be the exact dotted path — `wheels.auth.Authenticator`, not `Authenticator` — and the `injector()` call has to come first.
 
 ## What's next
 

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/tutorial/08-bonus-basecoat.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/tutorial/08-bonus-basecoat.mdx
@@ -77,13 +77,13 @@ The canonical way to install a Wheels package is `wheels packages add <name>`. T
 
    You should see `Basecoat.cfc`, `package.json`, `README.md`, and a `tests/` directory.
 
-3. Restart the server so `onApplicationStart` re-fires and `PackageLoader` discovers the new package:
+3. Restart the application so `onApplicationStart` re-fires and `PackageLoader` discovers the new package:
 
    ```bash title="your shell"
-   wheels stop && wheels start
+   wheels reload
    ```
 
-   `wheels reload` alone won't do — the package loader runs from `onApplicationStart`, which only fires on a full server boot.
+   `wheels reload` works because an authorized reload stops and restarts the application, re-running `onApplicationStart` — and with it the package loader. A full `wheels stop && wheels start` (which the install message suggests) does the same thing, just more heavily. (The CLI message claiming only a stop/start activates a package is outdated — tracked in [#3110](https://github.com/wheels-dev/wheels/issues/3110).)
 
 </Steps>
 
@@ -294,11 +294,11 @@ Three things to verify:
 
 ## Troubleshooting
 
-**`No matching function [UIBUTTON] found`** — the package didn't activate. Most common cause: you ran `wheels reload` instead of `wheels stop && wheels start`. PackageLoader runs in `onApplicationStart` which a full restart triggers; reload doesn't.
+**`No matching function [UIBUTTON] found`** — the package didn't activate. Both `wheels reload` and `wheels stop && wheels start` re-run `PackageLoader` (an authorized reload restarts the application, re-firing `onApplicationStart`), so the usual cause is a reload that silently no-op'd — a wrong or missing reload password — or the package landing somewhere other than `vendor/`. Run `wheels stop && wheels start` to rule out the password variable, and `ls vendor/wheels-basecoat` to confirm the files are there.
 
 **`No matching function [$UIBUILDID] found`** (or `[$UILUCIDEICON]`) — the package activated but its internal helpers can't be found. Fixed in `wheels-basecoat 1.0.3`. Older versions declared the `$`-prefixed helpers `private`, but Wheels' `PackageLoader` only carries PUBLIC methods across the mixin boundary, so public callers like `uiField` couldn't reach them. Run `wheels packages update wheels-basecoat --yes && wheels stop && wheels start`.
 
-**`No version of 'wheels-basecoat' satisfies runtime '0.0.0-dev'`** — the framework can't read its own version. Likely on a Wheels release older than `4.0.0-SNAPSHOT+1670` (the snapshot that includes the runtime-detection fix). Upgrade with `brew upgrade wheels` or `choco upgrade wheels` and re-run.
+**`No version of 'wheels-basecoat' satisfies runtime '0.0.0-dev'`** — the framework can't read its own version. Likely on a Wheels release older than `4.0.0-SNAPSHOT+1670` (the snapshot that includes the runtime-detection fix). Upgrade with `brew upgrade wheels` (macOS/Linux) or `scoop update wheels` (Windows) and re-run.
 
 **Page renders unstyled** — the bundled CSS isn't being served. Check `public/assets/basecoat/basecoat.min.css` exists (re-run the `cp -r vendor/wheels-basecoat/assets/basecoat public/assets/basecoat` step if not) and `curl -I http://localhost:8080/assets/basecoat/basecoat.min.css` returns 200.
 

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/tutorial/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/tutorial/index.mdx
@@ -34,7 +34,7 @@ A blog for an individual author. The final app supports:
 
 - **Framework:** Wheels 4.0 on Lucee 7 (via the bundled `wheels` CLI)
 - **Database:** SQLite, zero setup. Same engine the tutorial runs against in CI.
-- **Frontend:** Turbo Drive for page transitions, Turbo Frames for inline errors, Turbo Streams for comment updates. Loaded from a CDN script tag in Part 4; the `hotwire` package is the eventual canonical home.
+- **Frontend:** Turbo Drive for page transitions, Turbo Frames for inline errors, Turbo Streams for comment updates. Loaded from a CDN script tag in Part 4; the installable [`wheels-hotwire`](https://github.com/wheels-dev/wheels-hotwire) package (`wheels packages add wheels-hotwire`) is the canonical home once you're past the tutorial.
 - **Styling:** [simple.css](https://simplecss.org/), wired into the generated `app/views/layout.cfm` by `wheels new`. Classless — semantic HTML renders polished without any markup changes. The [`wheels-basecoat`](https://github.com/wheels-dev/wheels-basecoat) package is available as an optional shadcn/ui-quality component-kit upgrade after the tutorial.
 - **Auth:** Wheels' built-in `SessionStrategy` for session cookies. Hand-rolled version shown first for understanding, built-in version shown second for shipping.
 - **Tests:** WheelsTest (BDD), plus one Playwright-driven browser spec.
@@ -64,7 +64,7 @@ A blog for an individual author. The final app supports:
 - **SQLite.** All development runs against SQLite in `db/development.sqlite`. Zero setup. Matches the CI testing platform.
 - **Real names.** Code examples use `Post`, `Comment`, `user.email`, `publishedAt` — not `Foo`, `Bar`, or `someField`.
 - **Complete code.** Each block shows the whole function or view, not a fragment. You can always copy a block and have the feature work.
-- **Validated end-to-end.** Every code block in the tutorial is executed by the doc site's verify-docs harness against a real `wheels` CLI. If you see a block here, it compiles and runs.
+- **Validated.** Code blocks annotated with `{test:compile}` or `{test:cli}` are validated by the doc site's verify-docs harness against a real `wheels` CLI. Blocks without an annotation (shell transcripts, illustrative excerpts) are reviewed but not executed.
 
 ## Ready to start
 


### PR DESCRIPTION
## Summary

Final-wave docs fixes for **manifest group 2** of the 2026-06 guide behavioral audit: 8 findings across the 5 tutorial pages under `start-here/tutorial/`. Every fix documents live-verified current behavior; broken-but-unfixed CLI messaging is cited to its tracking issue rather than papered over.

## Findings fixed (audit IDs)

| ID | Page | Fix |
|---|---|---|
| tindex-01 | `index.mdx` | "Every code block is executed" → only `{test:compile}`/`{test:cli}`-annotated blocks are validated by verify-docs (4 of 11 blocks in Part 5 carry no annotation and are never executed) |
| t04-03 | `index.mdx`, `04-validations-frames.mdx` | `wheels-hotwire` is installable today (`wheels packages add wheels-hotwire`, verified 1.0.2) — replaced the "eventual canonical home" / "once installable" framing with the real package path. Also corrected the mechanics: the package emits script tags via its `hotwireIncludes()` helper (jsDelivr modules); it does not drop a bundled Turbo build into `public/` |
| t03-06 | `03-crud-scaffold.mdx` | "Three first-party packages ship today" → six (adds `wheels-i18n`, `wheels-seo-suite`, `wheels-legacy-adapter`), matching Part 8 and the live registry |
| t06-01 | `06-authentication.mdx` | `timestamps()` creates three columns — `createdAt`, `updatedAt`, **and** `deletedAt` (`TableDefinition.cfc:307-309`; matches Part 2 and CLAUDE.md anti-pattern 7) |
| t06-06 | `06-authentication.mdx` | CSRF-rotation paragraph removed — live-disproven: the same scraped token was accepted on 3 consecutive POSTs on the default session store, and `controller/csrf.cfc` contains no rotation logic. Meta-tag-scraping advice kept with the corrected rationale (token is stable per session; the meta tag is on every render while form hidden inputs aren't) |
| t06-08 | `06-authentication.mdx` (strategy-registration paragraph + troubleshooting) | `wheels reload` **does** re-fire `onApplicationStart` and re-run `config/services.cfm` — live-proven (probe counter incremented on every authorized `?reload=true`; the template reload path calls `applicationStop()`). Stale CLI messages claiming otherwise are cited to #3110. Kept the genuinely useful failure mode: a reload with a wrong/missing password silently skips the restart |
| t08-03 | `08-bonus-basecoat.mdx` (install step + troubleshooting) | Same reload contract: `?reload=true` re-runs `PackageLoader` (live-proven with a fake package dropped into `vendor/` on a running app). Install step now uses `wheels reload`; the CLI's "Run `wheels stop && wheels start` to activate" message is flagged as outdated per #3110 |
| t08-05 | `08-bonus-basecoat.mdx` | Dropped `choco upgrade wheels` (contradicts `installing.mdx` — Windows ships via Scoop) → `scoop update wheels` |

## Verification

- `pnpm verify:docs` (from `web/sites/guides`) on each of the 5 touched pages: **exit 0**, 22 tagged blocks pass, 0 fail. No tagged code blocks were modified.
- Evidence source: P2 audit manifest (`/tmp/p2-docs-manifest.md`) + verifier output for claims tindex-01, t03-06, t04-03, t06-01, t06-06, t06-08, t08-03, t08-05.

## Related

- #3110 — hot-reload contract: CLI messages (`Module.cfc:846`, `PackagesMainCli.cfc:211-217`) still claim reload skips `onApplicationStart`; this PR documents the verified behavior and cites the issue. The CLI message fix rides separately with #3110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
