### PR TITLE
ci: bump LuCLI pin to 0.6.1

### DIFF
--- a/.github/actions/setup-wheels-test-env/action.yml
+++ b/.github/actions/setup-wheels-test-env/action.yml
@@ -19,7 +19,7 @@ inputs:
   lucli-version:
     description: 'LuCLI release version'
     required: false
-    default: '0.3.7'
+    default: '0.6.1'
   install-playwright:
     description: 'Install Playwright + Chromium (set "false" to skip if no browser tests run)'
     required: false

--- a/.github/workflows/deploy-ci.yml
+++ b/.github/workflows/deploy-ci.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-      LUCLI_VERSION: "0.3.7"
+      LUCLI_VERSION: "0.6.1"
       WHEELS_CI: "true"
       PORT: "8080"
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.event.action != 'edited'
     runs-on: ubuntu-latest
     env:
-      LUCLI_VERSION: "0.3.7"
+      LUCLI_VERSION: "0.6.1"
       WHEELS_CI: "true"
       WHEELS_BROWSER_TEST_BASE_URL: "http://localhost:60007"
       WHEELS_BROWSER_CI_ENABLE: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ on:
 
 env:
   WHEELS_PRERELEASE: false
-  LUCLI_VERSION: "0.3.7"
+  LUCLI_VERSION: "0.6.1"
   # Route JS actions through Node 24 instead of the deprecated Node 20 runtime.
   # The lone Node 20 action here — Wandalen/wretry.action@v3, which wraps
   # softprops/action-gh-release — began failing its pre/post hooks with

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -13,7 +13,7 @@ permissions:
 env:
   WHEELS_PRERELEASE: true
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  LUCLI_VERSION: "0.3.7"
+  LUCLI_VERSION: "0.6.1"
 
 jobs:
   #############################################


### PR DESCRIPTION
## Summary

Pin-only bump of `develop` to [cybersonic/LuCLI 0.6.1](https://github.com/cybersonic/LuCLI/releases/tag/v0.6.1) for 4.0.6. This does not address #2963 (empty schemas on hand-rolled commands stay #2861).

## What changed

Bumped `LUCLI_VERSION` from `0.3.7` → `0.6.1` at the five live CI/release download sites:

- `.github/workflows/pr.yml` (required check: **Lucee 7 + SQLite (LuCLI)**)
- `.github/workflows/snapshot.yml`
- `.github/workflows/release.yml`
- `.github/workflows/deploy-ci.yml`
- `.github/actions/setup-wheels-test-env/action.yml`

Left alone: `publish-chocolatey.yml` (input, not a pin), Homebrew / distribution drafts, historical docs.

## Smoke results (HEAD `f14447796`)

- **Lucee 7 + SQLite (LuCLI)** success — core 4816 / CLI 1146, 0 fail. Job installed 0.6.1.
- TDD + commitlint success. Deploy CLI + Lucee 7 / Adobe 2023 smokes success.
- MCP `tools/list` consults `mcpToolSpecs()`. No `hint:` leak. No BaseModule internals.

## Leftovers

- Empty schemas on create/db/deploy/generate/info/migrate/packages/reload/routes/validate (#2861)
- Unknown `.lucli` verbs still exit 0
- Homebrew/formula pins not in this PR

## Type of Change

- [x] CI pin bump

## Feature Completeness Checklist

- [x] **DCO sign-off**
- [x] **Test runner passes** — GitHub LuCLI job + local `tools/test-local.sh`
