### PR TITLE
docs(web/guides): align deploy CLI reference with shipped positional/flat-alias surface

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/boot.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/boot.mdx
@@ -12,14 +12,14 @@ sidebar:
 ## Synopsis
 
 ```sh title="synopsis"
-wheels deploy accessory boot --name=<name|all> [--destination=<name>] [--dry-run]
+wheels deploy accessory boot <name|all> [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--name=<name>` | **Required.** Accessory name, or `all`. |
+| `<name>` | **Required positional.** Accessory name, or `all` to fan out. |
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print commands without executing. |
 
@@ -30,6 +30,6 @@ For each targeted accessory, emits `docker run` with the image, env, volumes, an
 ## Example
 
 ```bash title="example"
-wheels deploy accessory boot --name=db
-wheels deploy accessory boot --name=all
+wheels deploy accessory boot db
+wheels deploy accessory boot all
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/details.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/details.mdx
@@ -12,19 +12,19 @@ sidebar:
 ## Synopsis
 
 ``` title="synopsis"
-wheels deploy accessory details --name=<name|all> [--destination=<name>] [--dry-run]
+wheels deploy accessory details <name|all> [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--name=<name>` | **Required.** Accessory name, or `all`. |
+| `<name>` | **Required positional.** Accessory name, or `all` to fan out. |
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print commands without executing. |
 
 ## Example
 
 ```bash title="example"
-wheels deploy accessory details --name=db
+wheels deploy accessory details db
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/index.mdx
@@ -7,7 +7,7 @@ sidebar:
   order: 40
 ---
 
-Sidecar container lifecycle. Every accessory verb takes a `--name` (or `all` for fan-out) and targets the pinned host(s) for that accessory.
+Sidecar container lifecycle. Every accessory verb takes the accessory name as a **positional argument** (or `all` for fan-out) and targets the pinned host(s) for that accessory: `wheels deploy accessory boot db`.
 
 ## Verbs
 
@@ -22,15 +22,15 @@ Sidecar container lifecycle. Every accessory verb takes a `--name` (or `all` for
 | [`logs`](/v4-0-0/command-line-tools/commands/deploy/accessory/logs/) | Tail accessory logs. |
 | [`remove`](/v4-0-0/command-line-tools/commands/deploy/accessory/remove/) | Stop + remove the container. |
 
-## Common flags
+## Common arguments and flags
 
-| Flag | Description |
+| Argument / flag | Description |
 |------|-------------|
-| `--name=<name>` | **Required.** Accessory name, or `all` to fan out. |
+| `<name>` | **Required positional.** Accessory name, or `all` to fan out. |
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print commands without executing. |
 
-Missing `--name` throws `DeployAccessoryCli.MissingName`.
+Omitting the name throws `DeployAccessoryCli.MissingName`. There is no `--name=` flag — the deploy parser ignores it, so `--name=db` also ends in `DeployAccessoryCli.MissingName`.
 
 ## Relationship to `wheels deploy`
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/logs.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/logs.mdx
@@ -12,14 +12,14 @@ sidebar:
 ## Synopsis
 
 ``` title="synopsis"
-wheels deploy accessory logs --name=<name|all> [--tail=<N>] [--follow] [--destination=<name>] [--dry-run]
+wheels deploy accessory logs <name|all> [--tail=<N>] [--follow] [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--name=<name>` | **Required.** Accessory name, or `all`. |
+| `<name>` | **Required positional.** Accessory name, or `all` to fan out. |
 | `--tail=<N>` | Trailing lines per host. Default 100. |
 | `--follow` | Stream logs continuously. |
 | `--destination=<name>` | Overlay destination config. |
@@ -28,6 +28,6 @@ wheels deploy accessory logs --name=<name|all> [--tail=<N>] [--follow] [--destin
 ## Example
 
 ```bash title="example"
-wheels deploy accessory logs --name=db --tail=500
-wheels deploy accessory logs --name=redis --follow
+wheels deploy accessory logs db --tail=500
+wheels deploy accessory logs redis --follow
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/reboot.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/reboot.mdx
@@ -12,14 +12,14 @@ Stop, remove, and re-run the named accessory container. Useful after bumping the
 ## Synopsis
 
 ``` title="Synopsis"
-wheels deploy accessory reboot --name=<name|all> [--destination=<name>] [--dry-run]
+wheels deploy accessory reboot <name|all> [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--name=<name>` | **Required.** Accessory name, or `all`. |
+| `<name>` | **Required positional.** Accessory name, or `all` to fan out. |
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print commands without executing. |
 
@@ -30,5 +30,5 @@ Per accessory: `docker stop <service>-<name>`, `docker rm <service>-<name>`, the
 ## Example
 
 ```bash title="Example"
-wheels deploy accessory reboot --name=redis
+wheels deploy accessory reboot redis
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/remove.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/remove.mdx
@@ -18,19 +18,19 @@ Volumes persist after `accessory remove`. Data survives. If you want a truly cle
 ## Synopsis
 
 ``` title="synopsis"
-wheels deploy accessory remove --name=<name|all> [--destination=<name>] [--dry-run]
+wheels deploy accessory remove <name|all> [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--name=<name>` | **Required.** Accessory name, or `all`. |
+| `<name>` | **Required positional.** Accessory name, or `all` to fan out. |
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print commands without executing. |
 
 ## Example
 
 ```bash title="example"
-wheels deploy accessory remove --name=redis
+wheels deploy accessory remove redis
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/restart.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/restart.mdx
@@ -12,19 +12,19 @@ sidebar:
 ## Synopsis
 
 ``` title="synopsis"
-wheels deploy accessory restart --name=<name|all> [--destination=<name>] [--dry-run]
+wheels deploy accessory restart <name|all> [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--name=<name>` | **Required.** Accessory name, or `all`. |
+| `<name>` | **Required positional.** Accessory name, or `all` to fan out. |
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print commands without executing. |
 
 ## Example
 
 ```bash title="example"
-wheels deploy accessory restart --name=redis
+wheels deploy accessory restart redis
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/start.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/start.mdx
@@ -12,19 +12,19 @@ sidebar:
 ## Synopsis
 
 ``` title="Synopsis"
-wheels deploy accessory start --name=<name|all> [--destination=<name>] [--dry-run]
+wheels deploy accessory start <name|all> [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--name=<name>` | **Required.** Accessory name, or `all`. |
+| `<name>` | **Required positional.** Accessory name, or `all` to fan out. |
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print commands without executing. |
 
 ## Example
 
 ```bash title="Start a named accessory"
-wheels deploy accessory start --name=db
+wheels deploy accessory start db
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/stop.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/stop.mdx
@@ -12,19 +12,19 @@ sidebar:
 ## Synopsis
 
 ``` title="synopsis"
-wheels deploy accessory stop --name=<name|all> [--destination=<name>] [--dry-run]
+wheels deploy accessory stop <name|all> [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--name=<name>` | **Required.** Accessory name, or `all`. |
+| `<name>` | **Required positional.** Accessory name, or `all` to fan out. |
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print commands without executing. |
 
 ## Example
 
 ```bash title="illustrative"
-wheels deploy accessory stop --name=db
+wheels deploy accessory stop db
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/boot.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/boot.mdx
@@ -12,17 +12,19 @@ sidebar:
 ## Synopsis
 
 ``` title="synopsis"
-wheels deploy app boot --version=<v> [--role=<name>] [--destination=<name>] [--dry-run]
+wheels deploy app boot --release=<v> [--role=<name>] [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--version=<v>` | **Required.** Version to boot. Throws `DeployAppCli.MissingVersion` if absent. |
+| `--release=<v>` | **Required.** Version to boot. Throws `DeployAppCli.MissingVersion` if absent. |
 | `--role=<name>` | Limit to one role. Default: every role. |
 | `--destination=<name>` | Overlay `deploy.<name>.yml`. |
 | `--dry-run` | Print the `docker run` commands without executing. |
+
+A literal `--version=` flag does not work — the CLI's picocli root intercepts it before deploy dispatch ([#2674](https://github.com/wheels-dev/wheels/issues/2674)). Prefer non-numeric release labels: a purely numeric value like `--release=1` currently hangs ([#3111](https://github.com/wheels-dev/wheels/issues/3111)).
 
 ## Behavior
 
@@ -42,6 +44,6 @@ docker run --detach --restart unless-stopped \
 ## Example
 
 ```bash title="example"
-wheels deploy app boot --version=abc1234
-wheels deploy app boot --version=abc1234 --role=job
+wheels deploy app boot --release=abc1234
+wheels deploy app boot --release=abc1234 --role=job
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/containers.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/containers.mdx
@@ -23,7 +23,7 @@ wheels deploy app containers [--role=<name>] [--destination=<name>] [--dry-run]
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print the command without executing. |
 
-Unlike most `app` verbs, `--version` is **not** required — this verb enumerates every version.
+Unlike most `app` verbs, `--release` is **not** required — this verb enumerates every version.
 
 ## Behavior
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/details.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/details.mdx
@@ -12,14 +12,14 @@ sidebar:
 ## Synopsis
 
 ``` title="synopsis"
-wheels deploy app details --version=<v> [--role=<name>] [--destination=<name>] [--dry-run]
+wheels deploy app details --release=<v> [--role=<name>] [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--version=<v>` | **Required.** |
+| `--release=<v>` | **Required.** |
 | `--role=<name>` | Limit to one role. |
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print the commands without executing. |
@@ -33,5 +33,5 @@ For a broader sweep that shows every service-labelled container regardless of ve
 ## Example
 
 ```bash title="example"
-wheels deploy app details --version=abc1234
+wheels deploy app details --release=abc1234
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/images.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/images.mdx
@@ -23,7 +23,7 @@ wheels deploy app images [--role=<name>] [--destination=<name>] [--dry-run]
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print the command without executing. |
 
-`--version` is not required.
+`--release` is not required.
 
 ## Behavior
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/index.mdx
@@ -7,6 +7,8 @@ sidebar:
   order: 20
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 App container lifecycle. Every verb targets containers labelled with the current service, optionally filtered by `--role`.
 
 ## Verbs
@@ -28,7 +30,15 @@ App container lifecycle. Every verb targets containers labelled with the current
 
 | Flag | Description |
 |------|-------------|
-| `--version=<v>` | Required for boot/start/stop/details/live/maintenance/remove. |
+| `--release=<v>` | Required for boot/start/stop/details/live/maintenance/remove. |
 | `--role=<name>` | Limit to one role. Default: all roles. |
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print commands without executing. |
+
+<Aside type="note" title="--release, not --version">
+The version always travels as `--release=`. A literal `--version=` flag never reaches deploy dispatch — the CLI's picocli root intercepts it first and fails with `Invalid value for option '--version'` ([#2674](https://github.com/wheels-dev/wheels/issues/2674)).
+</Aside>
+
+<Aside type="caution" title="Purely numeric release values">
+A purely numeric release value (e.g. `--release=1`) currently hangs for ~75 seconds with `Operation timed out`, even under `--dry-run` ([#3111](https://github.com/wheels-dev/wheels/issues/3111)). Use a non-numeric label — a git short sha or a `v`-prefixed tag like `v1.2.3` — until that's fixed.
+</Aside>

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/live.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/live.mdx
@@ -14,14 +14,14 @@ Clear the server-side maintenance marker, resuming traffic. Pair with [`app main
 ## Synopsis
 
 ``` title="synopsis"
-wheels deploy app live --version=<v> [--role=<name>] [--destination=<name>] [--dry-run]
+wheels deploy app live --release=<v> [--role=<name>] [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--version=<v>` | **Required** by the same parser as the other app verbs. |
+| `--release=<v>` | **Required** by the same parser as the other app verbs. |
 | `--role=<name>` | Limit to one role. |
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print the commands without executing. |
@@ -37,5 +37,5 @@ The Phase 2 port uses a marker-file convention rather than `kamal-proxy`'s nativ
 ## Example
 
 ```bash title="illustrative — requires deployment infrastructure"
-wheels deploy app live --version=abc1234
+wheels deploy app live --release=abc1234
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/logs.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/logs.mdx
@@ -25,7 +25,7 @@ wheels deploy app logs [--tail=<N>] [--follow] [--container=<name>] [--role=<nam
 | `--role=<name>` | Limit to one role. |
 | `--destination=<name>` | Overlay destination config. |
 
-`--version` is not required.
+`--release` is not required.
 
 ## Behavior
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/maintenance.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/maintenance.mdx
@@ -14,14 +14,14 @@ Write the server-side maintenance marker. Pair with [`app live`](/v4-0-0/command
 ## Synopsis
 
 ```  title="synopsis"
-wheels deploy app maintenance --version=<v> [--role=<name>] [--destination=<name>] [--dry-run]
+wheels deploy app maintenance --release=<v> [--role=<name>] [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--version=<v>` | **Required** by the same parser as the other app verbs. |
+| `--release=<v>` | **Required** by the same parser as the other app verbs. |
 | `--role=<name>` | Limit to one role. |
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print the commands without executing. |
@@ -37,5 +37,5 @@ The Phase 2 port uses a marker-file convention rather than `kamal-proxy`'s nativ
 ## Example
 
 ```bash title="example"
-wheels deploy app maintenance --version=abc1234
+wheels deploy app maintenance --release=abc1234
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/remove.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/remove.mdx
@@ -12,14 +12,14 @@ Stop and remove app containers for the given version. Scoped to one version — 
 ## Synopsis
 
 ``` title="synopsis"
-wheels deploy app remove --version=<v> [--role=<name>] [--destination=<name>] [--dry-run]
+wheels deploy app remove --release=<v> [--role=<name>] [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--version=<v>` | **Required.** |
+| `--release=<v>` | **Required.** |
 | `--role=<name>` | Limit to one role. |
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print commands without executing. |
@@ -39,5 +39,5 @@ Prefer [`wheels deploy prune`](/v4-0-0/command-line-tools/commands/deploy/prune/
 ## Example
 
 ```bash title="illustrative — requires deploy infrastructure"
-wheels deploy app remove --version=abc1234
+wheels deploy app remove --release=abc1234
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/start.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/start.mdx
@@ -12,14 +12,14 @@ sidebar:
 ## Synopsis
 
 ``` title="synopsis"
-wheels deploy app start --version=<v> [--role=<name>] [--destination=<name>] [--dry-run]
+wheels deploy app start --release=<v> [--role=<name>] [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--version=<v>` | **Required.** Must match an existing container's version label. |
+| `--release=<v>` | **Required.** Must match an existing container's version label. |
 | `--role=<name>` | Limit to one role. |
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print the commands without executing. |
@@ -28,10 +28,10 @@ wheels deploy app start --version=<v> [--role=<name>] [--destination=<name>] [--
 
 Emits `docker start <service>-<role>-<version>` on every host in the targeted role(s). Fails per-host if the container doesn't exist.
 
-Does not touch the proxy. For traffic to flow to started containers, follow up with `wheels deploy rollback --version=<v>`.
+Does not touch the proxy. For traffic to flow to started containers, follow up with `wheels deploy rollback <v>`.
 
 ## Example
 
 ```bash title="example"
-wheels deploy app start --version=abc1234
+wheels deploy app start --release=abc1234
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/stop.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/stop.mdx
@@ -12,14 +12,14 @@ sidebar:
 ## Synopsis
 
 ```  title="Synopsis"
-wheels deploy app stop --version=<v> [--role=<name>] [--destination=<name>] [--dry-run]
+wheels deploy app stop --release=<v> [--role=<name>] [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--version=<v>` | **Required.** |
+| `--release=<v>` | **Required.** |
 | `--role=<name>` | Limit to one role. |
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print commands without executing. |
@@ -33,5 +33,5 @@ For traffic-safe shutdown, use `wheels deploy rollback` to the previous version 
 ## Example
 
 ```bash title="Example"
-wheels deploy app stop --version=abc1234
+wheels deploy app stop --release=abc1234
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/secrets/extract.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/secrets/extract.mdx
@@ -7,28 +7,30 @@ sidebar:
   order: 2
 ---
 
-Extract one key's value from a `KEY=VALUE` block. Useful inside hooks or wrapper scripts that pipe from `wheels deploy secrets fetch`.
+Extract one key's value from a `KEY=VALUE` block. Useful inside hooks or wrapper scripts that pipe from `wheels deploy fetch-secrets`.
+
+Invoke it through the **flat alias** `wheels deploy extract-secrets` — the nested `wheels deploy secrets extract` form is shadowed at the shell by the CLI's own `secrets` command ([#2697](https://github.com/wheels-dev/wheels/issues/2697), [#2699](https://github.com/wheels-dev/wheels/pull/2699)).
 
 ## Synopsis
 
 ``` title="synopsis"
-wheels deploy secrets extract --key=<name> --from=<block>
+wheels deploy extract-secrets <KEY> --from=<block>
 ```
 
-## Flags
+## Arguments and flags
 
-| Flag | Description |
+| Argument / flag | Description |
 |------|-------------|
-| `--key=<name>` | Key to extract. |
+| `<KEY>` | **Required positional.** Key to extract. There is no `--key=` flag — the parser ignores it, and the command returns an empty string. |
 | `--from=<block>` | The `KEY=VALUE` newline-separated text to extract from. |
 
 ## Behavior
 
-Scans `--from` line-by-line and returns the value for the first line whose key equals `--key`. Returns an empty string if the key isn't present.
+Scans `--from` line-by-line and returns the value for the first line whose key equals the positional `<KEY>`. Returns an empty string if the key isn't present.
 
 ## Example
 
 ```bash title="illustrative — shell variables not supported by harness"
-block=$(wheels deploy secrets fetch --adapter=op --from=op://Prod/App A B)
-a=$(wheels deploy secrets extract --key=A --from="$block")
+block=$(wheels deploy fetch-secrets --adapter=op --from=op://Prod/App A B)
+a=$(wheels deploy extract-secrets A --from="$block")
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/secrets/fetch.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/secrets/fetch.mdx
@@ -9,10 +9,12 @@ sidebar:
 
 Fetch one or more named keys from a named adapter. Prints them as `KEY=VALUE` lines — the format `.kamal/secrets` accepts via `$(...)`.
 
+Invoke it through the **flat alias** `wheels deploy fetch-secrets` — the nested `wheels deploy secrets fetch` form is shadowed at the shell by the CLI's own `secrets` command ([#2697](https://github.com/wheels-dev/wheels/issues/2697), [#2699](https://github.com/wheels-dev/wheels/pull/2699)).
+
 ## Synopsis
 
 ``` title="synopsis (illustrative — do not type)"
-wheels deploy secrets fetch --adapter=<name> [--account=<acct>] [--from=<scope>] <KEY>...
+wheels deploy fetch-secrets --adapter=<name> [--account=<acct>] [--from=<scope>] <KEY>...
 ```
 
 ## Flags
@@ -31,12 +33,12 @@ Shells out to the adapter's CLI tool with the given scope. Returns a newline-sep
 ## Examples
 
 ```bash title="examples (illustrative — do not type)"
-wheels deploy secrets fetch --adapter=op --from=op://Production/App DATABASE_URL
-wheels deploy secrets fetch --adapter=aws --from=prod/app DB_PASSWORD
+wheels deploy fetch-secrets --adapter=op --from=op://Production/App DATABASE_URL
+wheels deploy fetch-secrets --adapter=aws --from=prod/app DB_PASSWORD
 ```
 
 Wrap inside `.kamal/secrets` for batched resolution:
 
 ```bash title=".kamal/secrets (illustrative — do not type)"
-$(wheels deploy secrets fetch --adapter=op --from=op://Production/App DATABASE_URL WHEELS_MASTER_KEY)
+$(wheels deploy fetch-secrets --adapter=op --from=op://Production/App DATABASE_URL WHEELS_MASTER_KEY)
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/secrets/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/secrets/index.mdx
@@ -9,13 +9,15 @@ sidebar:
 
 Secret-store integration. Five built-in adapters (1Password, Bitwarden, AWS Secrets Manager, LastPass, Doppler), exposed behind three verbs.
 
+From the shell, use the **flat aliases** `wheels deploy fetch-secrets`, `wheels deploy extract-secrets`, and `wheels deploy print-secrets`. The nested `wheels deploy secrets <verb>` form is shadowed by the CLI's own top-level `secrets` command (the local secrets store) and prints that command's help instead ([#2697](https://github.com/wheels-dev/wheels/issues/2697), fixed by the flat aliases in [#2699](https://github.com/wheels-dev/wheels/pull/2699)). The nested form remains for direct callers that bypass the shell, such as MCP.
+
 ## Verbs
 
-| Verb | Purpose |
-|------|---------|
-| [`fetch`](/v4-0-0/command-line-tools/commands/deploy/secrets/fetch/) | Pull keys from a named adapter. |
-| [`extract`](/v4-0-0/command-line-tools/commands/deploy/secrets/extract/) | Extract one key from a `KEY=VALUE` block. |
-| [`print`](/v4-0-0/command-line-tools/commands/deploy/secrets/print/) | Print the resolved `.kamal/secrets`. |
+| Verb | Shell form | Purpose |
+|------|------------|---------|
+| [`fetch`](/v4-0-0/command-line-tools/commands/deploy/secrets/fetch/) | `wheels deploy fetch-secrets` | Pull keys from a named adapter. |
+| [`extract`](/v4-0-0/command-line-tools/commands/deploy/secrets/extract/) | `wheels deploy extract-secrets` | Extract one key from a `KEY=VALUE` block. |
+| [`print`](/v4-0-0/command-line-tools/commands/deploy/secrets/print/) | `wheels deploy print-secrets` | Print the resolved `.kamal/secrets`. |
 
 ## Adapter names
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/secrets/print.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/secrets/print.mdx
@@ -11,6 +11,8 @@ import { Aside } from '@astrojs/starlight/components';
 
 Print the fully resolved `.kamal/secrets` file as `KEY=VALUE` lines. All `$(...)` subshells expand.
 
+Invoke it through the **flat alias** `wheels deploy print-secrets` — the nested `wheels deploy secrets print` form is shadowed at the shell by the CLI's own `secrets` command ([#2697](https://github.com/wheels-dev/wheels/issues/2697), [#2699](https://github.com/wheels-dev/wheels/pull/2699)).
+
 <Aside type="caution">
 Output is plaintext secrets. Never paste this into logs, tickets, or shared terminals. Run in private.
 </Aside>
@@ -18,7 +20,7 @@ Output is plaintext secrets. Never paste this into logs, tickets, or shared term
 ## Synopsis
 
 ``` title="synopsis"
-wheels deploy secrets print [--destination=<name>] [--project-root=<path>]
+wheels deploy print-secrets [--destination=<name>]
 ```
 
 ## Flags
@@ -26,7 +28,8 @@ wheels deploy secrets print [--destination=<name>] [--project-root=<path>]
 | Flag | Description |
 |------|-------------|
 | `--destination=<name>` | Overlay `.kamal/secrets.<name>` on top of `.kamal/secrets`. |
-| `--project-root=<path>` | Override the project root. Defaults to the current directory. |
+
+The project root is always the current working directory — run the command from your project. There is no `--project-root=` flag (the deploy parser never reads one).
 
 ## Behavior
 
@@ -37,6 +40,6 @@ Useful to audit what the deploy flow will see before running it.
 ## Example
 
 ```bash title="illustrative"
-wheels deploy secrets print
-wheels deploy secrets print --destination=production
+wheels deploy print-secrets
+wheels deploy print-secrets --destination=production
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/server/bootstrap.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/server/bootstrap.mdx
@@ -9,10 +9,12 @@ sidebar:
 
 Install Docker on every host. Idempotent — re-runs on already-installed hosts are no-ops.
 
+Invoke it through the **flat alias** `wheels deploy bootstrap`. The nested `wheels deploy server bootstrap` form is shadowed at the shell — the CLI's picocli root owns a top-level `server` command for Lucee instance management and prints its help instead ([#2677](https://github.com/wheels-dev/wheels/issues/2677), fixed by the flat alias in [#2690](https://github.com/wheels-dev/wheels/pull/2690)). The nested form remains only for direct callers that bypass the shell, such as MCP.
+
 ## Synopsis
 
 ```txt title="synopsis"
-wheels deploy server bootstrap [--destination=<name>] [--dry-run]
+wheels deploy bootstrap [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
@@ -35,5 +37,5 @@ The convenience script runs as root (or via `sudo`). For production hardening, i
 ## Example
 
 ```bash title="example"
-wheels deploy server bootstrap
+wheels deploy bootstrap
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/server/exec.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/server/exec.mdx
@@ -9,30 +9,32 @@ sidebar:
 
 Run a command on every host. Filter to one host with `--host=`.
 
+Invoke it through the **flat alias** `wheels deploy exec`. The nested `wheels deploy server exec` form is shadowed at the shell — the CLI's picocli root owns a top-level `server` command and prints its help instead ([#2677](https://github.com/wheels-dev/wheels/issues/2677), fixed by the flat alias in [#2690](https://github.com/wheels-dev/wheels/pull/2690)). The nested form remains only for direct callers that bypass the shell, such as MCP.
+
 ## Synopsis
 
 ``` title="synopsis"
-wheels deploy server exec --cmd=<command> [--host=<host>] [--destination=<name>] [--dry-run]
+wheels deploy exec <command> [--host=<host>] [--destination=<name>] [--dry-run]
 ```
 
-## Flags
+## Arguments and flags
 
-| Flag | Description |
+| Argument / flag | Description |
 |------|-------------|
-| `--cmd=<command>` | **Required.** Shell command to run remotely. Throws `DeployServerCli.MissingCommand` if absent. |
+| `<command>` | **Required positional.** Shell command to run remotely. Every positional token after `exec` is joined into one command, so quoting is optional for simple commands — still quote anything with shell metacharacters (pipes, redirects) so your local shell does not interpret them first. Throws `DeployServerCli.MissingCommand` if absent — there is no `--cmd=` flag (the parser ignores it). |
 | `--host=<host>` | Limit to one host. Must match a host declared in `deploy.yml` — throws `DeployServerCli.UnknownHost` otherwise. |
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print the command without executing. |
 
 ## Behavior
 
-SSHes in parallel (or to one host) and runs `--cmd` verbatim. Output is prefixed by host.
+SSHes in parallel (or to one host) and runs the command verbatim. Output is prefixed by host.
 
 Useful for smoke-testing connectivity, reading environment details, or running one-off diagnostic commands without writing a hook.
 
 ## Example
 
 ```bash title="illustrative — requires live SSH hosts"
-wheels deploy server exec --cmd="uptime"
-wheels deploy server exec --cmd="docker ps" --host=192.0.2.10
+wheels deploy exec uptime
+wheels deploy exec "docker ps" --host=192.0.2.10
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/server/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/server/index.mdx
@@ -9,9 +9,11 @@ sidebar:
 
 Host-level operations that don't fit in the app/proxy/accessory model.
 
+From the shell, use the **flat aliases** `wheels deploy exec` and `wheels deploy bootstrap`. The nested `wheels deploy server <verb>` form is shadowed by the CLI's own top-level `server` command (Lucee instance management) and prints that command's help instead ([#2677](https://github.com/wheels-dev/wheels/issues/2677), [#2690](https://github.com/wheels-dev/wheels/pull/2690)). The nested form remains for direct callers that bypass the shell, such as MCP.
+
 ## Verbs
 
-| Verb | Purpose |
-|------|---------|
-| [`exec`](/v4-0-0/command-line-tools/commands/deploy/server/exec/) | Run a command on every host (optionally filtered). |
-| [`bootstrap`](/v4-0-0/command-line-tools/commands/deploy/server/bootstrap/) | Install Docker on a fresh host (idempotent). |
+| Verb | Shell form | Purpose |
+|------|------------|---------|
+| [`exec`](/v4-0-0/command-line-tools/commands/deploy/server/exec/) | `wheels deploy exec <command>` | Run a command on every host (optionally filtered). |
+| [`bootstrap`](/v4-0-0/command-line-tools/commands/deploy/server/bootstrap/) | `wheels deploy bootstrap` | Install Docker on a fresh host (idempotent). |


### PR DESCRIPTION
## Summary

Guide behavioral audit (P2), docs-fix group 3: the `wheels deploy` CLI reference tree under `command-line-tools/commands/deploy/` documented flag spellings and nested verbs that the shipped CLI never accepts. All 7 manifest findings (`deploy-accessory-01`, `deploy-app-01`, `deploy-server-01/02`, `deploy-secrets-01/02/03`) are live-verified against released 4.0.3 + current source (`cli/lucli/Module.cfc` deploy dispatch, `DeployArgsParser.cfc`, `DeploySecretsCli.cfc:83`). Docs-only — 27 `.mdx` pages, no code changes.

## Fixes

### accessory/* (9 pages) — `--name=` → positional
`wheels deploy accessory boot --name=db` fails with `DeployAccessoryCli.MissingName` (the parser has no `--name` arm; `Module.cfc` reads `positional[3]`). All synopses, flag tables, and examples now use the positional form (`wheels deploy accessory boot db`), and the index notes the flag is ignored.

### app/* (11 pages) — `--version=` → `--release=`
`--version` is absorbed by the picocli root before deploy dispatch (`Invalid value for option '--version'`, [#2674](https://github.com/wheels-dev/wheels/issues/2674)); the parser's alias is `--release` (`DeployArgsParser.cfc:39-44`). Replaced everywhere, added an interception aside on `app/index.mdx` + `app/boot.mdx`, and a caution that purely numeric release values hang ~75s even under `--dry-run` ([#3111](https://github.com/wheels-dev/wheels/issues/3111)). Also fixed `app/start.mdx` cross-reference to positional `wheels deploy rollback <v>`.

### server/{index,bootstrap,exec} — lead with flat aliases
Nested `wheels deploy server <verb>` is shadowed at the shell by LuCLI's top-level `server` command ([#2677](https://github.com/wheels-dev/wheels/issues/2677), flat aliases shipped in [#2690](https://github.com/wheels-dev/wheels/pull/2690)). Pages now lead with `wheels deploy bootstrap` / `wheels deploy exec <command>` and demote the nested form to an MCP/direct-caller note. `exec`'s command is positional (tokens joined); the documented `--cmd=` flag doesn't exist and ends in `DeployServerCli.MissingCommand`.

### secrets/{index,fetch,extract,print} — lead with flat aliases
Nested `wheels deploy secrets <verb>` is shadowed by LuCLI's top-level `secrets` command ([#2697](https://github.com/wheels-dev/wheels/issues/2697), flat aliases in [#2699](https://github.com/wheels-dev/wheels/pull/2699)). Pages now lead with `fetch-secrets` / `extract-secrets` / `print-secrets`. `extract`'s key is positional (`--key=` is ignored → empty output); removed `print`'s `--project-root=` row, which is never parsed (`DeploySecretsCli.cfc:83` always falls back to cwd) and documented the cwd contract instead.

## Verification

- `pnpm verify:docs` over all four touched directories → exit 0 (27 files scanned, 0 tagged blocks — reference pages are `title=`-only by design).
- Full guides build (`pnpm build`) → 433 pages, exit 0.
- Parser/dispatch behavior re-confirmed in source before each edit; `deployment/migrating-from-kamal.mdx` and `deployment/secrets.mdx` already teach the correct forms, so the reference tree now agrees with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
