### PR TITLE
Release 4.0.5

### DIFF
--- a/.github/workflows/distribution-install-smoke.yml
+++ b/.github/workflows/distribution-install-smoke.yml
@@ -1,0 +1,261 @@
+name: Distribution install smoke (brew / scoop / apt / yum)
+
+# End-to-end guardian for the four public package-manager install vectors.
+#
+# Every Wheels release fans out to Homebrew, Scoop, apt.wheels.dev and
+# yum.wheels.dev through independent downstream repos + workflows. Those break
+# in ways the release build itself can't see — and only surface when a user
+# can't install:
+#   - the Homebrew formula auto-update dies when LuCLI ships a binary-less tag
+#     (recurring; homebrew-wheels#383/#384)
+#   - the apt stable Packages index gets clobbered to 0 bytes by a bleeding-edge
+#     publish (#3218 — and the arm64 stable index is empty right now)
+#   - a tap PR never merges / a dispatch token loses scope, leaving a channel
+#     stuck on an old version
+#
+# This workflow installs the CLI the exact documented way on each channel and
+# asserts `wheels --version` reports the current GA. It runs daily (propagation
+# has settled by then) and on demand. It does NOT run on `release: published`
+# on purpose — right after a tag the channels lag, which would be a false red;
+# the daily run is the signal.
+#
+# Java is NOT set up by hand anywhere: every package declares/bundles it
+# (brew `depends_on "openjdk@21"`, the .deb `Depends: openjdk-21-jre-headless`,
+# the scoop manifest inlines OpenJDK, the .rpm Requires java-21) — so a missing
+# Java here is itself a real packaging regression worth catching.
+
+on:
+  schedule:
+    # Daily 14:00 UTC. Runs on the default branch (develop). Far enough after
+    # any release that all four channels have propagated.
+    - cron: '0 14 * * *'
+  workflow_dispatch:
+    inputs:
+      expected_version:
+        description: "Version every channel must serve (blank = latest GA tag)"
+        required: false
+        default: ""
+  pull_request:
+    branches: [develop]
+    paths:
+      # Self-test when the workflow itself changes.
+      - '.github/workflows/distribution-install-smoke.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    name: Resolve expected version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - name: Determine the GA version each channel must serve
+        id: v
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          # Untrusted (workflow_dispatch input) — kept in env and validated to
+          # semver below; never interpolated straight into a shell command.
+          INPUT: ${{ github.event.inputs.expected_version }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT:-}" ]; then
+            VER="${INPUT#v}"
+            echo "Using dispatch input: $VER"
+          else
+            VER="$(gh release view --repo "$REPO" --json tagName -q .tagName | sed 's/^v//')"
+            echo "Latest GA tag: $VER"
+          fi
+          if ! printf '%s' "$VER" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::could not resolve a clean semver expected version (got '$VER')"
+            exit 1
+          fi
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+          echo "All channels must serve wheels $VER"
+
+  homebrew:
+    needs: resolve
+    name: "Homebrew (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        # macos-latest is Apple Silicon (arm64); ubuntu-latest exercises the
+        # Linuxbrew path (amd64). Both are documented install targets.
+        os: [macos-latest, ubuntu-latest]
+    env:
+      EXPECTED: ${{ needs.resolve.outputs.version }}
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_INSTALL_FROM_API: "1"
+      NONINTERACTIVE: "1"
+    steps:
+      # GitHub's ubuntu runners ship Homebrew (Linuxbrew) but do NOT put it on
+      # PATH; macos runners do. Add it on Linux so `brew` resolves in the next
+      # steps (GITHUB_PATH persists across steps).
+      - name: Ensure Homebrew is on PATH (Linuxbrew)
+        if: runner.os == 'Linux'
+        run: echo "/home/linuxbrew/.linuxbrew/bin" >> "$GITHUB_PATH"
+      - name: brew tap + install (the documented path)
+        run: |
+          set -euo pipefail
+          brew tap wheels-dev/wheels
+          # Newer Homebrew refuses to load a formula from a third-party tap until
+          # it's trusted — a hard error on Linuxbrew, a warning on macOS. (Worth
+          # surfacing in the tap's install docs for Linuxbrew users.)
+          brew trust wheels-dev/wheels || true
+          brew install wheels
+      - name: Assert wheels --version == GA
+        env:
+          CHANNEL: "Homebrew (${{ matrix.os }})"
+        run: |
+          set -uo pipefail
+          RAW="$(wheels --version 2>&1 || true)"
+          # Extract the first semver from the output. Channels differ in format:
+          # the LuCLI/brew build prints "Wheels Version: 4.0.4" (+ an ASCII
+          # banner), the .deb/.rpm print "wheels 4.0.4 (stable)" — neither a
+          # keyword filter nor a fixed prefix is portable, so take the first
+          # x.y.z (the version always leads; the banner carries no semver).
+          GOT="$(printf '%s\n' "$RAW" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+          echo "${CHANNEL}: wheels --version => '${GOT}' (expected '${EXPECTED}')"
+          if [ "$GOT" != "$EXPECTED" ]; then
+            echo "::error::${CHANNEL} serves '${GOT}', expected '${EXPECTED}'"
+            echo "--- raw wheels --version ---"; printf '%s\n' "$RAW" | head -20
+            exit 1
+          fi
+
+  scoop:
+    needs: resolve
+    name: "Scoop (windows)"
+    runs-on: windows-latest
+    timeout-minutes: 20
+    env:
+      EXPECTED: ${{ needs.resolve.outputs.version }}
+    steps:
+      - name: scoop bucket add + install (the documented path)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (-not (Get-Command scoop -ErrorAction SilentlyContinue)) {
+            Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
+          }
+          scoop bucket add wheels https://github.com/wheels-dev/scoop-wheels
+          scoop install wheels
+          # scoop puts shims in ~\scoop\shims and edits the *persistent* user
+          # PATH (registry) — which the next step's shell does not inherit.
+          # Expose the shims dir to later steps explicitly so `wheels` resolves.
+          "$env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+      - name: Assert wheels --version == GA
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $raw = (wheels --version 2>&1 | Out-String)
+          $got = [regex]::Match($raw, '\d+\.\d+\.\d+').Value
+          Write-Host "Scoop: wheels --version => '$got' (expected '$env:EXPECTED')"
+          if ($got -ne $env:EXPECTED) {
+            Write-Host "::error::Scoop serves '$got', expected '$env:EXPECTED'"
+            Write-Host "--- raw wheels --version ---"
+            Write-Host $raw
+            exit 1
+          }
+
+  apt:
+    needs: resolve
+    name: "apt (${{ matrix.arch }})"
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    # arm64 stable is allowed to fail for now: the stable arm64 Packages index
+    # is currently empty (the per-channel clobber bug, #3218), so `apt install`
+    # 404s on arm64. continue-on-error surfaces it (annotation + neutral result)
+    # without blocking the suite. Flip to a hard failure once the arm64 index is
+    # repaired.
+    continue-on-error: ${{ matrix.arch == 'arm64' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    env:
+      EXPECTED: ${{ needs.resolve.outputs.version }}
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: Add apt.wheels.dev + install
+        run: |
+          set -euo pipefail
+          # The published wheels.gpg is ASCII-armored, so dearmor it into the
+          # keyring. (The apt-wheels README still shows a bare `tee` of the
+          # armored key — the user-facing docs should be updated to dearmor to
+          # match this; tracked as a follow-up.)
+          curl -fsSL https://apt.wheels.dev/wheels.gpg | sudo gpg --dearmor -o /usr/share/keyrings/wheels.gpg
+          echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev stable main" \
+            | sudo tee /etc/apt/sources.list.d/wheels.list >/dev/null
+          sudo apt-get update
+          sudo apt-get install -y wheels
+      - name: Assert wheels --version == GA
+        env:
+          CHANNEL: "apt (${{ matrix.arch }})"
+        run: |
+          set -uo pipefail
+          RAW="$(wheels --version 2>&1 || true)"
+          # Extract the first semver from the output. Channels differ in format:
+          # the LuCLI/brew build prints "Wheels Version: 4.0.4" (+ an ASCII
+          # banner), the .deb/.rpm print "wheels 4.0.4 (stable)" — neither a
+          # keyword filter nor a fixed prefix is portable, so take the first
+          # x.y.z (the version always leads; the banner carries no semver).
+          GOT="$(printf '%s\n' "$RAW" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+          echo "${CHANNEL}: wheels --version => '${GOT}' (expected '${EXPECTED}')"
+          if [ "$GOT" != "$EXPECTED" ]; then
+            echo "::error::${CHANNEL} serves '${GOT}', expected '${EXPECTED}'"
+            echo "--- raw wheels --version ---"; printf '%s\n' "$RAW" | head -20
+            exit 1
+          fi
+
+  yum:
+    needs: resolve
+    name: "yum (rocky 9)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # RHEL-family, dnf4 — matches the documented `dnf config-manager --add-repo`
+    # path. The release ships an x86_64 rpm, which this amd64 container matches.
+    #
+    # continue-on-error for now: the rpm installs cleanly and pulls in
+    # java-21-openjdk-headless, but `wheels --version` reports "cannot find a
+    # Java 21 runtime" — the wrapper's Java detection doesn't locate Rocky 9's
+    # headless JRE (the headless package registers no /usr/bin/java alternative).
+    # That's a real yum-vector packaging bug to fix in the rpm/wrapper; surfaced
+    # here, non-blocking until then. Flip to a hard failure once fixed.
+    continue-on-error: true
+    container:
+      image: rockylinux:9
+    env:
+      EXPECTED: ${{ needs.resolve.outputs.version }}
+    steps:
+      - name: Add yum.wheels.dev + install (the documented path)
+        run: |
+          set -euo pipefail
+          dnf -y install dnf-plugins-core
+          dnf -y config-manager --add-repo https://yum.wheels.dev/wheels.repo
+          dnf -y install wheels
+      - name: Assert wheels --version == GA
+        env:
+          CHANNEL: "yum (rocky 9)"
+        run: |
+          set -uo pipefail
+          RAW="$(wheels --version 2>&1 || true)"
+          # Extract the first semver from the output. Channels differ in format:
+          # the LuCLI/brew build prints "Wheels Version: 4.0.4" (+ an ASCII
+          # banner), the .deb/.rpm print "wheels 4.0.4 (stable)" — neither a
+          # keyword filter nor a fixed prefix is portable, so take the first
+          # x.y.z (the version always leads; the banner carries no semver).
+          GOT="$(printf '%s\n' "$RAW" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+          echo "${CHANNEL}: wheels --version => '${GOT}' (expected '${EXPECTED}')"
+          if [ "$GOT" != "$EXPECTED" ]; then
+            echo "::error::${CHANNEL} serves '${GOT}', expected '${EXPECTED}'"
+            echo "--- raw wheels --version ---"; printf '%s\n' "$RAW" | head -20
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,7 +331,7 @@ jobs:
       # Build .deb / .rpm Linux packages alongside the zip artifacts. nfpm
       # needs no Linux-specific build host (it's a single Go binary), so this
       # runs on the same ubuntu-latest runner as the rest of the pipeline.
-      # Generates wheels_<v>_amd64.deb and wheels-<v>.x86_64.rpm in dist/.
+      # Generates arch-independent wheels_<v>_all.deb and wheels-<v>.noarch.rpm.
       # See tools/distribution-drafts/linux-packages/ for the nfpm configs.
       - name: Install nfpm
         run: |
@@ -484,8 +484,8 @@ jobs:
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip.md5
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip.sha512
-              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels*_amd64.deb
-              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels*.x86_64.rpm
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels*_all.deb
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels*.noarch.rpm
 
       #############################################
       # Create Snapshot Pre-Release (develop only)
@@ -540,8 +540,8 @@ jobs:
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip.md5
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-module-*.zip.sha512
-              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels*_amd64.deb
-              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels*.x86_64.rpm
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels*_all.deb
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels*.noarch.rpm
 
       #############################################
       # Dispatch downstream package managers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ All historical references to "CFWheels" in this changelog have been preserved fo
 
 ---
 
+# [4.0.5](https://github.com/wheels-dev/wheels/releases/tag/v4.0.5) => 2026-06-19
+
+### Added
+
+- Linux `.deb` / `.rpm` packages are now architecture-independent (`all` / `noarch`) and install on **arm64 (aarch64)** as well as amd64 — the package launches the CLI through a portable `java -jar` launcher instead of an amd64-only native binary, so `apt install wheels` / `dnf install wheels` now work on arm64 hosts (#3223)
+
+### Fixed
+
+- The Wheels CLI `.rpm` now starts on RHEL-family distributions (Rocky Linux, Fedora, AlmaLinux): the `/usr/bin/wheels` wrapper's Java-21 probe only checked Debian/Ubuntu paths, so `wheels` failed with "cannot find a Java 21 runtime" even with `java-21-openjdk-headless` installed. It now also resolves the RHEL/Fedora JRE layout (and falls back to `java` on `PATH`) (#3223)
+
+---
+
 # [4.0.4](https://github.com/wheels-dev/wheels/releases/tag/v4.0.4) => 2026-06-18
 
 ### Added

--- a/tools/distribution-drafts/linux-packages/build-linux-packages.sh
+++ b/tools/distribution-drafts/linux-packages/build-linux-packages.sh
@@ -9,9 +9,9 @@
 #   LUCLI_LINUX_URL  — URL for the Linux LuCLI binary (default: cybersonic upstream)
 #   OUT_DIR          — where to write the .deb / .rpm (default: dist/)
 #
-# Outputs (in OUT_DIR):
-#   wheels_<v>_amd64.deb      (or wheels-be_<v>_amd64.deb for BE channel)
-#   wheels-<v>.x86_64.rpm
+# Outputs (in OUT_DIR) — architecture-independent (Java jar payload):
+#   wheels_<v>_all.deb        (or wheels-be_<v>_all.deb for BE channel)
+#   wheels-<v>.noarch.rpm
 #
 # This script is idempotent — it tears down and recreates the build/ staging dir.
 # Run from the repo root.
@@ -21,8 +21,14 @@ set -euo pipefail
 WHEELS_VERSION="${WHEELS_VERSION:?WHEELS_VERSION must be set}"
 CHANNEL="${CHANNEL:-stable}"
 ARTIFACTS_DIR="${ARTIFACTS_DIR:-artifacts/wheels/${WHEELS_VERSION}}"
-LUCLI_VERSION="${LUCLI_VERSION:-0.3.7}"
-LUCLI_LINUX_URL="${LUCLI_LINUX_URL:-https://github.com/cybersonic/LuCLI/releases/download/v${LUCLI_VERSION}/lucli-${LUCLI_VERSION}-linux}"
+LUCLI_VERSION="${LUCLI_VERSION:-0.3.17}"
+# Portable JAR launcher (runs on any arch with Java 21) instead of the amd64-only
+# native `lucli-linux` binary. This is what makes the .deb/.rpm architecture-
+# independent (all/noarch) so they install on arm64 too — and it matches how the
+# Scoop manifest already launches LuCLI. Routing to the bundled `wheels` module
+# is done via -Dlucli.binary.name=wheels in the wrapper (the native binary did it
+# via basename(argv[0])).
+LUCLI_JAR_URL="${LUCLI_JAR_URL:-https://github.com/cybersonic/LuCLI/releases/download/v${LUCLI_VERSION}/lucli-${LUCLI_VERSION}.jar}"
 SQLITE_JDBC_VERSION="3.49.1.0"
 SQLITE_JDBC_URL="https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/${SQLITE_JDBC_VERSION}/sqlite-jdbc-${SQLITE_JDBC_VERSION}.jar"
 OUT_DIR="${OUT_DIR:-dist}"
@@ -59,13 +65,13 @@ tar -xzf "${ARTIFACTS_DIR}/wheels-module-${WHEELS_VERSION}.tar.gz" -C "${BUILD_D
 # 2. Unzip the framework into build/framework/
 unzip -q "${ARTIFACTS_DIR}/wheels-core-${WHEELS_VERSION}.zip" -d "${BUILD_DIR}/build/framework/"
 
-# 3. Download the LuCLI Linux binary as build/wheels. Renaming at stage time
-#    (mirroring the brew formula's `libexec.install resource("lucli") => "wheels"`)
-#    means basename(argv[0]) is `wheels` when the wrapper execs it, so lucli's
-#    module dispatcher resolves `wheels start` to the bundled wheels module
-#    instead of throwing `Unknown command`. See issue #2700.
-curl -fsSL -o "${BUILD_DIR}/build/wheels" "${LUCLI_LINUX_URL}"
-chmod +x "${BUILD_DIR}/build/wheels"
+# 3. Download the portable LuCLI JAR as build/lucli.jar. The wrapper launches it
+#    with `java -Dlucli.binary.name=wheels -jar`, which both (a) routes to the
+#    bundled wheels module (the flag replaces the old basename(argv[0]) trick the
+#    native binary relied on) and (b) is architecture-independent, so the package
+#    installs on amd64 AND arm64. See issue #2700 (routing) and the arch-independent
+#    refactor.
+curl -fsSL -o "${BUILD_DIR}/build/lucli.jar" "${LUCLI_JAR_URL}"
 
 # 4. Download SQLite JDBC
 curl -fsSL -o "${BUILD_DIR}/build/sqlite-jdbc.jar" "${SQLITE_JDBC_URL}"
@@ -86,18 +92,39 @@ cat > "${BUILD_DIR}/build/wrapper.sh" <<'WRAPPER_EOF'
 
 set -euo pipefail
 
-# Honor user-set JAVA_HOME if present; otherwise probe for OpenJDK 21.
+# Honor user-set JAVA_HOME if present; otherwise probe for OpenJDK 21 across the
+# Debian/Ubuntu AND RHEL/Fedora layouts, on amd64 and arm64.
 if [ -z "${JAVA_HOME:-}" ]; then
   for candidate in \
     /usr/lib/jvm/java-21-openjdk-amd64 \
+    /usr/lib/jvm/java-21-openjdk-arm64 \
     /usr/lib/jvm/java-21-openjdk \
+    /usr/lib/jvm/jre-21-openjdk \
+    /usr/lib/jvm/java-21 \
+    /usr/lib/jvm/jre-21 \
     /usr/lib/jvm/temurin-21-jdk-amd64 \
+    /usr/lib/jvm/temurin-21-jdk-arm64 \
     /usr/lib/jvm/zulu-21 \
     /usr/lib/jvm/default-java; do
-    if [ -d "${candidate}" ]; then
+    if [ -x "${candidate}/bin/java" ]; then
       export JAVA_HOME="${candidate}"
       break
     fi
+  done
+fi
+# RHEL/Fedora install into a version-stamped dir (java-21-openjdk-21.0.x...elN.<arch>)
+# that the fixed names above don't match, but the headless package registers
+# /usr/bin/java via the alternatives system — resolve JAVA_HOME from it.
+if [ -z "${JAVA_HOME:-}" ] && command -v java >/dev/null 2>&1; then
+  _j="$(command -v java)"
+  command -v readlink >/dev/null 2>&1 && _j="$(readlink -f "${_j}" 2>/dev/null || echo "${_j}")"
+  _jh="${_j%/bin/java}"
+  [ -x "${_jh}/bin/java" ] && export JAVA_HOME="${_jh}"
+fi
+# Last resort: glob the version-stamped RHEL/Fedora directories directly.
+if [ -z "${JAVA_HOME:-}" ]; then
+  for d in /usr/lib/jvm/java-21-openjdk-* /usr/lib/jvm/*jre-21* /usr/lib/jvm/*-21-*; do
+    if [ -x "${d}/bin/java" ]; then export JAVA_HOME="${d}"; break; fi
   done
 fi
 if [ -z "${JAVA_HOME:-}" ] || [ ! -x "${JAVA_HOME}/bin/java" ]; then
@@ -139,7 +166,11 @@ if [ -n "${LUCEE_EXT_DIR}" ] && ! ls "${LUCEE_EXT_DIR}"/sqlite-jdbc*.jar >/dev/n
   cp /opt/wheels/sqlite-jdbc.jar "${LUCEE_EXT_DIR}/sqlite-jdbc.jar"
 fi
 
-exec /opt/wheels/wheels "$@"
+# Launch via the portable LuCLI jar. -Dlucli.binary.name=wheels routes to the
+# bundled wheels module (replacing the native binary's basename(argv[0]) trick),
+# and `java -jar` is architecture-independent so this same package runs on
+# amd64 and arm64. JAVA_HOME/bin is first on PATH (above), so `java` is the 21.
+exec "${JAVA_HOME}/bin/java" -Dlucli.binary.name=wheels -jar /opt/wheels/lucli.jar "$@"
 WRAPPER_EOF
 
 # 6. Stamp the version + channel into build/ so nfpm can ship them at
@@ -187,15 +218,19 @@ fi
 #   and .github/RELEASE_PLAYBOOK.md § "Common failure modes".
 DEB_RPM_VERSION="$(echo "${WHEELS_VERSION}" | sed 's/-snapshot/~snapshot/')"
 
-WHEELS_VERSION="${DEB_RPM_VERSION}" nfpm pkg \
+# Architecture-independent packages: the payload is the LuCLI jar + CFML source
+# + a shell wrapper (no native code), so a single package serves every arch.
+# deb uses `all`, rpm uses `noarch` — PKG_ARCH is interpolated into the nfpm
+# config's `arch:` field.
+PKG_ARCH=all WHEELS_VERSION="${DEB_RPM_VERSION}" nfpm pkg \
   --config "../${NFPM_CONFIG}" \
   --packager deb \
-  --target "${NFPM_OUT}/${PKG_NAME}_${DEB_RPM_VERSION}_amd64.deb"
+  --target "${NFPM_OUT}/${PKG_NAME}_${DEB_RPM_VERSION}_all.deb"
 
-WHEELS_VERSION="${DEB_RPM_VERSION}" nfpm pkg \
+PKG_ARCH=noarch WHEELS_VERSION="${DEB_RPM_VERSION}" nfpm pkg \
   --config "../${NFPM_CONFIG}" \
   --packager rpm \
-  --target "${NFPM_OUT}/${PKG_NAME}-${DEB_RPM_VERSION}.x86_64.rpm"
+  --target "${NFPM_OUT}/${PKG_NAME}-${DEB_RPM_VERSION}.noarch.rpm"
 
 echo "── Done ──"
 ls -la "${NFPM_OUT}/" | grep -E "${PKG_NAME}_|${PKG_NAME}-"

--- a/tools/distribution-drafts/linux-packages/nfpm-wheels-be.yaml
+++ b/tools/distribution-drafts/linux-packages/nfpm-wheels-be.yaml
@@ -11,7 +11,9 @@
 #   nfpm pkg --packager rpm --target dist/wheels-be-${WHEELS_VERSION}.x86_64.rpm
 
 name: wheels-be
-arch: amd64
+# Architecture-independent (Java jar + CFML + shell wrapper). PKG_ARCH is set by
+# build-linux-packages.sh — `all` for deb, `noarch` for rpm.
+arch: ${PKG_ARCH}
 platform: linux
 version: ${WHEELS_VERSION}
 section: devel
@@ -25,12 +27,12 @@ vendor: Wheels
 homepage: https://wheels.dev
 license: Apache-2.0
 contents:
-  # LuCLI renamed to `wheels` at stage time so argv[0]-based dispatch works.
-  # See #2700.
-  - src: ./build/wheels
-    dst: /opt/wheels/wheels
+  # Portable LuCLI launcher jar; the wrapper runs it via
+  # `java -Dlucli.binary.name=wheels -jar` (arch-independent). See #2700.
+  - src: ./build/lucli.jar
+    dst: /opt/wheels/lucli.jar
     file_info:
-      mode: 0755
+      mode: 0644
   - src: ./build/module/
     dst: /opt/wheels/module/
     type: tree

--- a/tools/distribution-drafts/linux-packages/nfpm-wheels.yaml
+++ b/tools/distribution-drafts/linux-packages/nfpm-wheels.yaml
@@ -11,7 +11,9 @@
 # The version is interpolated from the WHEELS_VERSION env var at build time.
 
 name: wheels
-arch: amd64
+# Architecture-independent: the payload is a Java jar + CFML + a shell wrapper.
+# PKG_ARCH is set by build-linux-packages.sh — `all` for deb, `noarch` for rpm.
+arch: ${PKG_ARCH}
 platform: linux
 version: ${WHEELS_VERSION}
 section: devel
@@ -25,14 +27,14 @@ vendor: Wheels
 homepage: https://wheels.dev
 license: Apache-2.0
 contents:
-  # The LuCLI binary, renamed to `wheels` at stage time so basename(argv[0])
-  # is `wheels` when the wrapper execs it — LuCLI's module dispatcher routes
-  # via argv[0], so renaming is what makes `wheels start` reach the bundled
-  # module. See #2700.
-  - src: ./build/wheels
-    dst: /opt/wheels/wheels
+  # The portable LuCLI launcher jar. The wrapper runs it with
+  # `java -Dlucli.binary.name=wheels -jar`, which routes to the bundled wheels
+  # module (the flag replaces the old basename(argv[0]) trick) and is
+  # architecture-independent — what makes this package all/noarch. See #2700.
+  - src: ./build/lucli.jar
+    dst: /opt/wheels/lucli.jar
     file_info:
-      mode: 0755
+      mode: 0644
   # The CLI module — what LuCLI dispatches `wheels new`, `wheels migrate`, etc. into.
   - src: ./build/module/
     dst: /opt/wheels/module/

--- a/vendor/wheels/tests/specs/cli/LinuxPackageStagingSpec.cfc
+++ b/vendor/wheels/tests/specs/cli/LinuxPackageStagingSpec.cfc
@@ -71,13 +71,18 @@ component extends="wheels.WheelsTest" {
 				it("emits a wrapper that routes lucli through the wheels module", () => {
 					var src = fileRead(buildScript);
 
-					// The wrapper must either:
-					//   (a) rename the binary so argv[0] is `wheels` and exec
-					//       it directly (the brew approach — lucli routes by
+					// The wrapper must route lucli through the wheels module in one
+					// of these forms:
+					//   (a) rename the native binary so argv[0] is `wheels` and exec
+					//       it directly (the old brew approach — lucli routes by
 					//       basename(argv[0])), OR
-					//   (b) call lucli via `modules run wheels "$@"` explicitly.
-					// Either way, the bare `exec /opt/wheels/lucli "$@"` form
-					// is incorrect and produces `Unknown command: 'start'`.
+					//   (b) call lucli via `modules run wheels "$@"` explicitly, OR
+					//   (c) launch the portable jar with the binary-name flag:
+					//       `exec java -Dlucli.binary.name=wheels -jar /opt/wheels/lucli.jar "$@"`
+					//       (the arch-independent form — the flag replaces the
+					//       basename(argv[0]) trick; same mechanism Scoop uses).
+					// The bare `exec /opt/wheels/lucli "$@"` form is incorrect and
+					// produces `Unknown command: 'start'`.
 					var execsBareLucli = reFindNoCase(
 						"exec[[:space:]]+/opt/wheels/lucli[[:space:]]+""?\$@""?",
 						src
@@ -98,11 +103,19 @@ component extends="wheels.WheelsTest" {
 						"exec[[:space:]]+/opt/wheels/lucli[[:space:]]+modules[[:space:]]+run[[:space:]]+wheels",
 						src
 					) > 0;
-					expect(routesByArgv0 || routesByModulesRun).toBeTrue(
-						"The wrapper must route lucli through the wheels module — either via "
-						& "argv[0] rename (`exec /opt/wheels/wheels ""$@""`) or explicit module "
-						& "dispatch (`exec /opt/wheels/lucli modules run wheels ""$@""`). "
-						& "See issue ##2700."
+					// Arch-independent jar launcher: `-Dlucli.binary.name=wheels`
+					// routes to the wheels module and `-jar .../lucli.jar` runs the
+					// portable launcher (installs/runs on amd64 AND arm64).
+					var routesByJar = reFindNoCase(
+						"-Dlucli\.binary\.name=wheels[^\n]*-jar[^\n]*lucli\.jar",
+						src
+					) > 0;
+					expect(routesByArgv0 || routesByModulesRun || routesByJar).toBeTrue(
+						"The wrapper must route lucli through the wheels module — via "
+						& "argv[0] rename (`exec /opt/wheels/wheels ""$@""`), explicit module "
+						& "dispatch (`exec /opt/wheels/lucli modules run wheels ""$@""`), or the "
+						& "portable jar launcher (`java -Dlucli.binary.name=wheels -jar "
+						& "/opt/wheels/lucli.jar ""$@""`). See issue ##2700."
 					);
 				});
 

--- a/wheels.json
+++ b/wheels.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://wheels.dev/schema/wheels.json/v1.json",
   "name": "Wheels.fw",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Wheels — CFML MVC framework",
   "homepage": "https://wheels.dev",
   "documentation": "https://wheels.dev/guides/",


### PR DESCRIPTION
Cuts **Wheels 4.0.5** — a Linux-packaging hotfix on top of the **unannounced** 4.0.4. Merges develop into main; divergence healed via `-s ours` (release tree byte-identical to develop — verified empty `git diff HEAD origin/develop`).

**Merge with a MERGE COMMIT, not squash.** The push to main fires `release.yml` → tags `v4.0.5` at the merge SHA → publishes the GitHub Release → dispatches to homebrew/scoop/apt/yum + the develop auto-bump.

## 4.0.5 scope (since 4.0.4)
- **Added:** Linux `.deb`/`.rpm` are now arch-independent (`all`/`noarch`) → install on **arm64**.
- **Fixed:** RHEL/Fedora Java-detection — the `.rpm` now starts on Rocky/Fedora/AlmaLinux.
- (internal) distribution install-smoke CI across brew/scoop/apt/yum.

## Why a new version instead of re-baking 4.0.4
4.0.4 wasn't announced, and re-baking would mean force-moving a published tag or leaving two same-version packages of different arch in the apt/yum pools. 4.0.5 cleanly supersedes it; announce 4.0.5.

## Downstream is already prepped
apt-wheels/yum-wheels receivers fetch the new `_all.deb`/`.noarch.rpm` names (merged), Homebrew is pinned to LuCLI 0.3.17 (#384), and brew/scoop are unaffected by the Linux change — so 4.0.5 should publish green across all channels.