### PR TITLE
test(model): use non-aggregate terminals in forUpdate chain specs

### DIFF
--- a/vendor/wheels/tests/specs/model/queryBuilderSpec.cfc
+++ b/vendor/wheels/tests/specs/model/queryBuilderSpec.cfc
@@ -279,11 +279,12 @@ component extends="wheels.WheelsTest" {
 
 				it("forUpdate() starts a chain", () => {
 					// FOR UPDATE is a no-op on SQLite/MSSQL; this pins the chain-entry dispatch, not the locking.
+					// Terminal must be non-aggregate: Postgres/CockroachDB reject COUNT(*) ... FOR UPDATE.
 					var result = model("author")
 						.forUpdate()
 						.where("lastName", "Djurner")
-						.count();
-					expect(result).toBe(1);
+						.get();
+					expect(result.recordcount).toBe(1);
 				})
 
 			})
@@ -291,11 +292,12 @@ component extends="wheels.WheelsTest" {
 			describe("scope chain to builder transition", () => {
 
 				it("forUpdate() transitions from a scope chain to the query builder", () => {
+					// Non-aggregate terminal for the same Postgres/CockroachDB FOR UPDATE restriction.
 					var result = model("authorScoped")
 						.withLastNameDjurner()
 						.forUpdate()
-						.count();
-					expect(result).toBe(1);
+						.get();
+					expect(result.recordcount).toBe(1);
 				})
 
 			})


### PR DESCRIPTION
## What

PR #3368's two `forUpdate()` chain-entry specs used `.count()` as the chain terminal. Postgres and CockroachDB reject `SELECT COUNT(*) ... FOR UPDATE` (\`FOR UPDATE is not allowed with aggregate functions\`), which broke the postgres and cockroachdb legs on **every engine** in the compat matrix (first surfaced by dispatch run 30972608328 on the #3365 branch after it picked up today's merges).

The specs pin chain-entry **dispatch**, not locking semantics, so switching to a non-aggregate `.get()` terminal asserts the same behavior and is legal on all supported engines.

## Test evidence

Run locally against the previously failing combination (lucee7 container + cockroachdb):

- lucee7 + cockroachdb: **4775 pass / 0 fail / 0 error** (was 2 errors)
- lucee7 + sqlite: **4763 pass / 0 fail / 0 error**

Spec-only change; unblocks the #3302 chain (Refs #3302, refs #3368).

🤖 Generated with [Claude Code](https://claude.com/claude-code)