### PR TITLE
fix(view): give welcome page an accurate title instead of "Wheels - Error"

### DIFF
--- a/changelog.d/3175-welcome-page-title.fixed.md
+++ b/changelog.d/3175-welcome-page-title.fixed.md
@@ -1,0 +1,1 @@
+- The welcome/congratulations page rendered with `<title>Wheels - Error</title>` because it shared the error screen's header; it now reads "Welcome to Wheels" while the error page keeps its title (#3175)

--- a/vendor/wheels/public/layout/_header_simple.cfm
+++ b/vendor/wheels/public/layout/_header_simple.cfm
@@ -11,6 +11,21 @@ if (StructKeyExists(request, "wheels") && IsStruct(request.wheels)) {
 	request.wheels.showDebugInformation = true;
 }
 
+// Page title. This shared simple header is used by BOTH the error screen
+// (default) AND the congratulations/welcome page. The including template can
+// override the title via request.wheels.simpleHeaderTitle; everything else
+// (errors via EventMethods.$runOnError) falls back to "Wheels - Error".
+// Read it here into a local so the <head> below stays markup-only. See #3175.
+local.simpleHeaderTitle = "Wheels - Error";
+if (
+	StructKeyExists(request, "wheels")
+	&& IsStruct(request.wheels)
+	&& StructKeyExists(request.wheels, "simpleHeaderTitle")
+	&& Len(request.wheels.simpleHeaderTitle)
+) {
+	local.simpleHeaderTitle = request.wheels.simpleHeaderTitle;
+}
+
 // Inline icon font (see _header.cfm and issue ##2421). Duplicated here
 // because error pages can render before _header.cfm has been visited.
 // Double-checked locking matches _header.cfm — see comment there for
@@ -36,7 +51,7 @@ if (!StructKeyExists(application.wheels, "iconsFontDataUri")) {
 <!DOCTYPE html>
 <html>
 <head>
-	<title>Wheels - Error</title>
+	<title>#EncodeForHTML(local.simpleHeaderTitle)#</title>
 	<meta charset="utf-8">
 	<meta name="robots" content="noindex,nofollow">
 	<style>

--- a/vendor/wheels/public/views/congratulations.cfm
+++ b/vendor/wheels/public/views/congratulations.cfm
@@ -1,4 +1,13 @@
 <!--- cfformat-ignore-start --->
+<cfscript>
+	// The shared _header_simple.cfm defaults its <title> to "Wheels - Error"
+	// (it was first written for the error screen). Override it here so a new
+	// user's first browser tab reads "Welcome to Wheels", not "Error" (#3175).
+	if (!StructKeyExists(request, "wheels") || !IsStruct(request.wheels)) {
+		request.wheels = {};
+	}
+	request.wheels.simpleHeaderTitle = "Welcome to Wheels";
+</cfscript>
 <!--- Use the slimmed _simple header (no top nav). Navigation to /wheels/info,
       /wheels/routes, /wheels/api, etc. is provided by the dev-mode debug bar
       emitted at onrequestend, so the welcome page only needs doctype/head/body

--- a/vendor/wheels/tests/specs/events/simpleHeaderTitleSpec.cfc
+++ b/vendor/wheels/tests/specs/events/simpleHeaderTitleSpec.cfc
@@ -1,0 +1,84 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		// GH #3175: the shared _header_simple.cfm hardcoded <title>Wheels - Error</title>.
+		// That header is included by BOTH the error screen (EventMethods.$runOnError)
+		// AND the congratulations/welcome page (Public.index → congratulations.cfm),
+		// so a brand-new user's first browser tab read "Error". The header now reads
+		// an optional request.wheels.simpleHeaderTitle override and falls back to the
+		// error title when it isn't set.
+		describe("_header_simple.cfm <title>", () => {
+
+			it("defaults to 'Wheels - Error' when no override is set (error screen)", () => {
+				var hadOverride = StructKeyExists(request, "wheels")
+					&& IsStruct(request.wheels)
+					&& StructKeyExists(request.wheels, "simpleHeaderTitle");
+				var prior = hadOverride ? request.wheels.simpleHeaderTitle : "";
+				try {
+					if (StructKeyExists(request, "wheels") && IsStruct(request.wheels)) {
+						StructDelete(request.wheels, "simpleHeaderTitle");
+					}
+					var actual = application.wo.$includeAndReturnOutput(
+						$template = "/wheels/public/layout/_header_simple.cfm"
+					);
+					expect(actual).toInclude("<title>Wheels - Error</title>");
+				} finally {
+					if (hadOverride) {
+						request.wheels.simpleHeaderTitle = prior;
+					} else if (StructKeyExists(request, "wheels") && IsStruct(request.wheels)) {
+						StructDelete(request.wheels, "simpleHeaderTitle");
+					}
+				}
+			});
+
+			it("uses request.wheels.simpleHeaderTitle when the including page sets it (welcome page)", () => {
+				var hadOverride = StructKeyExists(request, "wheels")
+					&& IsStruct(request.wheels)
+					&& StructKeyExists(request.wheels, "simpleHeaderTitle");
+				var prior = hadOverride ? request.wheels.simpleHeaderTitle : "";
+				try {
+					if (!StructKeyExists(request, "wheels") || !IsStruct(request.wheels)) {
+						request.wheels = {};
+					}
+					request.wheels.simpleHeaderTitle = "Welcome to Wheels";
+					var actual = application.wo.$includeAndReturnOutput(
+						$template = "/wheels/public/layout/_header_simple.cfm"
+					);
+					expect(actual).toInclude("<title>Welcome to Wheels</title>");
+					// And critically: the welcome page no longer says "Error".
+					expect(actual).notToInclude("<title>Wheels - Error</title>");
+				} finally {
+					if (hadOverride) {
+						request.wheels.simpleHeaderTitle = prior;
+					} else if (StructKeyExists(request, "wheels") && IsStruct(request.wheels)) {
+						StructDelete(request.wheels, "simpleHeaderTitle");
+					}
+				}
+			});
+
+			it("falls back to the error title when the override is an empty string", () => {
+				var hadOverride = StructKeyExists(request, "wheels")
+					&& IsStruct(request.wheels)
+					&& StructKeyExists(request.wheels, "simpleHeaderTitle");
+				var prior = hadOverride ? request.wheels.simpleHeaderTitle : "";
+				try {
+					if (!StructKeyExists(request, "wheels") || !IsStruct(request.wheels)) {
+						request.wheels = {};
+					}
+					request.wheels.simpleHeaderTitle = "";
+					var actual = application.wo.$includeAndReturnOutput(
+						$template = "/wheels/public/layout/_header_simple.cfm"
+					);
+					expect(actual).toInclude("<title>Wheels - Error</title>");
+				} finally {
+					if (hadOverride) {
+						request.wheels.simpleHeaderTitle = prior;
+					} else if (StructKeyExists(request, "wheels") && IsStruct(request.wheels)) {
+						StructDelete(request.wheels, "simpleHeaderTitle");
+					}
+				}
+			});
+		});
+	}
+}


