### PR TITLE
docs(web/blog): fix Adobe-breaking top-level var in from-wirebox-to-wheelsdi DI example

### DIFF
--- a/web/content/blog/posts/from-wirebox-to-wheelsdi.md
+++ b/web/content/blog/posts/from-wirebox-to-wheelsdi.md
@@ -46,10 +46,10 @@ PRs [#1883](https://github.com/wheels-dev/wheels/pull/1883) and [#1888](https://
 
 ```cfm
 // config/services.cfm — in-house DI, familiar surface
-var di = injector();
-di.map("emailService").to("app.lib.EmailService").asSingleton();
-di.map("currentUser").to("app.lib.CurrentUserResolver").asRequestScoped();
-di.bind("INotifier").to("app.lib.SlackNotifier").asSingleton();
+local.di = injector();
+local.di.map("emailService").to("app.lib.EmailService").asSingleton();
+local.di.map("currentUser").to("app.lib.CurrentUserResolver").asRequestScoped();
+local.di.bind("INotifier").to("app.lib.SlackNotifier").asSingleton();
 ```
 
 Scopes are explicit. Transient is the default — a fresh instance per call. Singleton lives for the application lifetime. Request-scoped lives for the duration of one HTTP request, cached on `request.$wheelsDICache`. Auto-wiring of `init()` arguments matches registered names when no explicit `initArguments` are passed, which is the common case and the reason most service definitions fit on one line.


### PR DESCRIPTION
## What

The published post **From WireBox to Wheels DI** has a `config/services.cfm` code example using a top-level `var di = injector();`. A bare top-level `var` statement **compile-errors on Adobe CF** ([#3063](https://github.com/wheels-dev/wheels/issues/3063)) — `config/services.cfm` is an included template, not a function body, so `var` isn't valid there on Adobe. Lucee/BoxLang tolerate it, but the snippet as shipped breaks for any Adobe reader who copies it.

Switched to the cross-engine-safe `local.di` form (matching the DI guide and CLAUDE.md), and updated the chained `.map()`/`.bind()` references to `local.di.*`.

## How this surfaced

Found during the Wheels 4.0 blog-series validation campaign. A validator claimed "the published guides ship the same `var di` form" — I verified, and the **guides are actually clean** (they already use `local.di`). The real occurrence was this one published blog post. The admin DB row (id 878) has been updated to match.

Content-only change to one blog `.md`; no executable code paths touched.