### PR TITLE
perf(dispatch): construct request-start Plugins only inside the mixins guard

### DIFF
--- a/changelog.d/request-start-plugins-guard-hoist.performance.md
+++ b/changelog.d/request-start-plugins-guard-hoist.performance.md
@@ -1,0 +1,1 @@
+- Mixin-free apps no longer pay a throwaway `wheels.Plugins` (plus its `wheels.Global` pseudo-constructor) instantiation on every request: `$runOnRequestStart` now constructs the instance only inside the `!StructIsEmpty(application.wheels.mixins)` guard where it is used (issue [#2897](https://github.com/wheels-dev/wheels/issues/2897), Stage 3 quick win).

--- a/vendor/wheels/events/EventMethods.cfc
+++ b/vendor/wheels/events/EventMethods.cfc
@@ -170,7 +170,6 @@ component extends="wheels.Global" implements="wheels.interfaces.events.EventHand
 			StructDelete(request.wheels, "redirectAfterReloadUrl");
 			$location(url = local.redirectAfterReloadUrl, addToken = false);
 		}
-		local.Mixins = new wheels.Plugins();
 		// If the first debug point has not already been set in a reload request we set it here.
 		if (application.wheels.showDebugInformation) {
 			if (StructKeyExists(request.wheels, "execution")) {
@@ -231,7 +230,11 @@ component extends="wheels.Global" implements="wheels.interfaces.events.EventHand
 		}
 
 		// Inject methods from plugins and packages directly to Application.cfc.
+		// The Plugins instance is constructed inside the guard on purpose: each
+		// construction also pays the wheels.Global pseudo-constructor, so
+		// mixin-free apps skip it entirely (issue #2897, Stage 3).
 		if (!StructIsEmpty(application.wheels.mixins)) {
+			local.Mixins = new wheels.Plugins();
 			$engineAdapter().prepareDIComplete(variables, this);
 			local.Mixins.$initializeMixins(variables);
 		}

--- a/vendor/wheels/tests/specs/events/RequestStartPluginsConstructionSpec.cfc
+++ b/vendor/wheels/tests/specs/events/RequestStartPluginsConstructionSpec.cfc
@@ -1,0 +1,129 @@
+/**
+ * Structural guard for issue ##2897 (Stage 3 quick win, PR A).
+ *
+ * EventMethods.cfc##$runOnRequestStart used to construct
+ * `local.Mixins = new wheels.Plugins()` unconditionally at the top of every
+ * request even though the instance is only ever used inside the
+ * `!StructIsEmpty(application.wheels.mixins)` guard. For mixin-free apps the
+ * construction was 100% wasted work — and not cheap: each `new wheels.Plugins()`
+ * also runs the 4,000+ line `wheels.Global` pseudo-constructor, including the
+ * `$promoteIncludedGlobalsToThis()` isCustomFunction scan over ~200 inherited
+ * UDFs. The fix hoists the construction inside the mixins-nonempty guard, so
+ * mixin-free requests skip it entirely.
+ *
+ * Why this gate is structural (honest design note): the construction site has
+ * no injection seam — `new wheels.Plugins()` is a direct constructor call and
+ * `wheels.Plugins` keeps no instance counter — and executing
+ * $runOnRequestStart inside a spec drags in the full request lifecycle (debug
+ * points, cgi copying, plugin reloads, maintenance handling) without making
+ * the construction observable anyway. So, like security/BareCfabortGuardSpec
+ * and events/OnAppStartBareHelperGuardSpec, the practical gate is a
+ * line-anchored source scan with comment-prefix skipping (deliberately NOT a
+ * global comment-strip regex — that shape hangs Lucee 7 on large sources).
+ * When Stage 3 proper (shared PluginObj) lands, constructions may disappear
+ * from this function entirely; the specs below are written to keep passing in
+ * that case.
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("$runOnRequestStart Plugins construction (issue ##2897 Stage 3)", () => {
+
+			it("constructs wheels.Plugins only inside the mixins-nonempty guard", () => {
+				var body = $runOnRequestStartBody();
+				var guardLine = 0;
+				var offenders = [];
+				var lineNumber = 0;
+
+				for (var rawLine in body.lines) {
+					lineNumber++;
+					var trimmed = Trim(Replace(rawLine, Chr(13), "", "all"));
+					// Skip comment-only lines; constructor mentions in prose are not calls.
+					if (Left(trimmed, 2) == "//" || Left(trimmed, 1) == "*" || Left(trimmed, 2) == "/*") {
+						continue;
+					}
+					if (guardLine == 0 && FindNoCase("StructIsEmpty(application.wheels.mixins)", trimmed)) {
+						guardLine = lineNumber;
+					}
+					if (FindNoCase("new wheels.Plugins(", trimmed) && (guardLine == 0 || lineNumber < guardLine)) {
+						ArrayAppend(offenders, "line #body.startLine + lineNumber - 1#");
+					}
+				}
+
+				expect(ArrayLen(offenders)).toBe(
+					0,
+					"new wheels.Plugins() constructed before/outside the "
+					& "!StructIsEmpty(application.wheels.mixins) guard in "
+					& "events/EventMethods.cfc##$runOnRequestStart at: #ArrayToList(offenders, ', ')#. "
+					& "Unconditional construction pays a throwaway Plugins + Global "
+					& "pseudo-constructor on every request of every mixin-free app "
+					& "(issue ##2897, Stage 3)."
+				);
+			});
+
+			it("still initializes mixins inside the guard when plugins or packages provide them", () => {
+				var body = $runOnRequestStartBody();
+				var source = ArrayToList(body.lines, Chr(10));
+				var guardPos = FindNoCase("StructIsEmpty(application.wheels.mixins)", source);
+				var initPos = FindNoCase("$initializeMixins(variables)", source);
+
+				expect(guardPos).toBeGT(
+					0,
+					"events/EventMethods.cfc##$runOnRequestStart no longer gates mixin "
+					& "integration on !StructIsEmpty(application.wheels.mixins)."
+				);
+				expect(initPos).toBeGT(
+					guardPos,
+					"events/EventMethods.cfc##$runOnRequestStart no longer calls "
+					& "$initializeMixins(variables) inside the mixins guard — plugin/package "
+					& "mixins would never integrate into Application.cfc."
+				);
+			});
+
+		});
+
+	}
+
+	/**
+	 * Extracts the $runOnRequestStart function body lines from
+	 * events/EventMethods.cfc (from its declaration up to the next function
+	 * declaration). Returns {lines, startLine} where startLine is the 1-based
+	 * file line of the declaration, so failure messages can report real
+	 * file line numbers.
+	 */
+	public struct function $runOnRequestStartBody() {
+		var content = FileRead(ExpandPath("/wheels/events/EventMethods.cfc"));
+		// includeEmptyFields=true keeps blank lines so line numbers match the source.
+		var fileLines = ListToArray(content, Chr(10), true);
+		var declarationPattern = "(public|private)\s+\w+\s+function\s+";
+		var result = {lines = [], startLine = 0};
+		var inBody = false;
+		var lineNumber = 0;
+
+		for (var rawLine in fileLines) {
+			lineNumber++;
+			if (!inBody) {
+				if (REFindNoCase(declarationPattern & "\$runOnRequestStart\b", rawLine)) {
+					inBody = true;
+					result.startLine = lineNumber;
+					ArrayAppend(result.lines, rawLine);
+				}
+				continue;
+			}
+			// Next function declaration ends the body.
+			if (REFindNoCase(declarationPattern & "[\w$]+\s*\(", rawLine)) {
+				break;
+			}
+			ArrayAppend(result.lines, rawLine);
+		}
+
+		expect(result.startLine).toBeGT(
+			0,
+			"Could not locate the $runOnRequestStart declaration in events/EventMethods.cfc — "
+			& "update RequestStartPluginsConstructionSpec.cfc if the function was renamed."
+		);
+		return result;
+	}
+
+}


### PR DESCRIPTION
## Summary

PR A of the staged plan on #2897 (Stages 2–4 design comment, 2026-06-11): the Stage 3 quick win.

`EventMethods.cfc#$runOnRequestStart` constructed `local.Mixins = new wheels.Plugins()` unconditionally at the top of **every request**, but the instance is only used inside the `!StructIsEmpty(application.wheels.mixins)` guard. For mixin-free apps the construction was 100% wasted — and not cheap: every `new wheels.Plugins()` also pays the `wheels.Global` pseudo-constructor, including the `$promoteIncludedGlobalsToThis()` `isCustomFunction` scan over ~200 inherited UDFs.

This PR moves the construction inside the guard. Zero semantic change for apps with mixins; mixin-free requests skip the throwaway instantiation entirely.

## Changes

- `vendor/wheels/events/EventMethods.cfc` — hoist `local.Mixins = new wheels.Plugins()` from the top of `$runOnRequestStart` (was line 173) into the `!StructIsEmpty(application.wheels.mixins)` block where it is consumed, with a comment explaining why the placement matters.
- `vendor/wheels/tests/specs/events/RequestStartPluginsConstructionSpec.cfc` — new structural guard spec (TDD red-first; failed on develop pointing at line 173, passes after the hoist):
  - pins that any `new wheels.Plugins(` in `$runOnRequestStart` occurs only inside the mixins-nonempty guard;
  - pins that `$initializeMixins(variables)` still runs inside the guard (the use site can't be silently deleted);
  - written to keep passing when Stage 3 proper (shared `PluginObj`, PR B) removes the construction from this function entirely.
- `changelog.d/request-start-plugins-guard-hoist.performance.md` — changelog fragment.

**Honest design note on the spec:** the construction site has no injection seam (`new wheels.Plugins()` is a direct constructor call with no instance counter), and executing `$runOnRequestStart` inside a spec drags in the full request lifecycle without making the construction observable anyway — so the practical gate is a line-anchored source scan with comment-prefix skipping, same approach as `security/BareCfabortGuardSpec.cfc` and `events/OnAppStartBareHelperGuardSpec.cfc` (deliberately not a global comment-strip regex, which hangs Lucee 7 on large sources).

## Test evidence

TDD red-first, new spec in isolation:

| Engine | Before fix | After fix |
|---|---|---|
| Lucee 7 (SQLite) | 1 pass / **1 fail** (offender at EventMethods.cfc:173) | 2 pass / 0 fail |
| Adobe 2023 (SQLite) | — | 2 pass / 0 fail |

Full core suite (Docker harness, `wheels-test-lucee7:v1.0.0` / `wheels-test-adobe2023:v1.0.1`):

| Engine | Result | Notes |
|---|---|---|
| Lucee 7 (SQLite) | 4501 pass / 12 fail / 0 error (4531 specs) | the 12 are the tolerated `internal.testClientSpec` harness artifacts — matches baseline |
| Adobe 2023 (SQLite) | 4511 pass / 1 fail / 1 error (4531 specs) | both artifacts (`migrator.typedColumnDefaultsSpec`, `security.RouteTesterHardeningSpec`) **reproduce on pristine develop with this change stashed** — pre-existing, unrelated areas |

Refs #2897 (PR A of the staged plan; PRs B–D track Stage 3 proper, DC15, and Stage 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
