### PR TITLE
docs(web/guides): name the dead cfwheels-base-template slug and redirect to wheels-base-template

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/installing-with-commandbox.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/installing-with-commandbox.mdx
@@ -124,7 +124,20 @@ The 3.x getting-started spine was built on CommandBox. Here's how each old step 
 | `wheels generate app myApp` / `wheels g app` | `wheels new myApp` |
 | `box server start` | Still works — or `wheels start` (Lucee, bundled with the CLI) |
 | ForgeBox plugins (`box install ...`, `forgebox install`) | The [`wheels packages`](/v4-0-0/digging-deeper/packages/) registry (CLI-only; not ForgeBox) |
-| `box install wheels-base-template` + `wheels-core` | Unchanged — still the supported way to fetch the framework with CommandBox |
+| `box install cfwheels-base-template` | **Slug changed** — `box install wheels-base-template` (the `cfwheels-`-prefixed slug is dead; see below) |
+
+<Aside type="caution" title="The `cfwheels-base-template` slug is gone — use `wheels-base-template`">
+If your 2.x muscle memory is `box install cfwheels-base-template`, that command no longer works. The pre-rebrand `cfwheels-`-prefixed ForgeBox slugs (`cfwheels-base-template`, `cfwheels`) are **deprecated and unmaintained** — `cfwheels-base-template` still resolves on ForgeBox but errors on its missing `cfwheels` core dependency and leaves an unrunnable skeleton. The framework rebranded to **Wheels** at 3.0, and the supported 4.x slugs dropped the prefix:
+
+- `cfwheels-base-template` → [`wheels-base-template`](#supported-install-the-framework)
+- `cfwheels` → `wheels-core`
+
+Install the modern slug instead:
+
+```bash title="illustrative — the supported 4.x slug"
+box install wheels-base-template
+```
+</Aside>
 
 The practical recommendation: keep CommandBox if you rely on it for Adobe CF or BoxLang server management, and add the `wheels` CLI alongside it for everything in the [feature-set list above](#not-supported-via-commandbox-the-wheels-cli-feature-set).
 


### PR DESCRIPTION
## Docs signpost for the dead `cfwheels-base-template` slug

Addresses the **documentation** sliver of #3182. The core of #3182 — capping the legacy `cfwheels-base-template` / `cfwheels-cli` ForgeBox slugs and the `cfwheels.org` apex DNS — requires credentialed ForgeBox + DNS actions only the maintainer can perform (see the deprecation runbook in #3182). This PR handles the one piece the guides own.

### What changed

`web/sites/guides/src/content/docs/v4-0-0/start-here/installing-with-commandbox.mdx`:

- The 2.x/3.x → 4.x migration table previously claimed `box install wheels-base-template` + `wheels-core` was **"Unchanged"** — inaccurate for a genuine 2.x user, whose slug *did* change (`cfwheels-base-template` → `wheels-base-template`). The row now reads **"Slug changed"**.
- Adds a caution `<Aside>` naming the dead `cfwheels-`-prefixed slugs and mapping them to the supported 4.x slugs (`cfwheels-base-template` → `wheels-base-template`, `cfwheels` → `wheels-core`), so a migrating 2.x user with `box install cfwheels-base-template` in muscle memory gets a clear redirect instead of a broken skeleton.

### Scope

- **Refs #3182** — does **not** close it. The ForgeBox-side tombstoning + apex DNS (the issue's acceptance criteria) remain a maintainer action.
- Originated as a post-merge review finding on #3198.
- Docs-only, one file, `+14/-1`.
