### PR TITLE
ci: make compat-matrix engine-job failures fail the run

### DIFF
--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -15,7 +15,6 @@ jobs:
   tests:
     name: "${{ matrix.cfengine }}"
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What

Deletes `continue-on-error: true` from the `tests` (engine) job in `.github/workflows/compat-matrix.yml`. The `rustcfml` job keeps its flag — it is an informational lane by design.

## Why now — the gate is cleared

The issue's own sequencing rule was: burn down the pre-existing leg debt first, then flip. That happened today:

1. PR #3365 (debt burn-down) merged as `6bff05441`.
2. Confirming dispatch [30976993285](https://github.com/wheels-dev/wheels/actions/runs/30976993285) on develop: **all 5 engine jobs green**, aggregate 132,170 pass with only the 6 oracle soft-fails (non-blocking via `SOFT_FAIL_DBS`, tracked under #2663).
3. The safe-slice hardening (zero-test guard, neutral soft-fail check, honest summary grid) merged earlier via #3366 and validated live on dispatch runs.

With this flip, a failing engine leg fails the run — the weekly banner becomes a real alarm instead of decoration.

Fixes #3302

🤖 Generated with [Claude Code](https://claude.com/claude-code)