### PR TITLE
docs(web/guides): purge retain_containers and the single-divergence claim from deploy guides

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/prune/all.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/prune/all.mdx
@@ -7,18 +7,19 @@ sidebar:
   order: 1
 ---
 
-Prune old containers and old images on every host, respecting `retain_containers:`.
+Prune old containers and old images on every host, keeping the most recent stopped containers per host (`--keep=<n>`, default 5).
 
 ## Synopsis
 
 ``` title="Synopsis"
-wheels deploy prune all [--destination=<name>] [--dry-run]
+wheels deploy prune all [--keep=<n>] [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
+| `--keep=<n>` | How many old (stopped) containers to keep per host. Default 5. There is no `deploy.yml` equivalent — Kamal's `retain_containers:` is rejected by the config validator. |
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print the commands without executing. |
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/prune/containers.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/prune/containers.mdx
@@ -7,18 +7,19 @@ sidebar:
   order: 3
 ---
 
-Prune old containers beyond `retain_containers:` on every host. The current live container and everything in the retention window survives.
+Prune old containers beyond the retention window (`--keep=<n>`, default 5) on every host. The current live container and everything in the retention window survives.
 
 ## Synopsis
 
 ``` title="synopsis"
-wheels deploy prune containers [--destination=<name>] [--dry-run]
+wheels deploy prune containers [--keep=<n>] [--destination=<name>] [--dry-run]
 ```
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
+| `--keep=<n>` | How many old (stopped) containers to keep per host. Default 5. There is no `deploy.yml` equivalent — Kamal's `retain_containers:` is rejected by the config validator. |
 | `--destination=<name>` | Overlay destination config. |
 | `--dry-run` | Print the commands without executing. |
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/prune/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/prune/index.mdx
@@ -19,7 +19,7 @@ Disk cleanup. Three verbs with increasing scope.
 
 ## Retention policy
 
-`retain_containers:` in `deploy.yml` (default 5) controls how many old containers per host are kept. Prune verbs never touch the current live container or anything within the retention window. Older items are fair game.
+The `--keep=<n>` flag on `prune all` and `prune containers` controls how many old containers per host are kept (default 5). There is no `deploy.yml` key for this — Kamal's `retain_containers:` is rejected by the config validator (`unknown top-level key`); pass `--keep` on the command line instead. Prune verbs never touch the current live container or anything within the retention window. Older items are fair game.
 
 ## When to prune
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/rollback.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/rollback.mdx
@@ -29,7 +29,7 @@ Omitting the version throws `DeployMainCli.MissingVersion`.
 
 For each role, for each host in sequence: `docker start <service>-<role>-<version>`, then `kamal-proxy deploy` to route fresh traffic to the resurrected container.
 
-Success requires the target containers to still exist on each host. `retain_containers:` in `deploy.yml` (default 5) controls how many old ones are kept; `wheels deploy prune` removes older ones. If a target container has been pruned, the `docker start` step fails — re-deploy from that sha instead.
+Success requires the target containers to still exist on each host. [`wheels deploy prune`](/v4-0-0/command-line-tools/commands/deploy/prune/) removes old containers, keeping the 5 most recent per host unless you pass `--keep=<n>` on the prune command line (there is no `deploy.yml` key for this — Kamal's `retain_containers:` is rejected by the config validator). If a target container has been pruned, the `docker start` step fails — re-deploy from that sha instead.
 
 ## Examples
 

--- a/web/sites/guides/src/content/docs/v4-0-0/deployment/architecture.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/deployment/architecture.mdx
@@ -14,7 +14,7 @@ This page is for readers who want to understand how `wheels deploy` is put toget
 
 - Why `wheels deploy` is a port of [Basecamp's Kamal](https://kamal-deploy.org/) rather than a new tool
 - The byte-compatibility contract that makes a Kamal-managed server takeoverable by `wheels deploy` without cleanup
-- The one deliberate divergence from Kamal's config schema (ERB removed; `${VAR}` interpolation kept unchanged) and why
+- The deliberate divergences from Kamal's config schema (ERB removed, unimplemented top-level keys rejected; `${VAR}` interpolation kept unchanged) and why
 - The commands-are-strings invariant that makes `--dry-run` trivial and lets the test suite run offline
 - How the three third-party JARs load in isolation so they don't collide with the rest of the JVM
 
@@ -63,9 +63,9 @@ If you have a working Ruby Kamal setup, you can run `wheels deploy config` again
 
 See [Migrating from Kamal](/v4-0-0/deployment/migrating-from-kamal/) for the complete switch-over checklist.
 
-## The one divergence: ERB removed
+## The big divergence: ERB removed
 
-`config/deploy.yml` does not support ERB. This is the only schema-level incompatibility with Ruby Kamal, and it's deliberate.
+`config/deploy.yml` does not support ERB. This is the main schema-level incompatibility with Ruby Kamal, and it's deliberate. (The other is that Kamal top-level keys the port hasn't implemented — `boot`, `logging`, `retain_containers`, … — are [rejected by the validator](/v4-0-0/deployment/config-reference/#rejected-kamal-keys) instead of silently ignored.)
 
 Ruby Kamal allows ERB inside `deploy.yml`:
 

--- a/web/sites/guides/src/content/docs/v4-0-0/deployment/config-reference.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/deployment/config-reference.mdx
@@ -289,7 +289,7 @@ Only uppercase-and-underscore tokens are expanded — `${APP_NAME}` matches; low
 No loops, conditionals, or method calls. If you need logic (e.g. different values per destination), resolve it in `.kamal/secrets` or a `.kamal/secrets.<destination>` overlay first and reference the result with `${VAR}`.
 
 <Aside type="caution" title="No ERB">
-Ruby Kamal supports `<%= ... %>` ERB inside `deploy.yml`. Wheels does not — rendering ERB would require embedding a Ruby runtime in the CFML CLI. This is the single schema divergence. Most ERB-using configs convert mechanically by replacing `<%= ENV["X"] %>` with `${X}`. See [Migrating from Kamal](/v4-0-0/deployment/migrating-from-kamal/) for the full conversion patterns.
+Ruby Kamal supports `<%= ... %>` ERB inside `deploy.yml`. Wheels does not — rendering ERB would require embedding a Ruby runtime in the CFML CLI. This and the [rejected top-level keys](#rejected-kamal-keys) above are the two schema divergences from Kamal. Most ERB-using configs convert mechanically by replacing `<%= ENV["X"] %>` with `${X}`. See [Migrating from Kamal](/v4-0-0/deployment/migrating-from-kamal/) for the full conversion patterns.
 </Aside>
 
 ## Destination overlays

--- a/web/sites/guides/src/content/docs/v4-0-0/deployment/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/deployment/index.mdx
@@ -23,7 +23,7 @@ A Wheels app in production is a Java webapp running on a CFML engine. That one f
 
 The port is byte-compatible with Ruby Kamal on the server side. Container names, labels, Docker network, lock-file paths, and the `.kamal/` directory layout all match exactly — a host managed by Ruby Kamal can be taken over by `wheels deploy` during evaluation, and vice versa. You don't need Ruby, a gem install, or a second CLI. The mirrored Kamal version is 2.4.0; the `kamal-proxy` image is pinned at v0.8.6.
 
-There is exactly one deliberate schema divergence: `deploy.yml` does not support ERB. Where Ruby Kamal writes `<%= ENV["APP_NAME"] %>`, Wheels writes `${APP_NAME}` — the same `${VAR}` env-var interpolation Kamal supports natively. Everything else is identical. See [Migrating from Kamal](/v4-0-0/deployment/migrating-from-kamal/) for the full story.
+There are two deliberate schema divergences. `deploy.yml` does not support ERB — where Ruby Kamal writes `<%= ENV["APP_NAME"] %>`, Wheels writes `${APP_NAME}`, the same `${VAR}` env-var interpolation Kamal supports natively. And Kamal top-level keys the port hasn't implemented (`boot`, `logging`, `retain_containers`, …) are [rejected by the validator](/v4-0-0/deployment/config-reference/#rejected-kamal-keys) rather than silently ignored. See [Migrating from Kamal](/v4-0-0/deployment/migrating-from-kamal/) for the full story.
 
 ## When to reach for `wheels deploy`
 
@@ -109,7 +109,7 @@ The framework is narrow about production. Wheels gives you a CFML app that boots
   <LinkCard
     title="Migrating from Kamal"
     href="/v4-0-0/deployment/migrating-from-kamal/"
-    description="For teams coming from Ruby Kamal — what's compatible, what's not, and the one schema divergence."
+    description="For teams coming from Ruby Kamal — what's compatible, what's not, and the two schema divergences."
   />
   <LinkCard
     title="Production Configuration"

--- a/web/sites/guides/src/content/docs/v4-0-0/deployment/migrating-from-kamal.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/deployment/migrating-from-kamal.mdx
@@ -1,6 +1,6 @@
 ---
 title: Migrating from Kamal
-description: For teams coming from Ruby Kamal — what wheels deploy inherits verbatim, the one deliberate schema divergence, and a concrete switch-over checklist.
+description: For teams coming from Ruby Kamal — what wheels deploy inherits verbatim, the two schema divergences (ERB and the rejected top-level keys), and a concrete switch-over checklist.
 type: howto
 sidebar:
   order: 12
@@ -8,17 +8,21 @@ sidebar:
 
 import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-This page is for teams already running Ruby Kamal who want to replace `kamal` with `wheels deploy`. The short version: your `config/deploy.yml`, `.kamal/secrets`, and `.kamal/hooks/*` largely work unchanged, with one schema exception — ERB inside `deploy.yml` — and one Phase 1 functional gap: `env.secret` delivery to containers is not implemented yet ([#2956](https://github.com/wheels-dev/wheels/issues/2956)/[#2957](https://github.com/wheels-dev/wheels/issues/2957)), so configs that rely on it aren't ready to migrate. Keep reading for the full story.
+This page is for teams already running Ruby Kamal who want to replace `kamal` with `wheels deploy`. The short version: your `.kamal/secrets` and `.kamal/hooks/*` work unchanged, and `config/deploy.yml` largely does too, with two schema exceptions — ERB inside `deploy.yml`, and a set of Kamal top-level keys the validator rejects because the port doesn't implement them — and one Phase 1 functional gap: `env.secret` delivery to containers is not implemented yet ([#2956](https://github.com/wheels-dev/wheels/issues/2956)/[#2957](https://github.com/wheels-dev/wheels/issues/2957)), so configs that rely on it aren't ready to migrate. Keep reading for the full story.
 
 **You'll learn:**
 
 - What `wheels deploy` keeps byte-compatible with Ruby Kamal
-- The one deliberate schema divergence — ERB removed; Kamal's `${VAR}` interpolation kept unchanged
+- The two deliberate schema divergences — ERB removed (Kamal's `${VAR}` interpolation kept unchanged), and unimplemented Kamal top-level keys rejected instead of silently ignored
 - The coexistence guarantee — running both tools against the same host during evaluation
 - A concrete switch-over checklist
 
 <Aside type="caution" title="ERB is not supported">
-`deploy.yml` in Ruby Kamal supports embedded ERB. `wheels deploy` does not. This is the only schema-level incompatibility. If you use ERB anywhere in your deploy config, you will need to convert it to `${VAR}` env-var interpolation (which Kamal already supports too) or move the logic into `.kamal/secrets`. See [The one divergence](#the-one-divergence) below.
+`deploy.yml` in Ruby Kamal supports embedded ERB. `wheels deploy` does not. If you use ERB anywhere in your deploy config, you will need to convert it to `${VAR}` env-var interpolation (which Kamal already supports too) or move the logic into `.kamal/secrets`. See [Divergence 1: ERB removed](#divergence-1-erb-removed) below.
+</Aside>
+
+<Aside type="caution" title="Unimplemented Kamal keys are rejected">
+The validator only accepts the top-level keys `wheels deploy` actually implements: `service`, `image`, `servers`, `registry`, `builder`, `env`, `ssh`, `proxy`, `accessories`. Kamal keys the port doesn't implement yet — `boot`, top-level `healthcheck`, `hooks`, `volumes`, `labels`, `logging`, `retain_containers`, `minimum_version`, `asset_path`, `require_destination`, `allow_empty_roles`, `run_directory`, `readiness_delay` — make every command fail with `unknown top-level key: '<name>'`. A typical Kamal config needs those keys deleted (or `healthcheck` moved under `proxy:`) before it loads. See [Divergence 2: rejected top-level keys](#divergence-2-rejected-top-level-keys) below.
 </Aside>
 
 ## What's byte-compatible
@@ -42,7 +46,7 @@ Why keep the `KAMAL_*` prefix? Because every hook anyone has ever written for Ru
 
 Why keep the `.kamal/` directory name? Because you can sit on both tools during evaluation — `kamal deploy` and `wheels deploy` read the same secrets and the same hooks. Switch back and forth freely; nothing on the server changes.
 
-## The one divergence
+## Divergence 1: ERB removed
 
 Ruby Kamal allows ERB inside `deploy.yml`:
 
@@ -79,6 +83,21 @@ If your existing config uses ERB logic — `<%= "blue" if ENV["ROLE"] == "stagin
 | `<%= ENV.fetch("FOO", "bar") %>` | `${FOO}` — set `FOO=bar` in `.kamal/secrets` for the default |
 | `<%= `git rev-parse --short HEAD`.chomp %>` | pass `--release=$(git rev-parse --short HEAD)` on the CLI, or set `VERSION` in `.kamal/secrets` and use `${VERSION}` |
 | `<%= ENV["STAGE"] == "prod" ? 1 : 0 %>` | set the resolved value in `.kamal/secrets.production` or `.kamal/secrets.staging` — destination overlays replace in-file logic |
+
+## Divergence 2: rejected top-level keys
+
+Kamal accepts a number of top-level `deploy.yml` keys that `wheels deploy` has not implemented. Rather than accepting them and silently doing nothing, the validator **rejects** them — any unimplemented key makes every command fail with `unknown top-level key: '<name>'` ([#3088](https://github.com/wheels-dev/wheels/issues/3088)).
+
+The accepted top-level keys are `service`, `image`, `servers`, `registry`, `builder`, `env`, `ssh`, `proxy`, and `accessories`. Everything else must come out of the file before it loads, including:
+
+- `boot` — hosts always deploy one at a time, sequentially ([#2957](https://github.com/wheels-dev/wheels/issues/2957))
+- top-level `healthcheck` — move it under `proxy.healthcheck:` instead
+- `hooks` — the hooks *feature* works (scripts are always loaded from `.kamal/hooks/`); only the path-override key is rejected
+- `volumes`, `labels`, `logging` — no app-container mounts, extra labels, or logging flags are emitted
+- `retain_containers` — pass `--keep=<n>` to [`wheels deploy prune`](/v4-0-0/command-line-tools/commands/deploy/prune/) instead (default keeps the 5 most recent)
+- `minimum_version`, `asset_path`, `require_destination`, `allow_empty_roles`, `run_directory`, `readiness_delay`
+
+See the [Rejected Kamal keys](/v4-0-0/deployment/config-reference/#rejected-kamal-keys) table in the config reference for what each key does in Kamal and the `wheels deploy` behavior you get instead.
 
 ## What changes in the CLI
 
@@ -117,13 +136,14 @@ This exists for evaluation, not long-term mixed use. Pick a tool per repo and st
 Before removing `kamal` from your ecosystem:
 
 1. **Scan `deploy.yml` for ERB.** `grep -n '<%' config/deploy.yml`. Every match needs conversion.
-2. **Review `.kamal/secrets` for shell compatibility.** `wheels deploy` evaluates the file through `bash`; if you relied on `sh`-only behavior, nothing changes, but confirm.
-3. **Install the Wheels CLI on every control machine that runs deploys.** See [installing the CLI](/v4-0-0/command-line-tools/installation/).
-4. **Run `wheels deploy config` and diff against `kamal config`.** Every field wheels emits should match kamal's. The reverse isn't true — wheels emits a subset during Phase 1.
-5. **Run `wheels deploy --dry-run`.** Every command it would run, printed with host prefixes. Confirm it matches what you expect.
-6. **Deploy a non-critical environment first.** Staging before production. Verify logs, health checks, rollback.
-7. **Update CI.** Replace any `bundle exec kamal ...` or `gem install kamal` lines with your Wheels CLI install command plus `wheels deploy ...`.
-8. **Remove `Gemfile` / `Gemfile.lock` Kamal entries.** Only after at least one successful production deploy with `wheels deploy`.
+2. **Remove rejected top-level keys.** Delete any key outside the accepted list (or move `healthcheck` under `proxy:`) — see [Divergence 2](#divergence-2-rejected-top-level-keys). `wheels deploy config` fails loudly on the first offender, so it doubles as the checker.
+3. **Review `.kamal/secrets` for shell compatibility.** `wheels deploy` evaluates the file through `bash`; if you relied on `sh`-only behavior, nothing changes, but confirm.
+4. **Install the Wheels CLI on every control machine that runs deploys.** See [installing the CLI](/v4-0-0/command-line-tools/installation/).
+5. **Run `wheels deploy config` and diff against `kamal config`.** Every field wheels emits should match kamal's. The reverse isn't true — wheels emits a subset during Phase 1.
+6. **Run `wheels deploy --dry-run`.** Every command it would run, printed with host prefixes. Confirm it matches what you expect.
+7. **Deploy a non-critical environment first.** Staging before production. Verify logs, health checks, rollback.
+8. **Update CI.** Replace any `bundle exec kamal ...` or `gem install kamal` lines with your Wheels CLI install command plus `wheels deploy ...`.
+9. **Remove `Gemfile` / `Gemfile.lock` Kamal entries.** Only after at least one successful production deploy with `wheels deploy`.
 
 ## What's explicitly not supported
 


### PR DESCRIPTION
Follow-up to #3144 (merged before this review pass could push). Two review findings on that PR were verified real and are fixed here:

## Finding 1 — four guide pages still taught `retain_containers:`

`rollback.mdx` and the three `prune` pages presented `retain_containers:` in `deploy.yml` as the working retention control. After #3144's allowlist trim, adding that key makes **every** deploy command fail with `unknown top-level key: 'retain_containers'` — the docs were instructing users to brick their config (issue #3088 acceptance (c)).

Fixed by rewording all four references to the real control — the `--keep=<n>` flag on `wheels deploy prune all|containers` (default 5; verified against `PruneCommands.cfc` / `DeployPruneCli.cfc` / `DeployArgsParser.cfc`) — and documenting `--keep=<n>` in the synopsis and flags table of both prune verb pages, where it was previously missing entirely.

## Finding 2 — "one schema exception" claim now false

`migrating-from-kamal.mdx` claimed a Ruby Kamal config works "with one schema exception — ERB", while #3144's validator hard-rejects 13 common Kamal top-level keys (`boot`, `logging`, `volumes`, `labels`, top-level `healthcheck`, `retain_containers`, `hooks`, …). #3144's own config-reference aside directs readers to this page for those keys, which said nothing about them.

Fixed by:
- New **"Divergence 2: rejected top-level keys"** section (accepted allowlist, rejected keys with per-key migration hints, link to the config-reference table) plus a matching intro `<Aside>`.
- Renamed "The one divergence" → "Divergence 1: ERB removed" and updated the in-page anchor (no external links referenced the old anchor).
- New switch-over checklist step 2: remove rejected keys (`wheels deploy config` fails loudly on the first offender, so it doubles as the checker); subsequent steps renumbered.
- Aligned the same now-false "exactly one / only / single schema divergence" wording in `deployment/index.mdx` (intro + LinkCard), `deployment/architecture.mdx` (heading + You'll-learn bullet), and `deployment/config-reference.mdx` (No-ERB aside).

## Verification

- Docs-only change (8 `.mdx` files, no code).
- Guides site builds clean on this branch: `pnpm --filter @wheels-dev/site-guides build` → 433 pages.
- New heading anchors (`#divergence-1-erb-removed`, `#divergence-2-rejected-top-level-keys`) and the `#rejected-kamal-keys` cross-page target verified present in the built HTML.
- `grep` sweep confirms zero remaining `retain_containers`-as-config or single-divergence claims under `v4-0-0/deployment/` and `v4-0-0/command-line-tools/`.

Housekeeping note: pushing the review fix to the original branch resurrected `peter/issue-3086-3088-deploy-validator` (it had been auto-deleted on merge). It can be deleted again; this PR carries the same commit cherry-picked onto develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)