### PR TITLE
fix(build): arch-independent Linux packages + RHEL Java detection (arm64 + yum fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,7 +331,7 @@ jobs:
       # Build .deb / .rpm Linux packages alongside the zip artifacts. nfpm
       # needs no Linux-specific build host (it's a single Go binary), so this
       # runs on the same ubuntu-latest runner as the rest of the pipeline.
-      # Generates wheels_<v>_amd64.deb and wheels-<v>.x86_64.rpm in dist/.
+      # Generates arch-independent wheels_<v>_all.deb and wheels-<v>.noarch.rpm.
       # See tools/distribution-drafts/linux-packages/ for the nfpm configs.
       - name: Install nfpm
         run: |
@@ -484,8 +484,8 @@ jobs:
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip.md5
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip.sha512
-              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels*_amd64.deb
-              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels*.x86_64.rpm
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels*_all.deb
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels*.noarch.rpm
 
       #############################################
       # Create Snapshot Pre-Release (develop only)
@@ -540,8 +540,8 @@ jobs:
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip.md5
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip.sha512
-              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels*_amd64.deb
-              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels*.x86_64.rpm
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels*_all.deb
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels*.noarch.rpm
 
       #############################################
       # Dispatch downstream package managers

--- a/tools/distribution-drafts/linux-packages/build-linux-packages.sh
+++ b/tools/distribution-drafts/linux-packages/build-linux-packages.sh
@@ -9,9 +9,9 @@
 #   LUCLI_LINUX_URL  — URL for the Linux LuCLI binary (default: cybersonic upstream)
 #   OUT_DIR          — where to write the .deb / .rpm (default: dist/)
 #
-# Outputs (in OUT_DIR):
-#   wheels_<v>_amd64.deb      (or wheels-be_<v>_amd64.deb for BE channel)
-#   wheels-<v>.x86_64.rpm
+# Outputs (in OUT_DIR) — architecture-independent (Java jar payload):
+#   wheels_<v>_all.deb        (or wheels-be_<v>_all.deb for BE channel)
+#   wheels-<v>.noarch.rpm
 #
 # This script is idempotent — it tears down and recreates the build/ staging dir.
 # Run from the repo root.
@@ -21,8 +21,14 @@ set -euo pipefail
 WHEELS_VERSION="${WHEELS_VERSION:?WHEELS_VERSION must be set}"
 CHANNEL="${CHANNEL:-stable}"
 ARTIFACTS_DIR="${ARTIFACTS_DIR:-artifacts/wheels/${WHEELS_VERSION}}"
-LUCLI_VERSION="${LUCLI_VERSION:-0.3.7}"
-LUCLI_LINUX_URL="${LUCLI_LINUX_URL:-https://github.com/cybersonic/LuCLI/releases/download/v${LUCLI_VERSION}/lucli-${LUCLI_VERSION}-linux}"
+LUCLI_VERSION="${LUCLI_VERSION:-0.3.17}"
+# Portable JAR launcher (runs on any arch with Java 21) instead of the amd64-only
+# native `lucli-linux` binary. This is what makes the .deb/.rpm architecture-
+# independent (all/noarch) so they install on arm64 too — and it matches how the
+# Scoop manifest already launches LuCLI. Routing to the bundled `wheels` module
+# is done via -Dlucli.binary.name=wheels in the wrapper (the native binary did it
+# via basename(argv[0])).
+LUCLI_JAR_URL="${LUCLI_JAR_URL:-https://github.com/cybersonic/LuCLI/releases/download/v${LUCLI_VERSION}/lucli-${LUCLI_VERSION}.jar}"
 SQLITE_JDBC_VERSION="3.49.1.0"
 SQLITE_JDBC_URL="https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/${SQLITE_JDBC_VERSION}/sqlite-jdbc-${SQLITE_JDBC_VERSION}.jar"
 OUT_DIR="${OUT_DIR:-dist}"
@@ -59,13 +65,13 @@ tar -xzf "${ARTIFACTS_DIR}/wheels-module-${WHEELS_VERSION}.tar.gz" -C "${BUILD_D
 # 2. Unzip the framework into build/framework/
 unzip -q "${ARTIFACTS_DIR}/wheels-core-${WHEELS_VERSION}.zip" -d "${BUILD_DIR}/build/framework/"
 
-# 3. Download the LuCLI Linux binary as build/wheels. Renaming at stage time
-#    (mirroring the brew formula's `libexec.install resource("lucli") => "wheels"`)
-#    means basename(argv[0]) is `wheels` when the wrapper execs it, so lucli's
-#    module dispatcher resolves `wheels start` to the bundled wheels module
-#    instead of throwing `Unknown command`. See issue #2700.
-curl -fsSL -o "${BUILD_DIR}/build/wheels" "${LUCLI_LINUX_URL}"
-chmod +x "${BUILD_DIR}/build/wheels"
+# 3. Download the portable LuCLI JAR as build/lucli.jar. The wrapper launches it
+#    with `java -Dlucli.binary.name=wheels -jar`, which both (a) routes to the
+#    bundled wheels module (the flag replaces the old basename(argv[0]) trick the
+#    native binary relied on) and (b) is architecture-independent, so the package
+#    installs on amd64 AND arm64. See issue #2700 (routing) and the arch-independent
+#    refactor.
+curl -fsSL -o "${BUILD_DIR}/build/lucli.jar" "${LUCLI_JAR_URL}"
 
 # 4. Download SQLite JDBC
 curl -fsSL -o "${BUILD_DIR}/build/sqlite-jdbc.jar" "${SQLITE_JDBC_URL}"
@@ -86,18 +92,39 @@ cat > "${BUILD_DIR}/build/wrapper.sh" <<'WRAPPER_EOF'
 
 set -euo pipefail
 
-# Honor user-set JAVA_HOME if present; otherwise probe for OpenJDK 21.
+# Honor user-set JAVA_HOME if present; otherwise probe for OpenJDK 21 across the
+# Debian/Ubuntu AND RHEL/Fedora layouts, on amd64 and arm64.
 if [ -z "${JAVA_HOME:-}" ]; then
   for candidate in \
     /usr/lib/jvm/java-21-openjdk-amd64 \
+    /usr/lib/jvm/java-21-openjdk-arm64 \
     /usr/lib/jvm/java-21-openjdk \
+    /usr/lib/jvm/jre-21-openjdk \
+    /usr/lib/jvm/java-21 \
+    /usr/lib/jvm/jre-21 \
     /usr/lib/jvm/temurin-21-jdk-amd64 \
+    /usr/lib/jvm/temurin-21-jdk-arm64 \
     /usr/lib/jvm/zulu-21 \
     /usr/lib/jvm/default-java; do
-    if [ -d "${candidate}" ]; then
+    if [ -x "${candidate}/bin/java" ]; then
       export JAVA_HOME="${candidate}"
       break
     fi
+  done
+fi
+# RHEL/Fedora install into a version-stamped dir (java-21-openjdk-21.0.x...elN.<arch>)
+# that the fixed names above don't match, but the headless package registers
+# /usr/bin/java via the alternatives system — resolve JAVA_HOME from it.
+if [ -z "${JAVA_HOME:-}" ] && command -v java >/dev/null 2>&1; then
+  _j="$(command -v java)"
+  command -v readlink >/dev/null 2>&1 && _j="$(readlink -f "${_j}" 2>/dev/null || echo "${_j}")"
+  _jh="${_j%/bin/java}"
+  [ -x "${_jh}/bin/java" ] && export JAVA_HOME="${_jh}"
+fi
+# Last resort: glob the version-stamped RHEL/Fedora directories directly.
+if [ -z "${JAVA_HOME:-}" ]; then
+  for d in /usr/lib/jvm/java-21-openjdk-* /usr/lib/jvm/*jre-21* /usr/lib/jvm/*-21-*; do
+    if [ -x "${d}/bin/java" ]; then export JAVA_HOME="${d}"; break; fi
   done
 fi
 if [ -z "${JAVA_HOME:-}" ] || [ ! -x "${JAVA_HOME}/bin/java" ]; then
@@ -139,7 +166,11 @@ if [ -n "${LUCEE_EXT_DIR}" ] && ! ls "${LUCEE_EXT_DIR}"/sqlite-jdbc*.jar >/dev/n
   cp /opt/wheels/sqlite-jdbc.jar "${LUCEE_EXT_DIR}/sqlite-jdbc.jar"
 fi
 
-exec /opt/wheels/wheels "$@"
+# Launch via the portable LuCLI jar. -Dlucli.binary.name=wheels routes to the
+# bundled wheels module (replacing the native binary's basename(argv[0]) trick),
+# and `java -jar` is architecture-independent so this same package runs on
+# amd64 and arm64. JAVA_HOME/bin is first on PATH (above), so `java` is the 21.
+exec "${JAVA_HOME}/bin/java" -Dlucli.binary.name=wheels -jar /opt/wheels/lucli.jar "$@"
 WRAPPER_EOF
 
 # 6. Stamp the version + channel into build/ so nfpm can ship them at
@@ -187,15 +218,19 @@ fi
 #   and .github/RELEASE_PLAYBOOK.md § "Common failure modes".
 DEB_RPM_VERSION="$(echo "${WHEELS_VERSION}" | sed 's/-snapshot/~snapshot/')"
 
-WHEELS_VERSION="${DEB_RPM_VERSION}" nfpm pkg \
+# Architecture-independent packages: the payload is the LuCLI jar + CFML source
+# + a shell wrapper (no native code), so a single package serves every arch.
+# deb uses `all`, rpm uses `noarch` — PKG_ARCH is interpolated into the nfpm
+# config's `arch:` field.
+PKG_ARCH=all WHEELS_VERSION="${DEB_RPM_VERSION}" nfpm pkg \
   --config "../${NFPM_CONFIG}" \
   --packager deb \
-  --target "${NFPM_OUT}/${PKG_NAME}_${DEB_RPM_VERSION}_amd64.deb"
+  --target "${NFPM_OUT}/${PKG_NAME}_${DEB_RPM_VERSION}_all.deb"
 
-WHEELS_VERSION="${DEB_RPM_VERSION}" nfpm pkg \
+PKG_ARCH=noarch WHEELS_VERSION="${DEB_RPM_VERSION}" nfpm pkg \
   --config "../${NFPM_CONFIG}" \
   --packager rpm \
-  --target "${NFPM_OUT}/${PKG_NAME}-${DEB_RPM_VERSION}.x86_64.rpm"
+  --target "${NFPM_OUT}/${PKG_NAME}-${DEB_RPM_VERSION}.noarch.rpm"
 
 echo "── Done ──"
 ls -la "${NFPM_OUT}/" | grep -E "${PKG_NAME}_|${PKG_NAME}-"

--- a/tools/distribution-drafts/linux-packages/nfpm-wheels-be.yaml
+++ b/tools/distribution-drafts/linux-packages/nfpm-wheels-be.yaml
@@ -11,7 +11,9 @@
 #   nfpm pkg --packager rpm --target dist/wheels-be-${WHEELS_VERSION}.x86_64.rpm
 
 name: wheels-be
-arch: amd64
+# Architecture-independent (Java jar + CFML + shell wrapper). PKG_ARCH is set by
+# build-linux-packages.sh — `all` for deb, `noarch` for rpm.
+arch: ${PKG_ARCH}
 platform: linux
 version: ${WHEELS_VERSION}
 section: devel
@@ -25,12 +27,12 @@ vendor: Wheels
 homepage: https://wheels.dev
 license: Apache-2.0
 contents:
-  # LuCLI renamed to `wheels` at stage time so argv[0]-based dispatch works.
-  # See #2700.
-  - src: ./build/wheels
-    dst: /opt/wheels/wheels
+  # Portable LuCLI launcher jar; the wrapper runs it via
+  # `java -Dlucli.binary.name=wheels -jar` (arch-independent). See #2700.
+  - src: ./build/lucli.jar
+    dst: /opt/wheels/lucli.jar
     file_info:
-      mode: 0755
+      mode: 0644
   - src: ./build/module/
     dst: /opt/wheels/module/
     type: tree

--- a/tools/distribution-drafts/linux-packages/nfpm-wheels.yaml
+++ b/tools/distribution-drafts/linux-packages/nfpm-wheels.yaml
@@ -11,7 +11,9 @@
 # The version is interpolated from the WHEELS_VERSION env var at build time.
 
 name: wheels
-arch: amd64
+# Architecture-independent: the payload is a Java jar + CFML + a shell wrapper.
+# PKG_ARCH is set by build-linux-packages.sh — `all` for deb, `noarch` for rpm.
+arch: ${PKG_ARCH}
 platform: linux
 version: ${WHEELS_VERSION}
 section: devel
@@ -25,14 +27,14 @@ vendor: Wheels
 homepage: https://wheels.dev
 license: Apache-2.0
 contents:
-  # The LuCLI binary, renamed to `wheels` at stage time so basename(argv[0])
-  # is `wheels` when the wrapper execs it — LuCLI's module dispatcher routes
-  # via argv[0], so renaming is what makes `wheels start` reach the bundled
-  # module. See #2700.
-  - src: ./build/wheels
-    dst: /opt/wheels/wheels
+  # The portable LuCLI launcher jar. The wrapper runs it with
+  # `java -Dlucli.binary.name=wheels -jar`, which routes to the bundled wheels
+  # module (the flag replaces the old basename(argv[0]) trick) and is
+  # architecture-independent — what makes this package all/noarch. See #2700.
+  - src: ./build/lucli.jar
+    dst: /opt/wheels/lucli.jar
     file_info:
-      mode: 0755
+      mode: 0644
   # The CLI module — what LuCLI dispatches `wheels new`, `wheels migrate`, etc. into.
   - src: ./build/module/
     dst: /opt/wheels/module/

--- a/vendor/wheels/tests/specs/cli/LinuxPackageStagingSpec.cfc
+++ b/vendor/wheels/tests/specs/cli/LinuxPackageStagingSpec.cfc
@@ -71,13 +71,18 @@ component extends="wheels.WheelsTest" {
 				it("emits a wrapper that routes lucli through the wheels module", () => {
 					var src = fileRead(buildScript);
 
-					// The wrapper must either:
-					//   (a) rename the binary so argv[0] is `wheels` and exec
-					//       it directly (the brew approach — lucli routes by
+					// The wrapper must route lucli through the wheels module in one
+					// of these forms:
+					//   (a) rename the native binary so argv[0] is `wheels` and exec
+					//       it directly (the old brew approach — lucli routes by
 					//       basename(argv[0])), OR
-					//   (b) call lucli via `modules run wheels "$@"` explicitly.
-					// Either way, the bare `exec /opt/wheels/lucli "$@"` form
-					// is incorrect and produces `Unknown command: 'start'`.
+					//   (b) call lucli via `modules run wheels "$@"` explicitly, OR
+					//   (c) launch the portable jar with the binary-name flag:
+					//       `exec java -Dlucli.binary.name=wheels -jar /opt/wheels/lucli.jar "$@"`
+					//       (the arch-independent form — the flag replaces the
+					//       basename(argv[0]) trick; same mechanism Scoop uses).
+					// The bare `exec /opt/wheels/lucli "$@"` form is incorrect and
+					// produces `Unknown command: 'start'`.
 					var execsBareLucli = reFindNoCase(
 						"exec[[:space:]]+/opt/wheels/lucli[[:space:]]+""?\$@""?",
 						src
@@ -98,11 +103,19 @@ component extends="wheels.WheelsTest" {
 						"exec[[:space:]]+/opt/wheels/lucli[[:space:]]+modules[[:space:]]+run[[:space:]]+wheels",
 						src
 					) > 0;
-					expect(routesByArgv0 || routesByModulesRun).toBeTrue(
-						"The wrapper must route lucli through the wheels module — either via "
-						& "argv[0] rename (`exec /opt/wheels/wheels ""$@""`) or explicit module "
-						& "dispatch (`exec /opt/wheels/lucli modules run wheels ""$@""`). "
-						& "See issue ##2700."
+					// Arch-independent jar launcher: `-Dlucli.binary.name=wheels`
+					// routes to the wheels module and `-jar .../lucli.jar` runs the
+					// portable launcher (installs/runs on amd64 AND arm64).
+					var routesByJar = reFindNoCase(
+						"-Dlucli\.binary\.name=wheels[^\n]*-jar[^\n]*lucli\.jar",
+						src
+					) > 0;
+					expect(routesByArgv0 || routesByModulesRun || routesByJar).toBeTrue(
+						"The wrapper must route lucli through the wheels module — via "
+						& "argv[0] rename (`exec /opt/wheels/wheels ""$@""`), explicit module "
+						& "dispatch (`exec /opt/wheels/lucli modules run wheels ""$@""`), or the "
+						& "portable jar launcher (`java -Dlucli.binary.name=wheels -jar "
+						& "/opt/wheels/lucli.jar ""$@""`). See issue ##2700."
 					);
 				});
 


### PR DESCRIPTION
Fixes the two distribution vectors the new install-smoke CI (#3222) flagged: **apt arm64** and **yum (Rocky 9)**.

## Root causes
- **arm64**: the `.deb`/`.rpm` bundled the **amd64-only native `lucli-linux` launcher** and were built as `amd64`/`x86_64` — so no arm64 package exists (empty arm64 apt index).
- **yum**: the wrapper's `JAVA_HOME` probe listed only Debian/Ubuntu paths, so on RHEL/Fedora `wheels --version` failed with *"cannot find a Java 21 runtime"* even though `java-21-openjdk-headless` was installed.

## Fix
Switch the Linux packages to the **portable `java -Dlucli.binary.name=wheels -jar lucli.jar` launcher** — the same approach Scoop already uses (the `-D` flag replaces the native binary's `basename(argv[0])` routing). The payload is now pure Java + CFML + a shell wrapper, so the packages are **architecture-independent**: `all` (deb) / `noarch` (rpm), installable on amd64 **and** arm64. Also broadened the Java probe to cover RHEL/Fedora layouts (`jre-21`, version-stamped dirs) with a `command -v java` fallback.

## Validation (Docker, build → install → `wheels --version` → module-routed `--help`)
| | `--version` | jar routes |
|---|---|---|
| Ubuntu amd64 (.deb, `all`) | 4.0.4 ✅ | ✅ (no regression) |
| Ubuntu arm64 (.deb, `all`) | 4.0.4 ✅ | ✅ |
| Rocky 9 amd64 (.rpm, `noarch`) | 4.0.4 ✅ | ✅ (was the yum failure) |
| Rocky 9 arm64 (.rpm, `noarch`) | 4.0.4 ✅ | ✅ |

## ⚠️ Coordinated merge required
This renames the release assets to `wheels_<v>_all.deb` / `wheels-<v>.noarch.rpm`. The **apt-wheels** and **yum-wheels** receiver workflows fetch the old `_amd64.deb` / `.x86_64.rpm` names, so this must land **together** with the matching receiver updates in those repos (separate PRs) — otherwise the next release's apt/yum publish 404s. apt-wheels also needs its regen to index the `all` deb under arm64 (the empty-arm64-index area, #3218).

🤖 Generated with [Claude Code](https://claude.com/claude-code)