### PR TITLE
docs(web/guides): fix basics + digging-deeper guide audit findings (group 5, un-gated)

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/basics/associations.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/basics/associations.mdx
@@ -229,6 +229,10 @@ Include multiple associations by comma-separating: `include="comments,author"`. 
 
 ## Many-to-many (through a join model)
 
+<Aside type="caution">
+  **`shortcut` is currently broken in 4.0.x.** Declaring `hasMany(name="...", shortcut="...")` poisons the association's expansion: the shortcut method, the plain join-rows method, *and* `findAll(include=...)` for that association all throw `Wheels.AssociationNotFound` at runtime. Track the fix in [#3109](https://github.com/wheels-dev/wheels/issues/3109). Until it lands, declare the plain `hasMany` join-model associations (no `shortcut`) and traverse the join model explicitly — `user.userRoles(include="role")` — or query the far side with an explicit join.
+</Aside>
+
 Wheels handles many-to-many through a real join model plus the `shortcut` argument on `hasMany`. If a User has many Roles via a UserRole join table, model the relationship as three classes:
 
 ```cfm {test:compile}

--- a/web/sites/guides/src/content/docs/v4-0-0/basics/forms-and-form-helpers.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/basics/forms-and-form-helpers.mdx
@@ -102,7 +102,7 @@ Every helper also accepts the standard Wheels form options — `label`, `labelPl
 See `vendor/wheels/view/formsobject.cfc` for the full argument surface.
 
 <Aside type="note">
-  **`checkBox` emits two inputs.** A single checkbox only submits its `name` when it's checked, which means unchecking a box sends no value at all and the controller never learns the user cleared it. `checkBox` works around this by also rendering a hidden `<input type="hidden" name="..." value="0">` just before the real checkbox. On submit, the last value wins: checked → `1`, unchecked → `0`. The underlying model always sees one of the two.
+  **`checkBox` emits two inputs.** A single checkbox only submits its `name` when it's checked, which means unchecking a box sends no value at all and the controller never learns the user cleared it. `checkBox` works around this by also rendering a hidden companion *after* the real checkbox, under a marker name — `<input type="hidden" name="post[published]($checkbox)" value="0">`. On submit, Wheels' dispatcher detects the `($checkbox)` key and applies its `uncheckedValue` only when the real field is absent from the form post: checked → `1`, unchecked → `0`. The underlying model always sees one of the two.
 </Aside>
 
 <Aside type="note">
@@ -162,7 +162,7 @@ The summary block only renders when the object has errors — on a new-form rend
 
 Wheels does not ship a standalone `label()` helper. Labels are a first-class argument on every object-bound form helper via `label=` and `labelPlacement=`:
 
-- `textField(objectName="post", property="title", label="Post title")` — wraps the input in a `<label for="post-title">Post title</label>` with `labelPlacement` controlling whether the text comes `before` (default), `after`, or `around` the input.
+- `textField(objectName="post", property="title", label="Post title")` — wraps the input in a `<label for="post-title">Post title</label>` with `labelPlacement` controlling whether the text comes `around` (default), `before`, or `after` the input.
 - `label=false` suppresses the auto-label — use this when you want to write the `<label>` tag by hand (for icons, extra classes, or explicit `for` attributes).
 
 The third and most common pattern is in the canonical example above: skip the `label` argument entirely and wrap the helper call inside a raw `<label>` element in your markup. The browser associates the label with the input via containment, no `for="..."` attribute needed.

--- a/web/sites/guides/src/content/docs/v4-0-0/basics/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/basics/index.mdx
@@ -6,4 +6,85 @@ sidebar:
   order: 3
 ---
 
