### PR TITLE
docs(web/guides): add Installing with CommandBox support-tier page

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/cfml-engines.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/cfml-engines.mdx
@@ -112,4 +112,9 @@ Wheels' BoxLang compatibility is verified per release in the same CI matrix as L
     href="/v4-0-0/command-line-tools/installation/"
     description="Detailed install reference for macOS, Windows, Linux."
   />
+  <LinkCard
+    title="Installing with CommandBox"
+    href="/v4-0-0/start-here/installing-with-commandbox/"
+    description="Install and serve the framework from ForgeBox. Support tiers explained."
+  />
 </CardGrid>

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/installing-with-commandbox.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/installing-with-commandbox.mdx
@@ -1,0 +1,154 @@
+---
+title: Installing with CommandBox
+description: Install and serve the Wheels framework from ForgeBox with CommandBox. Supported as a server manager and package fetcher — not as the Wheels developer CLI.
+type: howto
+sidebar:
+  order: 7
+---
+
+import { Aside, Steps, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+[CommandBox](https://www.ortussolutions.com/products/commandbox) is Ortus Solutions' CFML package manager and server runner. Wheels publishes its framework artifacts to [ForgeBox](https://forgebox.io/), so you can install and serve a Wheels app with `box` alone — no `wheels` CLI required.
+
+This page exists because CommandBox-centric 2.x/3.x teams need a clear answer to one question: **what is my supported workflow on Wheels 4?**
+
+## What CommandBox is supported for
+
+In Wheels 4, CommandBox is supported as a **server manager and package fetcher** — and that's the whole of it.
+
+| You want to… | CommandBox? | Tool |
+|---|---|---|
+| Install the framework from ForgeBox | **Yes** | `box install wheels-base-template` |
+| Run a CFML server (Lucee / Adobe CF / BoxLang) | **Yes** | `box server start` |
+| Vendor `wheels-core` into an existing app | **Yes** | `box install wheels-core` |
+| Scaffold an app, generators, migrate, test, console | **No** | the [`wheels` CLI](/v4-0-0/start-here/installing/) |
+| The packages registry, MCP server, deploy | **No** | the [`wheels` CLI](/v4-0-0/start-here/installing/) |
+
+The short version: **CommandBox gets you the framework and a running server. Reach for the [`wheels` CLI](/v4-0-0/start-here/installing/) for scaffolding** — generators, `wheels migrate`, `wheels test`, `wheels console`, the MCP server, the [packages registry](/v4-0-0/digging-deeper/packages/), and `wheels deploy`. None of those run through CommandBox.
+
+<Aside type="note" title="Two different package systems">
+ForgeBox (CommandBox) ships the *framework itself* — `wheels-core` and the app template. The Wheels **packages registry** (`wheels packages ...`) is a separate, `wheels`-CLI-only system for first-party add-ons like `wheels-hotwire` and `wheels-basecoat`. It is **not** on ForgeBox. See [Packages](/v4-0-0/digging-deeper/packages/).
+</Aside>
+
+## The ForgeBox packages
+
+Every stable Wheels release publishes four packages to ForgeBox (see `.github/workflows/release.yml`):
+
+| Slug | What it is |
+|---|---|
+| `wheels-base-template` | The full app skeleton. Declares `wheels-core` as a dependency, so installing it pulls the framework into `vendor/wheels/` too. **Start here.** |
+| `wheels-core` | The framework core only — installs into `vendor/wheels/`. Use it to vendor or upgrade the framework inside an existing app. |
+| `wheels-cli` | The **deprecated** legacy CommandBox CLI module. Predates 4.0 and does not know the 4.0 commands — see below. |
+| `wheels-starter-app` | A pre-built sample app for demos and experiments. |
+
+All four track the current release version (4.0.x at time of writing).
+
+## Supported: install the framework
+
+<Steps>
+
+1. Install CommandBox if you don't have it:
+
+   ```bash title="illustrative — install CommandBox"
+   # macOS
+   brew install commandbox
+   # Windows
+   choco install commandbox
+   # Linux: see https://commandbox.ortusbooks.com/setup/installation
+   ```
+
+2. Install the base template into an empty directory. This pulls `wheels-core` into `vendor/wheels/` via the template's declared `installPaths`:
+
+   ```bash title="illustrative — box pulls from ForgeBox"
+   mkdir myapp && cd myapp
+   box install wheels-base-template
+   ```
+
+   You'll get the modern Wheels 4.0 layout: `app/`, `config/`, `db/`, `public/` (the web root), `tests/`, a `server.json`, and the framework core in `vendor/wheels/`.
+
+</Steps>
+
+<Aside type="tip" title="Vendoring the framework into an existing app">
+If you already have a Wheels app and just want to add or upgrade the framework, install `wheels-core` on its own — it lands in `vendor/wheels/`:
+
+```bash title="illustrative"
+box install wheels-core
+```
+
+Use `box install wheels-core --force` to cleanly replace an older `vendor/wheels/`.
+</Aside>
+
+## Supported: serve
+
+The template ships a `server.json`, so a server start is a one-liner from the app root:
+
+```bash title="illustrative — box server start"
+box server start
+```
+
+Pin a specific engine the same way the [CFML Engines](/v4-0-0/start-here/cfml-engines/) page describes — CommandBox downloads it on first use:
+
+```bash title="illustrative — pin the engine"
+box server start cfengine=lucee@7        # or adobe@2025, or boxlang@latest
+```
+
+Reload the framework after a config or code change by hitting the reload URL directly (there is no `wheels reload` on this path):
+
+```text title="illustrative — reload URL"
+http://localhost:<port>/?reload=true&password=<your reload password>
+```
+
+## Not supported via CommandBox: the `wheels` CLI feature set
+
+CommandBox fetches and serves; it does **not** replace the developer CLI. The following all require the LuCLI-based `wheels` binary (install it from [brew / scoop / apt / yum](/v4-0-0/start-here/installing/) or a [manual JAR](/v4-0-0/command-line-tools/installation/#manual-jar-install)):
+
+- **Scaffolding** — `wheels new`, and every generator (`wheels generate model/controller/scaffold/...`).
+- **Migrations** — `wheels migrate latest|up|down|info|doctor`.
+- **Testing** — `wheels test`.
+- **Console** — `wheels console`.
+- **MCP server** — `wheels mcp wheels`.
+- **The packages registry** — `wheels packages ...` (first-party add-ons; **not** on ForgeBox).
+- **Deploy** — `wheels deploy`.
+
+<Aside type="caution" title="The legacy `wheels-cli` ForgeBox module is deprecated">
+The CommandBox module published as `wheels-cli` is the pre-4.0 CLI. It does **not** know the 4.0+ command set and is scheduled for removal in Wheels 5 (see [Upgrading 3.x → 4.x](/v4-0-0/upgrading/3x-to-4x/)). Do not install it for new work. The supported developer CLI is the standalone `wheels` binary — see [Installing Wheels](/v4-0-0/start-here/installing/).
+</Aside>
+
+## Coming from a 2.x / 3.x `box` workflow
+
+The 3.x getting-started spine was built on CommandBox. Here's how each old step maps onto Wheels 4:
+
+| 2.x / 3.x (CommandBox) | Wheels 4 |
+|---|---|
+| `box install wheels-cli` | Install the standalone [`wheels` CLI](/v4-0-0/start-here/installing/) (brew / scoop / apt / yum) |
+| `wheels generate app myApp` / `wheels g app` | `wheels new myApp` |
+| `box server start` | Still works — or `wheels start` (Lucee, bundled with the CLI) |
+| ForgeBox plugins (`box install ...`, `forgebox install`) | The [`wheels packages`](/v4-0-0/digging-deeper/packages/) registry (CLI-only; not ForgeBox) |
+| `box install wheels-base-template` + `wheels-core` | Unchanged — still the supported way to fetch the framework with CommandBox |
+
+The practical recommendation: keep CommandBox if you rely on it for Adobe CF or BoxLang server management, and add the `wheels` CLI alongside it for everything in the [feature-set list above](#not-supported-via-commandbox-the-wheels-cli-feature-set).
+
+## Related
+
+<CardGrid>
+  <LinkCard
+    title="Installing Wheels"
+    href="/v4-0-0/start-here/installing/"
+    description="Get the wheels CLI — generators, migrate, test, and more."
+  />
+  <LinkCard
+    title="CFML Engines"
+    href="/v4-0-0/start-here/cfml-engines/"
+    description="Run Wheels on Lucee, Adobe CF, or BoxLang via CommandBox."
+  />
+  <LinkCard
+    title="Packages"
+    href="/v4-0-0/digging-deeper/packages/"
+    description="First-party add-ons via the wheels packages registry."
+  />
+  <LinkCard
+    title="Upgrading 3.x → 4.x"
+    href="/v4-0-0/upgrading/3x-to-4x/"
+    description="What changed, including the wheels-cli deprecation."
+  />
+</CardGrid>

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/installing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/installing.mdx
@@ -20,6 +20,10 @@ Install the `wheels` CLI. Five minutes.
 The `wheels` CLI bundles a Lucee runtime — that's the easiest path for development and what the rest of these docs assume. The framework itself runs on Adobe ColdFusion 2023/2025 and BoxLang too; you'll use CommandBox to manage the engine instead of the bundled CLI. See [CFML Engines](/v4-0-0/start-here/cfml-engines/) for the setup.
 </Aside>
 
+<Aside type="note" title="Already a CommandBox user?">
+You can install and serve the framework straight from ForgeBox with `box install wheels-base-template` and `box server start` — no `wheels` CLI required. That path is supported as a server manager and package fetcher, but the generators, `migrate`, `test`, and the rest of the CLI feature set still need the `wheels` binary below. See [Installing with CommandBox](/v4-0-0/start-here/installing-with-commandbox/) for the support tiers.
+</Aside>
+
 <Aside type="note">
   **Prerequisite:** Java 21 or newer. `wheels` bundles a CFML runtime (Lucee) that targets JDK 21. Install it from [Adoptium](https://adoptium.net/) if you don't already have it, or on macOS:
 

--- a/web/sites/guides/src/sidebars/v4-0-0.json
+++ b/web/sites/guides/src/sidebars/v4-0-0.json
@@ -6,6 +6,7 @@
       { "label": "Welcome to Wheels", "link": "/v4-0-0/start-here/welcome/" },
       { "label": "Why Wheels?", "link": "/v4-0-0/start-here/why-wheels/" },
       { "label": "Installing Wheels", "link": "/v4-0-0/start-here/installing/" },
+      { "label": "Installing with CommandBox", "link": "/v4-0-0/start-here/installing-with-commandbox/" },
       { "label": "Your First 15 Minutes", "link": "/v4-0-0/start-here/first-15-minutes/" },
       {
         "label": "Tutorial: Build a Blog",


### PR DESCRIPTION
## What

Adds a new v4-0-0 guides page, **Installing with CommandBox** (`web/sites/guides/src/content/docs/v4-0-0/start-here/installing-with-commandbox.mdx`), plus sidebar entry and cross-links. Part of the ForgeBox/CommandBox path-repair campaign.

## Why

The v4 guides contained **zero** `box install` mentions (verified: `grep -rl 'box install' .../v4-0-0/` → 0 files), even though `release.yml` publishes four ForgeBox packages (`wheels-base-template`, `wheels-core`, `wheels-cli`, `wheels-starter-app`) on every stable release. CommandBox-centric 2.x/3.x teams had no answer to "what is my supported workflow on Wheels 4?"

## What the page states (the support tier, explicitly)

- **Supported:** install the framework via ForgeBox — `box install wheels-base-template` pulls `wheels-core` into `vendor/wheels/`; `box server start` serves it; reload URL + engine pinning documented. `box install wheels-core` for vendoring/upgrading an existing app.
- **Not supported via CommandBox:** the `wheels` CLI feature set — generators, `migrate`, `test`, `console`, MCP, the packages registry (CLI-only, not ForgeBox), deploy — install the LuCLI `wheels` binary (brew/scoop/apt/yum/manual JAR) for those.
- **Legacy-slug note:** the `wheels-cli` ForgeBox module is deprecated (removal in v5), points at the 4.x slugs and `wheels new`.
- **2.x/3.x → 4.0 mapping table.**

Written to the campaign **target end-state** (assumes keystone template fix #3176/#3173 and core fix #3177 land). #3177 is already on develop — `tools/build/core/box.json` uses `directory=vendor` + `packageDirectory=wheels`, and the base template's `installPaths` puts `wheels-core` in `vendor/wheels/`.

## {test:*} policy

The verify-docs harness only spawns the `wheels` binary — it cannot run `box`. Per the policy (harness ignores any block without a `{test:*}` meta flag; `lib/extract.mjs` `if (!parsed) continue;`), all `box` command blocks are marked illustrative (untagged with descriptive titles). Verified against the same approach already used by `cfml-engines.mdx`.

## Evidence

- Defect reproduced: `grep -rl 'box install' web/sites/guides/src/content/docs/v4-0-0/` → 0 files before this change.
- `pnpm verify:docs` (via `node scripts/verify-docs/verify-docs.mjs <new page>`): **EXIT=0**, `0 passed, 0 failed`, `found 0 tagged block(s)` — box blocks correctly ignored as illustrative.
- Combined run over the new page + edited `installing.mdx` + `cfml-engines.mdx`: **1 passed, 0 failed** (the 1 is the pre-existing `wheels --version` `{test:cli}` block in `installing.mdx`).
- Sidebar JSON re-validated with `json.load` after the edit.
- Cross-link targets/anchors confirmed to exist (`upgrading/3x-to-4x/`, `digging-deeper/packages/`, `command-line-tools/installation/#manual-jar-install`).

No changelog fragment — docs-only change (build-pipeline + CI + docs changes get none).

Fixes #3183.
Refs #3176, #3173, #3177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)