### PR TITLE
fix(build): retire dead 3.1.0 guide URL in docker engine settings templates

### DIFF
--- a/tools/docker/adobe2018/settings.cfm
+++ b/tools/docker/adobe2018/settings.cfm
@@ -3,7 +3,7 @@
 		Use this file to configure your application.
 		You can also use the environment specific files (e.g. /config/production/settings.cfm) to override settings set here.
 		Don't forget to issue a reload request (e.g. reload=true) after making changes.
-		See https://wheels.dev/3.1.0/guides/working-with-wheels/configuration-and-defaults for more info.
+		See https://guides.wheels.dev/v4-0-0/core-concepts/environments-and-configuration/ for more info.
 	*/
 
 	/*

--- a/tools/docker/adobe2021/settings.cfm
+++ b/tools/docker/adobe2021/settings.cfm
@@ -3,7 +3,7 @@
 		Use this file to configure your application.
 		You can also use the environment specific files (e.g. /config/production/settings.cfm) to override settings set here.
 		Don't forget to issue a reload request (e.g. reload=true) after making changes.
-		See https://wheels.dev/3.1.0/guides/working-with-wheels/configuration-and-defaults for more info.
+		See https://guides.wheels.dev/v4-0-0/core-concepts/environments-and-configuration/ for more info.
 	*/
 
 	/*

--- a/tools/docker/adobe2023/settings.cfm
+++ b/tools/docker/adobe2023/settings.cfm
@@ -3,7 +3,7 @@
 		Use this file to configure your application.
 		You can also use the environment specific files (e.g. /config/production/settings.cfm) to override settings set here.
 		Don't forget to issue a reload request (e.g. reload=true) after making changes.
-		See https://wheels.dev/3.1.0/guides/working-with-wheels/configuration-and-defaults for more info.
+		See https://guides.wheels.dev/v4-0-0/core-concepts/environments-and-configuration/ for more info.
 	*/
 
 	/*

--- a/tools/docker/adobe2025/settings.cfm
+++ b/tools/docker/adobe2025/settings.cfm
@@ -3,7 +3,7 @@
 		Use this file to configure your application.
 		You can also use the environment specific files (e.g. /config/production/settings.cfm) to override settings set here.
 		Don't forget to issue a reload request (e.g. reload=true) after making changes.
-		See https://wheels.dev/3.1.0/guides/working-with-wheels/configuration-and-defaults for more info.
+		See https://guides.wheels.dev/v4-0-0/core-concepts/environments-and-configuration/ for more info.
 	*/
 
 	/*

--- a/tools/docker/boxlang/settings.cfm
+++ b/tools/docker/boxlang/settings.cfm
@@ -3,7 +3,7 @@
 		Use this file to configure your application.
 		You can also use the environment specific files (e.g. /config/production/settings.cfm) to override settings set here.
 		Don't forget to issue a reload request (e.g. reload=true) after making changes.
-		See https://wheels.dev/3.1.0/guides/working-with-wheels/configuration-and-defaults for more info.
+		See https://guides.wheels.dev/v4-0-0/core-concepts/environments-and-configuration/ for more info.
 	*/
 
 	/*

--- a/tools/docker/lucee5/settings.cfm
+++ b/tools/docker/lucee5/settings.cfm
@@ -3,7 +3,7 @@
 		Use this file to configure your application.
 		You can also use the environment specific files (e.g. /config/production/settings.cfm) to override settings set here.
 		Don't forget to issue a reload request (e.g. reload=true) after making changes.
-		See https://wheels.dev/3.1.0/guides/working-with-wheels/configuration-and-defaults for more info.
+		See https://guides.wheels.dev/v4-0-0/core-concepts/environments-and-configuration/ for more info.
 	*/
 
 	/*

--- a/tools/docker/lucee6/settings.cfm
+++ b/tools/docker/lucee6/settings.cfm
@@ -3,7 +3,7 @@
 		Use this file to configure your application.
 		You can also use the environment specific files (e.g. /config/production/settings.cfm) to override settings set here.
 		Don't forget to issue a reload request (e.g. reload=true) after making changes.
-		See https://wheels.dev/3.1.0/guides/working-with-wheels/configuration-and-defaults for more info.
+		See https://guides.wheels.dev/v4-0-0/core-concepts/environments-and-configuration/ for more info.
 	*/
 
 	/*

--- a/tools/docker/lucee7/settings.cfm
+++ b/tools/docker/lucee7/settings.cfm
@@ -3,7 +3,7 @@
 		Use this file to configure your application.
 		You can also use the environment specific files (e.g. /config/production/settings.cfm) to override settings set here.
 		Don't forget to issue a reload request (e.g. reload=true) after making changes.
-		See https://wheels.dev/3.1.0/guides/working-with-wheels/configuration-and-defaults for more info.
+		See https://guides.wheels.dev/v4-0-0/core-concepts/environments-and-configuration/ for more info.
 	*/
 
 	/*


### PR DESCRIPTION
The compat-matrix workflow stages `tools/docker/<engine>/settings.cfm` over `config/settings.cfm`, and `ConfigRoutesStaleDocUrlSpec` (the #3281 dead-URL guard) scans `config/settings.cfm` — so the retired `wheels.dev/3.1.0` link in these eight templates failed **every engine × database leg** of the [2026-07-06 matrix run](https://github.com/wheels-dev/wheels/actions/runs/28809821005) uniformly. This was the only real new failure in that run: the apparent `testClientSpec` failures reproduced locally turned out to be a repro-harness port-mapping artifact (53/53 green with the matrix's own `60007:60007` mapping), and the `lucee7+mysql` leg failure predates today (present in the 2026-07-05 scheduled run).

Fix: point all eight templates at the live configuration guide URL, matching the demo app's `config/settings.cfm`.

**Verified**: `ConfigRoutesStaleDocUrlSpec` 4/4 and `testClientSpec` 53/53 on Lucee 7 + SQLite at develop HEAD with the fixed template staged (docker dir-mount repro of the exact matrix leg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)