### PR TITLE
fix(model): fail closed when a validation condition cannot be evaluated

### DIFF
--- a/changelog.d/evaluate-condition-fail-closed.fixed.md
+++ b/changelog.d/evaluate-condition-fail-closed.fixed.md
@@ -1,0 +1,1 @@
+- Unevaluable validation `condition` / `unless` expressions now throw `Wheels.InvalidValidationCondition` even when `showErrorInformation` is false, instead of silently skipping the validation (#3398)

--- a/vendor/wheels/model/validations.cfc
+++ b/vendor/wheels/model/validations.cfc
@@ -580,19 +580,14 @@ component {
 				try {
 					local[local.key] = $evaluateConditionString(arguments[local.item]);
 				} catch (any e) {
-					if ($get("showErrorInformation")) {
-						Throw(
-							type = "Wheels.InvalidValidationCondition",
-							message = "The `#local.item#` expression `#arguments[local.item]#` could not be evaluated: #e.message#",
-							extendedInfo = "Supported forms: `this.property`, `this.method()` (with named `key='val'` or positional `'val'` arguments), bare `method()` (optionally negated with `!`), and binary comparisons using eq/neq/lt/lte/gt/gte or ==/!=/</<=/>/>=."
-						);
-					}
-					cflog(
-						text = "Wheels: validation `#local.item#` expression `#arguments[local.item]#` could not be evaluated (#e.message#); validation skipped.",
-						type = "error",
-						file = "wheels-errors"
+					// Fail closed regardless of showErrorInformation. Returning
+					// false here means "skip this validation" ($validate), which
+					// is fail-open for a broken condition/unless expression.
+					Throw(
+						type = "Wheels.InvalidValidationCondition",
+						message = "The `#local.item#` expression `#arguments[local.item]#` could not be evaluated: #e.message#",
+						extendedInfo = "Supported forms: `this.property`, `this.method()` (with named `key='val'` or positional `'val'` arguments), bare `method()` (optionally negated with `!`), and binary comparisons using eq/neq/lt/lte/gt/gte or ==/!=/</<=/>/>=."
 					);
-					return false;
 				}
 			}
 		}

--- a/vendor/wheels/tests/specs/model/validationsSpec.cfc
+++ b/vendor/wheels/tests/specs/model/validationsSpec.cfc
@@ -310,13 +310,34 @@ component extends="wheels.WheelsTest" {
 				expect(callValid).toThrow("Wheels.InvalidValidationCondition")
 			})
 
-			it("skips the validation without throwing in production when a condition cannot be evaluated", () => {
+			// M1: $evaluateCondition must fail closed when the expression cannot
+			// be evaluated. Returning false here means "skip this validation"
+			// ($validate: if ($evaluateCondition(...))), which is fail-open.
+			it("throws when a condition cannot be evaluated even if showErrorInformation is false", () => {
 				args.condition = "noSuchMethod()"
 				user.validatesLengthOf(argumentCollection = args)
 				var originalShowErrorInformation = application.wheels.showErrorInformation
 				try {
 					application.wheels.showErrorInformation = false
-					expect(user.valid()).toBeTrue()
+					var callValid = () => {
+						user.valid()
+					}
+					expect(callValid).toThrow("Wheels.InvalidValidationCondition")
+				} finally {
+					application.wheels.showErrorInformation = originalShowErrorInformation
+				}
+			})
+
+			it("throws when an unless expression cannot be evaluated even if showErrorInformation is false", () => {
+				args.unless = "noSuchMethod()"
+				user.validatesLengthOf(argumentCollection = args)
+				var originalShowErrorInformation = application.wheels.showErrorInformation
+				try {
+					application.wheels.showErrorInformation = false
+					var callValid = () => {
+						user.valid()
+					}
+					expect(callValid).toThrow("Wheels.InvalidValidationCondition")
 				} finally {
 					application.wheels.showErrorInformation = originalShowErrorInformation
 				}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`$evaluateCondition` was fail-open when `showErrorInformation` is false: an unevaluable `condition` / `unless` expression was logged and the helper returned `false`, which `$validate` treats as “skip this validation.” A broken expression therefore skipped the guard in production.

This PR always throws `Wheels.InvalidValidationCondition` (same type and message shape as the existing development path) regardless of `showErrorInformation`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Documentation update
- [ ] Refactoring

## Feature Completeness Checklist

- [x] **DCO sign-off** -- Every commit carries `Signed-off-by:`
- [x] **Tests** -- Specs in `vendor/wheels/tests/specs/model/validationsSpec.cfc` assert throw on unevaluable `condition` and `unless` when `showErrorInformation=false`
- [ ] **Framework Docs** -- No public API change; not required
- [ ] **AI Reference Docs** -- Not required
- [ ] **CLAUDE.md** -- Not required
- [x] **Changelog fragment** -- `changelog.d/evaluate-condition-fail-closed.fixed.md`
- [x] **Test runner passes** -- Red then green on the named filter

## Test Plan

Driver (directory scope — a single-file `directory=` discovers 0 bundles):

```
wheels test --core --ci --filter=wheels.tests.specs.model
```

1. **Red** (test-only commit `7220553c2`): `967 passed, 2 failed`. Both new specs: “The incoming function did not throw an expected exception. Type=[Wheels.InvalidValidationCondition]”.
2. **Green** (after `8c1af9c5f`): `969 passed`.

## Hardener M1

| ID | Claim | Status | Filter / evidence |
| --- | --- | --- | --- |
| M1 | `$evaluateCondition` fail-closed when showErrorInformation=false | PROVEN (after green) | `wheels test --core --ci --filter=wheels.tests.specs.model` — red 967/2, green 969 |

HEAD: `8c1af9c5f5331d3c1907f5ffd3a6e20698c64c69`

Does not close unrelated issues. Does not start M2–M10.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93071f0d-0c73-433a-ae3e-3ceee3d7ceb0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93071f0d-0c73-433a-ae3e-3ceee3d7ceb0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

