### PR TITLE
docs(web/guides): add v4 Overriding Core Methods guide (#3343)

### DIFF
--- a/web/sites/guides/src/content/docs/v3-0-0/working-with-wheels/overriding-core-methods.md
+++ b/web/sites/guides/src/content/docs/v3-0-0/working-with-wheels/overriding-core-methods.md
@@ -3,6 +3,8 @@ title: Overriding Core Methods
 ---
 ## Overriding Core Wheels Methods (Wheels 3.x)
 
+> **Version scope:** In Wheels 3.x the `super`-prefixed convention described on this page applies to **model** methods only. Overriding controller and view helpers (e.g. `linkTo()`) with `superLinkTo()` delegation is not available in 3.x — that parity arrived in Wheels 4.0.x ([#3325](https://github.com/wheels-dev/wheels/issues/3325)). See the v4 guide: [Overriding Core Methods](/v4-0-0/digging-deeper/overriding-core-methods/).
+
 In Wheels 2.5, developers could override core framework methods (such as `findAll`) in their models and call the original Wheels implementation using the `super` scope.
 
 Due to internal framework restructuring in Wheels 3.0, this behavior no longer works using the traditional `super.methodName()` syntax. To restore this capability in a predictable and explicit way, Wheels now provides a new **`super`-prefixed method convention**.

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/index.mdx
@@ -96,6 +96,11 @@ The Digging Deeper section covers Wheels' advanced features — the ones you rea
     href="/v4-0-0/digging-deeper/dependency-injection-usage/"
     description="Practical DI patterns — test-double swapping, per-request resolvers, factories."
   />
+  <LinkCard
+    title="Overriding Core Methods"
+    href="/v4-0-0/digging-deeper/overriding-core-methods/"
+    description="Replace a framework method with your own and delegate to the original via super<name>."
+  />
 </CardGrid>
 
 ## See also

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/overriding-core-methods.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/overriding-core-methods.mdx
@@ -1,0 +1,165 @@
+---
+title: Overriding Core Methods
+description: Replace a framework method with your own and delegate to the original via the super-prefixed convention — in models, controllers, and view helpers.
+type: howto
+sidebar:
+  order: 16
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+This page shows you how to override a core Wheels method — a model finder, a controller helper, or a view helper like `linkTo()` — while still being able to call the framework's original implementation from inside your override. You'll use the `super`-prefixed method convention, pick the right place for each kind of override, and see when a pass-through argument (like `dataConfirm`) makes an override unnecessary in the first place.
+
+**You'll learn:**
+
+- How the `super<name>` convention works and why it replaced `super.methodName()`
+- How to override a model method and delegate with `superFindAll()`
+- How to override a controller or view helper and delegate with `superLinkTo()`
+- Where each override lives: a single controller, `app/controllers/Controller.cfc`, or `app/views/helpers.cfm`
+- When to skip the override entirely — the `data-*` pass-through pattern for confirm dialogs
+- Which 4.0.x versions support controller/view overrides, and the workaround for older builds
+
+## How the convention works
+
+Wheels assembles models and controllers by mixing framework methods into your components at startup. Because the framework's `findAll()`, `linkTo()`, and friends arrive as mixins rather than through CFML inheritance, `super.findAll()` does not reach them — that syntax stopped working in Wheels 3.0.
+
+Instead, when your component defines a method whose name collides with a framework mixin, Wheels keeps **your** version and registers the framework original under the same name prefixed with `super`. Override `findAll()` and the original becomes `superFindAll()`; override `linkTo()` and the original becomes `superLinkTo()`. Method names are case-insensitive, following normal CFML rules.
+
+The alias is only created when you actually override something. A controller or model that overrides nothing gains no extra `super*` keys.
+
+<Aside type="note" title="Model-only in 3.x, symmetric in 4.0.x">
+In Wheels 3.x this convention worked for **model** methods only. Controller and view helper parity arrived in the 4.0.x patch release carrying the fix for [#3325](https://github.com/wheels-dev/wheels/issues/3325) — see [the version callout below](#version-notes-and-the-pre-fix-workaround) if you're on an earlier 4.0.x build.
+</Aside>
+
+## Overriding a model method
+
+Define the method in your model CFC. Delegate to the original with `argumentCollection = arguments` so every argument your caller passed flows through unchanged:
+
+```cfm {test:compile} title="app/models/Post.cfc"
+component extends="Model" {
+
+	function config() {
+	}
+
+	public any function findAll() {
+		// custom logic before calling the framework original
+		return superFindAll(argumentCollection = arguments);
+	}
+
+}
+```
+
+This works for any public framework method mixed into models — `findOne()`, `columnNames()`, `save()`, and so on.
+
+## Overriding a controller or view helper
+
+The same convention applies to everything mixed into controllers, which includes all view helpers (views execute in the controller's `variables` scope). Overriding `linkTo()` and delegating to the framework original looks like this:
+
+```cfm {test:compile} title="app/controllers/Posts.cfc"
+component extends="Controller" {
+
+	function config() {
+	}
+
+	public string function linkTo() {
+		// example: give every generated link a default class
+		if (!StructKeyExists(arguments, "class")) {
+			arguments.class = "app-link";
+		}
+		return superLinkTo(argumentCollection = arguments);
+	}
+
+}
+```
+
+Every call to `#linkTo(...)#` in that controller's views now runs your version, and `superLinkTo()` hands off to the real framework helper — arguments, routing, and HTML escaping all behave exactly as stock.
+
+### Where the override lives
+
+- **One controller** — define the override in that controller's CFC, as above.
+- **Every controller** — define it in `app/controllers/Controller.cfc`, the base controller your controllers extend.
+- **View helpers, app-wide** — define it in `app/views/helpers.cfm`. That file is included into every controller before the framework mixins are integrated, so your version is already in place when the framework helper arrives — your version wins and the original is registered as `super<name>`.
+
+## Version notes and the pre-fix workaround
+
+Controller and view helper overrides gained `super<name>` delegation in the 4.0.x patch release that fixed [#3325](https://github.com/wheels-dev/wheels/issues/3325). Model overrides have supported it since 3.x.
+
+<Aside type="caution" title="On 4.0.x builds predating the #3325 fix">
+On earlier 4.0.x releases, overriding a controller or view helper works, but calling `superLinkTo()` (or any controller-side `super<name>`) throws at render time — the alias was never registered outside the model layer. If you can't upgrade yet, capture the framework original directly:
+
+```cfm
+component extends="Controller" {
+
+	function config() {
+		variables.coreLinkTo = CreateObject("component", "wheels.view.links").linkTo;
+	}
+
+	public string function linkTo() {
+		return coreLinkTo(argumentCollection = arguments);
+	}
+
+}
+```
+
+Delete the workaround and switch to `superLinkTo()` once you're on a build containing the fix.
+</Aside>
+
+<Aside type="note" title="What's overridable">
+The convention covers methods mixed into **models** and **controllers** (including view helpers). Router/mapper internals are not an app-override surface — there is no `super<name>` alias for mapper methods, and overriding them is not supported.
+</Aside>
+
+## Before you override: the `data-*` pass-through
+
+A common reason people reach for a `linkTo()` override is to add behavior like a JavaScript confirm dialog to generated links. You usually don't need an override for that: every HTML helper passes unknown arguments through as HTML attributes, and arguments starting with `data` are automatically hyphenized — `dataConfirm` becomes `data-confirm`, `data_confirm` works too.
+
+```cfm {test:compile} title="app/views/posts/index.cfm"
+<cfoutput>
+	#linkTo(
+		route = "editPost",
+		key = post.id,
+		text = "Edit",
+		dataConfirm = "Discard your current draft and edit this post?"
+	)#
+
+	#buttonTo(
+		route = "post",
+		key = post.id,
+		text = "Delete",
+		method = "delete",
+		dataConfirm = "Delete this post permanently?"
+	)#
+</cfoutput>
+```
+
+Pair it with one delegated listener instead of per-link JavaScript:
+
+```js title="app/assets/js/confirm.js"
+document.addEventListener("click", function (e) {
+	var el = e.target.closest("[data-confirm]");
+	if (el && !confirm(el.dataset.confirm)) {
+		e.preventDefault();
+		e.stopImmediatePropagation();
+	}
+}, true);
+```
+
+This replaces what plugins like `jsconfirm` did in older Wheels versions — no override, no plugin, and the attribute shows up on any helper that renders a tag.
+
+## Migrating from Wheels 2.5
+
+If you're upgrading an application from Wheels 2.5 that overrode core methods:
+
+1. Search for usages of `super.methodName()`
+2. Replace them with `superMethodName()` — for example, `super.findAll()` becomes `superFindAll()`
+3. Test the overridden behavior to make sure results match
+
+No changes are required for applications that don't override core methods.
+
+## Related guides
+
+<CardGrid>
+  <LinkCard title="Conventions over Configuration" href="/v4-0-0/core-concepts/conventions-over-configuration/" description="The naming and placement conventions that decide where overrides live." />
+  <LinkCard title="Controllers and Actions" href="/v4-0-0/basics/controllers-and-actions/" description="How controllers are assembled — the mixin surface your overrides sit on top of." />
+  <LinkCard title="Packages" href="/v4-0-0/digging-deeper/packages/" description="Package mixins can also override framework methods — the same super delegation applies." />
+  <LinkCard title="Upgrading to 4.x" href="/v4-0-0/upgrading/" description="Version-by-version upgrade notes, including behavior changes in the 4.0.x line." />
+</CardGrid>

--- a/web/sites/guides/src/sidebars/v4-0-0.json
+++ b/web/sites/guides/src/sidebars/v4-0-0.json
@@ -99,6 +99,7 @@
       { "label": "CORS", "link": "/v4-0-0/digging-deeper/cors/" },
       { "label": "Rate Limiting", "link": "/v4-0-0/digging-deeper/rate-limiting/" },
       { "label": "Dependency Injection Usage", "link": "/v4-0-0/digging-deeper/dependency-injection-usage/" },
+      { "label": "Overriding Core Methods", "link": "/v4-0-0/digging-deeper/overriding-core-methods/" },
       { "label": "Debug Panel", "link": "/v4-0-0/digging-deeper/debug-panel/" }
     ]
   },


### PR DESCRIPTION
## What / Why

The v4-0-0 guides tree had no "Overriding Core Methods" page — only the v3-0-0 page existed, and it over-promised the `super<name>` convention as general when it was model-only until the #3325 parity fix (PR #3357, merged 2026-08-04). This is the docs-only slice deferred from #3325.

## Approach

- **New page** `web/sites/guides/src/content/docs/v4-0-0/digging-deeper/overriding-core-methods.mdx`:
  - Documents the `super<name>` convention for models AND controllers/view helpers (4.0.x parity via #3325).
  - Placement conventions: single controller CFC, `app/controllers/Controller.cfc`, `app/views/helpers.cfm` (included before framework mixins, so the app version wins and the original is aliased).
  - `superLinkTo(argumentCollection = arguments)` delegation matching `vendor/wheels/tests/specs/controller/SuperOverrideSpec.cfc`; model example uses `superFindAll()`.
  - `dataConfirm` / `data-*` pass-through alternative (with delegated JS listener) for the jsconfirm use case — verified against `$tagAttribute()` hyphenization in `vendor/wheels/view/miscellaneous.cfc`.
  - Version callout: on 4.0.x builds predating the fix, controller/view `super<name>` errors; documented `variables.coreLinkTo = CreateObject("component", "wheels.view.links").linkTo` workaround.
  - Explicit note that router/mapper internals are NOT an override surface (deliberately excluded from #3357).
- **Sidebar**: registered in `web/sites/guides/src/sidebars/v4-0-0.json` (JSON validated) and added a LinkCard to the Digging Deeper section index — avoids the orphaned-page trap.
- **v3-0-0 page**: short version-scope note (convention is model-only in 3.x; parity arrived in 4.0.x via #3325).

## Test evidence

- Guides site builds clean: `pnpm run build` — 445 pages, no errors; new page rendered and present in sibling pages' sidebars.
- `verify-docs` on the new page: 3 tagged blocks, **3 passed, 0 failed**.
- Full core suite (Lucee 7 + SQLite, local): **4758 pass / 0 fail / 0 error** (docs-only change; suite run per repo policy).

Fixes #3343

🤖 Generated with [Claude Code](https://claude.com/claude-code)