### PR TITLE
fix(model): harden model-layer SHOULDs M2–M8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -412,7 +412,7 @@ model("User").byRole("admin").findAll(page=1, perPage=25);
 user.isDraft();                    // true/false
 model("User").draft().findAll();
 
-// Chainable query builder (injection-safe; values auto-quoted)
+// Chainable query builder (2-/3-arg where is injection-safe; 1-arg is raw SQL)
 model("User")
     .where("status", "active")
     .where("age", ">", 18)

--- a/changelog.d/model-hardener-m2-m8.added.md
+++ b/changelog.d/model-hardener-m2-m8.added.md
@@ -1,0 +1,1 @@
+- `set(massAssignmentStrict=true)` fail-closes mass assignment when a model has neither `accessibleProperties()` nor `protectedProperties()`; the default remains open for compatibility

--- a/changelog.d/model-hardener-m2-m8.changed.md
+++ b/changelog.d/model-hardener-m2-m8.changed.md
@@ -1,0 +1,3 @@
+- `validatesUniquenessOf` now defaults `includeSoftDeletes` to `false`, so a soft-deleted value can be reused unless the caller opts in (`includeSoftDeletes=true`)
+- `belongsTo` now defaults `joinType` to `outer` (`LEFT OUTER JOIN`), so `include` keeps parent rows that have no associated record; pass `joinType="inner"` to require a match
+- Query builder docs now state that single-argument `where()` / `orWhere()` is a raw-SQL passthrough; the 2- and 3-argument forms remain the parameterized contract

--- a/changelog.d/model-hardener-m2-m8.changed.md
+++ b/changelog.d/model-hardener-m2-m8.changed.md
@@ -1,3 +1,2 @@
 - `validatesUniquenessOf` now defaults `includeSoftDeletes` to `false`, so a soft-deleted value can be reused unless the caller opts in (`includeSoftDeletes=true`)
-- `belongsTo` now defaults `joinType` to `outer` (`LEFT OUTER JOIN`), so `include` keeps parent rows that have no associated record; pass `joinType="inner"` to require a match
 - Query builder docs now state that single-argument `where()` / `orWhere()` is a raw-SQL passthrough; the 2- and 3-argument forms remain the parameterized contract

--- a/changelog.d/model-hardener-m2-m8.fixed.md
+++ b/changelog.d/model-hardener-m2-m8.fixed.md
@@ -1,0 +1,3 @@
+- `create()` no longer mass-assigns properties onto the shared class model before instantiating the record
+- Nested `hasMany` collection keys no longer use a `GetTickCount` window heuristic to decide "new" vs existing; form identities use a `new-` prefix (or `_new`), and a failed `findByKey` no longer stamps the key as the child primary key
+- `hasChanged()` now treats `StructDelete` of a persisted property as a change

--- a/changelog.d/model-hardener-m2-m8.fixed.md
+++ b/changelog.d/model-hardener-m2-m8.fixed.md
@@ -1,3 +1,4 @@
 - `create()` no longer mass-assigns properties onto the shared class model before instantiating the record
 - Nested `hasMany` collection keys no longer use a `GetTickCount` window heuristic to decide "new" vs existing; form identities use a `new-` prefix (or `_new`), and a failed `findByKey` no longer stamps the key as the child primary key
 - `hasChanged()` now treats `StructDelete` of a persisted property as a change
+- `findAll(returnAs="struct")` invokes `afterFind` against each row struct instead of the shared class model, so callbacks that read persisted columns no longer depend on `create()` leaking onto the class

--- a/vendor/wheels/events/init/functions.cfm
+++ b/vendor/wheels/events/init/functions.cfm
@@ -3,7 +3,7 @@
 		application.$wheels.functions = {};
 		application.$wheels.functions.autoLink = {link = "all", encode = true};
 		application.$wheels.functions.average = {distinct = false, parameterize = true, ifNull = ""};
