### PR TITLE
feat(cli): restore the jobs worker CLI — wheels jobs work and status (#3090)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -659,7 +659,12 @@ result = (new wheels.Job()).processQueue(queue="mailers", limit=10);
 stats = (new wheels.Job()).queueStats();
 ```
 
-Worker CLI: none yet — `wheels jobs work|status|retry|purge|monitor` do not exist (`cli/lucli/Module.cfc` has no `jobs` command; invoking one errors — [#3090](https://github.com/wheels-dev/wheels/issues/3090)). Drive queues programmatically via `processQueue()` / `queueStats()` (above), e.g. from a scheduled task or cron-invoked script.
+Worker CLI (`cli/lucli/Module.cfc::jobs()` — thin wrapper over the `jobsProcessNext`/`jobsStatus` bridge commands in `vendor/wheels/public/views/cli.cfm`; requires a running server):
+```bash
+wheels jobs work --queue=mailers --interval=3   # long-lived worker loop; --max-jobs=N for one-shot batches, --quiet
+wheels jobs status [--queue=mailers] [--format=json]
+```
+The `retry`/`purge`/`monitor` verbs are tracked follow-ups ([#3090](https://github.com/wheels-dev/wheels/issues/3090)) — invoking one errors with the programmatic equivalent (`(new wheels.Job()).retryFailed()` / `.purgeCompleted()`).
 
 Backoff: `this.baseDelay = 2`, `this.maxDelay = 3600` in `config()`. Formula: `Min(baseDelay * 2^attempt, maxDelay)`. The `wheels_jobs` table is auto-created on first enqueue/processing — no migration needed.
 
@@ -716,7 +721,7 @@ User-facing `fix`/`feat` PRs add a **fragment file**, never a direct `CHANGELOG.
 
 There is no `wheels mcp setup` command — copy the JSON above into `.mcp.json` manually (see the MCP integration guide for OpenCode/Cursor variants).
 
-Tools are auto-discovered from `cli/lucli/Module.cfc` public functions. Names in `tools/list` are the bare function names — NOT `wheels_*`-prefixed (live-verified on the released 4.0.3 CLI): `analyze`, `create`, `db`, `deploy`, `destroy`, `doctor`, `generate`, `info`, `migrate`, `notes`, `packages`, `reload`, `routes`, `seed`, `stats`, `test`, `upgrade`, `validate` (18 tools; the `wheels` server entry in `.mcp.json` namespaces them per client). CLI-only tools (`main`, `mcp`, `d`, `g`, `new`, `console`, `start`, `stop`, `browser`) are hidden via `mcpHiddenTools()`.
+Tools are auto-discovered from `cli/lucli/Module.cfc` public functions. Names in `tools/list` are the bare function names — NOT `wheels_*`-prefixed (live-verified on the released 4.0.3 CLI): `analyze`, `create`, `db`, `deploy`, `destroy`, `doctor`, `generate`, `info`, `migrate`, `notes`, `packages`, `reload`, `routes`, `seed`, `stats`, `test`, `upgrade`, `validate` (18 tools; the `wheels` server entry in `.mcp.json` namespaces them per client). CLI-only tools (`main`, `mcp`, `d`, `g`, `new`, `console`, `start`, `stop`, `browser`, `jobs`) are hidden via `mcpHiddenTools()`.
 
 **Deprecated:** the in-dev-server HTTP endpoint at `/wheels/mcp`. Emits a deprecation notice on first request. Migrate to the stdio surface.
 

--- a/changelog.d/3090-jobs-worker-cli.added.md
+++ b/changelog.d/3090-jobs-worker-cli.added.md
@@ -1,0 +1,1 @@
+- `wheels jobs work` (long-lived worker loop with `--queue`, `--interval`, `--max-jobs`, `--quiet`) and `wheels jobs status` (`--queue`, `--format=json`) CLI commands — thin wrappers over the existing `jobsProcessNext`/`jobsStatus` framework bridge that was left without a CLI surface in the LuCLI migration; the `retry`/`purge`/`monitor` verbs remain tracked follow-ups (#3090)

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -186,6 +186,7 @@ component extends="modules.BaseModule" {
 			"start",    // dev server lifecycle (stateful)
 			"stop",     // dev server lifecycle (stateful)
 			"browser",  // multi-step browser testing flow
+			"jobs",     // `jobs work` is a long-lived poll loop — no single-call MCP semantics (like start/stop)
 			"mcpToolSpecs", // per-tool inputSchema registry read by LuCLI — not itself a tool
 			// $-prefixed internal helpers. Public ONLY so TestCommandSpec can
 			// unit-test them directly (the cli/CLAUDE.md "public for specs"
@@ -313,6 +314,16 @@ component extends="modules.BaseModule" {
 			.flag(name = "nobackup", default = false, description = "apply only: skip the vendor/wheels.bak-<timestamp> backup of the existing framework");
 	}
 
+	private any function jobsArgSpec() {
+		return new services.ArgSpec()
+			.positional(name = "action", default = "status", description = "work (long-lived worker loop) or status (queue snapshot). Defaults to status")
+			.option(name = "queue", default = "", description = "work: comma-delimited queue names to process in order. status: single queue to filter by. Empty = all queues")
+			.option(name = "interval", default = 5, type = "numeric", description = "work only: seconds to wait between polls when no job is available")
+			.option(name = "max-jobs", default = 0, type = "numeric", description = "work only: stop after this many jobs (successes + failures count). 0 = run until stopped")
+			.flag(name = "quiet", default = false, description = "work only: suppress per-job completion output, only print failures")
+			.option(name = "format", default = "table", description = "status only: output format, table or json");
+	}
+
 	// ─────────────────────────────────────────────────
 	//  version / help — banner + command listing
 	// ─────────────────────────────────────────────────
@@ -431,6 +442,8 @@ component extends="modules.BaseModule" {
 		help &= "  migrate             Run database migrations (latest, up, down, info, doctor, forget, pretend, rename-system-tables)" & nl;
 		help &= "  seed                Run database seeds" & nl;
 		help &= "  db                  Database management (reset, status, version)" & nl & nl;
+		help &= "Background Jobs:" & nl;
+		help &= "  jobs                Job queue worker and stats (work, status)" & nl & nl;
 		help &= "Testing & Inspection:" & nl;
 		help &= "  test                Run the test suite" & nl;
 		help &= "  browser             Browser-based tests (Playwright)" & nl;
@@ -2828,6 +2841,270 @@ component extends="modules.BaseModule" {
 				out("Valid commands: reset, status, version");
 				throw(type = "Wheels.InvalidArguments", message = "Unknown db command: #subcommand#");
 		}
+	}
+
+	// ─────────────────────────────────────────────────
+	//  jobs — Background job worker
+	// ─────────────────────────────────────────────────
+
+	/**
+	 * Parse `wheels jobs` arguments. Public ONLY so JobsCommandSpec can
+	 * unit-test the parse/validation surface directly (the cli/CLAUDE.md
+	 * "public for specs" carve-out) — the mcpHiddenTools() structural
+	 * $-prefix sweep keeps it off the MCP surface. Validation happens here,
+	 * before any server detection, so a bad flag yields a usage error
+	 * instead of a misleading "no server" diagnostic.
+	 */
+	public struct function $parseJobsArgs(required struct coll) {
+		var parsed = jobsArgSpec().parse(arguments.coll);
+		var opts = {
+			action = lCase(trim(parsed.action)),
+			queue = trim(parsed.queue),
+			interval = parsed.interval,
+			maxJobs = parsed["max-jobs"],
+			quiet = parsed.quiet,
+			format = lCase(trim(parsed.format))
+		};
+		if (!len(opts.action)) {
+			opts.action = "status";
+		}
+		if (opts.interval <= 0) {
+			throw(
+				type = "Wheels.InvalidArguments",
+				message = "--interval must be a positive number of seconds."
+			);
+		}
+		if (opts.maxJobs < 0) {
+			throw(
+				type = "Wheels.InvalidArguments",
+				message = "--max-jobs must be zero (unlimited) or a positive number."
+			);
+		}
+		if (!listFindNoCase("table,json", opts.format)) {
+			throw(
+				type = "Wheels.InvalidArguments",
+				message = "Unknown --format '#opts.format#'. Valid formats: table, json."
+			);
+		}
+		return opts;
+	}
+
+	/**
+	 * hint: Background job queue — `work` runs a long-lived worker loop, `status` prints per-queue counts (--format=json for machines). retry/purge/monitor are tracked follow-ups (issue 3090).
+	 */
+	public string function jobs() {
+		var opts = $parseJobsArgs(structuredArgs(arguments));
+
+		switch (opts.action) {
+			case "work":
+				return runJobsWork(opts);
+			case "status":
+				return runJobsStatus(opts);
+			// The framework bridge (vendor/wheels/public/views/cli.cfm) already
+			// implements jobsRetry/jobsPurge/jobsMonitor — the CLI verbs are
+			// deliberate follow-ups tracked in ##3090. Fail loudly with the
+			// programmatic equivalent instead of pretending the verb exists.
+			case "retry":
+			case "purge":
+			case "monitor":
+				out("'wheels jobs #opts.action#' is not implemented yet (tracked in issue ##3090).", "red");
+				out("Until it ships, drive it programmatically on the running app:", "yellow");
+				out("  retry:   (new wheels.Job()).retryFailed(queue=""..."")", "yellow");
+				out("  purge:   (new wheels.Job()).purgeCompleted(days=7, queue=""..."")", "yellow");
+				out("  monitor: poll `wheels jobs status --format=json` on an interval", "yellow");
+				throw(
+					type = "Wheels.InvalidArguments",
+					message = "'wheels jobs #opts.action#' is not implemented yet — see https://github.com/wheels-dev/wheels/issues/3090"
+				);
+			default:
+				out("Unknown jobs action: #opts.action#", "red");
+				out("Usage: wheels jobs [work|status] [--queue=<names>] [--interval=<seconds>] [--max-jobs=<n>] [--quiet] [--format=table|json]");
+				throw(type = "Wheels.InvalidArguments", message = "Unknown jobs action: #opts.action#");
+		}
+	}
+
+	/**
+	 * Long-lived worker loop: poll the framework's jobsProcessNext bridge
+	 * command, which claims and runs one pending job per call (optimistic
+	 * locking — safe to run several workers in parallel). Processing jobs
+	 * mutates application data, so this is write-side: strict server
+	 * identity (##2878) and POST + reload password (SEC-4 mutation gate).
+	 */
+	private string function runJobsWork(required struct opts) {
+		var serverPort = $requireRunningServer(
+			hints = [
+				"The job worker requires a running server bound to this project.",
+				"Set 'port' in lucee.json (or PORT in .env), then start with: wheels start"
+			],
+			requireProjectConfig = true
+		);
+
+		var workUrl = "http://localhost:#serverPort#/wheels/cli?command=jobsProcessNext&format=json";
+		if (len(arguments.opts.queue)) {
+			workUrl &= "&queues=" & urlEncodedFormat(arguments.opts.queue);
+		}
+
+		out("Wheels Job Worker", "cyan");
+		out("Queues: " & (len(arguments.opts.queue) ? arguments.opts.queue : "all"));
+		out("Poll interval: #arguments.opts.interval#s");
+		if (arguments.opts.maxJobs > 0) {
+			out("Max jobs: #arguments.opts.maxJobs#");
+		}
+		out("Press Ctrl+C to stop");
+		out("");
+
+		var counters = {processed = 0, failed = 0};
+		while (true) {
+			var httpResult = "";
+			try {
+				httpResult = makeBridgePost(workUrl);
+			} catch (any httpErr) {
+				// Connection loss is fatal: the worker exits non-zero so a
+				// process supervisor (systemd, Docker restart policy) brings
+				// it back once the server is reachable again, instead of the
+				// worker spinning silently against a dead port.
+				throw(
+					type    = "Wheels.Cli.CommandFailed",
+					message = "Job worker lost its connection to the server: #httpErr.message#",
+					detail  = httpErr.detail ?: ""
+				);
+			}
+
+			// parseCliResponse throws Wheels.Cli.CommandFailed when the bridge
+			// rejects the request (e.g. the mutation gate's reload-password or
+			// loopback checks) — permanent conditions, so the worker exits
+			// non-zero instead of retrying forever.
+			var result = parseCliResponse(httpResult, "Jobs work");
+			var jobResult = structKeyExists(result, "jobResult") && isStruct(result.jobResult)
+				? result.jobResult
+				: {skipped = true};
+			var idle = jobResult.skipped ?: true;
+
+			if (idle) {
+				// Queue empty — wait for the next poll below.
+			} else if (jobResult.success ?: false) {
+				counters.processed++;
+				if (!arguments.opts.quiet) {
+					out("[#timeFormat(now(), "HH:mm:ss")#] Completed: #jobResult.jobClass# (#jobResult.jobId#)", "green");
+				}
+			} else {
+				// The job itself failed — the framework already scheduled the
+				// retry (with backoff) or marked it failed; the worker keeps
+				// draining.
+				counters.failed++;
+				var errorMessage = len(jobResult.error ?: "") ? jobResult.error : "Unknown error";
+				out("[#timeFormat(now(), "HH:mm:ss")#] Failed: #jobResult.jobClass# - #errorMessage#", "red");
+			}
+
+			if (arguments.opts.maxJobs > 0 && (counters.processed + counters.failed) >= arguments.opts.maxJobs) {
+				out("");
+				out("Reached max jobs limit (#arguments.opts.maxJobs#). Shutting down.", "green");
+				out("Processed: #counters.processed# | Failed: #counters.failed#");
+				return "";
+			}
+
+			// Only sleep when the queue was empty — back-to-back pending jobs
+			// drain immediately. Failed jobs are rescheduled with future runAt
+			// timestamps, so an immediate re-poll cannot hot-loop on them.
+			if (idle) {
+				sleep(arguments.opts.interval * 1000);
+			}
+		}
+	}
+
+	/**
+	 * One-shot queue snapshot via the read-only jobsStatus bridge command.
+	 */
+	private string function runJobsStatus(required struct opts) {
+		var serverPort = $requireRunningServer(
+			hints = ["Start one with: wheels start"]
+		);
+
+		var statusUrl = "http://localhost:#serverPort#/wheels/cli?command=jobsStatus&format=json";
+		if (len(arguments.opts.queue)) {
+			statusUrl &= "&queue=" & urlEncodedFormat(arguments.opts.queue);
+		}
+
+		var httpResult = "";
+		try {
+			httpResult = makeHttpRequest(statusUrl);
+		} catch (any httpErr) {
+			throw(
+				type    = "Wheels.Cli.CommandFailed",
+				message = "Jobs status failed (connection error): #httpErr.message#",
+				detail  = httpErr.detail ?: ""
+			);
+		}
+
+		var result = parseCliResponse(httpResult, "Jobs status");
+		var stats = structKeyExists(result, "stats") && isStruct(result.stats) ? result.stats : {};
+
+		if (arguments.opts.format == "json") {
+			out(serializeJSON(stats));
+			return "";
+		}
+
+		out("Job Queue Status", "cyan");
+		out($formatJobsStatusTable(stats));
+		return "";
+	}
+
+	/**
+	 * Render JobWorker.getStats() output ({queues: {name: counts}, totals:
+	 * counts}) as a fixed-width table. Public ONLY so JobsCommandSpec can
+	 * unit-test the rendering without a running server (the cli/CLAUDE.md
+	 * "public for specs" carve-out) — the mcpHiddenTools() structural
+	 * $-prefix sweep keeps it off the MCP surface. Defensive against partial
+	 * payloads: the input is deserialized JSON from the bridge. Queue names
+	 * are sorted — struct iteration order is not insertion order at scale.
+	 */
+	public string function $formatJobsStatusTable(required struct stats) {
+		var nl = chr(10);
+		var queues = structKeyExists(arguments.stats, "queues") && isStruct(arguments.stats.queues)
+			? arguments.stats.queues
+			: {};
+		var totals = structKeyExists(arguments.stats, "totals") && isStruct(arguments.stats.totals)
+			? arguments.stats.totals
+			: {};
+
+		if (structIsEmpty(queues)) {
+			return "No jobs found.";
+		}
+
+		var header = "| " & $padJobsColumn("Queue", 20) & " | " & $padJobsColumn("Pending", 10) & " | "
+			& $padJobsColumn("Processing", 12) & " | " & $padJobsColumn("Completed", 12) & " | "
+			& $padJobsColumn("Failed", 10) & " | " & $padJobsColumn("Total", 10) & " |";
+		var separator = repeatString("-", len(header));
+		var lines = [separator, header, separator];
+
+		var queueNames = structKeyArray(queues);
+		arraySort(queueNames, "textnocase");
+		for (var queueName in queueNames) {
+			var rowCounts = isStruct(queues[queueName]) ? queues[queueName] : {};
+			arrayAppend(lines, $jobsStatusRow(queueName, rowCounts));
+		}
+		arrayAppend(lines, separator);
+		arrayAppend(lines, $jobsStatusRow("TOTAL", totals));
+		arrayAppend(lines, separator);
+
+		return arrayToList(lines, nl);
+	}
+
+	private string function $jobsStatusRow(required string label, required struct counts) {
+		return "| " & $padJobsColumn(arguments.label, 20) & " | "
+			& $padJobsColumn(arguments.counts.pending ?: 0, 10) & " | "
+			& $padJobsColumn(arguments.counts.processing ?: 0, 12) & " | "
+			& $padJobsColumn(arguments.counts.completed ?: 0, 12) & " | "
+			& $padJobsColumn(arguments.counts.failed ?: 0, 10) & " | "
+			& $padJobsColumn(arguments.counts.total ?: 0, 10) & " |";
+	}
+
+	private string function $padJobsColumn(required any value, required numeric width) {
+		var str = toString(arguments.value);
+		if (len(str) >= arguments.width) {
+			return left(str, arguments.width);
+		}
+		return str & repeatString(" ", arguments.width - len(str));
 	}
 
 	// ─────────────────────────────────────────────────

--- a/cli/lucli/tests/specs/commands/JobsCommandSpec.cfc
+++ b/cli/lucli/tests/specs/commands/JobsCommandSpec.cfc
@@ -1,0 +1,170 @@
+/**
+ * Tests the jobs command via Module.cfc (issue #3090).
+ *
+ * `wheels jobs work|status` was advertised by the guides and root CLAUDE.md
+ * since the original CommandBox-era implementation (#1934), but the command
+ * functions were lost in the LuCLI migration while the framework half
+ * (vendor/wheels/JobWorker.cfc + the jobs* bridge cases in
+ * vendor/wheels/public/views/cli.cfm) survived. These specs cover the
+ * restored CLI surface: argument parsing, verb routing, the deterministic
+ * no-server failure mode for `work`, the status table renderer, and the
+ * MCP hidden-tools entry.
+ *
+ * Server-dependent paths (a live `jobsStatus` / `jobsProcessNext` bridge
+ * round trip) are not unit-testable here — the stateless TestBox harness has
+ * no running Wheels server (see MigrateCommandSpec / #2829) — so they are
+ * exercised against the existing bridge cases manually and by the framework
+ * suite's JobWorkerSpec.
+ */
+component extends="wheels.wheelstest.system.BaseSpec" {
+
+	function beforeAll() {
+		variables.testHelper = new cli.lucli.tests.TestHelper();
+		variables.tempRoot = testHelper.scaffoldTempProject(expandPath("/"));
+
+		// Create vendor/wheels stub
+		directoryCreate(tempRoot & "/vendor/wheels", true, true);
+
+		variables.mod = new cli.lucli.Module(cwd = variables.tempRoot);
+	}
+
+	function afterAll() {
+		testHelper.cleanupTempProject(variables.tempRoot);
+	}
+
+	function run() {
+
+		describe("$parseJobsArgs — argument parsing", () => {
+
+			it("defaults to the status action with table format", () => {
+				var opts = mod.$parseJobsArgs({});
+				expect(opts.action).toBe("status");
+				expect(opts.queue).toBe("");
+				expect(opts.interval).toBe(5);
+				expect(opts.maxJobs).toBe(0);
+				expect(opts.quiet).toBeFalse();
+				expect(opts.format).toBe("table");
+			});
+
+			it("parses work with --queue and --interval", () => {
+				var opts = mod.$parseJobsArgs({arg1 = "work", queue = "mailers", interval = "3"});
+				expect(opts.action).toBe("work");
+				expect(opts.queue).toBe("mailers");
+				expect(opts.interval).toBe(3);
+			});
+
+			it("parses --max-jobs and --quiet for work", () => {
+				var opts = mod.$parseJobsArgs({arg1 = "work", "max-jobs" = "100", quiet = "true"});
+				expect(opts.maxJobs).toBe(100);
+				expect(opts.quiet).toBeTrue();
+			});
+
+			it("parses a comma-delimited queue list", () => {
+				var opts = mod.$parseJobsArgs({arg1 = "work", queue = "critical,default,low"});
+				expect(opts.queue).toBe("critical,default,low");
+			});
+
+			it("parses status with --format=json", () => {
+				var opts = mod.$parseJobsArgs({arg1 = "status", format = "json"});
+				expect(opts.action).toBe("status");
+				expect(opts.format).toBe("json");
+			});
+
+			it("throws Wheels.InvalidArguments when --interval is zero or negative", () => {
+				expect(() => mod.$parseJobsArgs({arg1 = "work", interval = "0"})).toThrow(type = "Wheels.InvalidArguments");
+			});
+
+			it("throws Wheels.InvalidArguments when --max-jobs is negative", () => {
+				expect(() => mod.$parseJobsArgs({arg1 = "work", "max-jobs" = "-1"})).toThrow(type = "Wheels.InvalidArguments");
+			});
+
+			it("throws Wheels.InvalidArguments on an unknown --format", () => {
+				expect(() => mod.$parseJobsArgs({arg1 = "status", format = "xml"})).toThrow(type = "Wheels.InvalidArguments");
+			});
+
+		});
+
+		describe("wheels jobs — verb routing", () => {
+
+			it("throws Wheels.InvalidArguments on an unknown action", () => {
+				expect(() => mod.jobs(arg1 = "bogus")).toThrow(type = "Wheels.InvalidArguments");
+			});
+
+			it("throws Wheels.InvalidArguments for the deferred retry verb", () => {
+				expect(() => mod.jobs(arg1 = "retry")).toThrow(type = "Wheels.InvalidArguments");
+			});
+
+			it("throws Wheels.InvalidArguments for the deferred purge verb", () => {
+				expect(() => mod.jobs(arg1 = "purge")).toThrow(type = "Wheels.InvalidArguments");
+			});
+
+			it("throws Wheels.InvalidArguments for the deferred monitor verb", () => {
+				expect(() => mod.jobs(arg1 = "monitor")).toThrow(type = "Wheels.InvalidArguments");
+			});
+
+			it("work refuses to run without a project-bound server port", () => {
+				// The temp project has no lucee.json / .env port config, and
+				// `work` is write-side (processes jobs), so detectServerPort's
+				// strict mode (#2878) deterministically finds no server.
+				expect(() => mod.jobs(arg1 = "work")).toThrow(type = "Wheels.ServerNotRunning");
+			});
+
+			it("rejects invalid options before touching server detection", () => {
+				// Parse-stage validation must fire first so a bad flag yields
+				// a usage error, not a misleading "no server" diagnostic.
+				expect(() => mod.jobs(arg1 = "work", interval = "0")).toThrow(type = "Wheels.InvalidArguments");
+			});
+
+		});
+
+		describe("$formatJobsStatusTable — status rendering", () => {
+
+			it("reports no jobs for an empty stats struct", () => {
+				var rendered = mod.$formatJobsStatusTable({
+					queues = {},
+					totals = {pending = 0, processing = 0, completed = 0, failed = 0, total = 0}
+				});
+				expect(rendered).toInclude("No jobs found");
+			});
+
+			it("renders one row per queue plus a totals row", () => {
+				var rendered = mod.$formatJobsStatusTable({
+					queues = {
+						"mailers" = {pending = 3, processing = 1, completed = 10, failed = 2, total = 16},
+						"default" = {pending = 0, processing = 0, completed = 5, failed = 0, total = 5}
+					},
+					totals = {pending = 3, processing = 1, completed = 15, failed = 2, total = 21}
+				});
+				expect(rendered).toInclude("mailers");
+				expect(rendered).toInclude("default");
+				expect(rendered).toInclude("TOTAL");
+				expect(rendered).toInclude("Pending");
+				expect(rendered).toInclude("Processing");
+				expect(rendered).toInclude("Completed");
+				expect(rendered).toInclude("Failed");
+				expect(rendered).toInclude("21");
+			});
+
+			it("tolerates a stats struct with missing keys", () => {
+				// The bridge response is deserialized JSON — defend against a
+				// partial payload instead of throwing mid-render.
+				var rendered = mod.$formatJobsStatusTable({});
+				expect(rendered).toInclude("No jobs found");
+			});
+
+		});
+
+		describe("MCP surface", () => {
+
+			it("hides the jobs command from MCP tools/list", () => {
+				// `jobs work` is a long-lived poll loop — it doesn't translate
+				// to single-call MCP semantics (same reasoning as start/stop).
+				var hidden = mod.mcpHiddenTools();
+				expect(arrayFindNoCase(hidden, "jobs")).toBeGT(0);
+			});
+
+		});
+
+	}
+
+}

--- a/web/sites/guides/src/content/docs/v4-0-0/deployment/observability-and-logging.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/deployment/observability-and-logging.mdx
@@ -330,7 +330,7 @@ A small set of signals covers almost every production incident a Wheels app will
 
 - **5xx rate** — from the reverse proxy access log or the APM agent. Alert when the ratio of 5xx responses crosses a threshold (1% over five minutes is a reasonable starting point).
 - **Response time p95** — the tail, not the average. A p95 creeping from 200 ms to 1.5 s signals a problem before the average moves.
-- **Job queue depth** — `(new wheels.Job()).queueStats()` reports pending, processing, and failed counts per queue; expose it from a (protected) controller action or a scheduled task that pushes the numbers to your metrics pipeline. Alert on pending counts that don't drain or failed counts that grow. (There is no `wheels jobs status` CLI command — a worker CLI is tracked in [#3090](https://github.com/wheels-dev/wheels/issues/3090).)
+- **Job queue depth** — `wheels jobs status --format=json` reports pending, processing, and failed counts per queue (scrape it from cron or a textfile exporter); the same numbers are available in-app via `(new wheels.Job()).queueStats()` from a (protected) controller action. Alert on pending counts that don't drain or failed counts that grow.
 - **Database connection pool saturation** — engine-specific metric. Lucee exposes datasource stats; Adobe does too. A pool pinned at its ceiling means requests are queuing to talk to the database.
 - **Health check failing** — your load balancer's view of app reachability. One pod occasionally failing is noise; all pods failing is an outage.
 - **Sentry error rate** — alert when the rate of captured exceptions for a release exceeds a baseline, or when a new error fingerprint appears post-deploy.

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/background-jobs.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/background-jobs.mdx
@@ -8,13 +8,13 @@ sidebar:
 
 import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-This page shows you how to move slow work out of the request cycle. You'll define a job class, enqueue it from a controller, drain the queue with `processQueue()` on a schedule, configure retries with exponential backoff, and route urgent work through a high-priority queue.
+This page shows you how to move slow work out of the request cycle. You'll define a job class, enqueue it from a controller, drain the queue with the `wheels jobs work` worker (or `processQueue()` on a schedule), configure retries with exponential backoff, and route urgent work through a high-priority queue.
 
 **You'll learn:**
 
 - How to define a job by extending `wheels.Job` and implementing `perform()`
 - How to enqueue jobs immediately, after a delay, or at a specific time
-- How to drain queues with `processQueue()` from a scheduled task or cron-driven script
+- How to drain queues with the `wheels jobs work` worker, or `processQueue()` from a scheduled task
 - How retries and backoff work, and how to tune them
 - How priority queues let critical work jump the line
 - How to monitor, retry, and purge jobs in production
@@ -88,11 +88,31 @@ component extends="Controller" {
 
 ## Process the queue
 
-<Aside type="caution">
-  **There is no `wheels jobs` CLI yet.** Earlier 4.0 docs described `wheels jobs work|status|retry|monitor|purge` commands, but the released CLI has no `jobs` command — invoking one errors. A worker CLI is tracked in [#3090](https://github.com/wheels-dev/wheels/issues/3090). Until it ships, drive the queue with the programmatic API on `wheels.Job`, shown below.
+The simplest way to drain the queue is the bundled worker — a long-lived CLI process that polls the `wheels_jobs` table, claims one `pending` job per cycle, and runs it. It talks to your running app server, so start that first (`wheels start`):
+
+```bash title="your shell"
+wheels jobs work                               # process all queues; loops until Ctrl-C
+wheels jobs work --queue=mailers               # only drain the mailers queue
+wheels jobs work --queue=mailers --interval=3  # poll every 3 seconds when idle (default 5)
+wheels jobs work --max-jobs=100                # stop after 100 jobs — one-shot batches from cron or CI
+wheels jobs work --quiet                       # suppress per-job output; failures still print
+```
+
+In production, run the worker under a process supervisor (systemd, Docker's restart policy, Kamal accessory containers): when it loses the server it exits non-zero and the supervisor restarts it. Run several workers for parallelism — the framework uses optimistic row locking, so two workers never run the same job twice. `--queue` accepts a comma-delimited list (`--queue=critical,default`); jobs across the listed queues run in `priority DESC, runAt ASC` order.
+
+Check queue health without tailing logs:
+
+```bash title="your shell"
+wheels jobs status                  # per-queue pending / processing / completed / failed table
+wheels jobs status --queue=mailers  # one queue only
+wheels jobs status --format=json    # machine-readable, for CI smoke tests or metric scrapes
+```
+
+<Aside type="note">
+  The `retry`, `purge`, and `monitor` verbs are tracked follow-ups in [#3090](https://github.com/wheels-dev/wheels/issues/3090) — invoking one errors and points you at the programmatic equivalent (`retryFailed()` / `purgeCompleted()`, shown below).
 </Aside>
 
-Processing is a poll: `processQueue()` picks up every `pending` job whose `runAt` has arrived, runs each one, and returns counts. Call it from anything that runs on a schedule — a CFML scheduled task, a cron-invoked script, or a controller action behind an admin route that your scheduler hits:
+You don't need a separate worker process, though. Processing is a poll: `processQueue()` picks up every `pending` job whose `runAt` has arrived, runs each one, and returns counts. Call it from anything that runs on a schedule — a CFML scheduled task, a cron-invoked script, or a controller action behind an admin route that your scheduler hits:
 
 ```cfm {test:compile} title="app/controllers/admin/Jobs.cfc (fragment)"
 component extends="Controller" {
@@ -190,7 +210,7 @@ Per-job `priority` is the finer instrument; queue-based separation is simpler to
 
 ## Monitoring in production
 
-There's no dashboard yet — it lands with the worker CLI tracked in [#3090](https://github.com/wheels-dev/wheels/issues/3090). The building block that exists today is `queueStats()`. Expose it from a small admin endpoint and point whatever you already use — Prometheus, Datadog, a custom scrape — at the JSON:
+For headless metrics, scrape `wheels jobs status --format=json` from a cron job or a Prometheus textfile exporter. (An interactive `wheels jobs monitor` dashboard is a tracked follow-up in [#3090](https://github.com/wheels-dev/wheels/issues/3090).) The same numbers are available in-app via `queueStats()` — expose it from a small admin endpoint and point whatever you already use — Prometheus, Datadog, a custom scrape — at the JSON:
 
 ```cfm {test:compile} title="app/controllers/admin/Jobs.cfc (fragment)"
 component extends="Controller" {

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/why-wheels.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/why-wheels.mdx
@@ -43,7 +43,7 @@ Closest conceptual neighbor. Both descended from the same Rails-era design.
 | View layer | ERB / Haml / etc. | `.cfm` templates (inline expressions via `#...#`) |
 | Hotwire | Bundled (Turbo Drive / Frames / Streams) | Via `wheels-hotwire` package (opt-in activation) |
 | Testing | Minitest / RSpec | WheelsTest (BDD, `describe`/`it`) |
-| Jobs | Active Job + Sidekiq/etc. | Built-in DB-backed job queue (`wheels.Job` / `processQueue()`); worker CLI tracked in [#3090](https://github.com/wheels-dev/wheels/issues/3090) |
+| Jobs | Active Job + Sidekiq/etc. | Built-in DB-backed job queue (`wheels jobs work` worker) |
 
 If you know Rails, the tutorial will feel familiar in pacing and idioms. The differences that bite most often:
 


### PR DESCRIPTION
## Summary

`wheels jobs work|status|retry|purge|monitor` had been advertised since the original CommandBox-era implementation ([#1934](https://github.com/wheels-dev/wheels/pull/1934), commit `631372f5c`), but the command files (`cli/src/commands/wheels/jobs/*.cfc`) were **lost in the LuCLI migration** while the framework half survived intact — `vendor/wheels/JobWorker.cfc` and the `jobsProcessNext`/`jobsStatus`/`jobsRetry`/`jobsPurge`/`jobsMonitor` bridge cases in `vendor/wheels/public/views/cli.cfm` (including the SEC-4 mutation-gate wiring for the write-side commands). Result: every copy-pasted invocation errored with `Component [modules.wheels.Module] has no function with name [jobs]`.

This restores the two core verbs as thin wrappers over the existing bridge, per the triage/research recommendation on #3090:

- **`wheels jobs work [--queue=<names>] [--interval=<s>] [--max-jobs=<n>] [--quiet]`** — long-lived worker loop over `jobsProcessNext` (one claimed job per poll; optimistic locking makes parallel workers safe). Write-side semantics match `wheels migrate`: strict project-bound server identity (#2878) + POST with the reload password (SEC-4 gate). Connection loss or a gate rejection exits non-zero so a supervisor restarts it — no silent spinning. Back-to-back pending jobs drain without sleeping; failed jobs are rescheduled with future `runAt` by the framework, so an immediate re-poll cannot hot-loop.
- **`wheels jobs status [--queue=<name>] [--format=table|json]`** — read-only snapshot over `jobsStatus`, rendered as a fixed-width per-queue table (queue names sorted — struct iteration order is not stable) or raw JSON for scraping.

Deliberately deferred (tracked as follow-ups on #3090): `retry`, `purge`, `monitor`. Invoking one fails loudly (non-zero exit) with the programmatic equivalent (`(new wheels.Job()).retryFailed()` / `.purgeCompleted()`), instead of pretending the verb exists.

Also:
- `jobs` added to `mcpHiddenTools()` — the `work` loop has no single-call MCP semantics (same reasoning as `start`/`stop`).
- ArgSpec-based parsing (`jobsArgSpec()` + `$parseJobsArgs()`); validation (`--interval > 0`, `--max-jobs >= 0`, `--format ∈ table,json`) fires **before** server detection so a bad flag yields a usage error, not a misleading "no server" diagnostic.
- `wheels help` lists the command; `wheels jobs --help` resolves via the hint convention.
- Docs re-advertise exactly the shipped surface: root `CLAUDE.md` worker block (was "none yet"), `background-jobs.mdx` (worker + status sections restored, deferred verbs noted), `observability-and-logging.mdx` alerting bullet, `why-wheels.mdx` comparison row. The `glossary.mdx` / `docker-deployment.mdx` mentions of `wheels jobs work` become true with this PR.
- `changelog.d/3090-jobs-worker-cli.added.md` fragment.

## Evidence

**CLI suite (Docker lucee7 harness, `/wheels/cli/tests?format=json`):**

| Run | Pass | Fail | Error | Skip |
|---|---|---|---|---|
| baseline (origin/develop) | 926 | 1 | 2 | 60 |
| with this PR | **944** (+18 = the new `JobsCommandSpec`) | 1 | 2 | 60 |

The 3 non-green bundles (`deploy.lib.SshClientSpec`, `deploy.lib.SshPoolSpec`, `integration.ServerCommandsSpec`'s "reload endpoint responds") are identical in the baseline run — pre-existing container-harness artifacts, untouched by this change. All 18 new `JobsCommandSpec` specs pass (parse/validation, verb routing incl. deferred-verb errors, no-server `Wheels.ServerNotRunning` for `work`, table rendering, MCP hidden entry).

**End-to-end (worktree CLI module via isolated `LUCLI_HOME` against the running lucee7 container):**

```
$ wheels jobs status            # empty queue
Job Queue Status
No jobs found.                  → exit 0

# enqueue ProbeJob via /wheels/console/eval, then:
$ wheels jobs status
| Queue   | Pending | Processing | Completed | Failed | Total |
| default | 1       | 0          | 0         | 0      | 1     |
| TOTAL   | 1       | 0          | 0         | 0      | 1     |

# jobsProcessNext bridge (loopback POST + password) drains it:
{"success":true,"message":"Processed job 1744E459-...","jobResult":{"SUCCESS":true,"SKIPPED":false,...}}

$ wheels jobs status --format=json
{"QUEUES":{"default":{"FAILED":0,"COMPLETED":1,"PENDING":0,"TOTAL":1,"PROCESSING":0}},"TOTALS":{...}}

$ wheels jobs retry             → exit 1, prints programmatic equivalent + issue link
$ wheels jobs bogus             → exit 1, usage
$ wheels jobs work --interval=0 → exit 1, validation error
$ wheels jobs work --max-jobs=1 # from the HOST against the container
  → banner prints, then exits 1 with "State-changing CLI commands are restricted to localhost."
```

That last case is the docker harness's host→container boundary tripping the SEC-4 loopback check — exactly the fail-fast behavior we want from the worker on a gate rejection; on a real install the CLI and server share a machine and the request is loopback (same as `wheels migrate latest`, which uses the identical `makeBridgePost` path).

Fixes #3090

🤖 Generated with [Claude Code](https://claude.com/claude-code)
