### PR TITLE
fix: replace HTMLEditFormat with EncodeForHTML in packagelist

### DIFF
--- a/changelog.d/3378-packagelist-encodeforhtml.fixed.md
+++ b/changelog.d/3378-packagelist-encodeforhtml.fixed.md
@@ -1,0 +1,1 @@
+- The Packages admin page (`/wheels/packages`) no longer calls `HTMLEditFormat`, which is missing on Adobe ColdFusion 2025 and caused HTTP 500. Registry names, descriptions, versions, errors, and homepage links are encoded with `EncodeForHTML` instead, matching the rest of the `/wheels` admin surface (#3378)

--- a/vendor/wheels/public/views/packagelist.cfm
+++ b/vendor/wheels/public/views/packagelist.cfm
@@ -127,7 +127,7 @@ for (local.key in packageMeta) {
 	<cfif Len(registryError)>
 		<div class="ui warning message">
 			<div class="header">Registry unavailable</div>
-			<p>#HTMLEditFormat(registryError)#</p>
+			<p>#EncodeForHTML(registryError)#</p>
 		</div>
 	<cfelseif ArrayLen(registryPackages) EQ 0>
 		<div class="ui message">
@@ -149,13 +149,13 @@ for (local.key in packageMeta) {
 					<cfset local.isInstalled = StructKeyExists(installedKeys, local.rpKey)>
 					<tr>
 						<td>
-							<strong>#HTMLEditFormat(local.rp.name)#</strong>
+							<strong>#EncodeForHTML(local.rp.name)#</strong>
 							<cfif Len(local.rp.homepage) AND REFindNoCase("^https?://", local.rp.homepage)>
-								<br><a href="#HTMLEditFormat(local.rp.homepage)#" target="_blank" rel="noopener" class="ui small grey text">homepage</a>
+								<br><a href="#EncodeForHTML(local.rp.homepage)#" target="_blank" rel="noopener" class="ui small grey text">homepage</a>
 							</cfif>
 						</td>
-						<td>#HTMLEditFormat(local.rp.description)#</td>
-						<td>#HTMLEditFormat(local.rp.latestVersion)#</td>
+						<td>#EncodeForHTML(local.rp.description)#</td>
+						<td>#EncodeForHTML(local.rp.latestVersion)#</td>
 						<td>
 							<cfif local.isInstalled>
 								<span class="ui label"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 512 512" fill="currentColor" style="vertical-align: middle; margin-right: 4px;"><path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>Installed</span>
@@ -165,10 +165,10 @@ for (local.key in packageMeta) {
 								      `add` (not `install`) is the canonical verb — LuCLI's built-in extension
 								      installer intercepts the literal subcommand `install`, so `wheels packages
 								      install <name>` never reaches Module.cfc. See PR #2374 / cli/lucli/services/packages/PackagesMainCli.cfc. --->
-								<code id="install-#HTMLEditFormat(local.rpKey)#">wheels packages add #HTMLEditFormat(local.rp.name)#</code>
+								<code id="install-#EncodeForHTML(local.rpKey)#">wheels packages add #EncodeForHTML(local.rp.name)#</code>
 								<button type="button"
 									class="ui tiny button"
-									aria-label="Copy install command for #HTMLEditFormat(local.rp.name)#"
+									aria-label="Copy install command for #EncodeForHTML(local.rp.name)#"
 									onclick="navigator.clipboard.writeText(document.getElementById('install-#JSStringFormat(local.rpKey)#').innerText)">
 									Copy
 								</button>

--- a/vendor/wheels/tests/specs/packages/PackageListHtmlEditFormatSpec.cfc
+++ b/vendor/wheels/tests/specs/packages/PackageListHtmlEditFormatSpec.cfc
@@ -1,0 +1,47 @@
+/**
+ * Adobe ColdFusion 2025 does not provide HTMLEditFormat (Variable
+ * HTMLEDITFORMAT is undefined). The Packages admin page
+ * (vendor/wheels/public/views/packagelist.cfm) used it for registry
+ * error text, names, descriptions, versions, homepage hrefs, and
+ * copy-command markup, so GET /wheels/packages 500s on that engine
+ * (issue #3378). Other /wheels admin views already encode with
+ * EncodeForHTML — the same BIF this spec requires.
+ *
+ * An Adobe 2025 BIF miss cannot be reproduced on the Lucee CI runner,
+ * so the gate is this structural scan of the view source.
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("packagelist.cfm HTML encoding (issue ##3378)", () => {
+
+			it("does not call HTMLEditFormat", () => {
+				var src = FileRead(ExpandPath("/wheels/public/views/packagelist.cfm"));
+				// Built by concatenation so a later admin-surface scan of
+				// this spec file cannot match the forbidden BIF name.
+				var forbidden = "HTML" & "EditFormat";
+
+				expect(FindNoCase(forbidden, src) GT 0).toBeFalse(
+					"packagelist.cfm must not call #forbidden# — Adobe ColdFusion 2025 "
+					& "does not provide that BIF (Variable HTMLEDITFORMAT is undefined), "
+					& "so /wheels/packages 500s. Use EncodeForHTML, the encoder already "
+					& "used by other /wheels admin views. See issue ##3378."
+				);
+			});
+
+			it("encodes registry output with EncodeForHTML", () => {
+				var src = FileRead(ExpandPath("/wheels/public/views/packagelist.cfm"));
+
+				expect(FindNoCase("EncodeForHTML(", src) GT 0).toBeTrue(
+					"packagelist.cfm should encode registry names, descriptions, "
+					& "versions, errors, and homepage links with EncodeForHTML, "
+					& "matching helpers.cfm and routetesterprocess.cfm. See issue ##3378."
+				);
+			});
+
+		});
+
+	}
+
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adobe ColdFusion 2025 does not provide `HTMLEditFormat`, so GET `/wheels/packages` 500s with `Variable HTMLEDITFORMAT is undefined`. This is one of the two bugs reported on #3378 (the other is wheels-basecoat `boolean switch` and is out of scope here).

`vendor/wheels/public/views/packagelist.cfm` now uses `EncodeForHTML` at every former `HTMLEditFormat` site — the same encoder already used by other `/wheels` admin views (`helpers.cfm`, `routetesterprocess.cfm`). Escaped output is unchanged. No other public views called `HTMLEditFormat`.

## Related Issue

#3378 (packages-admin half only; does not address the Basecoat `switch` compile error)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Documentation update
- [ ] Refactoring

## Feature Completeness Checklist

- [x] **DCO sign-off** -- Every commit carries `Signed-off-by:`
- [x] **Tests** -- Structural spec asserts `packagelist.cfm` no longer calls `HTMLEditFormat` and encodes with `EncodeForHTML`
- [ ] **Framework Docs** -- N/A (admin-page encoder swap)
- [ ] **AI Reference Docs** -- N/A
- [ ] **CLAUDE.md** -- N/A
- [x] **Changelog fragment** -- `changelog.d/3378-packagelist-encodeforhtml.fixed.md`
- [x] **Test runner passes** -- `wheels.tests.specs.packages` on Lucee 7 + SQLite: 136 pass / 0 fail / 0 error

## Test Plan

- [x] Source scan: `vendor/wheels/public/views/packagelist.cfm` has zero `HTMLEditFormat` and uses `EncodeForHTML`
- [x] `directory=wheels.tests.specs.packages` on local Lucee 7 + SQLite
- [x] Spec `PackageListHtmlEditFormatSpec` fails against the old view (2 fail) and passes after this change (136 pass)
- [x] Existing packagelist specs in the packages directory still pass

## Screenshots / Output

N/A — encoder swap; same escaped markup.

TDD red/green (Lucee 7 + SQLite, `directory=wheels.tests.specs.packages`):

- RED (temporary `HTMLEditFormat` restore): 134 pass, **2 fail** (`does not call HTMLEditFormat`, `encodes registry output with EncodeForHTML`)
- GREEN (this change): **136 pass**, 0 fail, 0 error, 15 bundles

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7afd4a06-d5e6-4a22-92ce-ca7fddd9a977?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7afd4a06-d5e6-4a22-92ce-ca7fddd9a977&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

