### PR TITLE
test(view): assert includePartial guard via error message instead of engine cfcatch.type

### DIFF
--- a/vendor/wheels/tests/specs/view/contentSpec.cfc
+++ b/vendor/wheels/tests/specs/view/contentSpec.cfc
@@ -60,12 +60,9 @@ component extends="wheels.WheelsTest" {
 				}
 
 				expect(issimplevalue(result)).toBeFalse()
-				// BoxLang compatibility: Different CFML engines may throw different error types
-				if (StructKeyExists(server, "boxlang")) {
-					expect(result.message).toInclude("The key [FRUIT] was not found in the struct.")
-				} else {
-					expect(result.type).toBe("expression")
-				}
+				// Engines classify undefined-variable errors under different cfcatch.type values, so assert
+				// the missing key name (proof the implicit data function was NOT invoked) instead of the type.
+				expect(result.message).toInclude("fruit")
 			})
 
 			it("is including partial with query", () => {


### PR DESCRIPTION
## Summary
The `includePartial` security spec asserted the engine's built-in error classification (`expect(result.type).toBe("expression")`) and already needed a BoxLang carve-out for the same reason this PR exists: cfcatch.type taxonomy for undefined-variable errors was never standardized across CFML engines (RustCFML, for example, classifies an arguments-scope miss as `Runtime`).

Replaced the type assertion (and deleted the BoxLang branch) with `expect(result.message).toInclude("fruit")` — a *stronger* assertion: the missing `fruit` key is direct proof the partial's implicit **public** data function was not invoked, which is the security behavior the spec pins. Passes on Lucee ("key [FRUIT] doesn't exist"), Adobe ("Element FRUIT is undefined in ARGUMENTS"), and BoxLang ("The key [FRUIT] was not found in the struct").

## Verification
- View suite (Lucee 7 + SQLite): 580 passed.
- Integration branch: adobe2023+MySQL and lucee7+MySQL clean vs develop baseline.

Test-only change; no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