### PR DESCRIPTION
## Problem

On a fresh install (every channel — LuCLI and CommandBox), the successfully-rendered welcome/congratulations page shows `<title>Wheels - Error</title>` in the browser tab. The very first thing a new user sees says "Error".

**Cause:** `vendor/wheels/public/views/congratulations.cfm` includes `../layout/_header_simple.cfm`, whose `<head>` hardcoded `<title>Wheels - Error</title>`. That shared header was originally written for the error screen and is reused by the welcome page.

Both includers of `_header_simple.cfm`:
- `vendor/wheels/public/views/congratulations.cfm:6` — `<cfinclude>` (welcome page)
- `vendor/wheels/events/EventMethods.cfc:104` — `$includeAndReturnOutput` (error screen via `$runOnError`)

## Fix

- `_header_simple.cfm` now reads an optional `request.wheels.simpleHeaderTitle` into its `<title>`, falling back to `"Wheels - Error"` when unset (so the error screen, which sets no override, is byte-for-byte unchanged). Title emitted via `EncodeForHTML`.
- `congratulations.cfm` sets `request.wheels.simpleHeaderTitle = "Welcome to Wheels"` before the include.

`request` scope is the existing shared channel between these templates (the same file already writes `request.wheels.showDebugInformation`), so it survives the `$includeAndReturnOutput` boundary the error path uses. No new cross-engine surface — pure CFML built-ins (`StructKeyExists`, `Len`, `EncodeForHTML`).

## Tests

New `vendor/wheels/tests/specs/events/simpleHeaderTitleSpec.cfc` renders `_header_simple.cfm` via `application.wo.$includeAndReturnOutput` (same harness as the sibling `onerrorSpec`) and asserts:
- no override → `<title>Wheels - Error</title>` (error screen preserved)
- override set → `<title>Welcome to Wheels</title>` and NOT the error title (welcome page)
- empty-string override → falls back to the error title

## Verification (verify-first)

- Reverted the fix to HEAD, re-ran the spec: welcome-page test **FAILED** (title was `Wheels - Error`), error-screen test still passed — proves the spec catches the bug.
- Reapplied the fix: all 3 pass.
- Full Lucee 7 + SQLite core suite: **4522 pass / 0 fail / 0 error**.

Adobe spot-check not required (pure markup/title; no `arguments`-as-attributeCollection or other cross-engine pattern touched).

Fixes #3175

🤖 Generated with [Claude Code](https://claude.com/claude-code)