-Placeholder — content lands in Phase 2.
+import { CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+The Basics covers the everyday surface of a Wheels app — the routing, controller, view, and model work you'll do on every feature. Each page is a task-oriented how-to. They're ordered to follow a request through the framework, but every page stands alone — jump to whichever matches what you're building right now.
+
+**You'll find:**
+
+- Routing, controllers, and the seven REST actions
+- Views, layouts, partials, and every form helper
+- Validations and rendering errors back to the user
+- Models, finders, associations, and the chainable query builder
+- Migrations, seeding, and multi-datasource setups
+
+## All Basics guides
+
+<CardGrid>
+  <LinkCard
+    title="Routing"
+    href="/v4-0-0/basics/routing/"
+    description="Define routes — resources, nested resources, namespaced routes, custom patterns, and route helpers."
+  />
+  <LinkCard
+    title="Controllers and Actions"
+    href="/v4-0-0/basics/controllers-and-actions/"
+    description="Writing a controller, the seven REST actions, filters, params, rendering, redirect, and flash."
+  />
+  <LinkCard
+    title="Views, Layouts, Partials"
+    href="/v4-0-0/basics/views-layouts-partials/"
+    description="Rendering templates, the default layout, extracting partials, and how controller data reaches the view."
+  />
+  <LinkCard
+    title="Forms and Form Helpers"
+    href="/v4-0-0/basics/forms-and-form-helpers/"
+    description="Every form helper Wheels ships — object-bound and tag-style — plus data-auto-id for stable test selectors."
+  />
+  <LinkCard
+    title="Validation and Error Display"
+    href="/v4-0-0/basics/validation-and-errors/"
+    description="Built-in validations, when they fire, the errors API, and rendering errors inline."
+  />
+  <LinkCard
+    title="Models and the ORM"
+    href="/v4-0-0/basics/models-and-the-orm/"
+    description="Defining a model, finders, persistence, and lifecycle callbacks — the everyday ORM surface."
+  />
+  <LinkCard
+    title="Associations"
+    href="/v4-0-0/basics/associations/"
+    description="Modeling relationships — hasMany, belongsTo, hasOne, nested creation, eager loading, cascade deletes."
+  />
+  <LinkCard
+    title="Migrations"
+    href="/v4-0-0/basics/migrations/"
+    description="Writing and running schema migrations — column types, indexes, foreign keys, and rollbacks."
+  />
+  <LinkCard
+    title="Seeding"
+    href="/v4-0-0/basics/seeding/"
+    description="Populate development and production databases with default records — idempotently."
+  />
+  <LinkCard
+    title="Query Builder and Scopes"
+    href="/v4-0-0/basics/query-builder-and-scopes/"
+    description="Chainable query builder, reusable scopes, enum declarations, and batch processing."
+  />
+  <LinkCard
+    title="Database and Multiple Datasources"
+    href="/v4-0-0/basics/database-and-multiple-datasources/"
+    description="Configuring the default datasource, per-model overrides, transactions, and raw queries."
+  />
+  <LinkCard
+    title="Shared Development Databases"
+    href="/v4-0-0/basics/shared-development-databases/"
+    description="Reconciling the migration tracking table when several developers share one dev database."
+  />
+</CardGrid>
+
+## See also
+
+- [Start Here](/v4-0-0/start-here/) — install Wheels and build your first app with the tutorial
+- [Core Concepts](/v4-0-0/core-concepts/) — the explanations behind what these guides show you how to do
+- [Digging Deeper](/v4-0-0/digging-deeper/) — authentication, jobs, caching, uploads, and the rest of the advanced surface

--- a/web/sites/guides/src/content/docs/v4-0-0/basics/models-and-the-orm.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/basics/models-and-the-orm.mdx
@@ -202,8 +202,10 @@ The ordering is strict: `beforeValidation` → validation runs → `afterValidat
 
 `afterFind` is the one callback that fires without a write: it runs once per record returned by a finder, which makes it the right place for decorating loaded records with derived values. Its contract differs by what the finder returns:
 
-- **Object-returning finders** (`findOne`, `findByKey`, `findAll(returnAs="objects")`) — the callback takes no arguments; read and mutate `this` directly.
-- **Query-returning finders** (`findAll` by default) — there is no object to mutate. The callback receives the row's columns as named arguments and decorates by *returning a struct*; any keys you return are merged back into the row (new keys become new query columns). Mutating `this` does nothing here.
+- **Object-returning finders** (`findOne`, `findByKey`, `findAll(returnAs="objects")`) — the callback receives the record's properties as named arguments. You can mutate `this` directly, or return a struct — the returned keys are applied back onto the object via `setProperties()`.
+- **Query-returning finders** (`findAll` by default) — there is no object per row. The callback receives the row's columns as named arguments and decorates by *returning a struct*; any keys you return are merged back into the row (new keys become new query columns). Mutating `this` does nothing here.
+
+Both modes receive named arguments and both honor a returned struct, so the portable pattern — one callback that decorates objects and query rows alike — is to compute from `arguments` and return a struct:
 
 ```cfm {test:compile}
 component extends="Model" {
@@ -212,12 +214,7 @@ component extends="Model" {
     }
 
     private function setFullName() {
-        if (StructKeyExists(arguments, "firstName")) {
-            // query row: decorate by returning a struct
-            return {fullName: arguments.firstName & " " & arguments.lastName};
-        }
-        // single object: mutate this
-        this.fullName = this.firstName & " " & this.lastName;
+        return {fullName: arguments.firstName & " " & arguments.lastName};
     }
 }
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/basics/models-and-the-orm.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/basics/models-and-the-orm.mdx
@@ -162,7 +162,7 @@ For a key-only delete without loading the record, use `model("Post").deleteByKey
 
 ## Lifecycle callbacks
 
-Callbacks register a `private` method to run at a specific point in the record's lifecycle. The method takes no arguments (the record is `this`), returns nothing, and can mutate any property on `this` before the write happens. Return `false` from a `before*` callback to cancel the operation.
+Callbacks register a method to run at a specific point in the record's lifecycle. For the write-cycle callbacks the method takes no arguments (the record is `this`), returns nothing, and can mutate any property on `this` before the write happens. Return `false` from a `before*` callback to cancel the operation. (`afterFind` is the exception — see below.)
 
 | Callback | When it fires |
 |----------|---------------|
@@ -177,7 +177,7 @@ Callbacks register a `private` method to run at a specific point in the record's
 | `beforeUpdate` / `afterUpdate` | Around UPDATE only |
 | `beforeDelete` / `afterDelete` | Around DELETE |
 
-Register callbacks in `config()` — `beforeSave("methodName")` or `beforeSave(methods="one,two")` when you want several. The methods themselves must be `private` and live on the same component.
+Register callbacks in `config()` — `beforeSave("methodName")` or `beforeSave(methods="one,two")` when you want several. The methods live on the same component and should be `private` — invocation is internal, so `public` also works, but a public callback method leaks onto the model's callable API.
 
 ```cfm {test:compile}
 component extends="Model" {
@@ -200,7 +200,27 @@ component extends="Model" {
 
 The ordering is strict: `beforeValidation` → validation runs → `afterValidation` → `beforeSave` → (`beforeCreate` or `beforeUpdate`) → SQL write → (`afterCreate` or `afterUpdate`) → `afterSave`. If any `before*` callback returns `false`, the chain stops and the write is skipped.
 
-`afterFind` is the one callback that fires without a write: it runs once per row returned by a finder, which makes it the right place for decorating loaded records with derived values.
+`afterFind` is the one callback that fires without a write: it runs once per record returned by a finder, which makes it the right place for decorating loaded records with derived values. Its contract differs by what the finder returns:
+
+- **Object-returning finders** (`findOne`, `findByKey`, `findAll(returnAs="objects")`) — the callback takes no arguments; read and mutate `this` directly.
+- **Query-returning finders** (`findAll` by default) — there is no object to mutate. The callback receives the row's columns as named arguments and decorates by *returning a struct*; any keys you return are merged back into the row (new keys become new query columns). Mutating `this` does nothing here.
+
+```cfm {test:compile}
+component extends="Model" {
+    function config() {
+        afterFind("setFullName");
+    }
+
+    private function setFullName() {
+        if (StructKeyExists(arguments, "firstName")) {
+            // query row: decorate by returning a struct
+            return {fullName: arguments.firstName & " " & arguments.lastName};
+        }
+        // single object: mutate this
+        this.fullName = this.firstName & " " & this.lastName;
+    }
+}
+```
 
 ## Custom methods
 

--- a/web/sites/guides/src/content/docs/v4-0-0/basics/validation-and-errors.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/basics/validation-and-errors.mdx
@@ -171,7 +171,7 @@ component extends="Model" {
 - `unless` — inverse of `condition`; the rule runs only when the expression returns `false`.
 
 <Aside type="tip">
-  Validations on associations — like requiring child records to be valid before the parent saves — are covered in the associations guide (coming up in this series). `validatesAssociated` is the relevant helper.
+  Validations on associations — like requiring child records to be valid before the parent saves — happen through nested properties: when a parent saves children via `nestedProperties()`, each child runs its own validations and an invalid child blocks the save. See the [associations guide](/v4-0-0/basics/associations/) for the setup. (There is no `validatesAssociated` helper in Wheels.)
 </Aside>
 
 ## Related guides

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/authentication-patterns.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/authentication-patterns.mdx
@@ -61,7 +61,7 @@ local.di.map("sessionStrategy").to("wheels.auth.SessionStrategy").asSingleton();
 
 Both are singletons — one instance per app lifetime. The authenticator holds its strategy registry in instance state, so a singleton is the correct scope.
 
-Wire the session strategy into the authenticator on app init. A cold reload registers it once; the `hasStrategy` check keeps a second reload from stacking duplicates:
+Wire the session strategy into the authenticator on app init. The `hasStrategy` check just avoids needlessly re-registering on a warm reload — duplicates can't stack either way, because `registerStrategy()` replaces any existing entry with the same name:
 
 ```cfm {test:compile} title="config/app.cfm or equivalent init hook"
 if (StructKeyExists(application, "wheelsdi") && application.wheelsdi.containsInstance("authenticator")) {
@@ -340,7 +340,7 @@ component extends="wheels.Controller" {
     private function authenticate() {
         var result = service("authenticator").authenticate(request);
         if (!result.success) {
-            if (request.format ?: "html" == "json") {
+            if ((request.format ?: "html") == "json") {
                 renderWith(data={error: result.error}, status=result.statusCode);
             } else {
                 flashInsert(error="Please log in first");

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/background-jobs.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/background-jobs.mdx
@@ -145,7 +145,7 @@ component extends="wheels.Job" {
 }
 ```
 
-The backoff formula is `Min(this.baseDelay * 2^attempt, this.maxDelay)`. With the example's settings (`maxRetries=5`, `baseDelay=2`, `maxDelay=3600`), you get retries at roughly 4s, 8s, 16s, 32s, 64s — small failures resolve quickly, while a stubborn outage stops hammering the external service once it hits the cap. (The framework default is `maxRetries=3`.)
+The backoff formula is `Min(this.baseDelay * 2^attempt, this.maxDelay)`, where `attempt` is the number of the attempt that just failed (1 for the first run). Note that `maxRetries` counts total attempts, not retries: with the example's settings (`maxRetries=5`, `baseDelay=2`, `maxDelay=3600`) the job runs at most five times — the first run plus four retries at roughly 4s, 8s, 16s, and 32s — and the fifth failure moves it to `failed`. Transient failures resolve quickly, and `maxDelay` caps the gap so a job configured with many attempts stops hammering the external service. (The framework default is `maxRetries=3`: the first run plus retries at 4s and 8s.)
 
 Because retries are automatic, your `perform()` must be **idempotent**. If the first attempt charged the card but failed to record the success, the second attempt must notice and skip. Store an idempotency key on the model and check it at the top of `perform()`.
 

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/background-jobs.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/background-jobs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Background Jobs
-description: Queue work for asynchronous processing — retries, priority queues, and the worker process.
+description: Queue work for asynchronous processing — retries, priority queues, and draining the queue on a schedule.
 type: howto
 sidebar:
   order: 3
@@ -8,13 +8,13 @@ sidebar:
 
 import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-This page shows you how to move slow work out of the request cycle. You'll define a job class, enqueue it from a controller, run a worker process to drain the queue, configure retries with exponential backoff, and route urgent work through a high-priority queue.
+This page shows you how to move slow work out of the request cycle. You'll define a job class, enqueue it from a controller, drain the queue with `processQueue()` on a schedule, configure retries with exponential backoff, and route urgent work through a high-priority queue.
 
 **You'll learn:**
 
 - How to define a job by extending `wheels.Job` and implementing `perform()`
 - How to enqueue jobs immediately, after a delay, or at a specific time
-- How to run `wheels jobs work` as a long-lived worker
+- How to drain queues with `processQueue()` from a scheduled task or cron-driven script
 - How retries and backoff work, and how to tune them
 - How priority queues let critical work jump the line
 - How to monitor, retry, and purge jobs in production
@@ -64,7 +64,7 @@ component extends="Controller" {
     function create() {
         user = model("User").new(params.user);
         if (user.save()) {
-            // Immediate — runs on the next worker poll
+            // Immediate — runs on the next processQueue() poll
             job = new app.jobs.SendWelcomeEmailJob();
             job.enqueue(data={userId: user.id});
 
@@ -84,31 +84,45 @@ component extends="Controller" {
 }
 ```
 
-`enqueue()`, `enqueueIn()`, and `enqueueAt()` all return a struct with the persisted row's `id`. The controller keeps responding fast — the actual email send happens when a worker picks the row up.
+`enqueue()`, `enqueueIn()`, and `enqueueAt()` all return a struct with the persisted row's `id`. The controller keeps responding fast — the actual email send happens when the next `processQueue()` poll picks the row up.
 
-## Run the worker
+## Process the queue
 
-The worker is a long-lived process that polls the `wheels_jobs` table and runs any `pending` job whose `runAt` has arrived. Start it from the CLI:
+<Aside type="caution">
+  **There is no `wheels jobs` CLI yet.** Earlier 4.0 docs described `wheels jobs work|status|retry|monitor|purge` commands, but the released CLI has no `jobs` command — invoking one errors. A worker CLI is tracked in [#3090](https://github.com/wheels-dev/wheels/issues/3090). Until it ships, drive the queue with the programmatic API on `wheels.Job`, shown below.
+</Aside>
 
-```bash {test:cli cmd="wheels --version" asserts-stdout="Wheels"}
-wheels --version
+Processing is a poll: `processQueue()` picks up every `pending` job whose `runAt` has arrived, runs each one, and returns counts. Call it from anything that runs on a schedule — a CFML scheduled task, a cron-invoked script, or a controller action behind an admin route that your scheduler hits:
+
+```cfm {test:compile} title="app/controllers/admin/Jobs.cfc (fragment)"
+component extends="Controller" {
+    function drain() {
+        worker = new wheels.Job();
+        result = worker.processQueue(queue="mailers", limit=10);
+        // result = {processed: n, failed: n, skipped: n, errors: [...]}
+        renderWith(data=result);
+    }
+}
 ```
 
-The commands themselves need a running app and database, so they don't smoke-test in docs — here's the shape:
+- `processQueue()` — process all queues, up to 10 jobs per call (the default `limit`).
+- `processQueue(queue="mailers")` — only drain the `mailers` queue.
+- `processQueue(limit=100)` — bigger batch for one-shot catch-ups.
 
-- `wheels jobs work` — process all queues; loops until Ctrl-C.
-- `wheels jobs work --queue=mailers` — only drain the `mailers` queue.
-- `wheels jobs work --queue=mailers --interval=3` — poll every 3 seconds instead of the 5-second default.
-- `wheels jobs work --max-jobs=100` — stop after 100 jobs (useful for one-shot batches).
-- `wheels jobs work --quiet` — suppress per-job output, only log errors.
+In production, schedule the call at whatever cadence matches your latency tolerance — every minute is plenty for emails. Run it from multiple schedulers for parallelism: the base class uses optimistic row locking, so two pollers won't process the same job twice (a row claimed between the SELECT and the claim shows up in the `skipped` count).
 
-In production, run the worker under a process supervisor (systemd, Docker's restart policy, Kamal's accessory containers) so it restarts if it crashes. Run multiple worker processes for parallelism — the base class uses optimistic row locking, so two workers won't process the same job twice.
+Check queue health without tailing logs — `queueStats()` returns per-status counts:
 
-Check queue health without tailing logs:
-
-- `wheels jobs status` — table of pending / processing / completed / failed per queue.
-- `wheels jobs status --queue=mailers` — just one queue.
-- `wheels jobs status --format=json` — machine-readable output for CI smoke tests or scraping.
+```cfm {test:compile} title="queue health"
+component extends="Controller" {
+    function status() {
+        stats = (new wheels.Job()).queueStats();                    // all queues
+        mailerStats = (new wheels.Job()).queueStats(queue="mailers"); // one queue
+        // {pending: n, processing: n, completed: n, failed: n, total: n}
+        renderWith(data=stats);
+    }
+}
+```
 
 ## Retries and backoff
 
@@ -131,59 +145,68 @@ component extends="wheels.Job" {
 }
 ```
 
-The backoff formula is `Min(this.baseDelay * 2^attempt, this.maxDelay)`. With the defaults (`baseDelay=2`, `maxDelay=3600`), you get retries at roughly 4s, 8s, 16s, 32s, 64s — small failures resolve quickly, while a stubborn outage stops hammering the external service once it hits the cap.
+The backoff formula is `Min(this.baseDelay * 2^attempt, this.maxDelay)`. With the example's settings (`maxRetries=5`, `baseDelay=2`, `maxDelay=3600`), you get retries at roughly 4s, 8s, 16s, 32s, 64s — small failures resolve quickly, while a stubborn outage stops hammering the external service once it hits the cap. (The framework default is `maxRetries=3`.)
 
 Because retries are automatic, your `perform()` must be **idempotent**. If the first attempt charged the card but failed to record the success, the second attempt must notice and skip. Store an idempotency key on the model and check it at the top of `perform()`.
 
-To kick failed jobs back into the queue — after you've fixed the bug, say — use the retry command:
+To kick failed jobs back into the queue — after you've fixed the bug, say — call `retryFailed()`:
 
-```bash title="your shell"
-wheels jobs retry                       # retry every failed job
-wheels jobs retry --queue=mailers       # only the mailers queue
-wheels jobs retry --limit=10            # cap at 10 jobs
+```cfm {test:compile} title="retry failed jobs"
+component extends="Controller" {
+    function retryAll() {
+        worker = new wheels.Job();
+        worker.retryFailed();                   // retry every failed job
+        worker.retryFailed(queue="mailers");    // only the mailers queue
+        redirectTo(back=true);
+    }
+}
 ```
 
-Retry resets `attempts` to zero and flips `status` back to `pending`.
+Retry resets `attempts` to zero, clears the stored error, and flips `status` back to `pending` — the next `processQueue()` poll picks the rows up.
 
 ## Priority queues
 
-Different queues can run at different cadences. Give the worker a comma-separated list in priority order and it drains the first queue before falling through to the next:
+Two levers control which work runs first. Within a single `processQueue()` call, jobs run in `priority DESC, runAt ASC` order — set `this.priority` in `config()` (higher first) or pass `priority=` at enqueue time and urgent rows jump the line. Across queues, drain them in the order you care about:
 
-```bash title="your shell"
-wheels jobs work --queue=critical,default,low
+```cfm {test:compile} title="drain in priority order"
+component extends="Controller" {
+    function drain() {
+        worker = new wheels.Job();
+        worker.processQueue(queue="critical", limit=50);
+        worker.processQueue(queue="default", limit=20);
+        worker.processQueue(queue="low", limit=5);
+        renderText("ok");
+    }
+}
 ```
 
-The worker processes every `pending` job in `critical` first, then `default`, then `low`. Queues are just string labels on the `wheels_jobs.queue` column — create as many as you need. A typical split:
+Every `pending` job in `critical` (up to the limit) goes first, then `default`, then `low`. Queues are just string labels on the `wheels_jobs.queue` column — create as many as you need. A typical split:
 
 - `critical` — payment retries, password resets, anything user-visible.
 - `default` — welcome emails, webhooks, routine follow-ups.
 - `low` — nightly analytics rollups, cleanup, anything that can wait.
 
-You can also bias ordering within a queue with `this.priority` in `config()` (higher first), but queue-based separation is simpler to reason about.
+Per-job `priority` is the finer instrument; queue-based separation is simpler to reason about. Use queues for cadence, `priority` for jumping the line within one.
 
 ## Monitoring in production
 
-For an interactive dashboard, run:
+There's no dashboard yet — it lands with the worker CLI tracked in [#3090](https://github.com/wheels-dev/wheels/issues/3090). The building block that exists today is `queueStats()`. Expose it from a small admin endpoint and point whatever you already use — Prometheus, Datadog, a custom scrape — at the JSON:
 
-```bash title="your shell"
-wheels jobs monitor                     # refresh every 3 seconds
-wheels jobs monitor --interval=5        # slower refresh
-wheels jobs monitor --queue=mailers     # one queue only
+```cfm {test:compile} title="app/controllers/admin/Jobs.cfc (fragment)"
+component extends="Controller" {
+    function metrics() {
+        renderWith(data=(new wheels.Job()).queueStats());
+    }
+}
 ```
 
-The dashboard shows per-queue counts, throughput over the last 60 minutes, error rate, and recent job activity. It also reports any jobs recovered from stuck `processing` state (worker crashed mid-job).
-
-For headless metrics, pipe `wheels jobs status --format=json` into whatever you already use — Prometheus, Datadog, a custom scrape:
-
-```bash title="your shell"
-wheels jobs status --format=json
-```
+Alert on two signals: `failed` growing, and `pending` not shrinking between polls. The first means a job class is throwing past its retries; the second means nothing is draining the queue.
 
 ## The jobs table
 
 Jobs persist to a `wheels_jobs` table keyed by UUID. The base class auto-creates it the first time `enqueue()` or `processQueue()` runs — no migration needed. Columns: `id`, `jobClass`, `queue`, `data` (JSON), `priority`, `status` (`pending`/`processing`/`completed`/`failed`), `attempts`, `maxRetries`, `lastError`, `runAt`, `completedAt`, `failedAt`, `createdAt`, `updatedAt`. See `vendor/wheels/Job.cfc` (`$ensureJobTable`) for the exact schema — it adapts column types per database (MySQL, PostgreSQL, SQL Server, H2, SQLite, Oracle).
 
-You never need to touch the table directly. Query it through the CLI commands or `queueStats()`:
+You never need to touch the table directly. Query it through `queueStats()`:
 
 ```cfm {test:compile} title="programmatic stats"
 component extends="Controller" {
@@ -228,16 +251,23 @@ Testing `perform()` in isolation keeps the spec fast and avoids the complexity o
 
 ## Purging old rows
 
-Completed and failed rows accumulate forever unless you prune them. The purge command takes days and status flags:
+Completed and failed rows accumulate forever unless you prune them. `purgeCompleted()` deletes completed rows older than a cutoff:
 
-```bash title="your shell"
-wheels jobs purge                                 # completed jobs older than 7 days
-wheels jobs purge --completed --older-than=30     # completed older than 30 days
-wheels jobs purge --failed --older-than=90        # failed jobs older than 90 days
-wheels jobs purge --completed --failed --queue=mailers
+```cfm {test:compile} title="prune the table"
+component extends="Controller" {
+    function purge() {
+        worker = new wheels.Job();
+        worker.purgeCompleted();                          // completed jobs older than 7 days
+        worker.purgeCompleted(days=30);                   // completed older than 30 days
+        worker.purgeCompleted(days=30, queue="mailers");  // one queue only
+        renderText("ok");
+    }
+}
 ```
 
-Run it from a cron or scheduled task. A weekly purge of completed rows older than 30 days keeps the table small without losing recent history for debugging.
+It only touches `status='completed'` rows — failed rows persist until you clear them yourself, which is deliberate: they're your error log. Retry them with `retryFailed()` or delete them with your own SQL once you've extracted what you need from `lastError`.
+
+Run the purge from a cron or scheduled task. A weekly purge of completed rows older than 30 days keeps the table small without losing recent history for debugging.
 
 ## Common patterns
 
@@ -267,7 +297,7 @@ Run it from a cron or scheduled task. A weekly purge of completed rows older tha
   />
   <LinkCard
     title="Environments and Configuration"
-    description="Where to tune worker intervals and retry caps per environment (dev, staging, production)."
+    description="Where to tune polling cadence and retry caps per environment (dev, staging, production)."
     href="/v4-0-0/core-concepts/environments-and-configuration/"
   />
 </CardGrid>

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/dependency-injection-usage.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/dependency-injection-usage.mdx
@@ -64,7 +64,7 @@ component extends="wheels.WheelsTest" {
 }
 ```
 
-Two things to know. First, the swap is global for the duration of the test — any code path that resolves `emailService` during that `it` block gets the fake, including model callbacks and background jobs that run inline. Second, because `asSingleton()` caches the first instance per component path, you want the fake under a *different* component path than the real one (`tests._assets.FakeEmailService` vs `app.lib.EmailService`) so the cache doesn't hand you a stale real instance.
+Two things to know. First, the swap is global for the duration of the test — any code path that resolves `emailService` during that `it` block gets the fake, including model callbacks and background jobs that run inline. Second, the singleton cache is keyed by the *alias* (`emailService`), and re-binding the alias only invalidates the cached instance when the new target is a *different* component path. That's why the fake lives under its own path (`tests._assets.FakeEmailService` vs `app.lib.EmailService`): the different-path re-bind evicts the cached real instance, so the next `service("emailService")` constructs the fake instead of handing back the stale singleton.
 
 ## Per-request resolvers
 
@@ -241,7 +241,7 @@ When `service("name")` throws `Wheels.Injector` or hands back the wrong thing, r
 
 - **Is the registration in `config/services.cfm`?** The file is loaded once at app start. Typos don't surface until resolution time.
 - **Did the app reload after you edited `services.cfm`?** Run `wheels reload` or hit `?reload=true&password=...`. Service registrations are *not* re-read per request.
-- **Does the binding name match exactly?** Names are case-sensitive. `service("EmailService")` and `service("emailService")` are different keys.
+- **Does the binding name match?** Names are case-insensitive — the injector stores bindings in plain CFML structs, so `service("EmailService")` and `service("emailService")` resolve the same registration. A "name not found" error means the name genuinely was never registered, not a casing mismatch.
 - **Is `.to(...)` pointing at a valid dotted path?** A typo in the target path throws at `createObject()` time, not at registration time. The error surfaces the first time someone resolves the name.
 - **Circular dependency?** If A's `init()` auto-wires B and B's `init()` auto-wires A, the injector throws `Wheels.DI.CircularDependency` with the resolution chain. Break the cycle by turning one side into a factory or resolving lazily.
 

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/route-model-binding.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/route-model-binding.mdx
@@ -105,7 +105,7 @@ mapper()
 `binding="BlogPost"` resolves the `BlogPost` model and stores the instance under `params.blogPost` (the lowercase-initial form of the class name). The `binding` argument accepts `true`, `false`, or a simple string — any non-boolean string is treated as the model class to load.
 
 <Aside type="tip">
-  If the model class doesn't exist (for example, the resource is routing to a controller that doesn't have a backing model), the dispatcher silently skips binding instead of throwing. This keeps non-model resources — health checks, static pages, API gateways — working without extra configuration.
+  The silent skip applies only to **conventional** binding (`binding=true`): when the convention-derived model class doesn't exist (for example, the resource is routing to a controller that doesn't have a backing model), the dispatcher skips binding instead of throwing. This keeps non-model resources — health checks, static pages, API gateways — working without extra configuration. An **explicit** name is different: if `binding="BlogPost"` names a model class that can't be resolved, the dispatcher rethrows the failure as a configuration error — you asked for that class by name, so a typo should surface, not vanish.
 </Aside>
 
 ## Scope-level binding


### PR DESCRIPTION
Final-wave docs-fix PR from the 2026-06 guide behavioral audit — manifest group 5 (basics + digging-deeper), **un-gated subset only**. Every correction below is established in the P2 audit manifest with source- or live-probe evidence.

## What changed

### basics/

| Page | Finding | Fix |
|---|---|---|
| `models-and-the-orm.mdx` | orm-12 | Callbacks contract corrected: `afterFind` on **query-returning** finders receives the row's columns as named arguments and decorates by *returning a struct* (`$queryCallback`, `vendor/wheels/model/callbacks.cfc:296` — `$invoke(method, invokeArgs = row)` + `QueryAddColumn` merge); mutating `this` only works for object-returning finders. Added a dual-mode example. "Must be private" softened to the real convention — invocation is internal, `public` works but leaks onto the model API. |
| `associations.mdx` | assoc-09 (partial) | Added a caution that `hasMany(shortcut=...)` is **currently broken** — declaring it makes `user.roles()`, `user.userRoles()`, and `findAll(include="userRoles")` all throw `Wheels.AssociationNotFound` (live-reproduced on develop). Cites #3109. The full example rewrite stays blocked on the code fix per the manifest gate. |
| `validation-and-errors.mdx` | valid-09 | Removed the reference to `validatesAssociated` — the helper does not exist anywhere in `vendor/wheels/` (repo-wide grep: zero hits). Points at nested-properties validation instead. |
| `forms-and-form-helpers.mdx` | forms-05 | `checkBox` companion mechanism corrected: hidden input renders **after** the checkbox under marker name `<name>($checkbox)` (`formsobject.cfc:906-917`), and the dispatcher applies `uncheckedValue` only when the real field is absent (`Dispatch.cfc:816`) — not "same name, last value wins". Observable contract unchanged. |
| `forms-and-form-helpers.mdx` | forms-09 | `labelPlacement` default is `around`, not `before` (every defaults block in `vendor/wheels/events/init/functions.cfm`). |
| `index.mdx` | index-01 | Replaced the "Placeholder — content lands in Phase 2" stub with a real section landing page linking all 12 content pages (same shape as `digging-deeper/index.mdx`). |

### digging-deeper/

| Page | Finding | Fix |
|---|---|---|
| `background-jobs.mdx` | background-jobs-01/-09 | Rewrote "Run the worker", retry block, "Priority queues", "Monitoring in production", and "Purging old rows" around the programmatic surface that actually exists and is source-verified: `processQueue(queue, limit)`, `queueStats(queue)`, `retryFailed(queue)`, `purgeCompleted(days, queue)` (`Job.cfc:228/464/497/526`), driven from a scheduled task. The page previously documented a `wheels jobs work\|status\|retry\|monitor\|purge` CLI that does not exist (released 4.0.3 errors "has no function with name [jobs]") — caution added citing #3090, which tracks the worker CLI. Also clarified the 4s–64s backoff list holds under the example's `maxRetries=5` (framework default is 3), priority ordering is `priority DESC, runAt ASC` within a `processQueue()` call, and `purgeCompleted()` touches only completed rows. |
| `route-model-binding.mdx` | rmb-04 | Scoped the silent-skip aside: it applies only to **conventional** binding; an explicit `binding="BlogPost"` that fails to resolve **rethrows** as a configuration error (`Dispatch.cfc` rethrow, pinned by `routeModelBindingSpec.cfc:109`). Closes #3118. |
| `dependency-injection-usage.mdx` | di-02, di-03 | Singleton cache is keyed by **alias**, not component path (`Injector.cfc:25-29`); a different-path re-bind invalidates the cached instance (`:97-108`) — which is *why* the test-double recipe works. And binding names are **case-insensitive** (plain-struct storage + `structKeyExists`, probed on Lucee) — removed the "names are case-sensitive" debugging bullet. Closes #3117. |
| `authentication-patterns.mdx` | auth-09, auth-03 | Parenthesized the elvis: `if ((request.format ?: "html") == "json")`. The unparenthesized form parses as `request.format ?: ("html" == "json")` — on-engine probe shows it throws `Can't cast String [json] to a boolean` whenever `request.format` exists, so the JSON branch could never execute. Closes #3116. Also fixed the `hasStrategy` rationale: `registerStrategy()` replaces same-name entries, so duplicates cannot stack — the guard merely avoids needless re-registration. |

## Skipped per manifest gates

- **orm-03** (`tableName()` setter) — held for the #3104 design decision.
- **assoc-09 full example rewrite** — blocked on the #3109 framework fix; only the caution ships now.

## Verification

- `verify:docs` exit 0 on all 9 touched pages (72 tagged blocks pass, including the new `{test:compile}` blocks in background-jobs and models-and-the-orm).
- Guides site builds clean (`pnpm --filter @wheels-dev/site-guides build`, 433 pages).
- All framework-behavior claims re-checked against `vendor/wheels/` source on this branch (`Job.cfc`, `Injector.cfc`, `callbacks.cfc`, `formsobject.cfc`, `functions.cfm`).

Closes #3116. Closes #3117. Closes #3118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
