### PR TITLE
fix(web): make lockup logo color-scheme aware so it stays visible in dark mode

### DIFF
--- a/changelog.d/3264-dark-mode-logo.fixed.md
+++ b/changelog.d/3264-dark-mode-logo.fixed.md
@@ -1,0 +1,1 @@
+- Fixed the wheels.dev header and footer logo being invisible in dark mode — the `lockup` logo variant now swaps to the white lockup under `prefers-color-scheme: dark` via a pure-CSS toggle ([#3264](https://github.com/wheels-dev/wheels/issues/3264))

--- a/web/packages/ui/src/components/Logo.astro
+++ b/web/packages/ui/src/components/Logo.astro
@@ -22,16 +22,12 @@ const lockupHeights = {
 	md: 28,
 	lg: 40,
 };
-
-const isLockup = variant === 'lockup' || variant === 'lockup-on-dark';
-const src =
-	variant === 'mark' ? markPng : variant === 'lockup-on-dark' ? lockupWhitePng : lockupPng;
 ---
 
 {
 	variant === 'mark' && (
 		<img
-			src={src.src}
+			src={markPng.src}
 			width={markSizes[size].w}
 			height={markSizes[size].h}
 			alt="Wheels"
@@ -43,9 +39,32 @@ const src =
 }
 
 {
-	isLockup && (
+	variant === 'lockup' && (
+		<>
+			<img
+				src={lockupPng.src}
+				height={lockupHeights[size]}
+				alt="wheels.dev"
+				class:list={['wd-logo', 'wd-logo--lockup', 'wd-logo--lockup-light', className]}
+				loading="eager"
+				decoding="async"
+			/>
+			<img
+				src={lockupWhitePng.src}
+				height={lockupHeights[size]}
+				alt="wheels.dev"
+				class:list={['wd-logo', 'wd-logo--lockup', 'wd-logo--lockup-dark', className]}
+				loading="eager"
+				decoding="async"
+			/>
+		</>
+	)
+}
+
+{
+	variant === 'lockup-on-dark' && (
 		<img
-			src={src.src}
+			src={lockupWhitePng.src}
 			height={lockupHeights[size]}
 			alt="wheels.dev"
 			class:list={['wd-logo', 'wd-logo--lockup', className]}
@@ -62,5 +81,19 @@ const src =
 	}
 	.wd-logo--lockup {
 		width: auto;
+	}
+	/* Auto color-scheme lockup: dark-ink in light mode, white in dark mode.
+	   The site's dark mode is CSS-only (prefers-color-scheme in tokens.css),
+	   so the swap must be pure CSS too — see #3264. */
+	.wd-logo--lockup-dark {
+		display: none;
+	}
+	@media (prefers-color-scheme: dark) {
+		.wd-logo--lockup-light {
+			display: none;
+		}
+		.wd-logo--lockup-dark {
+			display: inline-block;
+		}
 	}
 </style>


### PR DESCRIPTION
Closes #3264

## Problem

The Wheels logo is invisible on wheels.dev in dark mode (reported from iOS Safari). `Logo.astro` mapped `variant="lockup"` unconditionally to the dark-ink `wheels-logo.png`, and both `Header.astro` and `Footer.astro` use that variant — so every site consuming the shared header/footer (landing, guides, api, blog, packages) showed a dark logo on a dark background.

## Fix

`web/packages/ui/src/components/Logo.astro` only. The sites' dark mode is CSS-only (`@media (prefers-color-scheme: dark)` in `tokens.css` — no JS toggle, no `data-theme`), so the swap is pure CSS too:

- `variant="lockup"` now renders **both** the dark-ink and the white lockup (`wheels-logo-white.png`, already an asset of this component) and toggles them with the same `prefers-color-scheme: dark` media query. The hidden image is `display:none`, so there's no layout shift.
- `variant="mark"` and `variant="lockup-on-dark"` are unchanged.
- Added a `changelog.d/3264-dark-mode-logo.fixed.md` fragment.

This is the fix shape wheels-bot proposed on the issue (it couldn't open the PR itself because `web/` is outside the TDD-gated scope — hence the `docs/bot-*` branch prefix).

## Verification

No CFML spec surface (pure static-site change), so verification is against the built sites:

- All five sites build (`pnpm build`), and every dist's pages contain the light/dark lockup pair + scoped media-query CSS.
- Web unit tests: 18/18 pass (`pnpm test`; only the packages site has test files).
- Playwright probe against the built landing site served locally: under emulated `colorScheme: dark` the white lockup is the computed-visible image in both header and footer (page bg `rgb(15,15,14)`); under `light` the dark-ink lockup renders exactly as before.
- `pnpm format` run on the changed file; `prettier --check` passes for it (40 other files have pre-existing style drift on `develop` — left untouched).

## Visual baselines

Deliberately **not** refreshed: light-mode rendering is pixel-identical (the local visual run diffs the base commit and this branch against the CI-captured Linux baselines by the *exact same* pixel count — 77,873 px on landing — i.e. the entire diff is the documented macOS-vs-CI font-rendering mismatch, zero pixels attributable to this change). The baselines are light-mode CI captures, and the script itself warns local refreshes poison them — if a dark-mode baseline is ever added it should come from the CI artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)