-		application.$wheels.functions.belongsTo = {joinType = "outer"};
+		application.$wheels.functions.belongsTo = {joinType = "inner"};
 		application.$wheels.functions.buttonTo = {
 			onlyPath = true,
 			host = "",

--- a/vendor/wheels/events/init/functions.cfm
+++ b/vendor/wheels/events/init/functions.cfm
@@ -3,7 +3,7 @@
 		application.$wheels.functions = {};
 		application.$wheels.functions.autoLink = {link = "all", encode = true};
 		application.$wheels.functions.average = {distinct = false, parameterize = true, ifNull = ""};
-		application.$wheels.functions.belongsTo = {joinType = "inner"};
+		application.$wheels.functions.belongsTo = {joinType = "outer"};
 		application.$wheels.functions.buttonTo = {
 			onlyPath = true,
 			host = "",
@@ -749,7 +749,8 @@
 		application.$wheels.functions.validatesPresenceOf = {message = "[property] can't be empty"};
 		application.$wheels.functions.validatesUniquenessOf = {
 			message = "[property] has already been taken",
-			allowBlank = false
+			allowBlank = false,
+			includeSoftDeletes = false
 		};
 		application.$wheels.functions.verifies = {handler = ""};
 		application.$wheels.functions.wordTruncate = {length = 5, truncateString = "..."};

--- a/vendor/wheels/events/init/security.cfm
+++ b/vendor/wheels/events/init/security.cfm
@@ -62,4 +62,9 @@
 		// reload rate-limit keying. Leave false unless the app sits behind a trusted reverse proxy
 		// that overwrites — never appends to — these headers.
 		application.$wheels.trustProxyHeaders = false;
+
+		// Mass assignment is open unless accessibleProperties() or
+		// protectedProperties() is configured. Set true to fail closed when
+		// neither list exists — a breaking opt-in, not the framework default.
+		application.$wheels.massAssignmentStrict = false;
 </cfscript>

--- a/vendor/wheels/global/settings.cfm
+++ b/vendor/wheels/global/settings.cfm
@@ -87,7 +87,7 @@
 			&& StructKeyExists(request.wheels.tenant, "config")
 			&& StructKeyExists(request.wheels.tenant.config, arguments.name)
 			&& !ListFindNoCase(
-				"encryptionAlgorithm,encryptionSecretKey,encryptionEncoding,CSRFProtection,csrfStore,reloadPassword,obfuscateUrls",
+				"encryptionAlgorithm,encryptionSecretKey,encryptionEncoding,CSRFProtection,csrfStore,reloadPassword,obfuscateUrls,massAssignmentStrict",
 				arguments.name
 			)
 		) {

--- a/vendor/wheels/model/create.cfc
+++ b/vendor/wheels/model/create.cfc
@@ -27,7 +27,8 @@ component {
 		$args(name = "create", args = arguments);
 		$setProperties(
 			argumentCollection = arguments,
-			filterList = "properties,parameterize,reload,validate,transaction,callbacks"
+			filterList = "properties,parameterize,reload,validate,transaction,callbacks",
+			setOnModel = false
 		);
 		local.rv = new (argumentCollection = arguments);
 		local.rv.save(

--- a/vendor/wheels/model/nestedproperties.cfc
+++ b/vendor/wheels/model/nestedproperties.cfc
@@ -194,38 +194,26 @@ component {
 		}
 		if (IsStruct(arguments.value)) {
 			for (local.item in arguments.value) {
-				// Check to see if the id is a tickcount, if so the object is new.
-				if (IsNumeric(local.item) && Ceiling(Right(GetTickCount(), 12) / 900000000) == Ceiling(local.item / 900000000)) {
-					ArrayAppend(
-						this[arguments.property],
-						$getAssociationObject(
-							property = arguments.property,
-							value = arguments.value[local.item],
-							association = arguments.association,
-							delete = arguments.delete
-						)
-					);
-					$updateCollectionObject(property = arguments.property, value = arguments.value[local.item]);
-				} else {
-					// Get our primary keys.
+				if (!$isNewNestedCollectionKey(collectionKey = local.item, value = arguments.value[local.item])) {
+					// Existing-row key: copy the struct key into the primary key fields.
 					local.keys = local.model.primaryKey();
 					local.itemArray = ListToArray(local.item, ",", true);
 					local.iEnd = ListLen(local.keys);
 					for (local.i = 1; local.i <= local.iEnd; local.i++) {
 						arguments.value[local.item][ListGetAt(local.keys, local.i)] = local.itemArray[local.i];
 					}
-
-					ArrayAppend(
-						this[arguments.property],
-						$getAssociationObject(
-							property = arguments.property,
-							value = arguments.value[local.item],
-							association = arguments.association,
-							delete = arguments.delete
-						)
-					);
-					$updateCollectionObject(property = arguments.property, value = arguments.value[local.item]);
 				}
+
+				ArrayAppend(
+					this[arguments.property],
+					$getAssociationObject(
+						property = arguments.property,
+						value = arguments.value[local.item],
+						association = arguments.association,
+						delete = arguments.delete
+					)
+				);
+				$updateCollectionObject(property = arguments.property, value = arguments.value[local.item]);
 			}
 		} else if (IsArray(arguments.value)) {
 			for (local.i = 1; local.i <= ArrayLen(arguments.value); local.i++) {
@@ -314,7 +302,7 @@ component {
 			local.args.key = $createPrimaryKeyList(params = arguments.value, keys = local.model.primaryKey());
 			if (IsObject(arguments.value)) {
 				local.object = arguments.value;
-			} else if (Len(local.args.key)) {
+			} else 			if (Len(local.args.key)) {
 				local.object = local.model.findByKey(argumentCollection = local.args);
 			}
 
@@ -324,6 +312,8 @@ component {
 				local.delete = true;
 			}
 			if (!IsObject(local.object) && !local.delete) {
+				// Key was not a persisted PK — do not stamp it onto a new child.
+				$clearNestedPrimaryKeys(value = arguments.value, keys = local.model.primaryKey());
 				StructDelete(local.args, "key");
 				return $invoke(componentReference = local.model, method = "new", invokeArgs = local.args);
 			} else if (Len(local.args.key) && local.delete && arguments.association.nested.delete && arguments.delete) {
@@ -332,6 +322,36 @@ component {
 			}
 		}
 		return local.object;
+	}
+
+	/**
+	 * True when a hasMany nested-properties struct key identifies a new
+	 * child: an explicit `_new` flag, a blank key, or a `new` / `new-*` /
+	 * `new_*` token from `key($returnTickCountWhenNew=true)`.
+	 */
+	public boolean function $isNewNestedCollectionKey(required any collectionKey, required struct value) {
+		if (StructKeyExists(arguments.value, "_new") && IsBoolean(arguments.value["_new"]) && arguments.value["_new"]) {
+			return true;
+		}
+		local.keyString = ToString(arguments.collectionKey);
+		if (!Len(Trim(local.keyString))) {
+			return true;
+		}
+		if (ReFindNoCase("^new([-_].*)?$", local.keyString)) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Removes primary-key fields from a nested-properties value struct so a
+	 * failed findByKey does not stamp a form identity onto a new child.
+	 */
+	public void function $clearNestedPrimaryKeys(required struct value, required string keys) {
+		local.iEnd = ListLen(arguments.keys);
+		for (local.i = 1; local.i <= local.iEnd; local.i++) {
+			StructDelete(arguments.value, ListGetAt(arguments.keys, local.i));
+		}
 	}
 
 	/**

--- a/vendor/wheels/model/properties.cfc
+++ b/vendor/wheels/model/properties.cfc
@@ -217,7 +217,7 @@ component {
 			}
 		}
 		if (!Len(local.rv) && arguments.$returnTickCountWhenNew) {
-			local.rv = variables.wheels.tickCountId;
+			local.rv = "new-" & variables.wheels.tickCountId;
 		}
 
 		/* To fix the bug below:
@@ -398,6 +398,9 @@ component {
 						return true;
 					}
 				}
+			} else if (StructKeyExists(variables.$persistedProperties, local.key)) {
+				// Persisted property was removed from the instance (e.g. StructDelete).
+				return true;
 			}
 		}
 		// if we get here, it means that all of the properties that were checked had a value in
@@ -499,20 +502,26 @@ component {
 		}
 
 		// loop through the properties and see if they can be set based off of the accessible properties lists
+		local.hasWhiteList = StructKeyExists(variables.wheels.class.accessibleProperties, "whiteList");
+		local.hasBlackList = StructKeyExists(variables.wheels.class.accessibleProperties, "blackList");
+		local.strictOpen = arguments.$useFilterLists && !local.hasWhiteList && !local.hasBlackList && $get("massAssignmentStrict");
 		for (local.key in arguments.properties) {
 			// required to ignore null keys
 			if (StructKeyExists(arguments.properties, local.key)) {
 				local.accessible = true;
+				if (local.strictOpen) {
+					local.accessible = false;
+				}
 				if (
 					arguments.$useFilterLists &&
-					StructKeyExists(variables.wheels.class.accessibleProperties, "whiteList")
+					local.hasWhiteList
 					&& !StructKeyExists(variables.wheels.class.accessibleProperties.whiteList, local.key)
 				) {
 					local.accessible = false;
 				}
 				if (
 					arguments.$useFilterLists
-					&& StructKeyExists(variables.wheels.class.accessibleProperties, "blackList")
+					&& local.hasBlackList
 					&& StructKeyExists(variables.wheels.class.accessibleProperties.blackList, local.key)
 				) {
 					local.accessible = false;

--- a/vendor/wheels/model/query/QueryBuilder.cfc
+++ b/vendor/wheels/model/query/QueryBuilder.cfc
@@ -1,5 +1,5 @@
 /**
- * A chainable, injection-safe query builder for Wheels models.
+ * A chainable query builder for Wheels models.
  * Provides a fluent API alternative to the traditional `findAll(where="...")` string approach.
  *
  * Usage:
@@ -10,8 +10,11 @@
  *       .limit(25)
  *       .get();
  *
- * All values are safely quoted using the model's database adapter, preventing SQL injection.
- * The builder ultimately delegates to the model's standard finder methods (findAll, findOne, etc.).
+ * The 2- and 3-argument `where()` / `orWhere()` forms quote values through the
+ * model's database adapter. The single-argument form is a raw-SQL passthrough
+ * for trusted clauses only — it is not parameterized. Prefer the 2-/3-arg forms
+ * for user input. The builder ultimately delegates to the model's standard
+ * finder methods (findAll, findOne, etc.).
  */
 component output="false" {
 

--- a/vendor/wheels/model/serialize.cfc
+++ b/vendor/wheels/model/serialize.cfc
@@ -174,9 +174,14 @@ component {
 					Called the afterFind hook, the hook adds the arguments defined in the hook to the object so get the properties using properties() function and then append the property struct to the individual record struct
 				*/
 				if (arguments.callbacks && structKeyExists(this, 'afterFindCallback') && arguments.returnas eq "struct") {
-					$callback("afterFind", arguments.callbacks);
-					local.objectProps = properties();
-					structAppend(local.struct, local.objectProps);
+					// Invoke against the row struct, not the class model. The previous
+					// `$callback("afterFind")` + `properties()` path ran afterFind on
+					// `this` (the shared class) and only worked when create() had leaked
+					// column values onto that singleton.
+					local.afterFindResult = $invoke(method = "afterFindCallback", invokeArgs = local.struct);
+					if (StructKeyExists(local, "afterFindResult") && IsStruct(local.afterFindResult)) {
+						structAppend(local.struct, local.afterFindResult);
+					}
 				}
 
 				ArrayAppend(local.rv, local.struct);

--- a/vendor/wheels/model/validations.cfc
+++ b/vendor/wheels/model/validations.cfc
@@ -310,7 +310,7 @@ component {
 		string scope = "",
 		string condition = "",
 		string unless = "",
-		boolean includeSoftDeletes = "true"
+		boolean includeSoftDeletes = "false"
 	) {
 		$args(name = "validatesUniquenessOf", args = arguments);
 		arguments.scope = $listClean(arguments.scope);
@@ -728,7 +728,7 @@ component {
 		required string message,
 		string scope = "",
 		struct properties = "#this.properties()#",
-		boolean includeSoftDeletes = "true"
+		boolean includeSoftDeletes = "false"
 	) {
 		if (!IsBoolean(variables.wheels.class.tableName) || variables.wheels.class.tableName) {
 			local.where = [];

--- a/vendor/wheels/public/docs/reference/model/accessibleproperties.txt
+++ b/vendor/wheels/public/docs/reference/model/accessibleproperties.txt
@@ -1,3 +1,7 @@
+// Mass assignment is open by default: with neither accessibleProperties() nor
+// protectedProperties(), every property can be set via new() / create() / update().
+// set(massAssignmentStrict=true) fail-closes that case (opt-in; not the default).
+
 // 1. Allow only `isActive` to be set through mass assignment (e.g. `updateAll()`, `new()`, `update()`).
 config() {
 	accessibleProperties("isActive");

--- a/vendor/wheels/public/docs/reference/model/belongsto.txt
+++ b/vendor/wheels/public/docs/reference/model/belongsto.txt
@@ -5,8 +5,9 @@ belongsTo("author");
 // 2. Override naming conventions by specifying `modelName` and `foreignKey` explicitly.
 belongsTo(name="bookWriter", modelName="author", foreignKey="authorId");
 
-// 3. Use a LEFT OUTER JOIN instead of the default INNER JOIN when including this association.
-belongsTo(name="category", joinType="outer");
+// 3. Use an INNER JOIN when this model should always have a matching parent
+//    (the default is LEFT OUTER JOIN, which keeps rows with no associated record).
+belongsTo(name="category", joinType="inner");
 
 // 4. Declare a polymorphic belongsTo association (e.g. a Comment that can belong to a Post or a Photo).
 // Wheels will look for `commentableId` and `commentableType` columns on the comments table.

--- a/vendor/wheels/public/docs/reference/model/belongsto.txt
+++ b/vendor/wheels/public/docs/reference/model/belongsto.txt
@@ -5,9 +5,8 @@ belongsTo("author");
 // 2. Override naming conventions by specifying `modelName` and `foreignKey` explicitly.
 belongsTo(name="bookWriter", modelName="author", foreignKey="authorId");
 
-// 3. Use an INNER JOIN when this model should always have a matching parent
-//    (the default is LEFT OUTER JOIN, which keeps rows with no associated record).
-belongsTo(name="category", joinType="inner");
+// 3. Use a LEFT OUTER JOIN instead of the default INNER JOIN when including this association.
+belongsTo(name="category", joinType="outer");
 
 // 4. Declare a polymorphic belongsTo association (e.g. a Comment that can belong to a Post or a Photo).
 // Wheels will look for `commentableId` and `commentableType` columns on the comments table.

--- a/vendor/wheels/public/docs/reference/model/protectedproperties.txt
+++ b/vendor/wheels/public/docs/reference/model/protectedproperties.txt
@@ -1,3 +1,6 @@
+// Without accessibleProperties() or protectedProperties(), mass assignment is open.
+// set(massAssignmentStrict=true) fail-closes that case (opt-in; not the default).
+
 // 1. Protect a comma-delimited list of properties from mass assignment in `models/User.cfc`.
 // `firstName` and `lastName` cannot be changed via `updateAll()`, `new()`, `update()`, etc.
 function config() {

--- a/vendor/wheels/public/docs/reference/model/validatesuniquenessof.txt
+++ b/vendor/wheels/public/docs/reference/model/validatesuniquenessof.txt
@@ -16,5 +16,5 @@ validatesUniquenessOf(property="slug", when="onCreate");
 // 6. Run the check only when a condition is true
 validatesUniquenessOf(property="referralCode", condition="this.isAffiliate()");
 
-// 7. Exclude soft-deleted records from the uniqueness check so a previously-deleted value can be reused
-validatesUniquenessOf(property="username", includeSoftDeletes=false);
+// 7. Include soft-deleted records in the uniqueness check so a previously-deleted value stays reserved
+validatesUniquenessOf(property="username", includeSoftDeletes=true);

--- a/vendor/wheels/tests/specs/model/crudSpec.cfc
+++ b/vendor/wheels/tests/specs/model/crudSpec.cfc
@@ -1287,16 +1287,16 @@ component extends="wheels.WheelsTest" {
 			})
 
 			// Regression for issue #449 (must NOT be undone by the #3245 fix): a genuine
-			// HABTM / `through` bridge nested include keeps the parenthesized grouping so
-			// the bridge's INNER join stays scoped to the OUTER-joined bridge table.
-			// Team.memberTeams is a hasMany (outer bridge); its nested `member` inner
-			// join references the bridge table, so the grouping is correct here.
+			// HABTM / `through` bridge nested include. Team.memberTeams is a hasMany
+			// (outer bridge); nested `member` is belongsTo (outer by default), so both
+			// joins stay flat and parent rows are preserved.
 			it("preserves nested grouping for a HABTM/through bridge include (issue ##449)", () => {
 				actual = g.model("team").$fromClause(include = "memberTeams(member)")
 
 				expect(actual).toBe(
 					"FROM #qi('c_o_r_e_teams')#"
-					& " LEFT OUTER JOIN (#qi('c_o_r_e_memberteams')# INNER JOIN #qi('c_o_r_e_members')# ON #qi('c_o_r_e_memberteams')#.#qi('memberid')# = #qi('c_o_r_e_members')#.#qi('id')#) ON #qi('c_o_r_e_teams')#.#qi('id')# = #qi('c_o_r_e_memberteams')#.#qi('teamid')#"
+					& " LEFT OUTER JOIN #qi('c_o_r_e_memberteams')# ON #qi('c_o_r_e_teams')#.#qi('id')# = #qi('c_o_r_e_memberteams')#.#qi('teamid')#"
+					& " LEFT OUTER JOIN #qi('c_o_r_e_members')# ON #qi('c_o_r_e_memberteams')#.#qi('memberid')# = #qi('c_o_r_e_members')#.#qi('id')#"
 				)
 			})
 
@@ -1305,8 +1305,8 @@ component extends="wheels.WheelsTest" {
 			// got the nested group's INNER join spliced into it — referencing a table the
 			// query has not introduced yet (ORA-00904 / "unknown column in on clause").
 			// `Post.c_o_r_e_comments` and `Post.classifications` are both hasMany (outer);
-			// `Classification.tag` is a belongsTo (inner) whose ON clause references
-			// `classifications`, so it belongs to the classifications group and nowhere else.
+			// `Classification.tag` is a belongsTo (outer by default) whose ON clause
+			// references `classifications`. All three joins stay flat.
 			it("scopes a nested inner join to its own parent, not to every outer join (issue ##3334)", () => {
 				actual = g.model("post").$fromClause(include = "c_o_r_e_comments,classifications(tag)")
 
@@ -1315,7 +1315,8 @@ component extends="wheels.WheelsTest" {
 				expect(actual).toBe(
 					"FROM #qi('c_o_r_e_posts')#"
 					& " LEFT OUTER JOIN #qi('c_o_r_e_comments')# ON #qi('c_o_r_e_posts')#.#qi('id')# = #qi('c_o_r_e_comments')#.#qi('postid')#"
-					& " LEFT OUTER JOIN (#qi('c_o_r_e_classifications')# INNER JOIN #qi('c_o_r_e_tags')# ON #qi('c_o_r_e_classifications')#.#qi('tagid')# = #qi('c_o_r_e_tags')#.#qi('id')#) ON #qi('c_o_r_e_posts')#.#qi('id')# = #qi('c_o_r_e_classifications')#.#qi('postid')#"
+					& " LEFT OUTER JOIN #qi('c_o_r_e_classifications')# ON #qi('c_o_r_e_posts')#.#qi('id')# = #qi('c_o_r_e_classifications')#.#qi('postid')#"
+					& " LEFT OUTER JOIN #qi('c_o_r_e_tags')# ON #qi('c_o_r_e_classifications')#.#qi('tagid')# = #qi('c_o_r_e_tags')#.#qi('id')#"
 				)
 			})
 
@@ -1331,7 +1332,8 @@ component extends="wheels.WheelsTest" {
 				expect(actual).toBe(
 					"FROM #qi('c_o_r_e_posts')#"
 					& " LEFT OUTER JOIN #qi('c_o_r_e_authors')# ON #qi('c_o_r_e_posts')#.#qi('authorid')# = #qi('c_o_r_e_authors')#.#qi('id')#"
-					& " LEFT OUTER JOIN (#qi('c_o_r_e_classifications')# INNER JOIN #qi('c_o_r_e_tags')# ON #qi('c_o_r_e_classifications')#.#qi('tagid')# = #qi('c_o_r_e_tags')#.#qi('id')#) ON #qi('c_o_r_e_posts')#.#qi('id')# = #qi('c_o_r_e_classifications')#.#qi('postid')#"
+					& " LEFT OUTER JOIN #qi('c_o_r_e_classifications')# ON #qi('c_o_r_e_posts')#.#qi('id')# = #qi('c_o_r_e_classifications')#.#qi('postid')#"
+					& " LEFT OUTER JOIN #qi('c_o_r_e_tags')# ON #qi('c_o_r_e_classifications')#.#qi('tagid')# = #qi('c_o_r_e_tags')#.#qi('id')#"
 				)
 			})
 
@@ -1378,7 +1380,8 @@ component extends="wheels.WheelsTest" {
 			// from the association tree, so include order only reorders the emitted joins.
 			it("emits the same joins wherever the nested group sits in the include (issue ##3334)", () => {
 				comments = " LEFT OUTER JOIN #qi('c_o_r_e_comments')# ON #qi('c_o_r_e_posts')#.#qi('id')# = #qi('c_o_r_e_comments')#.#qi('postid')#"
-				classifications = " LEFT OUTER JOIN (#qi('c_o_r_e_classifications')# INNER JOIN #qi('c_o_r_e_tags')# ON #qi('c_o_r_e_classifications')#.#qi('tagid')# = #qi('c_o_r_e_tags')#.#qi('id')#) ON #qi('c_o_r_e_posts')#.#qi('id')# = #qi('c_o_r_e_classifications')#.#qi('postid')#"
+				classifications = " LEFT OUTER JOIN #qi('c_o_r_e_classifications')# ON #qi('c_o_r_e_posts')#.#qi('id')# = #qi('c_o_r_e_classifications')#.#qi('postid')#"
+					& " LEFT OUTER JOIN #qi('c_o_r_e_tags')# ON #qi('c_o_r_e_classifications')#.#qi('tagid')# = #qi('c_o_r_e_tags')#.#qi('id')#"
 
 				expect(g.model("post").$fromClause(include = "c_o_r_e_comments,classifications(tag)")).toBe(
 					"FROM #qi('c_o_r_e_posts')#" & comments & classifications

--- a/vendor/wheels/tests/specs/model/crudSpec.cfc
+++ b/vendor/wheels/tests/specs/model/crudSpec.cfc
@@ -101,11 +101,11 @@ component extends="wheels.WheelsTest" {
 				StructDelete(author, "firstName")
 				result = author.hasChanged()
 
-				expect(result).toBeFalse()
+				expect(result).toBeTrue()
 
 				result = author.hasChanged("firstName")
 
-				expect(result).toBeFalse()
+				expect(result).toBeTrue()
 
 				result = author.hasChanged("somethingThatDoesNotExist")
 
@@ -1268,12 +1268,12 @@ component extends="wheels.WheelsTest" {
 			// emit FLAT sibling joins so the root FROM table stays in scope for every
 			// ON condition. Wheels 3 over-fired the issue #449 parenthesized grouping
 			// here, scoping the root out and triggering MySQL "Unknown column ... in
-			// 'on clause'". `author.user` is a belongsTo (inner) and `author.posts` /
+			// 'on clause'". `author.user` is a belongsTo (outer) and `author.posts` /
 			// `user.galleries` are hasMany (outer) — exactly the reported shape.
 			it("emits flat joins for a belongsTo-chain nested include (issue ##3245)", () => {
 				actual = g.model("author").$fromClause(include = "posts,user(galleries)")
 
-				// No join here qualifies for grouping: `user` is INNER but sits at the root
+				// No join here qualifies for grouping: `user` is OUTER at the root
 				// (nothing encloses it, and its ON references the root `authors`), and
 				// `galleries` is OUTER. Every join stays at the top level, so the root table
 				// remains in scope for every ON condition.
@@ -1281,7 +1281,7 @@ component extends="wheels.WheelsTest" {
 				expect(actual).toBe(
 					"FROM #qi('c_o_r_e_authors')#"
 					& " LEFT OUTER JOIN #qi('c_o_r_e_posts')# ON #qi('c_o_r_e_authors')#.#qi('id')# = #qi('c_o_r_e_posts')#.#qi('authorid')# AND #qi('c_o_r_e_posts')#.#qi('deletedat')# IS NULL"
-					& " INNER JOIN #qi('c_o_r_e_users')# ON #qi('c_o_r_e_authors')#.#qi('firstname')# = #qi('c_o_r_e_users')#.#qi('firstname')#"
+					& " LEFT OUTER JOIN #qi('c_o_r_e_users')# ON #qi('c_o_r_e_authors')#.#qi('firstname')# = #qi('c_o_r_e_users')#.#qi('firstname')#"
 					& " LEFT OUTER JOIN #qi('c_o_r_e_galleries')# ON #qi('c_o_r_e_users')#.#qi('id')# = #qi('c_o_r_e_galleries')#.#qi('userid')#"
 				)
 			})
@@ -1320,17 +1320,17 @@ component extends="wheels.WheelsTest" {
 			})
 
 			// Second shape of issue #3334, and a residual case of issue #3245 that the
-			// #3245 gate does not cover: a ROOT-level inner join (`Post.author` is a
-			// belongsTo) alongside a nested group. Its ON clause references the root
+			// #3245 gate does not cover: a ROOT-level belongsTo join (`Post.author`)
+			// alongside a nested group. Its ON clause references the root
 			// `posts` table, so pulling it inside the classifications parentheses scopes
 			// the root out — the same "unknown column in on clause" failure #3245 fixed
 			// for the flat branch. A root-level join has no enclosing group; it stays flat.
-			it("keeps a root-level inner join out of the nested group (issue ##3334)", () => {
+			it("keeps a root-level belongsTo join out of the nested group (issue ##3334)", () => {
 				actual = g.model("post").$fromClause(include = "author,classifications(tag)")
 
 				expect(actual).toBe(
 					"FROM #qi('c_o_r_e_posts')#"
-					& " INNER JOIN #qi('c_o_r_e_authors')# ON #qi('c_o_r_e_posts')#.#qi('authorid')# = #qi('c_o_r_e_authors')#.#qi('id')#"
+					& " LEFT OUTER JOIN #qi('c_o_r_e_authors')# ON #qi('c_o_r_e_posts')#.#qi('authorid')# = #qi('c_o_r_e_authors')#.#qi('id')#"
 					& " LEFT OUTER JOIN (#qi('c_o_r_e_classifications')# INNER JOIN #qi('c_o_r_e_tags')# ON #qi('c_o_r_e_classifications')#.#qi('tagid')# = #qi('c_o_r_e_tags')#.#qi('id')#) ON #qi('c_o_r_e_posts')#.#qi('id')# = #qi('c_o_r_e_classifications')#.#qi('postid')#"
 				)
 			})

--- a/vendor/wheels/tests/specs/model/crudSpec.cfc
+++ b/vendor/wheels/tests/specs/model/crudSpec.cfc
@@ -1268,12 +1268,12 @@ component extends="wheels.WheelsTest" {
 			// emit FLAT sibling joins so the root FROM table stays in scope for every
 			// ON condition. Wheels 3 over-fired the issue #449 parenthesized grouping
 			// here, scoping the root out and triggering MySQL "Unknown column ... in
-			// 'on clause'". `author.user` is a belongsTo (outer) and `author.posts` /
+			// 'on clause'". `author.user` is a belongsTo (inner) and `author.posts` /
 			// `user.galleries` are hasMany (outer) — exactly the reported shape.
 			it("emits flat joins for a belongsTo-chain nested include (issue ##3245)", () => {
 				actual = g.model("author").$fromClause(include = "posts,user(galleries)")
 
-				// No join here qualifies for grouping: `user` is OUTER at the root
+				// No join here qualifies for grouping: `user` is INNER but sits at the root
 				// (nothing encloses it, and its ON references the root `authors`), and
 				// `galleries` is OUTER. Every join stays at the top level, so the root table
 				// remains in scope for every ON condition.
@@ -1281,22 +1281,22 @@ component extends="wheels.WheelsTest" {
 				expect(actual).toBe(
 					"FROM #qi('c_o_r_e_authors')#"
 					& " LEFT OUTER JOIN #qi('c_o_r_e_posts')# ON #qi('c_o_r_e_authors')#.#qi('id')# = #qi('c_o_r_e_posts')#.#qi('authorid')# AND #qi('c_o_r_e_posts')#.#qi('deletedat')# IS NULL"
-					& " LEFT OUTER JOIN #qi('c_o_r_e_users')# ON #qi('c_o_r_e_authors')#.#qi('firstname')# = #qi('c_o_r_e_users')#.#qi('firstname')#"
+					& " INNER JOIN #qi('c_o_r_e_users')# ON #qi('c_o_r_e_authors')#.#qi('firstname')# = #qi('c_o_r_e_users')#.#qi('firstname')#"
 					& " LEFT OUTER JOIN #qi('c_o_r_e_galleries')# ON #qi('c_o_r_e_users')#.#qi('id')# = #qi('c_o_r_e_galleries')#.#qi('userid')#"
 				)
 			})
 
 			// Regression for issue #449 (must NOT be undone by the #3245 fix): a genuine
-			// HABTM / `through` bridge nested include. Team.memberTeams is a hasMany
-			// (outer bridge); nested `member` is belongsTo (outer by default), so both
-			// joins stay flat and parent rows are preserved.
+			// HABTM / `through` bridge nested include keeps the parenthesized grouping so
+			// the bridge's INNER join stays scoped to the OUTER-joined bridge table.
+			// Team.memberTeams is a hasMany (outer bridge); its nested `member` inner
+			// join references the bridge table, so the grouping is correct here.
 			it("preserves nested grouping for a HABTM/through bridge include (issue ##449)", () => {
 				actual = g.model("team").$fromClause(include = "memberTeams(member)")
 
 				expect(actual).toBe(
 					"FROM #qi('c_o_r_e_teams')#"
-					& " LEFT OUTER JOIN #qi('c_o_r_e_memberteams')# ON #qi('c_o_r_e_teams')#.#qi('id')# = #qi('c_o_r_e_memberteams')#.#qi('teamid')#"
-					& " LEFT OUTER JOIN #qi('c_o_r_e_members')# ON #qi('c_o_r_e_memberteams')#.#qi('memberid')# = #qi('c_o_r_e_members')#.#qi('id')#"
+					& " LEFT OUTER JOIN (#qi('c_o_r_e_memberteams')# INNER JOIN #qi('c_o_r_e_members')# ON #qi('c_o_r_e_memberteams')#.#qi('memberid')# = #qi('c_o_r_e_members')#.#qi('id')#) ON #qi('c_o_r_e_teams')#.#qi('id')# = #qi('c_o_r_e_memberteams')#.#qi('teamid')#"
 				)
 			})
 
@@ -1305,8 +1305,8 @@ component extends="wheels.WheelsTest" {
 			// got the nested group's INNER join spliced into it — referencing a table the
 			// query has not introduced yet (ORA-00904 / "unknown column in on clause").
 			// `Post.c_o_r_e_comments` and `Post.classifications` are both hasMany (outer);
-			// `Classification.tag` is a belongsTo (outer by default) whose ON clause
-			// references `classifications`. All three joins stay flat.
+			// `Classification.tag` is a belongsTo (inner) whose ON clause references
+			// `classifications`, so it belongs to the classifications group and nowhere else.
 			it("scopes a nested inner join to its own parent, not to every outer join (issue ##3334)", () => {
 				actual = g.model("post").$fromClause(include = "c_o_r_e_comments,classifications(tag)")
 
@@ -1315,25 +1315,23 @@ component extends="wheels.WheelsTest" {
 				expect(actual).toBe(
 					"FROM #qi('c_o_r_e_posts')#"
 					& " LEFT OUTER JOIN #qi('c_o_r_e_comments')# ON #qi('c_o_r_e_posts')#.#qi('id')# = #qi('c_o_r_e_comments')#.#qi('postid')#"
-					& " LEFT OUTER JOIN #qi('c_o_r_e_classifications')# ON #qi('c_o_r_e_posts')#.#qi('id')# = #qi('c_o_r_e_classifications')#.#qi('postid')#"
-					& " LEFT OUTER JOIN #qi('c_o_r_e_tags')# ON #qi('c_o_r_e_classifications')#.#qi('tagid')# = #qi('c_o_r_e_tags')#.#qi('id')#"
+					& " LEFT OUTER JOIN (#qi('c_o_r_e_classifications')# INNER JOIN #qi('c_o_r_e_tags')# ON #qi('c_o_r_e_classifications')#.#qi('tagid')# = #qi('c_o_r_e_tags')#.#qi('id')#) ON #qi('c_o_r_e_posts')#.#qi('id')# = #qi('c_o_r_e_classifications')#.#qi('postid')#"
 				)
 			})
 
 			// Second shape of issue #3334, and a residual case of issue #3245 that the
-			// #3245 gate does not cover: a ROOT-level belongsTo join (`Post.author`)
-			// alongside a nested group. Its ON clause references the root
+			// #3245 gate does not cover: a ROOT-level inner join (`Post.author` is a
+			// belongsTo) alongside a nested group. Its ON clause references the root
 			// `posts` table, so pulling it inside the classifications parentheses scopes
 			// the root out — the same "unknown column in on clause" failure #3245 fixed
 			// for the flat branch. A root-level join has no enclosing group; it stays flat.
-			it("keeps a root-level belongsTo join out of the nested group (issue ##3334)", () => {
+			it("keeps a root-level inner join out of the nested group (issue ##3334)", () => {
 				actual = g.model("post").$fromClause(include = "author,classifications(tag)")
 
 				expect(actual).toBe(
 					"FROM #qi('c_o_r_e_posts')#"
-					& " LEFT OUTER JOIN #qi('c_o_r_e_authors')# ON #qi('c_o_r_e_posts')#.#qi('authorid')# = #qi('c_o_r_e_authors')#.#qi('id')#"
-					& " LEFT OUTER JOIN #qi('c_o_r_e_classifications')# ON #qi('c_o_r_e_posts')#.#qi('id')# = #qi('c_o_r_e_classifications')#.#qi('postid')#"
-					& " LEFT OUTER JOIN #qi('c_o_r_e_tags')# ON #qi('c_o_r_e_classifications')#.#qi('tagid')# = #qi('c_o_r_e_tags')#.#qi('id')#"
+					& " INNER JOIN #qi('c_o_r_e_authors')# ON #qi('c_o_r_e_posts')#.#qi('authorid')# = #qi('c_o_r_e_authors')#.#qi('id')#"
+					& " LEFT OUTER JOIN (#qi('c_o_r_e_classifications')# INNER JOIN #qi('c_o_r_e_tags')# ON #qi('c_o_r_e_classifications')#.#qi('tagid')# = #qi('c_o_r_e_tags')#.#qi('id')#) ON #qi('c_o_r_e_posts')#.#qi('id')# = #qi('c_o_r_e_classifications')#.#qi('postid')#"
 				)
 			})
 
@@ -1380,8 +1378,7 @@ component extends="wheels.WheelsTest" {
 			// from the association tree, so include order only reorders the emitted joins.
 			it("emits the same joins wherever the nested group sits in the include (issue ##3334)", () => {
 				comments = " LEFT OUTER JOIN #qi('c_o_r_e_comments')# ON #qi('c_o_r_e_posts')#.#qi('id')# = #qi('c_o_r_e_comments')#.#qi('postid')#"
-				classifications = " LEFT OUTER JOIN #qi('c_o_r_e_classifications')# ON #qi('c_o_r_e_posts')#.#qi('id')# = #qi('c_o_r_e_classifications')#.#qi('postid')#"
-					& " LEFT OUTER JOIN #qi('c_o_r_e_tags')# ON #qi('c_o_r_e_classifications')#.#qi('tagid')# = #qi('c_o_r_e_tags')#.#qi('id')#"
+				classifications = " LEFT OUTER JOIN (#qi('c_o_r_e_classifications')# INNER JOIN #qi('c_o_r_e_tags')# ON #qi('c_o_r_e_classifications')#.#qi('tagid')# = #qi('c_o_r_e_tags')#.#qi('id')#) ON #qi('c_o_r_e_posts')#.#qi('id')# = #qi('c_o_r_e_classifications')#.#qi('postid')#"
 
 				expect(g.model("post").$fromClause(include = "c_o_r_e_comments,classifications(tag)")).toBe(
 					"FROM #qi('c_o_r_e_posts')#" & comments & classifications

--- a/vendor/wheels/tests/specs/model/hardener/ModelHardenerM2M8Spec.cfc
+++ b/vendor/wheels/tests/specs/model/hardener/ModelHardenerM2M8Spec.cfc
@@ -1,0 +1,186 @@
+/**
+ * Hardener SHOULDs M2–M8 (model layer).
+ *
+ * Directory-scoped so `wheels test --core --ci --filter=model.hardener`
+ * discovers this folder (a single-file directory= scope finds 0 bundles).
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		g = application.wo
+
+		describe("M2 validatesUniquenessOf includeSoftDeletes default", () => {
+
+			it("does not treat a soft-deleted row as a taken value by default", () => {
+				transaction action="begin" {
+					var orgPost = g.model("post").findOne();
+					var newPost = g.model("post").new(orgPost.properties());
+					orgPost.delete();
+					expect(newPost.valid()).toBeTrue();
+					transaction action="rollback";
+				}
+			});
+
+			it("still treats a soft-deleted row as taken when includeSoftDeletes is true", () => {
+				transaction action="begin" {
+					var orgPost = g.model("post").findOne();
+					var newPost = g.model("post").new(orgPost.properties());
+					orgPost.delete();
+					newPost.validatesUniquenessOf(properties = "title", includeSoftDeletes = true);
+					expect(newPost.valid()).toBeFalse();
+					transaction action="rollback";
+				}
+			});
+
+		});
+
+		describe("M3 QueryBuilder single-arg where is raw SQL", () => {
+
+			it("does not advertise the builder as universally injection-safe", () => {
+				var src = FileRead(ExpandPath("/wheels/model/query/QueryBuilder.cfc"));
+				expect(FindNoCase("preventing SQL injection", src)).toBe(
+					0,
+					"Class comment must not claim every where() form prevents SQL injection."
+				);
+				expect(FindNoCase("raw", src)).toBeGT(0);
+			});
+
+			it("interpolates a single-argument where() clause verbatim", () => {
+				var modelRef = g.model("author");
+				var qb = new wheels.model.query.QueryBuilder(modelReference = modelRef);
+				qb.where("lastName = 'x' OR 1=1");
+				expect(qb.$buildFinderArgs().where).toBe("lastName = 'x' OR 1=1");
+			});
+
+		});
+
+		describe("M4 create() must not pollute the shared class model", () => {
+
+			afterEach(() => {
+				var authorClass = g.model("author");
+				if (StructKeyExists(authorClass, "firstName") && authorClass.firstName == "ClassLeakXYZ") {
+					StructDelete(authorClass, "firstName");
+				}
+			});
+
+			it("does not write mass-assigned properties onto the class model", () => {
+				var authorClass = g.model("author");
+				StructDelete(authorClass, "firstName");
+				transaction action="begin" {
+					authorClass.create(firstName = "ClassLeakXYZ", lastName = "Probe");
+					transaction action="rollback";
+				}
+				var leaked = StructKeyExists(authorClass, "firstName") && authorClass.firstName == "ClassLeakXYZ";
+				expect(leaked).toBeFalse();
+			});
+
+		});
+
+		describe("M5 hasMany nested keys must not use GetTickCount", () => {
+
+			it("does not stamp an out-of-window numeric key as the child primary key", () => {
+				var tick = Val(Right(GetTickCount(), 12));
+				var currentWindow = Ceiling(tick / 900000000);
+				var candidateA = 2700000000;
+				var candidateB = 4500000000;
+				var staleKey = (Ceiling(candidateA / 900000000) == currentWindow) ? candidateB : candidateA;
+				var nested = {};
+				nested[staleKey] = {filename = "m5.jpg", DESCRIPTION1 = "m5"};
+				var gallery = g.model("gallery").new(
+					title = "M5 Gallery",
+					description = "nested key probe",
+					userId = 1
+				);
+				gallery.$setCollectionAssociationProperty(
+					property = "photos",
+					value = nested,
+					association = gallery.$classData().associations.photos
+				);
+				expect(ArrayLen(gallery.photos)).toBe(1);
+				expect(gallery.photos[1].isNew()).toBeTrue();
+				if (StructKeyExists(gallery.photos[1], "id") && !IsNull(gallery.photos[1].id) && Len(gallery.photos[1].id)) {
+					expect(ToString(gallery.photos[1].id)).notToBe(ToString(staleKey));
+				}
+			});
+
+			it("treats an explicit new- marker as a new child rather than a primary key", () => {
+				var gallery = g.model("gallery").new(
+					title = "M5 New Marker",
+					description = "nested key probe",
+					userId = 1
+				);
+				gallery.$setCollectionAssociationProperty(
+					property = "photos",
+					value = {"new-1": {filename = "m5-new.jpg", DESCRIPTION1 = "m5-new"}},
+					association = gallery.$classData().associations.photos
+				);
+				expect(ArrayLen(gallery.photos)).toBe(1);
+				expect(gallery.photos[1].isNew()).toBeTrue();
+				if (StructKeyExists(gallery.photos[1], "id") && !IsNull(gallery.photos[1].id) && Len(gallery.photos[1].id)) {
+					expect(ToString(gallery.photos[1].id)).notToBe("new-1");
+				}
+			});
+
+		});
+
+		describe("M6 belongsTo include must keep orphan parents", () => {
+
+			it("keeps parent rows that have no associated record", () => {
+				transaction action="begin" {
+					var post = g.model("post").findOne();
+					g.model("post").updateByKey(
+						key = post.id,
+						authorId = "",
+						validate = false,
+						transaction = "none"
+					);
+					var allCount = g.model("post").count();
+					var included = g.model("post").findAll(include = "author");
+					expect(included.recordcount).toBe(allCount);
+					transaction action="rollback";
+				}
+			});
+
+		});
+
+		describe("M7 hasChanged detects StructDelete of a persisted property", () => {
+
+			it("returns true after StructDelete of a persisted property", () => {
+				var author = g.model("author").findOne();
+				StructDelete(author, "firstName");
+				expect(author.hasChanged("firstName")).toBeTrue();
+				expect(author.hasChanged()).toBeTrue();
+			});
+
+			it("still returns false for a property that was never present", () => {
+				var author = g.model("author").findOne();
+				expect(author.hasChanged("somethingThatDoesNotExist")).toBeFalse();
+			});
+
+		});
+
+		describe("M8 mass assignment default and strict option", () => {
+
+			afterEach(() => {
+				application.wheels.massAssignmentStrict = false;
+			});
+
+			it("is open by default when neither accessible nor protected is configured", () => {
+				var author = g.model("author").new(properties = {firstName = "OpenDefault", lastName = "Probe"});
+				expect(author.firstName).toBe("OpenDefault");
+				expect(author.lastName).toBe("Probe");
+			});
+
+			it("massAssignmentStrict leaves unlisted properties unassigned when neither list is configured", () => {
+				application.wheels.massAssignmentStrict = true;
+				var author = g.model("author").new(properties = {firstName = "StrictBlocked", lastName = "Probe"});
+				var assigned = StructKeyExists(author, "firstName") && author.firstName == "StrictBlocked";
+				expect(assigned).toBeFalse();
+			});
+
+		});
+
+	}
+
+}

--- a/vendor/wheels/tests/specs/model/hardener/ModelHardenerM2M8Spec.cfc
+++ b/vendor/wheels/tests/specs/model/hardener/ModelHardenerM2M8Spec.cfc
@@ -126,10 +126,9 @@ component extends="wheels.WheelsTest" {
 
 		describe("M6 belongsTo include default is inner; outer is opt-in", () => {
 
-			afterEach(() => {
-				var associations = g.model("post").$classData().associations;
-				associations.author.joinType = "inner";
-				$resetJoinMemo("post", "author");
+			it("registers belongsTo with joinType inner by default", () => {
+				expect(g.model("post").$classData().associations.author.joinType).toBe("inner");
+				expect(g.model("post").$fromClause(include = "author")).toInclude("INNER JOIN");
 			});
 
 			it("drops parent rows that have no associated record by default", () => {
@@ -141,6 +140,8 @@ component extends="wheels.WheelsTest" {
 						validate = false,
 						transaction = "none"
 					);
+					post.reload();
+					expect(post.authorId).toBeEmpty();
 					var allCount = g.model("post").count();
 					var included = g.model("post").findAll(include = "author");
 					expect(included.recordcount).toBeLT(allCount);
@@ -149,22 +150,12 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("keeps orphan parents when the association opts in with joinType=outer", () => {
-				var associations = g.model("post").$classData().associations;
-				associations.author.joinType = "outer";
-				$resetJoinMemo("post", "author");
-				transaction action="begin" {
-					var post = g.model("post").findOne();
-					g.model("post").updateByKey(
-						key = post.id,
-						authorId = "",
-						validate = false,
-						transaction = "none"
-					);
-					var allCount = g.model("post").count();
-					var included = g.model("post").findAll(include = "author");
-					expect(included.recordcount).toBe(allCount);
-					transaction action="rollback";
-				}
+				expect(g.model("tag").$classData().associations.parent.joinType).toBe("outer");
+				expect(g.model("tag").$fromClause(include = "parent")).toInclude("LEFT OUTER JOIN");
+				var allCount = g.model("tag").count();
+				var included = g.model("tag").findAll(include = "parent");
+				expect(allCount).toBeGT(0);
+				expect(included.recordcount).toBe(allCount);
 			});
 
 		});
@@ -206,17 +197,6 @@ component extends="wheels.WheelsTest" {
 
 		});
 
-	}
-
-	/**
-	 * Clears $expandedAssociations join memo so a runtime joinType flip is honoured.
-	 */
-	private void function $resetJoinMemo(required string modelName, required string association) {
-		var associations = application.wo.model(arguments.modelName).$classData().associations;
-		if (StructKeyExists(associations, arguments.association)) {
-			StructDelete(associations[arguments.association], "join");
-			StructDelete(associations[arguments.association], "joinVariants");
-		}
 	}
 
 }

--- a/vendor/wheels/tests/specs/model/hardener/ModelHardenerM2M8Spec.cfc
+++ b/vendor/wheels/tests/specs/model/hardener/ModelHardenerM2M8Spec.cfc
@@ -124,9 +124,34 @@ component extends="wheels.WheelsTest" {
 
 		});
 
-		describe("M6 belongsTo include must keep orphan parents", () => {
+		describe("M6 belongsTo include default is inner; outer is opt-in", () => {
 
-			it("keeps parent rows that have no associated record", () => {
+			afterEach(() => {
+				var associations = g.model("post").$classData().associations;
+				associations.author.joinType = "inner";
+				$resetJoinMemo("post", "author");
+			});
+
+			it("drops parent rows that have no associated record by default", () => {
+				transaction action="begin" {
+					var post = g.model("post").findOne();
+					g.model("post").updateByKey(
+						key = post.id,
+						authorId = "",
+						validate = false,
+						transaction = "none"
+					);
+					var allCount = g.model("post").count();
+					var included = g.model("post").findAll(include = "author");
+					expect(included.recordcount).toBeLT(allCount);
+					transaction action="rollback";
+				}
+			});
+
+			it("keeps orphan parents when the association opts in with joinType=outer", () => {
+				var associations = g.model("post").$classData().associations;
+				associations.author.joinType = "outer";
+				$resetJoinMemo("post", "author");
 				transaction action="begin" {
 					var post = g.model("post").findOne();
 					g.model("post").updateByKey(
@@ -181,6 +206,17 @@ component extends="wheels.WheelsTest" {
 
 		});
 
+	}
+
+	/**
+	 * Clears $expandedAssociations join memo so a runtime joinType flip is honoured.
+	 */
+	private void function $resetJoinMemo(required string modelName, required string association) {
+		var associations = application.wo.model(arguments.modelName).$classData().associations;
+		if (StructKeyExists(associations, arguments.association)) {
+			StructDelete(associations[arguments.association], "join");
+			StructDelete(associations[arguments.association], "joinVariants");
+		}
 	}
 
 }

--- a/vendor/wheels/tests/specs/model/queryBuilderSpec.cfc
+++ b/vendor/wheels/tests/specs/model/queryBuilderSpec.cfc
@@ -17,7 +17,7 @@ component extends="wheels.WheelsTest" {
 					expect(result.recordcount).toBeGT(0);
 				})
 
-				it("passes through raw SQL strings (1-arg form)", () => {
+				it("passes through raw SQL strings (1-arg trusted-input form)", () => {
 					var result = model("author").where("lastName = 'Djurner'").get();
 					expect(result.recordcount).toBe(1);
 				})

--- a/vendor/wheels/tests/specs/model/validationsSpec.cfc
+++ b/vendor/wheels/tests/specs/model/validationsSpec.cfc
@@ -1019,14 +1019,14 @@ component extends="wheels.WheelsTest" {
 				}
 			})
 
-			it("validatesUniquenessOf_takes_softdeletes_into_account", () => {
+			it("validatesUniquenessOf_excludes_softdeletes_by_default", () => {
 				transaction action="begin" {
 					org_post = g.model('post').findOne()
 					properties = org_post.properties()
 					new_post = g.model('post').new(properties)
 					org_post.delete()
 					valid = new_post.valid()
-					expect(valid).toBeFalse()
+					expect(valid).toBeTrue()
 					transaction action="rollback";
 				}
 			})

--- a/web/sites/api/src/content/docs/v4-0-0/model-configuration/belongsto.md
+++ b/web/sites/api/src/content/docs/v4-0-0/model-configuration/belongsto.md
@@ -30,7 +30,7 @@ Use this association when this model contains a foreign key referencing another 
 | `modelName` | `string` | no | — | Name of associated model (usually not needed if you follow Wheels conventions because the model name will be deduced from the `name` argument). |
 | `foreignKey` | `string` | no | — | Foreign key property name (usually not needed if you follow Wheels conventions since the foreign key name will be deduced from the `name` argument). |
 | `joinKey` | `string` | no | — | Column name to join to if not the primary key (usually not needed if you follow Wheels conventions since the join key will be the table's primary key/keys). |
-| `joinType` | `string` | no | `inner` | Use to set the join type when joining associated tables. Possible values are `inner` (for `INNER JOIN`) and `outer` (for `LEFT OUTER JOIN`). |
+| `joinType` | `string` | no | `outer` | Use to set the join type when joining associated tables. Possible values are `inner` (for `INNER JOIN`) and `outer` (for `LEFT OUTER JOIN`). Default `outer` keeps parent rows that have no associated record. |
 | `polymorphic` | `boolean` | no | `false` |  |
 
 </div>

--- a/web/sites/api/src/content/docs/v4-0-0/model-configuration/belongsto.md
+++ b/web/sites/api/src/content/docs/v4-0-0/model-configuration/belongsto.md
@@ -30,7 +30,7 @@ Use this association when this model contains a foreign key referencing another 
 | `modelName` | `string` | no | — | Name of associated model (usually not needed if you follow Wheels conventions because the model name will be deduced from the `name` argument). |
 | `foreignKey` | `string` | no | — | Foreign key property name (usually not needed if you follow Wheels conventions since the foreign key name will be deduced from the `name` argument). |
 | `joinKey` | `string` | no | — | Column name to join to if not the primary key (usually not needed if you follow Wheels conventions since the join key will be the table's primary key/keys). |
-| `joinType` | `string` | no | `outer` | Use to set the join type when joining associated tables. Possible values are `inner` (for `INNER JOIN`) and `outer` (for `LEFT OUTER JOIN`). Default `outer` keeps parent rows that have no associated record. |
+| `joinType` | `string` | no | `inner` | Use to set the join type when joining associated tables. Possible values are `inner` (for `INNER JOIN`) and `outer` (for `LEFT OUTER JOIN`). |
 | `polymorphic` | `boolean` | no | `false` |  |
 
 </div>

--- a/web/sites/api/src/content/docs/v4-0-0/model-configuration/validatesuniquenessof.md
+++ b/web/sites/api/src/content/docs/v4-0-0/model-configuration/validatesuniquenessof.md
@@ -35,7 +35,7 @@ When the record is updated, the same check is made but disregarding the record i
 | `scope` | `string` | no | — | One or more properties by which to limit the scope of the uniqueness constraint. |
 | `condition` | `string` | no | — | String expression to be evaluated that decides if validation will be run (if the expression returns `true` validation will run). |
 | `unless` | `string` | no | — | String expression to be evaluated that decides if validation will be run (if the expression returns `false` validation will run). |
-| `includeSoftDeletes` | `boolean` | no | `true` | Set to `true` to include soft-deleted records in the queries that this method runs. |
+| `includeSoftDeletes` | `boolean` | no | `false` | Set to `true` to include soft-deleted records in the uniqueness check. The default excludes them so a previously deleted value can be reused. |
 
 </div>
 

--- a/web/sites/guides/src/content/docs/v4-0-0/basics/query-builder-and-scopes.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/basics/query-builder-and-scopes.mdx
@@ -41,7 +41,7 @@ component extends="Controller" {
 }
 ```
 
-The two-argument form of `where` means equality. The three-argument form takes an operator in the middle — `>`, `<`, `>=`, `<=`, `!=`, `LIKE`, and so on. Stack multiple `.where(...)` calls and they AND together.
+The two-argument form of `where` means equality. The three-argument form takes an operator in the middle — `>`, `<`, `>=`, `<=`, `!=`, `LIKE`, and so on. Stack multiple `.where(...)` calls and they AND together. A single-argument `where("status = 'published'")` is a raw-SQL passthrough for trusted clauses only — it is not quoted or parameterized. Use the 2- or 3-argument forms for values that came from the request.
 
 ### Builder methods
 

--- a/web/sites/guides/src/content/docs/v4-0-0/upgrading/whats-new-in-4.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/upgrading/whats-new-in-4.mdx
@@ -14,7 +14,7 @@ You know Wheels. You have a 3.x app in production. This page is the ten-minute a
 
 **Built-in dependency injection.** Register services in `config/services.cfm`, resolve with `service()` or `inject()`, scope as transient, singleton, or request. This is the change that removed the WireBox dependency — the container is `vendor/wheels/Injector.cfc`, part of the framework. → [The Dependency Injection Container](/v4-0-0/core-concepts/dependency-injection/)
 
-**Chainable query builder, scopes, and enums.** `model("User").where("status","active").whereNotNull("emailVerifiedAt").orderBy("name").get()` — injection-safe, values auto-quoted. Named scopes compose (`model("User").active().recent().findAll()`), and `enum()` generates checkers and scopes from a property definition. → [Query Builder and Scopes](/v4-0-0/basics/query-builder-and-scopes/)
+**Chainable query builder, scopes, and enums.** `model("User").where("status","active").whereNotNull("emailVerifiedAt").orderBy("name").get()` — 2-/3-arg `where` is injection-safe (values auto-quoted); 1-arg `where` is raw SQL. Named scopes compose (`model("User").active().recent().findAll()`), and `enum()` generates checkers and scopes from a property definition. → [Query Builder and Scopes](/v4-0-0/basics/query-builder-and-scopes/)
 
 **Background jobs.** `app/jobs/` CFCs extending `wheels.Job`, with queues, delayed/scheduled enqueue, retries with exponential backoff, and a worker loop (`wheels jobs work`). The `wheels_jobs` table auto-creates on first use. → [Background Jobs](/v4-0-0/digging-deeper/background-jobs/)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Model-layer Hardener SHOULDs M2–M8. Red proofs and green locks live in `vendor/wheels/tests/specs/model/hardener/`.

**M6 is default-inner + opt-in outer.** `belongsTo` include still defaults to `joinType="inner"` (orphans are dropped). Pass `joinType="outer"` on the association to keep parent rows with no associated record. This PR does **not** change the belongsTo default to outer.

Does not close #3378 or basecoat #15. Does not close unrelated issues. **Do not merge. Keep draft.**

## Type of Change

- [x] Bug fix
- [x] Enhancement to existing feature
- [x] Documentation update

## Feature Completeness Checklist

- [x] **DCO sign-off** -- Every commit carries `Signed-off-by:`
- [x] **Tests** -- `vendor/wheels/tests/specs/model/hardener/ModelHardenerM2M8Spec.cfc` plus existing-spec pin updates in `validationsSpec`, `crudSpec`, `queryBuilderSpec`
- [x] **Framework Docs** -- `web/sites/guides/src/content/docs/v4-0-0/basics/query-builder-and-scopes.mdx`, `upgrading/whats-new-in-4.mdx`; API `belongsto.md` (default **inner**), `validatesuniquenessof.md`; `vendor/wheels/public/docs/reference/model/{belongsto,validatesuniquenessof,accessibleproperties,protectedproperties}.txt`
- [x] **AI Reference Docs** -- `CLAUDE.md` query-builder line names the 1-arg raw-SQL exception
- [x] **CLAUDE.md** -- updated for the query-builder contract
- [x] **Changelog fragment** -- `changelog.d/model-hardener-m2-m8.{added,changed,fixed}.md` (no "belongsTo now defaults to outer" claim)
- [x] **Test runner** -- filters below on HEAD `596f22e3c`. Full LuCLI still needs CI confirmation on this HEAD.

## Test Plan

```
wheels test --core --ci --filter=model.hardener
wheels test --core --ci --filter=model
```

(`directory=` must point at a folder; a single-file scope discovers 0 bundles.)

1. **Red** (`add1daaa4` prove-red only): `4 passed, 7 failed, 1 error(s)`.
2. **Green** (`acfdf85ca` fix commit): `12 passed`.
3. **HOLD rewrite** (`596f22e3c`): restore default-inner + opt-in outer; `afterFind` on `returnAs=struct` rows.

Local on `596f22e3c`:

- `wheels test --core --ci --filter=model.hardener` → **14 passed (0.04s)**
- `wheels test --core --ci --filter=model` → **983 passed (2.14s)** (includes callbacks `returnAs=struct` / VIEWS path and restored #449/#3334 SQL pins)

## PROVEN / UNPROVEN

| ID | Claim | Status | Filter / evidence |
| --- | --- | --- | --- |
| M2 | `validatesUniquenessOf` default `includeSoftDeletes=false` so a soft-deleted value can be reused | **PROVEN** | `wheels test --core --ci --filter=model.hardener` — **14 passed** |
| M3 | QueryBuilder 1-arg `where()` is raw SQL; class/docs no longer claim universal injection-safety | **PROVEN** | same filter |
| M4 | `create()` does not mass-assign onto the shared class model (`setOnModel=false`) | **PROVEN** | same filter |
| M5 | Nested `hasMany` keys use `new-` / `_new` / blank PK, not a `GetTickCount` window | **PROVEN** | same filter |
| M6 | Default `belongsTo` include is **inner** (orphans dropped). Opt-in `joinType=outer` **keeps** orphans. | **PROVEN** default-inner + opt-in outer. **Do not claim outer default.** | same filter + restored #449/#3334 `crudSpec` SQL pins in `filter=model` |
| M7 | `hasChanged` treats `StructDelete` of a persisted property as a change; `findAll(returnAs="struct")` afterFind no longer reads columns off the class | **PROVEN** | hardener + `filter=model` (983 passed; VIEWS path in `serialize.cfc`) |
| M8 | Fail-closed mass assignment by default | **UNPROVEN / DEFERRED**. Opt-in only: `set(massAssignmentStrict=true)`. Default stays open. | same filter |

HEAD: `596f22e3c0d7e42ff29d510e6a6826fe0aa9ddec`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c85efd8-d331-4c5b-b58a-889cb0730057?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c85efd8-d331-4c5b-b58a-889cb0730057&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>