### PR TITLE
docs(web/guides): add What's New in 4.0 and URL Rewriting, fix vm-deployment recipe (restructure phase 5)

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/deployment/url-rewriting.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/deployment/url-rewriting.mdx
@@ -1,0 +1,86 @@
+---
+title: URL Rewriting
+description: Pretty URLs on every server — the one rewrite rule Wheels needs, shown for Tuckey, nginx, Apache, and IIS, plus the Partial fallback that needs no server config.
+type: howto
+---
+
+import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+
+Every Wheels deployment needs an answer to one question: how does `/posts/1` reach `public/index.cfm`? This page is that answer for every server the community runs — it's one rewrite rule, worn four ways.
+
+## The three modes
+
+`config/settings.cfm` sets the mode with `set(URLRewriting="...")`:
+
+| Mode | URLs look like | Requires |
+|---|---|---|
+| `"On"` (template default) | `/posts/1` | A web-server rewrite rule (this page) |
+| `"Partial"` | `/index.cfm/posts/1` | Nothing beyond `cgi.path_info` support — every setup covered here has it |
+| `"Off"` | `/index.cfm?controller=posts&action=show&key=1` | Nothing |
+
+The framework generates links (`linkTo`, `urlFor`, form actions) in whatever shape the mode declares — so the mode and your server config must agree. If you can't (or don't want to) touch server config, set `"Partial"` and everything works with zero rules; `"On"` is purely cosmetic on top of that.
+
+## The rule, in words
+
+Rewrite every request that is **not a real file** to `/index.cfm/<original-path>`, and never serve `.cfm`/`.cfc` source as static content. Static assets (`stylesheets/`, `javascripts/`, `images/`, `files/`, `robots.txt`, …) are real files under `public/`, so they fall through untouched.
+
+## Per server
+
+### Tuckey — wheels CLI and CommandBox servers
+
+If the `wheels` CLI or CommandBox serves your app, you're already done: the shipped `public/urlrewrite.xml` configures the Tuckey UrlRewriteFilter both servers run. It rewrites everything except a known asset/exclusion list to `/index.cfm/$1`. Leave the file alone unless you add a top-level static path — then add it to the `<condition>` exclusion list. (On any other server this file is inert and can be deleted.)
+
+### nginx
+
+```nginx title="server block (root points at public/)"
+root /opt/myapp/current/public;
+
+# Static files are served directly; anything else becomes a Wheels route.
+location / {
+    try_files $uri @rewrite;
+}
+
+location @rewrite {
+    rewrite ^/(.*)$ /index.cfm/$1 last;
+}
+
+# All CFML goes to the engine — never serve .cfm/.cfc source from disk.
+location ~ \.(cfm|cfc) {
+    proxy_pass http://127.0.0.1:8888;
+    proxy_http_version 1.1;
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+```
+
+The full production server block (TLS, upstream keepalive, logging) lives in [VM and Bare-metal Deployment](/v4-0-0/deployment/vm-deployment/#nginx-reverse-proxy).
+
+### Apache (mod_rewrite + mod_proxy)
+
+```apache title="vhost or public/.htaccess"
+RewriteEngine On
+
+# Anything that isn't a real file or directory becomes a Wheels route.
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^(.*)$ /index.cfm/$1 [PT,L]
+```
+
+With Apache in front of a servlet engine you'll also have a proxy/connector rule (mod_proxy, mod_cfml, or AJP) sending `*.cfm` to the engine — the rewrite must run before it, which the `[PT]` (pass-through) flag ensures. In a `.htaccess` context drop the leading slash from the target (`index.cfm/$1`).
+
+### IIS
+
+The IIS URL Rewrite Module translation — including the connector setup around it — lives on [IIS and Windows Deployment](/v4-0-0/deployment/iis-and-windows/); the rule itself is the same shape: match everything, negate real files and directories, rewrite to `index.cfm/{R:1}`.
+
+## Verifying
+
+1. `curl -I https://yourapp.example.com/index.cfm` — the engine answers (200/302, not raw CFML source). If you get source code, your CFML handler/proxy isn't wired — fix that before touching rewrites.
+2. `curl -I https://yourapp.example.com/index.cfm/posts` — routes resolve in `Partial` form regardless of rewrite rules. If this 404s at the *framework* level, the problem is your routes, not rewriting.
+3. `curl -I https://yourapp.example.com/posts` — only works once the rewrite rule is live and `URLRewriting="On"`.
+4. `curl -I https://yourapp.example.com/stylesheets/app.css` — still a direct static hit; if this proxies to the engine, your rule is missing the real-file exclusion.
+
+<Aside type="note" title="The dot-format twin">
+The shipped Tuckey config also rewrites `/posts.json` to `/posts?format=json`. On other servers you can skip that rule — Wheels also reads the format from the path inside `/index.cfm/posts.json`, and content negotiation via the `Accept` header works everywhere. Add it only if you need bare `/posts.json` URLs without the rewrite-to-index step.
+</Aside>

--- a/web/sites/guides/src/content/docs/v4-0-0/deployment/vm-deployment.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/deployment/vm-deployment.mdx
@@ -1,6 +1,6 @@
 ---
 title: VM and bare-metal deployment
-description: Deploy a Wheels app to a Linux VM with Lucee 7, systemd, nginx, and a zero-downtime symlink swap.
+description: Deploy a Wheels app to a Linux VM with Lucee 7, systemd, nginx, and an atomic symlink release swap.
 type: howto
 sidebar:
   order: 4
@@ -8,7 +8,7 @@ sidebar:
 
 import { Aside, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
 
-This page shows you how to run a Wheels app on a traditional Linux VM — no containers, no orchestrator, just Lucee under systemd with nginx in front. You'll install Lucee 7, lay out the app under `/opt/myapp`, write a systemd unit, terminate TLS in nginx, and run a zero-downtime release swap with `rsync` and a symlink.
+This page shows you how to run a Wheels app on a traditional Linux VM — no containers, no orchestrator, just Lucee under systemd with nginx in front. You'll install Lucee 7, lay out the app under `/opt/myapp`, write a systemd unit, terminate TLS in nginx, and run an atomic release swap with `rsync` and a symlink — near-zero downtime, with a two-instance variant for true zero.
 
 **You'll learn:**
 
@@ -191,12 +191,20 @@ server {
 
     root /opt/myapp/current/public;
 
-    # Serve static files directly; fall back to Lucee for dynamic requests.
+    # Static files are served directly; anything else becomes a Wheels route.
     location / {
-        try_files $uri @lucee;
+        try_files $uri @rewrite;
     }
 
-    location @lucee {
+    # Pretty URLs: /posts/1 -> /index.cfm/posts/1 — the rewrite that
+    # URLRewriting="On" expects. See the URL Rewriting guide for the
+    # same rule on Apache, IIS, and Tuckey.
+    location @rewrite {
+        rewrite ^/(.*)$ /index.cfm/$1 last;
+    }
+
+    # All CFML goes to Lucee — never serve .cfm/.cfc source from disk.
+    location ~ \.(cfm|cfc) {
         proxy_pass         http://myapp_lucee;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;
@@ -211,6 +219,8 @@ server {
     error_log  /opt/myapp/shared/logs/nginx.error.log;
 }
 ```
+
+The `@rewrite` block is what makes `URLRewriting="On"` work — without it every generated link 404s. [URL Rewriting](/v4-0-0/deployment/url-rewriting/) covers the same rule for Apache, IIS, and Tuckey, plus the `Partial` fallback if you'd rather skip server rewrites entirely.
 
 Enable the site and reload:
 
@@ -251,9 +261,9 @@ sudo firewall-cmd --reload
 
 Lucee's own HTTP listener binds to `127.0.0.1` by convention — confirm in your Lucee/CommandBox server config. A Lucee listener on `0.0.0.0:8888` behind an open firewall exposes the admin panel to the world.
 
-## Zero-downtime deploy
+## The release swap
 
-The release swap is three steps on the VM: rsync the new code in, run migrations, flip the symlink. nginx gets a `reload` so it re-resolves the symlink; systemd gets nothing — Lucee keeps serving out of the old release until the next restart.
+The swap is: rsync the new code in, flip the symlink, restart. nginx gets a `reload` so it re-resolves the symlink; Lucee gets a restart to boot the new release — a one-to-two-second blip (see step 6 for the genuinely zero-downtime variant).
 
 From your build machine or CI runner:
 
@@ -283,13 +293,12 @@ From your build machine or CI runner:
    EOF
    ```
 
-4. **Run migrations against the new release.** Point the CLI at the new release so it reads the new migration files.
+4. **Decide how migrations run.** Nothing on this VM has the `wheels` CLI, and the staged release has no running app for the CLI to talk to anyway — so pick one of the in-framework paths:
 
-   ```bash title="Run database migrations on the new release"
-   ssh lucee@myapp.example.com "cd /opt/myapp/releases/$RELEASE && wheels migrate latest"
-   ```
+   - **At boot (simplest):** `set(autoMigrateDatabase=true)` in `config/production/settings.cfm`. When Lucee restarts in step 6, the new release applies its own pending migrations before serving. If a migration fails, the failure surfaces at boot — flip the symlink back and restart to return to the old release.
+   - **After the flip, on demand:** trigger the migrator programmatically through a protected code path — `application.wheels.migrator.migrateToLatest()` — from an authenticated admin action or deploy hook. See [Running migrations without the wheels CLI](/v4-0-0/basics/migrations/#running-migrations-without-the-wheels-cli).
 
-   If a migration fails, stop here. The old `current` symlink is still live; nothing changed for users.
+   Either way, on a single node there is a moment where old code and new schema (or vice versa) overlap — write migrations to be backward-compatible for one release (add columns before code uses them; drop them one release after code stops), and rehearse risky ones against a staging copy first.
 
 5. **Flip the symlink.**
 
@@ -317,7 +326,7 @@ From your build machine or CI runner:
 
 </Steps>
 
-**Rolling back** is the swap in reverse — `ln -sfn /opt/myapp/releases/<previous> /opt/myapp/current` and reload. If the failed deploy ran a migration, roll the migration back first (`wheels migrate down`) or accept that the older code is running against a newer schema.
+**Rolling back** is the swap in reverse — `ln -sfn /opt/myapp/releases/<previous> /opt/myapp/current`, reload nginx, restart Lucee. If the failed deploy applied a migration, roll it back first (programmatically via `application.wheels.migrator.migrateTo(previousVersion)`, or run the migration's `down()` SQL by hand) — or accept that the older code is briefly running against a newer schema, which is exactly what backward-compatible migrations buy you.
 
 ## Log rotation
 

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/packages.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/packages.mdx
@@ -70,7 +70,11 @@ Six packages are maintained as first-party modules under the `wheels-dev` GitHub
 - **[`wheels-i18n`](https://github.com/wheels-dev/wheels-i18n)** — Internationalization with JSON-file or database-backed translations, parameter interpolation, and pluralization. Mixes into controllers.
 - **[`wheels-seo-suite`](https://github.com/wheels-dev/wheels-seo-suite)** — Meta tags, Open Graph, Twitter Cards, canonical URLs, XML sitemaps, robots.txt, and an in-page debug/admin panel. Mixes into controllers.
 
-In development mode, the debug bar's **Packages** tab shows both the currently installed packages (from `vendor/`) and a live "Available from registry" table pulled from the same 24-hour registry cache used by the CLI. This lets you discover and compare first-party packages without leaving your browser.
+In development mode, the debug bar's Environment panel lists the currently installed packages (from `vendor/`), and its Tools tab links to `/wheels/packages` for the fuller view — see [Debug Panel](/v4-0-0/digging-deeper/debug-panel/). Registry browsing (what's *available*, not just what's installed) is a CLI feature: `wheels packages list` / `search` / `show`.
+
+<Aside type="note" title="The packages registry is not ForgeBox">
+Two different registries serve the CFML world, and Wheels touches both — for different things. **ForgeBox** (forgebox.io, Ortus) is where CommandBox installs from; Wheels publishes the *framework artifacts* there (`wheels-core`, `wheels-base-template`) so `box install` works. The **Wheels packages registry** ([`wheels-dev/wheels-packages`](https://github.com/wheels-dev/wheels-packages) on GitHub) is what `wheels packages add` installs from — it indexes the first-party packages on this page. A package listed here is not necessarily on ForgeBox and vice versa; if you're CommandBox-only, install packages by extracting their release into `vendor/<name>/` and reloading (the loader doesn't care how files arrived).
+</Aside>
 
 ## The `package.json` manifest
 

--- a/web/sites/guides/src/content/docs/v4-0-0/glossary.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/glossary.mdx
@@ -50,7 +50,7 @@ Terms that carry a specific Wheels meaning. Each entry links to the guide page w
 
 **Enum.** A declaration that a property takes one of a fixed set of named values, auto-generating an inclusion validation, boolean checkers, and scopes. See [Query Builder and Scopes](/v4-0-0/basics/query-builder-and-scopes/).
 
-**Environment.** One of `development`, `testing`, `production`, or `maintenance` — determined by `WHEELS_ENV` and controlling which `config/<environment>/settings.cfm` overrides load. See [Environments and Configuration](/v4-0-0/core-concepts/environments-and-configuration/).
+**Environment.** One of `development`, `testing`, `production`, or `maintenance` — set by `set(environment="...")` in `config/environment.cfm` and controlling which `config/<environment>/settings.cfm` overrides load. (Exporting `WHEELS_ENV` does *not* change it on a stock app unless you wire `environment.cfm` to read it.) See [Environments and Configuration](/v4-0-0/core-concepts/environments-and-configuration/).
 
 ## F
 
@@ -102,7 +102,7 @@ Terms that carry a specific Wheels meaning. Each entry links to the guide page w
 
 **Package.** An optional first-party module distributed as a standalone repository (indexed by the [`wheels-dev/wheels-packages`](https://github.com/wheels-dev/wheels-packages) registry) and activated by being installed into `vendor/<name>/`. `PackageLoader` discovers and loads each on startup inside its own try/catch. See [Packages](/v4-0-0/digging-deeper/packages/).
 
-**`package.json`.** The manifest at the root of every package — `name`, `version`, `wheelsVersion`, `provides.mixins`, `provides.middleware`, `dependencies`. See [Packages](/v4-0-0/digging-deeper/packages/).
+**`package.json`.** The manifest at the root of every package — `name`, `version`, `wheelsVersion`, `provides.mixins`, `provides.middleware`, and the dependency fields `requires` / `replaces` / `suggests` (the loader ignores a legacy `dependencies` key). See [Packages](/v4-0-0/digging-deeper/packages/).
 
 **Partial.** A view fragment whose filename starts with an underscore (`_form.cfm`), included via `includePartial(partial="form")` or rendered directly with `renderPartial`. See [Views, Layouts, Partials](/v4-0-0/basics/views-layouts-partials/).
 
@@ -110,7 +110,7 @@ Terms that carry a specific Wheels meaning. Each entry links to the guide page w
 
 **Primary key.** The column Wheels treats as the row's identity — `id` by convention; override with `setPrimaryKey()`. See [Models and the ORM](/v4-0-0/basics/models-and-the-orm/).
 
-**Priority queue.** A named queue on `wheels_jobs.queue` that the worker drains ahead of others when run with `--queue=critical,default,low`. See [Background Jobs](/v4-0-0/digging-deeper/background-jobs/).
+**Priority queue.** A named queue on `wheels_jobs.queue`. A worker started with `--queue=critical,default,low` polls only the listed queues; ordering *across* them comes from each job's `priority` field (`priority DESC, runAt ASC`), not from the list position. See [Background Jobs](/v4-0-0/digging-deeper/background-jobs/).
 
 ## Q
 

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/welcome.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/welcome.mdx
@@ -36,7 +36,7 @@ You're probably in one of these camps:
 
 - You've built with Rails, Laravel, or Django and want to know what Wheels looks like. Start with [Why Wheels?](/v4-0-0/start-here/why-wheels/) for a head-to-head comparison, then follow the tutorial.
 - You inherited a CFML codebase and want to modernize it. Read [Why Wheels?](/v4-0-0/start-here/why-wheels/) to see where 4.0 sits relative to older CFML frameworks, then jump to [Upgrading](/v4-0-0/upgrading/).
-- You know Wheels 3.x and want to see what changed. The tutorial shows off 4.0-native features (Turbo via Hotwire, built-in auth, query builder, enums, seeds, middleware). After that, [Upgrading to 4.0](/v4-0-0/upgrading/) has the migration checklist.
+- You know Wheels 3.x and want to see what changed. [What's New in 4.0](/v4-0-0/upgrading/whats-new-in-4/) is the ten-minute feature tour; after that, [Upgrading to 4.0](/v4-0-0/upgrading/) has the migration checklist.
 
 These guides are not for framework contributors (see `CONTRIBUTING.md` in the repo) and not a method-by-method API reference (see [api.wheels.dev](https://api.wheels.dev)).
 

--- a/web/sites/guides/src/content/docs/v4-0-0/upgrading/whats-new-in-4.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/upgrading/whats-new-in-4.mdx
@@ -1,0 +1,56 @@
+---
+title: What's New in 4.0
+description: The at-a-glance case for upgrading from 3.x — headline features, the tooling story, and where to go next.
+type: explanation
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+You know Wheels. You have a 3.x app in production. This page is the ten-minute answer to "what does 4.0 actually give me?" — features first, tooling second, and the pointers into the upgrade path when you're convinced.
+
+## Headline features
+
+**Middleware pipeline.** Cross-cutting request handling at the dispatch level — global via `set(middleware=[...])` or scoped to route groups. Ships with `RequestId`, `SecurityHeaders`, `Cors`, and `RateLimiter` (fixed-window, sliding-window, or token-bucket; memory or database storage). → [Middleware Pipeline](/v4-0-0/core-concepts/middleware-pipeline/)
+
+**Built-in dependency injection.** Register services in `config/services.cfm`, resolve with `service()` or `inject()`, scope as transient, singleton, or request. This is the change that removed the WireBox dependency — the container is `vendor/wheels/Injector.cfc`, part of the framework. → [The Dependency Injection Container](/v4-0-0/core-concepts/dependency-injection/)
+
+**Chainable query builder, scopes, and enums.** `model("User").where("status","active").whereNotNull("emailVerifiedAt").orderBy("name").get()` — injection-safe, values auto-quoted. Named scopes compose (`model("User").active().recent().findAll()`), and `enum()` generates checkers and scopes from a property definition. → [Query Builder and Scopes](/v4-0-0/basics/query-builder-and-scopes/)
+
+**Background jobs.** `app/jobs/` CFCs extending `wheels.Job`, with queues, delayed/scheduled enqueue, retries with exponential backoff, and a worker loop (`wheels jobs work`). The `wheels_jobs` table auto-creates on first use. → [Background Jobs](/v4-0-0/digging-deeper/background-jobs/)
+
+**Packages.** The successor to the legacy plugin system: modules installed into `vendor/<name>/`, auto-discovered from their `package.json`, with per-package error isolation. First-party packages include `wheels-sentry`, `wheels-hotwire`, `wheels-basecoat`, `wheels-i18n`, and `wheels-legacy-adapter` (3.x shims for a staged migration). → [Packages](/v4-0-0/digging-deeper/packages/)
+
+**Auth strategies.** Session, token, and JWT authentication ship in the framework (`wheels.auth.SessionStrategy`, `TokenStrategy`, `JwtService`) instead of every app hand-rolling them. → [Authentication Patterns](/v4-0-0/digging-deeper/authentication-patterns/)
+
+**Real-time responses.** Server-Sent Events helpers (`renderSSE()`, streaming writers) and channels for pub/sub. → [Server-Sent Events](/v4-0-0/digging-deeper/server-sent-events/), [Channels](/v4-0-0/digging-deeper/channels/)
+
+**Route model binding.** `.resources(name="users", binding=true)` resolves `params.key` into `params.user` before the action runs, 404ing on missing records so your actions don't repeat the lookup. → [Route Model Binding](/v4-0-0/digging-deeper/route-model-binding/)
+
+**WheelsTest.** A BDD test framework (`describe`/`it`/`expect`) built into the framework — the TestBox dependency is gone, and browser testing via Playwright is one `wheels browser setup` away. → [Testing](/v4-0-0/testing/)
+
+**`wheels deploy`.** A Kamal-inspired zero-downtime deployer built into the CLI — `deploy.yml`, Docker builds, TLS-terminating proxy, rollbacks. Optional: the self-managed [Docker](/v4-0-0/deployment/docker-deployment/), [VM](/v4-0-0/deployment/vm-deployment/), and [IIS](/v4-0-0/deployment/iis-and-windows/) paths are documented as first-class too. → [Deployment & Operations](/v4-0-0/deployment/)
+
+Smaller but daily-life: composable pagination (`paginationNav()` with Bootstrap/Tailwind presets), idempotent seeding (`seedOnce()`), migration reconciliation for shared dev databases (`migrate doctor`/`forget`/`pretend`), HTML5 form helpers, and a rebuilt debug bar.
+
+## The tooling story, honestly
+
+4.0 ships a first-party CLI — `wheels new`, generators, `migrate`, `test`, `console`, `deploy` — built on the LuCLI runtime and installed via Homebrew, Scoop, or apt/yum. Three sentences for the teams watching this warily:
+
+1. **CommandBox keeps working** — supported as a server manager and package fetcher (`box install wheels-base-template`, `box server start`), indefinitely.
+2. **No tooling is required at all** — the framework has zero external dependencies in 4.0, [installs from two zips](/v4-0-0/start-here/manual-installation/), and every CLI task has an [in-framework equivalent](/v4-0-0/start-here/working-without-the-cli/).
+3. **The CLI is an accelerator, not a gate** — everything it does goes through surfaces your app exposes anyway.
+
+Pick your path in one page: [Choosing Your Tooling](/v4-0-0/start-here/choosing-your-tooling/).
+
+## Breaking changes, in one breath
+
+Eleven, all enumerated with remediations in the upgrade guide. The ones most likely to touch a 3.x app: CORS defaults flipped from wildcard to deny-all, `application.wirebox` became `application.wheelsdi`, `wheels.Test` became `wheels.WheelsTest`, `tests/specs/functions/` became `tests/specs/functional/`, and production hardening (HSTS, CSRF key, environment-switch lockdown) is on by default. The [`wheels-legacy-adapter`](https://github.com/wheels-dev/wheels-legacy-adapter) package shims most 3.x patterns while you migrate.
+
+## Where to go next
+
+<CardGrid>
+  <LinkCard title="Upgrading from 3.x to 4.0" href="/v4-0-0/upgrading/3x-to-4x/" description="Every breaking change, with the exact remediation for each." />
+  <LinkCard title="Upgrading Without the CLI" href="/v4-0-0/upgrading/manual-upgrades/" description="The vendor/wheels swap recipe — zips, no tooling." />
+  <LinkCard title="Tutorial: Build a Blog" href="/v4-0-0/start-here/tutorial/" description="See the 4.0-native features in one continuous build." />
+  <LinkCard title="Reading the Changelog" href="/v4-0-0/upgrading/changelog/" description="Where release-by-release detail lives." />
+</CardGrid>

--- a/web/sites/guides/src/sidebars/v4-0-0.json
+++ b/web/sites/guides/src/sidebars/v4-0-0.json
@@ -39,6 +39,7 @@
     "label": "Upgrading & Releases",
     "link": "/v4-0-0/upgrading/",
     "items": [
+      { "label": "What's New in 4.0", "link": "/v4-0-0/upgrading/whats-new-in-4/" },
       { "label": "Upgrading from 3.x to 4.0", "link": "/v4-0-0/upgrading/3x-to-4x/" },
       { "label": "Upgrading Without the CLI", "link": "/v4-0-0/upgrading/manual-upgrades/" },
       { "label": "Upgrading from 2.x to 3.x", "link": "/v4-0-0/upgrading/2x-to-3x/" },
@@ -129,7 +130,8 @@
         "items": [
           { "label": "Docker Deployment", "link": "/v4-0-0/deployment/docker-deployment/" },
           { "label": "VM and Bare-metal Deployment", "link": "/v4-0-0/deployment/vm-deployment/" },
-          { "label": "IIS and Windows Deployment", "link": "/v4-0-0/deployment/iis-and-windows/" }
+          { "label": "IIS and Windows Deployment", "link": "/v4-0-0/deployment/iis-and-windows/" },
+          { "label": "URL Rewriting", "link": "/v4-0-0/deployment/url-rewriting/" }
         ]
       },
       {


### PR DESCRIPTION
## Summary

Phase 5 of the guides restructure driven by discussion #1838 (follows #3275–#3278): **upgrade & orientation completion**. Two new pages, a repaired VM deploy recipe, the ForgeBox disambiguation, and three Glossary corrections. The Upgrading & Releases group promoted in Phase 1 is now fully populated.

### New pages

- **What's New in 4.0** (`upgrading/whats-new-in-4`) — the fast-track feature tour `welcome.mdx` promised the 3.x-veteran camp but never served: middleware, built-in DI (the WireBox-removal story), query builder/scopes/enums, jobs, packages, auth strategies, SSE/channels, route model binding, WheelsTest, `wheels deploy` — each with its guide link. Includes the "tooling story, honestly" section (CommandBox keeps working / no tooling required at all / the CLI is an accelerator) for the mikegrogan segment, and breaking changes in one breath. `welcome.mdx` now links it.
- **URL Rewriting** (`deployment/url-rewriting`) — pretty URLs were undocumented anywhere in v4 while every deployment depends on them (blastiko's ask in #1838). One page: the `On`/`Partial`/`Off` modes, the rule in words, the concrete rule for **Tuckey** (shipped `urlrewrite.xml`), **nginx**, **Apache mod_rewrite**, and **IIS** (cross-linked), plus a 4-step verification checklist.

### vm-deployment repairs (all audit-flagged)

- **The nginx config never rewrote to `/index.cfm`** — the page's own production checklist said that means "every link breaks." It also had `try_files $uri` serving `.cfm` source as static content on direct hits. Replaced with the `try_files → @rewrite → CFML-proxy` shape, linked to the new URL Rewriting page.
- **Deploy step 4 ran `wheels migrate latest` over SSH on a server where the CLI was never installed** — and the staged release has no running app for the CLI to bind to anyway. Rewritten around the in-framework paths: `autoMigrateDatabase=true` at boot (failure = flip back and restart), or programmatic `migrator.migrateToLatest()` post-flip, with the backward-compatible-migrations guidance both approaches imply.
- **"Zero-downtime" softened** to what the recipe delivers: atomic symlink swap, a one-to-two-second Lucee restart, and the two-instance variant noted for true zero.

### Other

- **packages.mdx**: removed the false claim that the debug bar shows a live "Available from registry" table (verified false against the code and debug-panel.mdx); added the **ForgeBox vs wheels-packages-registry** disambiguation — two registries, different jobs, including the CommandBox-only package install path (extract into `vendor/`, reload).
- **Glossary**: three drifted entries corrected — *Environment* (set in `config/environment.cfm`; `WHEELS_ENV` alone doesn't change it — the entry previously planted exactly the misconception the Environments page exists to correct), *package.json* (`requires`/`replaces`/`suggests`, not the ignored legacy `dependencies`), *Priority queue* (cross-queue order is `priority DESC, runAt ASC`, not `--queue` list position).

## Verification

- `astro build` passes: **443 pages**; 0 sidebar orphans, 0 dangling links, 0 broken internal links.
- Both new pages render; the `#nginx-reverse-proxy` anchor url-rewriting references confirmed in built HTML.
- Glossary corrections verified against `environments-and-configuration.mdx:70`, `background-jobs.mdx:101`, and the packages manifest documentation.

## What remains

- [ ] Phase 6 (final): dedupe/residue sweep — Kamal table single-sourcing, tutorial author-residue strip, remaining minor cross-page contradictions
- [ ] The #1838 draft reply (held) — now every page it should link exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)