### PR TITLE
build(forgebox): assert wheels-* slug allowlist before publishing

### DIFF
--- a/tools/build/scripts/publish-to-forgebox.sh
+++ b/tools/build/scripts/publish-to-forgebox.sh
@@ -77,6 +77,37 @@ publish_package() {
         exit 1
     fi
 
+    # Slug allowlist guard (defensive — see #3182).
+    #
+    # `box publish` derives the ForgeBox slug from box.json["slug"], NOT from
+    # any argument this script passes. A 4.0 publish must ONLY ever land on a
+    # wheels-* slug. The deprecated 2.x channel slugs — cfwheels-base-template
+    # (76k installs) and cfwheels-cli — must never receive a 4.0 artifact: a
+    # 2.x user running `box install cfwheels-base-template` would otherwise get
+    # a broken modern install. The publish path is already safe by construction
+    # (every template box.json carries a wheels-* slug and the prepare-*.sh
+    # scripts only substitute the version placeholder), but a stray edit to a
+    # box.json — or a future cfwheels-* compatibility shim — could regress that
+    # silently. This assert fails the release loudly instead of mispublishing.
+    local PACKAGE_SLUG
+    PACKAGE_SLUG="$(jq -r '.slug // empty' "$PACKAGE_DIR/box.json")"
+    if [ -z "$PACKAGE_SLUG" ]; then
+        echo "ERROR: box.json in $PACKAGE_DIR has no \"slug\" — cannot validate the publish target!"
+        exit 1
+    fi
+    case "$PACKAGE_SLUG" in
+        wheels-*)
+            echo "  Slug allowlist: '$PACKAGE_SLUG' is an approved wheels-* target."
+            ;;
+        *)
+            echo "ERROR: refusing to publish slug '$PACKAGE_SLUG' from $PACKAGE_DIR."
+            echo "       Only wheels-* slugs may be published. The legacy 2.x slugs"
+            echo "       (cfwheels-base-template, cfwheels-cli) are frozen and must"
+            echo "       never receive a 4.0 artifact — see #3182."
+            exit 1
+            ;;
+    esac
+
     # Verify package contents
     if ! verify_package_contents "$PACKAGE_DIR" "$PACKAGE_NAME"; then
         echo "ERROR: Package verification failed!"


### PR DESCRIPTION
## What

Adds a defensive slug-allowlist assert to `tools/build/scripts/publish-to-forgebox.sh`. Before logging in and publishing each package, the script now reads the resolved `box.json["slug"]` and **refuses to publish any slug that is not `wheels-*`** (and refuses a missing slug), failing the release loudly instead of ever mispublishing to a deprecated `cfwheels-*` slug.

## Why (Refs #3182)

`box publish` derives the published ForgeBox slug from each package's `box.json["slug"]`, **not** from any argument this script passes. The 4.0 pipeline must only ever land on the `wheels-*` slugs. The legacy 2.x slugs — `cfwheels-base-template` (~76k installs) and `cfwheels-cli` — are frozen and must never receive a 4.0 artifact.

## Safety verification (PART A is largely a no-op verification + this defensive assert)

I traced the entire publish path. **The pipeline is already safe by construction — no code path can land a 4.0 publish on a `cfwheels-*` slug:**

- `publish-to-forgebox.sh` publishes from four directories; `box publish` reads the slug from each dir's `box.json`. Every source box.json slug is `wheels-*`:
  - `tools/build/base/box.json` → `wheels-base-template`
  - `tools/build/core/box.json` → `wheels-core`
  - `tools/build/cli/box.json` → `wheels-cli`
  - `examples/starter-app/box.json` → `wheels-starter-app`
- The `prepare-*.sh` scripts `cp` those box.json templates verbatim and only substitute the `@build.version@` placeholder — no slug rewriting.
- The only `cfwheels-` strings in the repo are the ForgeBox **type** taxonomy (`"type":"cfwheels-templates"` — a category, not a slug) and read-only legacy plugin-name normalization in `cli/src/models/PluginService.cfc` (not a publish path).
- The publish script never reads or overrides a slug from anywhere else.

So this PR is the "tiny defensive assert worth shipping" called for in #3182 — it pins the invariant so a stray box.json edit or a future `cfwheels-*` compatibility shim can't silently regress it.

## Testing

Verify-first (reproduced absence of guard, then proved behavior with fixtures):

- `bash -n` syntax check: passes.
- Allowlist accepts all four real `wheels-*` slugs.
- End-to-end against fixtures with a stubbed `box`: a `wheels-base-template` fixture passes and proceeds to publish; a poisoned `cfwheels-base-template` fixture is **refused before `box` is ever invoked**, and `publish_package` exits `1`.

## Notes

Build-pipeline change — no changelog fragment (per repo policy, build/CI/docs get none). The companion PART B (deprecating the live `cfwheels-*` ForgeBox listings) is a credentialed ForgeBox action and is **not** a repo change; a step-by-step runbook with the exact deprecation README content and `box` commands was produced separately for the maintainer to run.

Refs #3182

🤖 Generated with [Claude Code](https://claude.com/claude-code)