### PR TITLE
docs(web/guides): give every tooling-gated task page a without-the-CLI path (restructure phase 4)

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/basics/database-and-multiple-datasources.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/basics/database-and-multiple-datasources.mdx
@@ -30,9 +30,52 @@ Wheels reads `dataSourceName` from `config/settings.cfm` at application start an
 set(dataSourceName = "myapp_dev");
 ```
 
-The name you set here must match a datasource registered with your CFML engine. In Lucee that's configured in `lucee.json` (or `/lucee/admin/` for server-scope datasources); in Adobe it's in the admin UI. Check your engine's documentation for the registration shape — Wheels only cares that the name resolves to a working connection. In development, a name that doesn't resolve surfaces as a `Wheels.DataSourceNotFound` error page naming the datasource (served with HTTP 404).
+The name you set here must match a datasource registered with your CFML engine — Wheels only cares that the name resolves to a working connection. The next section shows the registration shape for each setup. In development, a name that doesn't resolve surfaces as a `Wheels.DataSourceNotFound` error page naming the datasource (served with HTTP 404).
 
-`config/settings.cfm` is the shared file loaded in every environment. The next section shows how to override it per environment.
+`config/settings.cfm` is the shared file loaded in every environment; [per-environment overrides](#per-environment-datasource) shadow it.
+
+## Registering a datasource
+
+Where the registration lives depends on what serves your app:
+
+**With the wheels CLI** — datasources live in `lucee.json` at the app root. `wheels new` writes the SQLite pair for you; add more under `configuration.datasources` using the same shape:
+
+```json title="lucee.json (excerpt — the shape wheels new generates)"
+"configuration": {
+  "datasources": {
+    "myapp_dev": {
+      "class": "org.sqlite.JDBC",
+      "database": "myapp_dev",
+      "dbdriver": "Other",
+      "dsn": "jdbc:sqlite:{project}/db/development.sqlite",
+      "host": "", "username": "", "password": ""
+    }
+  }
+}
+```
+
+For MySQL/Postgres, swap `class`/`dsn` for the driver's JDBC form (e.g. `com.mysql.cj.jdbc.Driver` with `jdbc:mysql://localhost:3306/myapp`). Restart the server (`wheels stop && wheels start`) after editing.
+
+**With CommandBox** — the scaffolded `box.json` already includes `commandbox-cfconfig`; declare datasources in `server.json` and CFConfig applies them at server start:
+
+```json title="server.json (excerpt)"
+"cfconfig": {
+  "datasources": {
+    "myapp_dev": {
+      "dbdriver": "MySQL",
+      "host": "localhost", "port": 3306,
+      "database": "myapp",
+      "username": "wheels", "password": "${DB_PASSWORD}"
+    }
+  }
+}
+```
+
+**With your own server (manual installs)** — register the datasource in the engine's admin: Lucee's server or web admin, or the **ColdFusion Administrator** on Adobe (don't rely on runtime-defined datasources on ACF — admin-registered is the reliable path).
+
+<Aside type="caution" title="Adobe ColdFusion + MySQL 8">
+If the app connects but models and the migrator act as if your tables don't exist, add `nullCatalogMeansCurrent=true` to the datasource's Connection String in the CF Administrator — MySQL Connector/J 8 changed its metadata default and schema reads come back empty without it. Details in [IIS and Windows Deployment](/v4-0-0/deployment/iis-and-windows/#adobe-coldfusion--mysql-8).
+</Aside>
 
 ## Per-environment datasource
 
@@ -151,7 +194,7 @@ Transactions commit when the block exits cleanly and roll back on any thrown exc
 
 ## Raw queries
 
-For the rare query the ORM can't express cleanly — a reporting aggregate, a window function, a vendor-specific feature — drop through to native CFML `queryExecute()`. Point it at your model's datasource with the `datasource` option and use positional parameters for any user input.
+For the rare query the ORM can't express cleanly — a reporting aggregate, a window function, a vendor-specific feature — drop through to native CFML `queryExecute()`. Point it at the app's configured datasource with the `datasource` option (don't hardcode an environment-specific name — that undoes the per-environment configuration above) and use positional parameters for any user input.
 
 ```cfm {test:compile}
 component extends="Model" {
@@ -159,7 +202,7 @@ component extends="Model" {
         return queryExecute(
             "SELECT userId, COUNT(*) AS postCount FROM posts GROUP BY userId ORDER BY postCount DESC LIMIT ?",
             [arguments.limit],
-            {datasource: "myapp_production"}
+            {datasource: get("dataSourceName")}
         );
     }
 }

--- a/web/sites/guides/src/content/docs/v4-0-0/basics/migrations.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/basics/migrations.mdx
@@ -12,8 +12,9 @@ Migrations are versioned CFCs that carry your schema forward and back. Each one 
 
 **You'll learn:**
 
-- The seven `wheels migrate` subcommands — four for the day-to-day workflow, three for reconciliation when something's off
-- How to generate a migration file and what the timestamped filename means
+- Running migrations — with the `wheels` CLI, and without it (browser GUI or programmatic)
+- The `wheels migrate` subcommands — the day-to-day four, plus reconciliation for when something's off
+- How to generate or hand-write a migration file and what the timestamped filename means
 - The column builder methods on `createTable` — `string`, `integer`, `datetime`, `references`, `timestamps`
 - How to add and remove indexes and foreign keys without dropping a table
 - How to add, rename, and remove columns on an existing table
@@ -23,7 +24,7 @@ Migrations are versioned CFCs that carry your schema forward and back. Each one 
   A migration describes schema — the tables and columns your models map to. For the model side — finders, validations, callbacks — see [Models and the ORM](/v4-0-0/basics/models-and-the-orm/).
 </Aside>
 
-## Running migrations
+## Running migrations with the wheels CLI
 
 Four subcommands cover the day-to-day workflow. Each one connects to your app's datasource and reads the migration history out of `wheels_migrator_versions`, so the app has to be running for them to work — without a server, every `wheels migrate` subcommand refuses with a pointer at `wheels start` instead of guessing at a database. See [Installing Wheels](/v4-0-0/start-here/installing/) for the server setup.
 
@@ -37,9 +38,7 @@ wheels migrate info
 - `wheels migrate info` — show which migrations have run and which are still pending. Read-only; safe any time. Orphan versions (rows in the tracking table with no matching file in `app/migrator/migrations/`) are flagged with `[?] <version> <name> (applied <timestamp>)` when the enriched `wheels_migrator_versions.name` / `.applied_at` columns are populated, or `[?] <version> ********** NO FILE **********` (Rails-style) for legacy rows that pre-date the schema enrichment.
 
 <Aside type="caution" title="Write commands require a project-bound server">
-`wheels migrate latest`, `migrate up`, `migrate down`, `migrate forget`, `migrate pretend`, `migrate rename-system-tables`, `wheels seed`, and `wheels db reset` (which runs migrate + seed) only connect to a server whose port is explicitly configured for this project — via the `port` field in `lucee.json` (created by `wheels new`, or set manually) or the `PORT` variable in `.env`. They refuse the common-port fallback (8080, etc.) to prevent silently targeting a sibling app's server when you work on multiple projects. If you see `Wheels.ServerNotRunning`, run `wheels start` in this project's directory first.
-
-`wheels migrate info` and `wheels migrate doctor` are read-only, so they keep the common-port fallback like the other read-side commands (`wheels info`, `wheels routes`, …): with no project-bound port configured they probe 8080, 60000, 3000, and 8500 and attach to the first responding server. Because a sibling project's server on one of those ports would report the *wrong* app's migration state, they print a yellow notice whenever the fallback was used — set `port` in `lucee.json` (or `PORT` in `.env`) to pin them to this project ([#3080](https://github.com/wheels-dev/wheels/issues/3080)).
+Migrate's write commands only connect to a server whose port is explicitly configured for *this* project — the `port` field in `lucee.json` or `PORT` in `.env` — so they can't silently target a sibling app's server. If you see `Wheels.ServerNotRunning`, run `wheels start` in this project's directory first (read-only commands like `migrate info` fall back to probing common ports and print a notice when they do — [#3080](https://github.com/wheels-dev/wheels/issues/3080); the [Database commands reference](/v4-0-0/command-line-tools/wheels-commands/database/) has the full port-resolution rules).
 </Aside>
 
 The runner wraps each migration in a transaction so a failing `up()` or `down()` rolls back cleanly on databases that support transactional DDL — but that support varies, so read the caution below before relying on it. One more caveat for scripts and CI: a failed migration is loud in the command output but the CLI currently still exits `0`, so don't gate a pipeline on the exit code alone ([#3081](https://github.com/wheels-dev/wheels/issues/3081)).
@@ -47,6 +46,17 @@ The runner wraps each migration in a transaction so a failing `up()` or `down()`
 <Aside type="caution" title="DDL auto-commit on MySQL and Oracle">
 On MySQL and Oracle, DDL statements (`CREATE TABLE`, `ALTER TABLE`, `DROP TABLE`, …) implicitly commit the surrounding transaction. A multi-statement migration that fails midway on those databases leaves the statements that already ran committed — partial schema the transaction wrapper cannot undo. PostgreSQL, SQL Server, and SQLite support transactional DDL, so the all-or-nothing guarantee holds there. On MySQL/Oracle, prefer small single-purpose migrations, and if one does die halfway, use `wheels migrate doctor` and the reconciliation subcommands below to get the tracking table and schema back in line.
 </Aside>
+
+## Running migrations without the wheels CLI
+
+The CLI is a convenience, not a requirement — CommandBox teams and manual installs have the same capabilities:
+
+- **Browser GUI** — `/wheels/migrator` shows applied and pending migrations with run/rollback controls. Like all `/wheels/*` surfaces it's **development-only** (hard allowlist since 4.0.4, [#2903](https://github.com/wheels-dev/wheels/pull/2903)).
+- **Programmatic** — `application.wheels.migrator.migrateToLatest()` and `.migrateTo(version)` run the same runner from any server-side code path in **any environment**: a deploy hook, a protected admin action, a one-off script. `application.wheels.migrator.getCurrentMigrationVersion()` reads the current state.
+- **At startup** — `set(autoMigrateDatabase=true)` in `config/settings.cfm` applies pending migrations when the application starts. Handy for single-node setups where "deploy then migrate" ordering is a chore; think twice on multi-node deployments (every node races to migrate on boot).
+- **Writing the files** — a migration is a plain CFC in `app/migrator/migrations/` named `YYYYMMDDHHMMSS_description.cfc` with `up()`/`down()` methods; the generator below just saves you the boilerplate. Copy an existing file as your starting point.
+
+The full no-CLI task map lives at [Working Without the CLI](/v4-0-0/start-here/working-without-the-cli/).
 
 ## Reconciliation subcommands
 
@@ -246,7 +256,7 @@ component extends="wheels.migrator.Migration" hint="Seed admin role" {
 }
 ```
 
-Quote string values inline; wrap each statement in `execute()` individually. For anything structural — building a compound object, branching on current rows — consider writing a one-off script under `app/scripts/` and calling it from your deploy pipeline instead.
+Quote string values inline; wrap each statement in `execute()` individually. For anything structural — building a compound object, branching on current rows — consider writing a one-off script under `app/lib/` and calling it from your deploy pipeline instead.
 
 ## Reversible vs irreversible
 

--- a/web/sites/guides/src/content/docs/v4-0-0/basics/seeding.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/basics/seeding.mdx
@@ -83,7 +83,7 @@ Save that as `app/db/seeds/development.cfm` and it runs after `seeds.cfm` whenev
 
 Execution order is fixed: `app/db/seeds.cfm` runs first (always), then `app/db/seeds/<environment>.cfm` (if present). Both files share the same transaction — a failure in either rolls the whole run back.
 
-## Running seeds
+## Running seeds with the wheels CLI
 
 Seeds run against your app's datasource, so the server has to be up — with no server running, `wheels seed` refuses and points you at `wheels start` rather than seeding the wrong database.
 
@@ -100,6 +100,18 @@ The commands you'll actually use day-to-day:
 There is no `wheels generate seed` command — it errors with `Unknown generator type: seed`. The snippets generator above is the scaffold path.
 
 You may also see references to `wheels seed --generate`, a legacy flag from before `seedOnce()` existed that bypasses your seed files and generates random fake records for every model. It's currently non-functional: every model errors internally, zero rows are created, and the command still reports success ([#3082](https://github.com/wheels-dev/wheels/issues/3082)). Don't use it — write explicit `seedOnce()` calls where you control the data.
+
+## Running seeds without the wheels CLI
+
+The seeder is a framework object, so any server-side code path can invoke it — no CLI required:
+
+```cfm title="illustrative — a deploy hook or protected admin action"
+result = application.wheels.seeder.runSeeds();
+// or target a specific environment's seed files:
+result = application.wheels.seeder.runSeeds(environment="production");
+```
+
+That's the exact call `wheels seed` makes, with the same transaction wrapper and the same `seeds.cfm` → `seeds/<environment>.cfm` order. It works in **any environment**, which makes it the production path too: call it from a deploy hook or an authenticated admin action rather than shelling into the box. The full no-CLI task map lives at [Working Without the CLI](/v4-0-0/start-here/working-without-the-cli/).
 
 ## Multiple `seedOnce` calls in one file
 
@@ -142,7 +154,7 @@ For any of those, write a one-off migration or a script under `app/lib/` that yo
 
 Tests should not run production seeds. The test harness has its own fixture setup — `tests/populate.cfm` in the WheelsTest convention — that builds whatever records each spec needs and tears them down between runs. Pointing the seeder at a test database would couple your specs to whatever rows happen to live in `seeds.cfm`, which is the opposite of what fixtures are for.
 
-Testing content lands in Phase 2b; until then, see the stub at [Testing](/v4-0-0/testing/).
+See [Fixtures & Test Data](/v4-0-0/testing/fixtures-and-test-data/) for the populate lifecycle and per-spec isolation patterns.
 
 ## Related guides
 

--- a/web/sites/guides/src/content/docs/v4-0-0/contributing/running-framework-tests.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/contributing/running-framework-tests.mdx
@@ -1,0 +1,140 @@
+---
+title: Running the Framework Test Suite
+description: For framework contributors — tools/test-local.sh, the /wheels/core/tests runner, the Docker cross-engine matrix, and the gotchas that bite first PRs.
+type: howto
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+This page is for people hacking on **Wheels itself** — the code in `vendor/wheels/` of the [framework repo](https://github.com/wheels-dev/wheels). If you're testing *your application*, you want [Running Tests Locally](/v4-0-0/testing/running-tests-locally/); nothing on this page exists in a scaffolded app.
+
+The fast inner loop is Lucee 7 + SQLite via `tools/test-local.sh`. The Docker matrix exists for the other job: proving a change works across every engine and database before you push.
+
+## The one-shot script — `tools/test-local.sh`
+
+`tools/test-local.sh` is what every framework contributor runs before pushing. It creates the two SQLite test databases (`wheelstestdb.db` and `wheelstestdb_tenant_b.db`), starts a disposable server on port 8080 if one isn't already up, downloads the SQLite JDBC driver if missing, runs the suite, and prints coloured pass/fail output. On exit it stops any server it started.
+
+```bash title="your shell — in the wheels repo root"
+bash tools/test-local.sh              # run all core tests
+bash tools/test-local.sh model        # run model specs only
+bash tools/test-local.sh security     # run security specs only
+bash tools/test-local.sh browser      # run browser specs (Playwright JARs required)
+```
+
+The script accepts these short aliases as the first argument: `model` / `models`, `controller` / `controllers`, `view` / `views`, `security`, `middleware`, `dispatch`, `migrator`. Anything else is passed through as a literal directory path (dot-notation, rooted at `wheels.tests.specs.`).
+
+Environment knobs:
+
+- `PORT=9090 bash tools/test-local.sh` — use a non-default port (handy when 8080 is in use).
+- `DB=mysql bash tools/test-local.sh` — run against a different database; bring up the container yourself first (see the Docker matrix below).
+- `WHEELS_BROWSER_TEST_BASE_URL` — auto-set to `http://localhost:${PORT}` so browser specs hit the same server the script starts.
+
+You can also run the framework suite through the CLI: `wheels test --core`, with `--db=<sqlite|h2|mysql|postgres|sqlserver|oracle|cockroachdb>` selecting between the `wheelstestdb_*` datasources the matrix wires up (`--db` is only honoured with `--core`).
+
+## The core test-runner URL
+
+The fastest iteration loop is hitting the runner directly over HTTP — this is what the script calls under the hood:
+
+```bash title="direct HTTP access (dev server running)"
+# Run everything
+curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json"
+
+# Filter by directory
+curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json&directory=wheels.tests.specs.model"
+
+# Filter to a single spec file — use testBundles, not directory
+curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json&testBundles=wheels.tests.specs.model.callbacksSpec"
+
+# Skip populate when iterating on one spec and the schema is already in place
+curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json&populate=false&testBundles=wheels.tests.specs.model.callbacksSpec"
+
+# Scope to a single installed package's tests (e.g. wheels-sentry, wheels-i18n)
+curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json&directory=vendor.wheels-sentry.tests"
+```
+
+`directory=` only filters down to a *directory* — pointing it at a single spec file matches zero bundles and runs nothing; use `testBundles=` for one file. The core endpoint only accepts `directory` values starting with `wheels.tests` (or `vendor.<package>.tests`); anything else is rejected and the **full** suite runs instead — the JSON flags this with `directoryRejected: true` and a `warnings[]` entry rather than silently reporting green ([#3083](https://github.com/wheels-dev/wheels/issues/3083)). `populate=false` is the other inner-loop trick: populate drops and recreates every test table, so skipping it once the schema exists shaves the run down to just your specs.
+
+<Aside type="note" title="Scope-visibility fields in the JSON response">
+  The payload includes `directoryRequested`, `directoryResolved`, `directoryRejected`, `bundlesDiscovered`, and `warnings[]`. A path naming a single spec file yields `bundlesDiscovered: 0` and a warning — reach for `testBundles=` instead.
+</Aside>
+
+## Docker cross-engine matrix
+
+`compose.yml` at the repo root ships a service per supported engine, bind-mounted to your checkout — edit code, hit the port, no rebuilds. `tools/test-matrix.sh` wraps it end-to-end (`tools/test-matrix.sh lucee6,adobe2025 sqlite` mirrors CI's compat matrix); or drive it by hand:
+
+```bash title="your shell — in the wheels repo root"
+# Start Lucee 7 + Adobe 2025 (minimum for a cross-engine check)
+docker compose up -d lucee7 adobe2025
+
+# Wait ~60s for startup, then run both
+curl -s -o /tmp/lucee7.json   "http://localhost:60007/wheels/core/tests?db=sqlite&format=json"
+curl -s -o /tmp/adobe2025.json "http://localhost:62025/wheels/core/tests?db=sqlite&format=json"
+
+# Summarize
+for f in /tmp/lucee7.json /tmp/adobe2025.json; do
+  python3 -c "
+import json
+d = json.load(open('$f'))
+print('$f', d['totalPass'], 'pass', d['totalFail'], 'fail', d['totalError'], 'error')
+"
+done
+```
+
+| Engine | Service | Port |
+|--------|---------|------|
+| Lucee 5 | `lucee5` | 60005 |
+| Lucee 6 | `lucee6` | 60006 |
+| Lucee 7 | `lucee7` | 60007 |
+| Adobe 2018 | `adobe2018` | 62018 |
+| Adobe 2021 | `adobe2021` | 62021 |
+| Adobe 2023 | `adobe2023` | 62023 |
+| Adobe 2025 | `adobe2025` | 62025 |
+| BoxLang | `boxlang` | 60001 |
+
+<Aside type="tip">
+  At minimum, run one Lucee and one Adobe before pushing — their runtimes diverge in ways pure-Lucee tests don't catch. Do not iterate on Adobe failures through CI; reproduce locally (round-tripping GitHub Actions burns ~20 minutes per attempt).
+</Aside>
+
+## Testing against specific databases
+
+Each engine ships with H2 and SQLite baked in. Everything else is a compose service you bring up alongside the engine: `mysql`, `postgres`, `sqlserver`, `cockroachdb`, `oracle`.
+
+```bash title="your shell — multi-database"
+docker compose up -d lucee7 mysql
+curl -sf "http://localhost:60007/wheels/core/tests?db=mysql&format=json"
+```
+
+Supported `db` values: `sqlite` (script default), `h2`, `mysql`, `postgres`, `sqlserver`, `oracle`, `cockroachdb`. Oracle is soft-failed in CI — failures log warnings but don't block the build. (The `docker-compose.db-*.yml` files at the repo root are dev-stack overlays for the demo app, not test-matrix services.)
+
+## Cross-engine gotchas
+
+The runtime differences that catch first-time framework contributors — each one has stung a real PR. The full list lives in [Coding Standards](/v4-0-0/contributing/coding-standards/#cross-engine-rules); the ones that bite in *tests* specifically:
+
+- **`struct.map()`** resolves to the built-in struct member function on Lucee/Adobe, not your CFC method.
+- **`application` scope members** — Adobe CF rejects function members on the `application` scope.
+- **Closure `this` capture** — share references across closures with `var ctx = { ref: obj }`.
+- **`obj["key"]()` inside closures** crashes Adobe 2021/2023's parser — split into `var fn = obj["key"]; fn();`.
+- **Arrays copy by value in struct literals on Adobe** — reference through a parent struct instead.
+- **`private` mixin functions are not integrated** — `$integrateComponents()` copies only `public` methods; helpers in `vendor/wheels/model/*.cfc` and friends must be `public` with a `$` prefix.
+
+## Contributor failure modes
+
+- **Docker daemon not running** — start Docker Desktop (macOS/Windows) or `systemctl start docker` (Linux).
+- **Port already in use** — `lsof -i :60007` and stop the holder; or `PORT=` a different one for the script.
+- **Populate SQL errors** — "Table already exists" means a stale table from a previous engine-specific run (add `DROP TABLE IF EXISTS`); "No such function: NOW" means cross-engine SQL drift — use `CURRENT_TIMESTAMP`.
+- **Stale SQLite files** — `rm -f wheelstestdb.db wheelstestdb_tenant_b.db` between weird runs.
+- **Server not responding after `compose up`** — engines cold-start in 30–90 seconds; check `docker compose logs <service>` if it stays down past two minutes.
+
+```bash title="cleanup"
+docker compose down
+rm -f wheelstestdb.db wheelstestdb_tenant_b.db
+wheels stop
+```
+
+## Related
+
+<CardGrid>
+  <LinkCard title="Coding Standards" href="/v4-0-0/contributing/coding-standards/" description="The cross-engine rules in full, plus the pre-push test bar." />
+  <LinkCard title="Submitting Pull Requests" href="/v4-0-0/contributing/pull-requests/" description="What CI runs and what reviewers expect." />
+  <LinkCard title="Running Tests Locally" href="/v4-0-0/testing/running-tests-locally/" description="Testing your application (not the framework)." />
+</CardGrid>

--- a/web/sites/guides/src/content/docs/v4-0-0/testing/ci-integration.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/testing/ci-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: CI Integration
-description: Running Wheels tests in GitHub Actions — cross-engine matrix, reporters, browser gating, soft-fail databases.
+description: Run your app's test suite in GitHub Actions — with the wheels CLI or with CommandBox — plus reporters, browser gating, caching, and the failure modes that eat CI minutes.
 type: howto
 sidebar:
   order: 10
@@ -8,24 +8,23 @@ sidebar:
 
 import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-The pattern that works for Wheels in CI is the same pattern that works locally — Lucee 7 + SQLite for the fast gate, Docker-driven matrix for the thorough one — wrapped in YAML. The framework's own `.github/workflows/` is the reference implementation: `pr.yml` boots LuCLI on a single runner for the fast path, and `compat-matrix.yml` runs the full engine x database grid on a schedule. This page walks the pieces you'd copy into your own application's workflow: the minimum viable run, the cross-engine matrix, the browser-test gate, soft-fail databases, caching, and the failure modes that eat CI minutes.
+CI for a Wheels app is the local loop wrapped in YAML: install a runtime, start the app, run the suite, fail the build on red. This page gives that shape twice — once with the `wheels` CLI, once without it (CommandBox) — plus the pieces you add as your suite grows: reporters, browser-test gating, cross-engine matrices, and caching.
 
 **You'll learn:**
 
-- A minimum-viable GitHub Actions workflow for running `wheels test` in CI
-- Which reporter names the CLI accepts today and how CI consumes the output
-- How to drive the cross-engine matrix via Docker Compose
+- A minimum-viable GitHub Actions workflow for a scaffolded Wheels app — with and without the CLI
+- Which reporter names the CLI accepts and how CI consumes the output
 - How to opt browser specs in or out with `WHEELS_CI` and `WHEELS_BROWSER_CI_ENABLE`
-- How to mark a flaky database as soft-fail so it can't block a PR
+- Cross-engine matrices, soft-fail cells, and caching
 - Common CI failures and what they actually mean
 
 <Aside type="note">
-  You should already know how to run tests locally. See [Running Tests Locally](/v4-0-0/testing/running-tests-locally/) for `wheels test`, `tools/test-local.sh`, and the Docker Compose map of ports and databases.
+  You should already know how to run tests locally — see [Running Tests Locally](/v4-0-0/testing/running-tests-locally/). Contributing to the framework itself? Its CI reference implementation lives in the repo's `.github/workflows/` and is covered from [Running the Framework Test Suite](/v4-0-0/contributing/running-framework-tests/).
 </Aside>
 
-## GitHub Actions — minimum viable
+## Minimum viable — with the wheels CLI
 
-The smallest workflow that runs the suite on every pull request: check out the code, install Java 21, install LuCLI, create the SQLite database files, start the server, and run the tests. Everything else on this page is additions to this shape.
+The `wheels` CLI installs on an `ubuntu-latest` runner from the signed apt repository — the same commands as the [installation guide](/v4-0-0/command-line-tools/installation/#linux-apt--yum) — and the package pulls OpenJDK 21 in as a dependency, so there's no separate Java step:
 
 ```yaml title=".github/workflows/tests.yml"
 name: tests
@@ -39,97 +38,96 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Java 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
-      - name: Install LuCLI
+      - name: Install the wheels CLI
         run: |
-          curl -sL "https://github.com/cybersonic/LuCLI/releases/download/v0.3.7/lucli-0.3.7-linux" \
-            -o /usr/local/bin/lucli
-          chmod +x /usr/local/bin/lucli
+          curl -fsSL https://apt.wheels.dev/wheels.gpg \
+            | sudo gpg --dearmor -o /usr/share/keyrings/wheels.gpg
+          echo "deb [signed-by=/usr/share/keyrings/wheels.gpg] https://apt.wheels.dev stable main" \
+            | sudo tee /etc/apt/sources.list.d/wheels.list
+          sudo apt-get update && sudo apt-get install -y wheels
+          wheels --version
 
-      - name: Create SQLite test databases
-        run: |
-          sudo apt-get update -y && sudo apt-get install -y --no-install-recommends sqlite3
-          sqlite3 wheelstestdb.db "SELECT 1;"
-          sqlite3 wheelstestdb_tenant_b.db "SELECT 1;"
+      - name: Start the app
+        run: wheels start
 
-      - name: Start Lucee and run tests
-        run: bash tools/test-local.sh
+      - name: Run the suite
+        run: wheels test --ci
 ```
 
-Three details to notice:
+Treat this as the shape, not gospel — the step that varies per app is the database. A fresh `wheels new` app tests against SQLite (`wheels test` swaps onto the `<datasource>_test` database and `tests/populate.cfm` builds the schema), which works on a bare runner. If your app tests against MySQL or Postgres, add a [service container](https://docs.github.com/en/actions/using-containerized-services/about-service-containers) and make sure the test datasource points at it.
 
-- **`actions/setup-java@v4` sets `JAVA_HOME` for you.** The LuCLI preflight refuses to start if `JAVA_HOME` is unset, and it is the single most common first-CI failure. The official `setup-java` action exports `JAVA_HOME` into the subsequent steps' environment, so you never have to set it by hand.
-- **`WHEELS_CI=true`** is a signal for the test harness — most visibly, it gates browser specs (covered below). You want it on every CI job.
-- **`tools/test-local.sh`** is the bundled shell script. It boots a LuCLI server, waits for it, warms the app, runs the suite, and prints a pass/fail summary with a non-zero exit code on failure. For most app repos, calling it is simpler than re-implementing the dance inline.
+Two details worth knowing:
 
-If you want the raw CLI instead of the bash wrapper, the equivalent is `wheels start` followed by `wheels test --ci`.
+- **`WHEELS_CI=true`** is a signal for the test harness — most visibly it gates browser specs (below). Set it on every CI job.
+- **`wheels test --ci`** exits non-zero on failure and emits one GitHub Actions `::error` annotation per failed or errored spec, so failures surface inline in the PR checks ([#3113](https://github.com/wheels-dev/wheels/issues/3113)).
+
+## Minimum viable — without the wheels CLI
+
+CommandBox shops (or anyone who'd rather not add a tool to CI) run the same suite through the [test-runner URL](/v4-0-0/testing/running-tests-locally/#without-the-wheels-cli). Ortus publishes a setup action for CommandBox:
+
+```yaml title=".github/workflows/tests.yml"
+name: tests
+on: [pull_request, push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      WHEELS_CI: "true"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up CommandBox
+        uses: Ortus-Solutions/setup-commandbox@v2
+
+      - name: Install dependencies and start the server
+        run: |
+          box install
+          box server start
+
+      - name: Run the suite
+        run: |
+          curl -s --max-time 600 -o results.json \
+            "http://localhost:8080/wheels/app/tests?format=json"
+          python3 -c "
+          import json
+          d = json.load(open('results.json'))
+          print(d.get('totalPass',0), 'pass', d.get('totalFail',0), 'fail', d.get('totalError',0), 'error')
+          raise SystemExit(0 if d.get('totalFail',0)==0 and d.get('totalError',0)==0 else 1)
+          "
+```
+
+Adjust the port to whatever your `server.json` declares. Two constraints:
+
+- **The app must run as `development`** — the `/wheels/*` runner surfaces are development-only ([#2903](https://github.com/wheels-dev/wheels/pull/2903)). A CI job is exactly the place that's fine; just don't point this at a production-configured deployment.
+- **The runner uses the app's configured datasource** (no `<datasource>_test` auto-swap without the CLI) — configure the CI app's datasource to a throwaway database and let `tests/populate.cfm` build it.
+
+A filtered run that names a directory the runner doesn't recognize silently runs the **full** suite ([#3083](https://github.com/wheels-dev/wheels/issues/3083)) — when you filter in CI (`&directory=tests.specs.models`), also assert the run wasn't vacuous (a suspiciously low spec count or a zero-bundle warning in the payload).
 
 ## Reporter output for CI
 
-The `wheels test` command accepts a `--reporter=<name>` flag. The CLI always requests JSON from the test endpoint, then formats the result for the reporter you picked:
+`wheels test` accepts `--reporter=<name>`; the CLI always requests JSON from the runner, then formats it:
 
-| Flag | Behaviour today |
+| Flag | Behaviour |
 | --- | --- |
-| `--reporter=simple` (default) | Human-readable summary: `N passed (Xs)` on green, plus failure details on red |
-| `--reporter=json` | Emits the raw JSON result document — pipe it to `jq` or a post-processor |
-| `--reporter=tap` | Emits TAP version 13 (`1..N`, `ok` / `not ok` lines) for TAP-consuming CI tooling |
-| `--ci` | Emits one GitHub Actions `::error` workflow-command annotation per failed or errored spec, so failures appear inline in CI logs and PR-check panels. Exit code is non-zero on failure regardless. |
-| `--verbose` / `-v` | Prints the full bundle → suite → spec tree (one `[PASS]`/`[FAIL]` line per spec) with the default `simple` reporter; flag position doesn't matter (`wheels -v test` works too). Binaries built on a LuCLI runtime that predates the [#3113](https://github.com/wheels-dev/wheels/issues/3113) launcher fix drop the signal and print the plain summary |
+| `--reporter=simple` (default) | Human-readable summary: `N passed (Xs)` on green, failure details on red |
+| `--reporter=json` | Emits the raw JSON result document — pipe to `jq` or a post-processor |
+| `--reporter=tap` | Emits TAP version 13 (`1..N`, `ok` / `not ok` lines) for TAP-consuming tooling |
+| `--ci` | GitHub Actions `::error` annotations per failure, on top of the non-zero exit code |
+| `--verbose` / `-v` | Full bundle → suite → spec tree with the default reporter |
 
-For machine-readable results you can also call the test runner URL directly and post-process the JSON. That is exactly what `tools/ci/run-tests.sh` does in this repo: it `curl`s `/wheels/core/tests?db=sqlite&format=json`, parses the totals in Python, emits a JUnit XML file that `actions/upload-artifact` ingests for the GitHub summary, and fails the build when the payload reports a rejected `directory=` scope or a 0-bundle discovery.
-
-```bash title="tools/ci/run-tests.sh (excerpt)"
-curl -s -o "$RESULT_FILE" --max-time 600 \
-  "http://localhost:${PORT}/wheels/core/tests?db=sqlite&format=json"
-
-# Scope-visibility guard (issue #3083): the runner reports a rejected
-# directory= (silently swapped for the full default suite) and 0-bundle
-# discoveries in the JSON payload. Surface any warnings[] and fail hard on
-# either signal — a green total from the wrong scope must not pass CI.
-python3 -c "
-import json
-d = json.load(open('$RESULT_FILE'))
-for w in d.get('warnings', []):
-    print('::warning::' + str(w))
-" 2>/dev/null || true
-DIR_REJECTED=$(python3 -c "import json; d=json.load(open('$RESULT_FILE')); print('true' if d.get('directoryRejected') else 'false')" 2>/dev/null || echo "false")
-BUNDLES_DISCOVERED=$(python3 -c "import json; d=json.load(open('$RESULT_FILE')); print(int(d.get('bundlesDiscovered', -1)))" 2>/dev/null || echo "-1")
-if [ "$DIR_REJECTED" = "true" ]; then
-  echo "::error::Test runner rejected the requested directory= scope and ran the full default suite instead (directoryRejected=true)"
-  CORE_OK=false
-fi
-if [ "$BUNDLES_DISCOVERED" = "0" ]; then
-  echo "::error::Test runner discovered 0 bundles for the resolved scope — the run was vacuously green (bundlesDiscovered=0)"
-  CORE_OK=false
-fi
-```
-
-<Aside type="tip">
-  If you want PR annotations on the "Files changed" tab, emit JUnit XML from the JSON results and feed it to `EnricoMi/publish-unit-test-result-action`. The pattern is copy-paste from `.github/workflows/pr.yml` in the Wheels repo.
-</Aside>
+Without the CLI, `?format=json` on the runner URL gives you the same document to post-process. If you want PR annotations on the "Files changed" tab, emit JUnit XML from the JSON and feed it to `EnricoMi/publish-unit-test-result-action`.
 
 ## Browser test gating in CI
 
-Browser specs are expensive to run in CI — they need the Playwright JARs (~370MB) and a Chromium install — so the framework ships an opt-in gate. Two environment variables decide whether `BrowserTest` specs execute or skip gracefully:
+Browser specs need the Playwright JARs (~370MB) and Chromium, so the framework ships an opt-in gate. Two environment variables decide whether `BrowserTest` specs execute or skip gracefully:
 
 - **`WHEELS_CI=true`** — mark the environment as CI
 - **`WHEELS_BROWSER_CI_ENABLE=true`** (or `1` or `yes`) — opt browser specs in
 
-If `WHEELS_CI` is set and `WHEELS_BROWSER_CI_ENABLE` is not one of `true,1,yes`, `BrowserTest.cfc` sets `this.browserTestSkipped = true` in `beforeAll`, and `browserDescribe`'s `aroundEach` skips every `it` automatically. The suite stays green; the browser tests simply don't count.
+If `WHEELS_CI` is set and the opt-in isn't, `BrowserTest.cfc` sets `this.browserTestSkipped = true` in `beforeAll` and every browser `it` skips automatically — the suite stays green; the browser tests simply don't count.
 
-```yaml title=".github/workflows/tests.yml (fragment)"
-env:
-  WHEELS_CI: "true"
-  # Uncomment to run browser specs in CI:
-  # WHEELS_BROWSER_CI_ENABLE: "true"
-```
-
-When you do opt in, cache the Playwright install — it's the slowest single step in the workflow.
+When you do opt in, cache the Playwright install — it's the slowest single step in the workflow:
 
 ```yaml title=".github/workflows/tests.yml (fragment)"
 - name: Cache Playwright
@@ -143,143 +141,82 @@ When you do opt in, cache the Playwright install — it's the slowest single ste
       playwright-
 
 - name: Install Playwright
-  if: steps.playwright-cache.outputs.cache-hit != 'true'
   run: wheels browser setup
 ```
 
 The cache key hashes `browser-manifest.json` so a Playwright version bump invalidates the cache automatically.
 
-## Cross-engine matrix via Docker
+## Cross-engine matrix
 
-`pr.yml` covers Lucee 7 + SQLite. For the full cross-engine story, you run Docker Compose from the repo root and hit each engine's port directly — the same pattern documented in [Running Tests Locally](/v4-0-0/testing/running-tests-locally/). Wrapped in a GitHub Actions matrix, every cell is an independent runner:
+Your app deploys to one engine, but if you support several (or you're mid-migration), a matrix over CommandBox's `cfengine` values runs the suite on each — every cell is an independent runner:
 
-```yaml title=".github/workflows/compat-matrix.yml"
+```yaml title=".github/workflows/tests.yml (fragment)"
 jobs:
   matrix-tests:
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
-        engine: [lucee6, lucee7, adobe2023, adobe2025, boxlang]
-        database: [sqlite, mysql, postgres]
+        cfengine: ["lucee@6", "lucee@7", "adobe@2023", "adobe@2025"]
     env:
-      PORT_lucee6: 60006
-      PORT_lucee7: 60007
-      PORT_adobe2023: 62023
-      PORT_adobe2025: 62025
-      PORT_boxlang: 60001
+      WHEELS_CI: "true"
     steps:
       - uses: actions/checkout@v4
-
-      - name: Start engine
-        run: docker compose up -d ${{ matrix.engine }}
-
-      - name: Wait for engine
+      - uses: Ortus-Solutions/setup-commandbox@v2
+      - name: Start server on ${{ matrix.cfengine }}
+        run: box server start cfengine=${{ matrix.cfengine }}
+      - name: Run the suite
         run: |
-          PORT_VAR="PORT_${{ matrix.engine }}"
-          PORT="${!PORT_VAR}"
-          for i in $(seq 1 60); do
-            if curl -sf "http://localhost:${PORT}/" > /dev/null; then break; fi
-            sleep 2
-          done
-
-      - name: Run tests
-        run: |
-          PORT_VAR="PORT_${{ matrix.engine }}"
-          PORT="${!PORT_VAR}"
-          curl -sf "http://localhost:${PORT}/wheels/core/tests?db=${{ matrix.database }}&format=json" \
-            > results.json
+          curl -s --max-time 600 -o results.json \
+            "http://localhost:8080/wheels/app/tests?format=json"
           python3 -c "import json; d=json.load(open('results.json')); \
-            exit(0 if d['totalFail']==0 and d['totalError']==0 else 1)"
+            raise SystemExit(0 if d.get('totalFail',0)==0 and d.get('totalError',0)==0 else 1)"
 ```
 
-Three things worth knowing:
+`fail-fast: false` matters: without it, one Adobe failure kills the Lucee cells before you learn whether Lucee was green.
 
-- **`compose.yml` lives at the repo root.** Older docs sometimes pointed at `rig/compose.yml`; that location is gone. Run `docker compose ...` from the checkout root.
-- **`fail-fast: false`** lets the other cells finish when one fails. Without it, a single Adobe CF failure kills Lucee before you see whether Lucee was green.
-- **External databases are additional `docker compose up` targets.** `mysql`, `postgres`, `sqlserver`, and `cockroachdb` have their own service definitions; `docker compose up -d postgres` brings Postgres up alongside the engine container.
+### Soft-fail cells
 
-## Soft-fail databases
+When one cell has known failures that shouldn't block PRs while a fix is in flight, mark just that cell:
 
-Some database engines have known-failing tests that aren't worth blocking a PR over while the fix is in flight. The pattern is a combination of `continue-on-error: true` on the matrix cell and an explicit `include:` entry that marks the cell as expected-to-fail.
-
-```yaml title=".github/workflows/compat-matrix.yml (fragment)"
+```yaml title=".github/workflows/tests.yml (fragment)"
 strategy:
   fail-fast: false
   matrix:
-    database: [sqlite, mysql, postgres, cockroachdb]
+    cfengine: ["lucee@7", "adobe@2025"]
     include:
-      - database: cockroachdb
+      - cfengine: "adobe@2025"
         soft_fail: true
 steps:
-  - name: Run tests
+  - name: Run the suite
     continue-on-error: ${{ matrix.soft_fail == true }}
-    run: bash tools/ci/run-tests.sh
+    run: ...
 ```
 
-The framework's `compat-matrix.yml` uses a `SOFT_FAIL_DBS` shell variable instead of a matrix flag — same idea. Once the underlying tests are fixed, drop the database from the soft-fail list so failures start blocking again.
+Drop the flag as soon as the underlying tests are fixed, so failures block again.
 
-## Caching dependencies
+## Caching
 
-`actions/setup-java@v4` caches the JDK for you. The things worth caching explicitly are the LuCLI Lucee Express install (downloads ~60MB on first run), the Maven cache if any step resolves JARs, and the Playwright install if you run browser specs.
-
-```yaml title=".github/workflows/tests.yml (fragment)"
-- name: Cache LuCLI Lucee Express
-  uses: actions/cache@v4
-  with:
-    path: |
-      ~/.lucli
-      ~/.m2
-    key: lucli-${{ runner.os }}-${{ hashFiles('box.json') }}
-    restore-keys: |
-      lucli-${{ runner.os }}-
-```
-
-The key hashes `box.json` so a version bump invalidates the cache, but the `restore-keys` fallback lets PRs without version changes reuse the most recent cache.
-
-## Parallel execution
-
-The only parallelism the framework ships today is matrix parallelism — every cell of `strategy.matrix` runs on its own runner in GitHub Actions. There is no `--parallel` flag on `wheels test` and no in-process parallel runner exposed through the CLI. If you need more throughput, split your matrix further (by engine, by database, by directory filter) rather than trying to parallelise a single suite.
-
-```yaml title=".github/workflows/tests.yml (fragment)"
-strategy:
-  fail-fast: false
-  matrix:
-    directory:
-      - tests.specs.model
-      - tests.specs.controller
-      - tests.specs.view
-      - tests.specs.dispatch
-      - tests.specs.migrator
-steps:
-  - name: Run filtered suite
-    run: wheels test --filter=${{ matrix.directory }}
-```
-
-Each cell runs independently on its own runner with its own LuCLI server — the suites don't share state and can't collide.
+Beyond Playwright (above): on the CLI path, the runtime home is `~/.wheels` (Lucee Express downloads ~60MB on first start); on the CommandBox path, CommandBox caches engines under `~/.CommandBox`. Both are cacheable with `actions/cache@v4` keyed on a version file, though on hosted runners the win is modest — measure before adding cache complexity.
 
 ## Common CI failures
 
-The handful of failures that eat the most CI minutes, with the one-line diagnosis for each:
-
-- **`JAVA_HOME is not set`** — LuCLI's preflight fires an actionable error. Use `actions/setup-java@v4`; it exports `JAVA_HOME` for you. Never set it by hand in a later step.
-- **Playwright JARs missing, browser specs silently skip** — expected when you haven't installed Playwright. If you want browser specs to run, add a `wheels browser setup` step and the `actions/cache@v4` block above.
-- **`docker compose` not found** — the `ubuntu-latest` runner includes Docker, but some self-hosted runners don't. Add `docker/setup-buildx-action@v3` if you hit it.
-- **Lucee starts but the test request times out** — the first hit to `/` pays the full Wheels bootstrap cost. Warm the app with `curl -s "http://localhost:PORT/?reload=true&password=..."` before you curl the test endpoint, and raise `--max-time` on the test curl to 600.
-- **Tests pass locally but fail in CI** — almost always a cross-engine gotcha (Adobe's `application` scope, Lucee's struct member functions, closure `this` capture). Reproduce by running the same engine locally via Docker Compose before you debug CI logs.
-- **Flaky `wheels new` in parallel runs** — a known LuCLI race when multiple cells scaffold apps into the same shared cache. Reduce matrix parallelism or add a retry step.
-- **Test job green, PR still red** — check the reporter job. `EnricoMi/publish-unit-test-result-action` reports failures independently of the test step's exit code.
+- **Runner can't find Java** — on the apt path the package installs OpenJDK 21 and the wrapper exports `JAVA_HOME`; if you install the CLI another way, add `actions/setup-java@v4` (it exports `JAVA_HOME` for subsequent steps).
+- **404 from `/wheels/app/tests`** — the CI app isn't running as `development` (the allowlist), or the port doesn't match your `server.json`.
+- **Server starts but the first test request times out** — the first hit pays the full app bootstrap. Warm it with a plain `curl -s http://localhost:8080/ > /dev/null` before the test curl, and keep `--max-time 600`.
+- **Playwright JARs missing, browser specs silently skip** — expected until you opt in; add `wheels browser setup` plus the cache block.
+- **Tests pass locally but fail in CI on another engine** — almost always a cross-engine difference (Adobe's `application` scope, struct member functions, closure `this` capture). Reproduce the same engine locally before debugging CI logs.
+- **Test job green, PR still red** — check the reporter job; `publish-unit-test-result-action` reports independently of the test step's exit code.
 
 ## Other CI systems
 
-GitLab CI, CircleCI, Jenkins, Buildkite — the shape is identical. Install Java 21, install the `wheels` CLI, create the SQLite databases, start a server, run the tests, collect results. The shell commands don't change; only the surrounding YAML or DSL does. There is no Wheels-specific CI integration beyond the JSON endpoint (`/wheels/core/tests?format=json`) for machine-readable results and the `WHEELS_CI` / `WHEELS_BROWSER_CI_ENABLE` environment variables for browser-spec gating.
+GitLab CI, CircleCI, Jenkins, Buildkite — the shape is identical: install a runtime (the `wheels` CLI or CommandBox), start the app in `development`, hit the runner, fail on red. The only Wheels-specific pieces are the JSON endpoint (`/wheels/app/tests?format=json`), the `--ci` flag, and the `WHEELS_CI` / `WHEELS_BROWSER_CI_ENABLE` gating variables.
 
 ## Related guides
 
 <CardGrid>
-  <LinkCard title="Running Tests Locally" href="/v4-0-0/testing/running-tests-locally/" description="The fast path with wheels test and tools/test-local.sh, plus the Docker cross-engine matrix." />
-  <LinkCard title="Browser Tests" href="/v4-0-0/testing/browser-tests/" description="Installing Playwright, writing browser specs, and the beforeEach/afterEach lifecycle." />
-  <LinkCard title="Testing Overview" href="/v4-0-0/testing/" description="The shape of the test suite and when to reach for each test type." />
-  <LinkCard title="Fixtures & Test Data" href="/v4-0-0/testing/fixtures-and-test-data/" description="The populate.cfm lifecycle, test models, and per-spec isolation." />
+  <LinkCard title="Running Tests Locally" href="/v4-0-0/testing/running-tests-locally/" description="The local loop this page wraps — with the CLI and without." />
+  <LinkCard title="Browser Tests" href="/v4-0-0/testing/browser-tests/" description="Installing Playwright, writing browser specs, and the lifecycle." />
+  <LinkCard title="Fixtures & Test Data" href="/v4-0-0/testing/fixtures-and-test-data/" description="The populate.cfm lifecycle your CI database depends on." />
+  <LinkCard title="Running the Framework Test Suite" href="/v4-0-0/contributing/running-framework-tests/" description="The framework repo's own CI patterns, for contributors." />
 </CardGrid>

--- a/web/sites/guides/src/content/docs/v4-0-0/testing/running-tests-locally.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/testing/running-tests-locally.mdx
@@ -1,6 +1,6 @@
 ---
 title: Running Tests Locally
-description: Running the test suite — wheels test CLI, tools/test-local.sh, filtering, Docker cross-engine matrix.
+description: Run your app's test suite with the wheels CLI or straight through the browser test runner — filtering, reporters, test databases, and the failure modes that eat time.
 type: howto
 sidebar:
   order: 9
@@ -8,226 +8,90 @@ sidebar:
 
 import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-The fast path for day-to-day development is Lucee 7 + SQLite, driven by `wheels test` or the one-shot script `tools/test-local.sh`. Neither needs Docker, neither needs an external database, and both finish in seconds on a warm server. The Docker matrix exists for the other reason you run tests: proving a change works across every engine and every supported database before you push. This page covers both paths, plus the filter knobs, the raw test-runner URL, and the failure modes that eat the most time.
+Your app's specs live under `tests/specs/` and run through the framework's built-in runner. There are two equal ways to drive it: the `wheels` CLI from your terminal, or the runner's URL from any browser or HTTP client — the CLI calls that same URL under the hood, so nothing about your tooling choice changes what runs.
 
 **You'll learn:**
 
-- The fastest way to run the suite — `wheels test` and `tools/test-local.sh`
-- How to filter by directory or single spec, both from the CLI and the test-runner URL
-- How to drive the Docker cross-engine matrix for pre-merge verification
-- How to target a specific database (SQLite, H2, MySQL, Postgres, SQL Server, CockroachDB, Oracle)
-- The cross-engine gotchas that bite first-time contributors
-- The common failure modes — `JAVA_HOME` unset, port conflicts, missing Playwright JARs
+- Running the suite with the wheels CLI — and without it
+- Filtering by directory or a single spec, in both paths
+- How the test database behaves
+- The common failure modes and their fixes
 
 <Aside type="note">
-  You should already know what a spec looks like. See [Model Tests](/v4-0-0/testing/model-tests/) for BDD shape and [Fixtures & Test Data](/v4-0-0/testing/fixtures-and-test-data/) for the populate lifecycle.
+  You should already know what a spec looks like. See [Model Tests](/v4-0-0/testing/model-tests/) for BDD shape and [Fixtures & Test Data](/v4-0-0/testing/fixtures-and-test-data/) for the populate lifecycle. Looking to run **the framework's own suite** (you're contributing to Wheels itself)? That's a different page: [Running the Framework Test Suite](/v4-0-0/contributing/running-framework-tests/).
 </Aside>
 
-## Prerequisites
+## With the wheels CLI
 
-Before either path works, you need a handful of tools on `PATH`:
+`wheels test` detects your running dev server, reloads the app, hits the test runner, and prints pass/fail counts. No ceremony:
 
-- **Java 21+** — `brew install openjdk@21` on macOS, your distro's OpenJDK package on Linux, Adoptium on Windows.
-- **`JAVA_HOME` set** — only matters when no Java is otherwise discoverable: the Homebrew install wraps the binary and exports `JAVA_HOME` itself, so brew users never see the preflight refusal. On other install paths, if the CLI can't find a JVM it refuses to start and points you at Adoptium — set `JAVA_HOME` in your shell profile (`export JAVA_HOME=$(/usr/libexec/java_home -v 21)` on macOS).
-- **The `wheels` CLI** — `brew install wheels`, `choco install wheels`, or the install script on Linux. The Wheels CLI is built on the LuCLI runtime; we ship the runtime under the `wheels` brand so you only ever invoke it as `wheels`.
-- **SQLite** — usually pre-installed; `brew install sqlite` if not. Needed for the default test database.
-- **Docker Desktop or Docker Engine** — only if you're running the cross-engine matrix.
-
-```bash {test:cli cmd="wheels --version" asserts-stdout="Wheels"}
-wheels --version
-```
-
-## The fastest path — `wheels test`
-
-`wheels test` is the single command you'll use most often. It detects a running Wheels server, reloads the app, hits the test runner, and prints pass/fail counts to your terminal. No Docker, no ceremony.
-
-```bash title="your shell — in the wheels repo root"
+```bash title="your shell — in your app root"
 # Run the full suite
 wheels test
 
 # Filter by directory (positional or --filter)
-wheels test model
-wheels test --filter=controller
+wheels test models
+wheels test --filter=controllers
 
 # Pick a reporter — simple (default), json, tap
 wheels test --reporter=tap
-
-# Target a specific test database — only meaningful with --core
-wheels test --core --db=mysql
 
 # CI mode: emits GitHub Actions ::error annotations per failed/errored spec
 wheels test --ci
 ```
 
-The supported flags today are `--filter=<dir>`, `--reporter=<simple|json|tap>`, `--db=<sqlite|h2|mysql|postgres|sqlserver|oracle|cockroachdb>` (only honoured with `--core`), `--verbose` / `-v`, `--ci`, `--core` (run the framework's own suite instead of the app suite), `--no-test-db` (don't auto-swap to `<datasource>_test`), and `--base-path=<path>` (URL prefix for subfolder-mounted apps — auto-derived from `WHEELS_SUBPATH` or `set(subpath=...)` when omitted). A positional argument acts as the filter. The CLI always requests JSON from the underlying runner and formats the result for the chosen reporter.
+The supported flags are `--filter=<dir>`, `--reporter=<simple|json|tap>`, `--verbose` / `-v`, `--ci`, `--no-test-db` (don't auto-swap to the `<datasource>_test` test database), and `--base-path=<path>` (URL prefix for subfolder-mounted apps — auto-derived from `WHEELS_SUBPATH` or `set(subpath=...)` when omitted). A positional argument acts as the filter. There's also `--core` (with `--db=`) for running the framework's own suite — see [the framework-testing page](/v4-0-0/contributing/running-framework-tests/).
 
-<Aside type="note" title="--db is for --core only">
-The framework's matrix self-tests (`--core`) wire up a `wheelstestdb_<engine>` datasource per supported engine — that's what `--db` selects between. App tests run against the datasource your project is configured for; passing `--db` to an app run prints a warning and is otherwise ignored. To run your app suite against a different engine, set the engine in your shell environment before invoking `wheels test` — see [the testing CLI reference](/v4-0-0/command-line-tools/wheels-commands/testing/#testing-against-different-engines) for the env-var pattern. This matches Rails (`DATABASE_URL`), Laravel (`DB_CONNECTION`), Symfony (`APP_ENV=test`), and Phoenix (`MIX_ENV`) — DB selection is a process-level concern, not a per-invocation flag.
+<Aside type="note" title="The test database">
+By default `wheels test` swaps your app onto a test copy of its datasource (`<datasource>_test` — for a fresh `wheels new` app that's the `db/test.sqlite` file scaffolded next to `db/development.sqlite`). First run against an empty test DB, the framework includes `tests/populate.cfm` so you can build schema and fixtures; subsequent runs reuse it. Pass `--no-test-db` to run against your development database instead.
 </Aside>
 
-<Aside type="tip">
-  `wheels test` always runs the app suite by default — even in the framework repo, where `vendor/wheels/tests/` exists. Pass `--core` explicitly to run the framework suite. (Earlier builds auto-detected core mode from the presence of `vendor/wheels/tests/`; that behavior was removed because it silently ran the wrong suite for user apps.)
-</Aside>
+## Without the wheels CLI
 
-## LuCLI one-shot: `tools/test-local.sh`
+The runner is a URL. With your app running in the `development` environment — under CommandBox, your own IIS/nginx setup, anything — hit:
 
-`tools/test-local.sh` is the script every framework contributor runs before pushing. It does everything `wheels test` does, plus: creates the two SQLite test databases (`wheelstestdb.db` and `wheelstestdb_tenant_b.db`), starts a disposable LuCLI server on port 8080 if one isn't already up, downloads the SQLite JDBC driver into LuCLI's `lib/ext` if missing, runs the tests, parses the JSON, and prints coloured pass/fail output. On exit it stops the server if it started one.
+```bash title="browser or curl"
+# Run everything (browser-friendly HTML report)
+http://localhost:8080/wheels/app/tests
 
-```bash title="your shell — in the wheels repo root"
-bash tools/test-local.sh              # run all core tests
-bash tools/test-local.sh model        # run model specs only
-bash tools/test-local.sh security     # run security specs only
-bash tools/test-local.sh browser      # run browser specs (Playwright JARs required)
+# Machine-readable, and exactly what the CLI consumes
+curl "http://localhost:8080/wheels/app/tests?format=json"
+
+# Filter by directory (dot-notation, rooted at your app's tests/ mapping)
+curl "http://localhost:8080/wheels/app/tests?format=json&directory=tests.specs.models"
 ```
 
-The script accepts these short aliases as the first argument: `model` / `models`, `controller` / `controllers`, `view` / `views`, `security`, `middleware`, `dispatch`, `migrator`. Anything else is passed through as a literal directory path (dot-notation, rooted at `wheels.tests.specs.`).
+Keep the dev loop as: change a spec, refresh the URL. Two things to know:
 
-Environment knobs:
+- **Development only.** The `/wheels/*` surfaces are gated by a development-only allowlist (since 4.0.4, [#2903](https://github.com/wheels-dev/wheels/pull/2903)) — in any other environment they return 404. Run tests where the app runs as `development` (locally, or a CI job configured that way — see [CI Integration](/v4-0-0/testing/ci-integration/)).
+- **The datasource is whatever the app is using.** The `<datasource>_test` auto-swap is a CLI convenience; the raw runner exercises the datasource your app is currently configured with. If you drive tests by URL routinely, point your development datasource at a database you're happy to have `tests/populate.cfm` rebuild — or keep populate idempotent (it should be anyway; see [Fixtures & Test Data](/v4-0-0/testing/fixtures-and-test-data/)).
 
-- `PORT=9090 bash tools/test-local.sh` — use a non-default port (handy when 8080 is in use).
-- `DB=mysql bash tools/test-local.sh` — run against a different database; you'll need to bring up the container yourself first (see the Docker matrix below).
-- `WHEELS_BROWSER_TEST_BASE_URL` — auto-set to `http://localhost:${PORT}` so browser specs hit the same server the script starts. Override it if you're pointing browser tests at a different host.
+An unrecognized `directory=` value is ignored and the **full** suite runs instead ([#3083](https://github.com/wheels-dev/wheels/issues/3083)) — if a filtered run looks suspiciously slow or broad, check the value against your `tests/specs/` layout.
 
-## The test-runner URL
+## Filtering
 
-When you need to iterate on a single spec file without rebooting anything — fastest inner loop — hit the test runner directly over HTTP. This is what `wheels test` and `tools/test-local.sh` call under the hood.
+| Method | With the wheels CLI | Without |
+|--------|---------------------|---------|
+| By directory | `wheels test models` | `&directory=tests.specs.models` |
+| One category of many | `wheels test --filter=controllers` | `&directory=tests.specs.controllers` |
+| Skip in source | `xdescribe(...)` / `xit(...)` — built into WheelsTest | same |
 
-```bash title="direct HTTP access (dev server running)"
-# Run everything
-curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json"
-
-# Filter by directory
-curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json&directory=wheels.tests.specs.model"
-
-# Filter to a single spec file — fastest iteration loop (use testBundles, not directory)
-curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json&testBundles=wheels.tests.specs.model.callbacksSpec"
-
-# Skip populate when iterating on one spec and the schema is already in place
-curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json&populate=false&testBundles=wheels.tests.specs.model.callbacksSpec"
-
-# Scope to a single installed package's tests (e.g. wheels-sentry, wheels-i18n)
-curl "http://localhost:60007/wheels/core/tests?db=sqlite&format=json&directory=vendor.wheels-sentry.tests"
-```
-
-`directory=` only filters down to a *directory* — pointing it at a single spec file matches zero bundles and runs nothing. For one file, pass the bundle's dotted path via `testBundles=` instead. Also note the core endpoint only accepts `directory` values starting with `wheels.tests` (or `vendor.<package>.tests`); anything else is rejected and the **full** suite runs instead — the JSON response flags this with `directoryRejected: true` and a `warnings[]` entry rather than silently reporting green ([#3083](https://github.com/wheels-dev/wheels/issues/3083)), so check those fields when a filtered run looks suspiciously slow. The `populate=false` query param is the other trick that makes tight inner loops possible. Populate drops and recreates every test table — a second or two on SQLite but much slower on networked databases. Once the schema is in place for the run, skipping populate shaves the wait down to just your specs executing.
-
-<Aside type="note" title="Scope-visibility fields in the JSON response">
-  The JSON payload includes `directoryRequested`, `directoryResolved`, `directoryRejected`, `bundlesDiscovered`, and `warnings[]`. When a `directory=` value fails the allowlist the runner substitutes the default and sets `directoryRejected: true` with a `warnings[]` entry — the run is no longer silently green for the wrong scope. A path that names a single spec file rather than a directory yields `bundlesDiscovered: 0` and a warning; use `testBundles=` to target a single file directly.
-</Aside>
-
-## Filtering tests
-
-The runner accepts filters at every layer. Pick whichever matches your workflow.
-
-| Method | How |
-|--------|-----|
-| By directory (CLI) | `wheels test model` or `wheels test --filter=controller` |
-| By directory (script) | `bash tools/test-local.sh model` |
-| By directory (URL) | `&directory=wheels.tests.specs.model` |
-| By single spec file (URL) | `&testBundles=wheels.tests.specs.model.callbacksSpec` |
-| By installed package (URL) | `&directory=vendor.wheels-sentry.tests` |
-| Skip in source | `xdescribe("...", ...)` / `xit("...", ...)` — built into WheelsTest |
-| Skip the whole populate | `&populate=false` on the URL (schema must already exist) |
-
-WheelsTest does not ship tag-based include/exclude filtering at this release. Use directory filtering plus `xdescribe` / `xit` in the spec source when you need finer control.
-
-## Docker cross-engine matrix
-
-Every Wheels release ships compose services for the supported engines in `compose.yml` at the repo root. The services share a bind-mounted copy of the repo, so there's nothing to rebuild when you edit code — just hit the port.
-
-```bash title="your shell — in the wheels repo root"
-# Start Lucee 7 + Adobe 2025 (minimum for a cross-engine check)
-docker compose up -d lucee7 adobe2025
-
-# Wait ~60s for startup, then run both
-curl -s -o /tmp/lucee7.json   "http://localhost:60007/wheels/core/tests?db=sqlite&format=json"
-curl -s -o /tmp/adobe2025.json "http://localhost:62025/wheels/core/tests?db=sqlite&format=json"
-
-# Summarize
-for f in /tmp/lucee7.json /tmp/adobe2025.json; do
-  python3 -c "
-import json
-d = json.load(open('$f'))
-print('$f', d['totalPass'], 'pass', d['totalFail'], 'fail', d['totalError'], 'error')
-"
-done
-```
-
-The service names and ports:
-
-| Engine | Service | Port |
-|--------|---------|------|
-| Lucee 5 | `lucee5` | 60005 |
-| Lucee 6 | `lucee6` | 60006 |
-| Lucee 7 | `lucee7` | 60007 |
-| Adobe 2018 | `adobe2018` | 62018 |
-| Adobe 2021 | `adobe2021` | 62021 |
-| Adobe 2023 | `adobe2023` | 62023 |
-| Adobe 2025 | `adobe2025` | 62025 |
-| BoxLang | `boxlang` | 60001 |
-
-<Aside type="tip">
-  At minimum, run one Lucee and one Adobe before pushing. Their runtime behaviours diverge in ways pure-Lucee tests don't catch — struct member functions, application scope, closure `this` capture, bracket-notation function calls.
-</Aside>
-
-## Testing against specific databases
-
-Each engine ships with H2 and SQLite baked in — no container needed for either. Every other database is a separate compose service you bring up alongside the engine: `compose.yml` ships `mysql`, `postgres`, `sqlserver`, `cockroachdb`, and `oracle` services. (The `docker-compose.db-h2.yml` / `db-mysql.yml` / `db-postgres.yml` files at the repo root are dev-stack overlays for the demo app, not test-matrix services.)
-
-```bash title="your shell — multi-database"
-# Start Lucee 7 + MySQL
-docker compose up -d lucee7 mysql
-
-# Run against MySQL
-curl -sf "http://localhost:60007/wheels/core/tests?db=mysql&format=json"
-```
-
-Supported `db` values on the URL: `sqlite` (default for the script and local runs), `h2` (default on some engines), `mysql`, `postgres`, `sqlserver`, `oracle`, `cockroachdb`. Oracle is currently soft-failed in CI — failures log warnings but don't block the build.
-
-## Cross-engine gotchas
-
-These are the runtime differences that catch first-time framework contributors. Each one has stung a real PR.
-
-- **`struct.map()`** — Lucee and Adobe resolve `obj.map()` as the built-in struct member function, not your CFC method. Use a different name (`mapInstance()`) or call the method via bracket notation.
-- **`application` scope members** — Adobe CF does not support function members on the `application` scope. Pass a plain struct context into closures instead.
-- **Closure `this` capture** — CFML closures capture `this` from the declaring scope at definition time. Share references across closures with `var ctx = { ref: obj }` rather than reassigning `this`.
-- **Bracket-notation function calls inside closures** — Adobe CF 2021 and 2023 parsers crash on `obj["key"]()` inside a closure. Split into two statements: `var fn = obj["key"]; fn();`.
-- **Array by-value in struct literals on Adobe** — Adobe copies arrays by value in `{ arr = myArray }`. Closures that append to the copy don't affect the original. Reference via a parent struct: `{ owner = parent }` then `owner.arr`.
-- **`private` mixin functions not integrated** — the framework's `$integrateComponents()` copies only `public` methods into model and controller objects. Helpers in mixin CFCs (e.g., `vendor/wheels/model/*.cfc`) must use `public` access with a `$` prefix for scoping. `private` may pass BoxLang and fail Lucee and Adobe.
+WheelsTest doesn't ship tag-based include/exclude filtering at this release; directory filtering plus `xdescribe`/`xit` in the spec source is the supported granularity.
 
 ## Common failure modes
 
-These are the errors you'll actually hit. Fix-ups first, diagnosis second.
-
-- **No Java found** — on non-brew installs, the CLI's preflight refuses to start and prints a pointer to Adoptium when it can't locate a JVM; set `JAVA_HOME` in your shell profile and re-source. Homebrew installs are immune — the brew wrapper exports `JAVA_HOME` itself.
-- **Docker daemon not running** — `docker compose up` fails with `Cannot connect to the Docker daemon`. Start Docker Desktop (macOS, Windows) or `systemctl start docker` (Linux).
-- **Port already in use** — `docker compose up` fails with `bind: address already in use` or a local `wheels start` is already on the port. Find the holder with `lsof -i :60007` and stop it.
-- **Playwright JARs missing** — browser specs skip with `this.browserTestSkipped = true` instead of failing, so the suite stays green. Run `wheels browser setup` once to install the JARs and Chromium.
-- **Populate SQL errors** — read the error. "Table already exists" means a stale table from a previous engine-specific run; add a `DROP TABLE IF EXISTS` first. "No such function: NOW" (or similar) means cross-engine SQL drift; use `CURRENT_TIMESTAMP` — it's ANSI SQL and works on every supported engine, while `NOW()` fails on SQLite and SQL Server.
-- **Flaky `wheels new` in parallel harness runs** — a known LuCLI race (framework gap tracker #11). Retry once, or serialize the runs until the fix lands.
-- **Server not responding after `compose up`** — engines need 30–90 seconds to cold-start. `curl -I http://localhost:60007/` returns connection-refused until the engine is ready. If it stays down after two minutes, check `docker compose logs <service>`.
-- **"1 error(s)" with a bundle path but no failing assertion** — the BDD runner caught a load-time or setup error for that spec file. Two common causes: (1) `it()` called directly inside `run()` without an enclosing `describe()` block, or (2) `beforeAll()` throwing an exception. The runner captures both against the bundle and populates `globalException` — check the spec file at the path shown in the summary for the underlying throw.
-
-## Cleanup
-
-Clean up is cheap but easy to forget. Left-over SQLite files and running containers are the usual culprits behind "why did my next run behave weirdly".
-
-```bash title="your shell"
-# Stop all engine containers
-docker compose down
-
-# Purge SQLite test databases between runs
-rm -f wheelstestdb.db wheelstestdb_tenant_b.db
-
-# Stop any local server the script started
-wheels stop
-```
+- **No Java found** (CLI path) — on non-brew installs the CLI refuses to start and points at Adoptium when it can't find a JVM; set `JAVA_HOME` in your shell profile. Homebrew installs export it themselves.
+- **404 from `/wheels/app/tests`** — the app isn't running as `development` (the allowlist above), or your server isn't pointing at this app's `public/`.
+- **Port already in use** — a previous `wheels start` or another server holds the port; `lsof -i :<port>` and stop it.
+- **Playwright JARs missing** — browser specs skip with `this.browserTestSkipped = true` instead of failing, so the suite stays green. Run `wheels browser setup` once, or see [Browser Tests](/v4-0-0/testing/browser-tests/).
+- **Populate SQL errors** — "Table already exists" means a stale table from a previous run; add `DROP TABLE IF EXISTS` first. "No such function: NOW" (or similar) means cross-engine SQL drift; use `CURRENT_TIMESTAMP` — it's ANSI SQL and works everywhere, while `NOW()` fails on SQLite and SQL Server.
+- **"1 error(s)" with a bundle path but no failing assertion** — the runner caught a load-time or setup error in that spec file. The two common causes: `it()` called directly inside `run()` without an enclosing `describe()`, or `beforeAll()` throwing. Check the spec file at the path shown in the summary.
 
 ## Related guides
 
 <CardGrid>
+  <LinkCard title="CI Integration" href="/v4-0-0/testing/ci-integration/" description="Running the suite in GitHub Actions — with or without the CLI." />
   <LinkCard title="Fixtures & Test Data" href="/v4-0-0/testing/fixtures-and-test-data/" description="The populate.cfm lifecycle, test models, and per-spec isolation." />
   <LinkCard title="Browser Tests" href="/v4-0-0/testing/browser-tests/" description="Installing Playwright and running browser specs locally." />
-  <LinkCard title="Testing Overview" href="/v4-0-0/testing/" description="The shape of the test suite and when to reach for each test type." />
-  <LinkCard title="Model Tests" href="/v4-0-0/testing/model-tests/" description="BDD specs for validations, callbacks, scopes, and associations." />
+  <LinkCard title="Running the Framework Test Suite" href="/v4-0-0/contributing/running-framework-tests/" description="Contributing to Wheels itself? The core suite, matrix, and gotchas." />
 </CardGrid>

--- a/web/sites/guides/src/sidebars/v4-0-0.json
+++ b/web/sites/guides/src/sidebars/v4-0-0.json
@@ -153,6 +153,7 @@
     "items": [
       { "label": "Submitting Pull Requests", "link": "/v4-0-0/contributing/pull-requests/" },
       { "label": "Coding Standards", "link": "/v4-0-0/contributing/coding-standards/" },
+      { "label": "Running the Framework Test Suite", "link": "/v4-0-0/contributing/running-framework-tests/" },
       { "label": "Writing Documentation", "link": "/v4-0-0/contributing/writing-docs/" }
     ]
   },


### PR DESCRIPTION
## Summary

Phase 4 of the guides restructure driven by discussion #1838 (follows #3275, #3276, #3277): the **dual-path task rewrites**. Every tooling-gated task page now presents "With the wheels CLI" and "Without the wheels CLI" as equal-footing paths — the label deliberately says *without the wheels CLI* (not "without tooling") so CommandBox readers recognize it as their supported path.

### Testing section — app-facing at last

- **Running Tests Locally** rewritten app-first: `wheels test` and the `/wheels/app/tests` runner presented as the same thing driven two ways (the CLI calls that URL). Documents the dev-only allowlist and the honest datasource caveat: the `<datasource>_test` auto-swap is a CLI convenience — the raw runner uses the app's configured datasource.
- **Running the Framework Test Suite** (NEW, under Contributing): receives everything evicted — `tools/test-local.sh`, the `/wheels/core/tests` URL surface, the Docker engine matrix + port table, cross-engine gotchas, contributor failure modes. The Testing section no longer teaches app developers about `wheelstestdb.db` files they'll never have.
- **CI Integration** rewritten around workflows that run from a *scaffolded app* — the audit's harshest finding here was that the published minimum-viable job ran `bash tools/test-local.sh` (a framework-repo artifact) and installed a **pinned third-party `lucli-0.3.7` binary**, contradicting the guides' own branding. Now: the CLI path installs from the signed apt repo (documented commands; the deb pulls OpenJDK 21 as a dependency) and runs `wheels test --ci`; the no-CLI path uses `Ortus-Solutions/setup-commandbox` + the JSON runner endpoint with an explicit exit-code check. The cross-engine matrix iterates CommandBox `cfengine` values instead of framework compose services, and the filter examples now match the app layout (the old ones would have discovered zero bundles).

### Basics section

- **Migrations**: new "Running migrations without the wheels CLI" section — the dev-only `/wheels/migrator` GUI, programmatic `application.wheels.migrator.migrateToLatest()` / `.migrateTo()` (any environment), `autoMigrateDatabase` at startup with the multi-node caveat, and hand-writing migration files. The heavy port-resolution aside is compressed to three lines with a reference link, and `app/scripts/` → `app/lib/` (the directory the template actually ships — resolves the contradiction with Seeding the audit flagged).
- **Seeding**: new "Running seeds without the wheels CLI" section — `application.wheels.seeder.runSeeds(environment=…)`, verified at `Seeder.cfc:46`, noted as the production path (deploy hook / admin action). The "Testing content lands in Phase 2b" internal-roadmap line is gone.
- **Database and Multiple Datasources**: the audit's core finding was that the page never showed how to actually *register* a datasource. New "Registering a datasource" section with the concrete shape for all three setups: the `lucee.json` block `wheels new` generates (verified against the CLI template and `buildSQLiteDatasourcesBlock`), CommandBox `server.json` cfconfig (the scaffolded `box.json` already ships `commandbox-cfconfig`), and engine-admin registration with the ACF + MySQL 8 `nullCatalogMeansCurrent` gotcha cross-linked to the IIS page. The raw-query example no longer hardcodes `datasource: "myapp_production"` (now `get("dataSourceName")`).

## Verification

- `astro build` passes: **441 pages**; 0 sidebar orphans, 0 dangling links, 0 broken internal links.
- All four new fragment anchors (`#without-the-wheels-cli`, `#registering-a-datasource`, `#linux-apt--yum`, `#adobe-coldfusion--mysql-8`) confirmed present in built HTML.
- Ground truths re-verified this phase: `Seeder.cfc::runSeeds(environment=)`, `Migrator.cfc` programmatic surface, the `lucee.json` datasource shape from `Module.cfc::buildSQLiteDatasourcesBlock`, `commandbox-cfconfig` in the shipped base-template `box.json`, and the documented apt install commands.

## Notes for review

- The two CI workflow YAMLs are written strictly from documented, verified commands but haven't been executed on a live GitHub runner — same "treat as the shape" honesty the pages themselves state. If you want, a follow-up can add a real workflow to a scaffolded test app repo to pin them.
- Remaining phases: 5 (What's New in 4.0 + URL Rewriting pages, vm-deployment nginx fix, Glossary corrections) and 6 (dedupe/residue sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)