### PR TITLE
docs: name the MCP packages tool by its bare name

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/packages.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/packages.mdx
@@ -317,7 +317,7 @@ The install/update surface is covered by the commands shown earlier under [The a
 - `wheels packages add <name>@<version>` — pin a specific version; omit for the latest compatible.
 - `wheels packages add <name> --force` — overwrite an existing `vendor/<name>/`.
 
-The canonical verb is `add`. On the shell surface, `wheels packages install foo` is intercepted by LuCLI's built-in extension installer before it reaches the Wheels package handler, so it silently no-ops (the same trap that renamed `wheels browser install` to `wheels browser setup`). On v4.0.0 the same `install` argument also no-ops via the stdio MCP server (`wheels_packages`) and other in-process callers; the transparent `install` → `add` alias on MCP / in-process paths landed in v4.0.1 — see the v4.0.1 snapshot docs. Use `add` for compatibility across all 4.x releases.
+The canonical verb is `add`. On the shell surface, `wheels packages install foo` is intercepted by LuCLI's built-in extension installer before it reaches the Wheels package handler, so it silently no-ops (the same trap that renamed `wheels browser install` to `wheels browser setup`). On v4.0.0 the same `install` argument also no-ops via the stdio MCP server (the `packages` tool) and other in-process callers; the transparent `install` → `add` alias on MCP / in-process paths landed in v4.0.1 — see the v4.0.1 snapshot docs. Use `add` for compatibility across all 4.x releases.
 - `wheels packages update --all --yes` — bulk-update every installed package, no prompt.
 - `wheels packages registry refresh | info` — manage the 24-hour registry cache.
 


### PR DESCRIPTION
## What

The stdio MCP surface (`wheels mcp wheels`) advertises every tool by its **bare function name** — `generate`, `migrate`, `packages`, … — not a `wheels_`-prefixed form. The packages guide was the last `v4-0-0` doc still calling it `wheels_packages`; this swaps it for "the `packages` tool".

## Why

Live-verified against the released 4.0.3 CLI:

```
$ wheels mcp wheels --once tools/list
→ 18 tools: analyze, create, db, deploy, destroy, doctor, generate, info,
  migrate, notes, packages, reload, routes, seed, stats, test, upgrade, validate
```

`tools/call` resolves by exact match (LuCLI `McpCommand.java`), so a prefixed name (`wheels_packages`) would return `Unknown tool`. The guide table, the `mcp()` help text (`Module.cfc`), and `CLAUDE.md` were already corrected on develop in a prior sweep — this closes the one remaining v4 doc leftover.

Found while fact-checking two scheduled blog posts (the same prefix error appeared in the MCP post and was corrected in the publishing admin).

## Scope

- One-line prose change in `web/sites/guides/.../v4-0-0/digging-deeper/packages.mdx`. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)