### PR TITLE
fix(controller): harden $callAction ViewNotFound and $useLayout wipe (B5–B6)

### DIFF
--- a/changelog.d/controller-hardener-b5-b6.fixed.md
+++ b/changelog.d/controller-hardener-b5-b6.fixed.md
@@ -1,4 +1,4 @@
-- `$callAction()` no longer remaps layout or render exceptions to `Wheels.ViewNotFound` just because `action.cfm` is missing; only genuine missing-view includes become 404
+- `$callAction()` no longer remaps layout or render exceptions to `Wheels.ViewNotFound` just because `action.cfm` is missing; only genuine missing-view includes become typed `Wheels.ViewNotFound`. `$callAction()` now always Throws that type (it no longer include+aborts via `$throwErrorOrShow404Page`). `processAction()` still presents the production 404 page for ViewNotFound, so HTTP 404 for apps is unchanged.
 - `$useLayout()` keeps a chosen `usesLayout` match when a later declaration does not apply, instead of resetting to `useDefault` (layout bypass)
 - Action cache no longer stores a redirect-only empty body
 - `filterChain()` returns a copy so callers cannot mutate the live filter chain

--- a/changelog.d/controller-hardener-b5-b6.fixed.md
+++ b/changelog.d/controller-hardener-b5-b6.fixed.md
@@ -1,0 +1,8 @@
+- `$callAction()` no longer remaps layout or render exceptions to `Wheels.ViewNotFound` just because `action.cfm` is missing; only genuine missing-view includes become 404
+- `$useLayout()` keeps a chosen `usesLayout` match when a later declaration does not apply, instead of resetting to `useDefault` (layout bypass)
+- Action cache no longer stores a redirect-only empty body
+- `filterChain()` returns a copy so callers cannot mutate the live filter chain
+- `$findRoute()` throws `Wheels.RouteNotFound` when no same-named candidate matches, instead of returning the last declaration
+- `filters(placement="prepend")` keeps multi-`through` order (`a,b,c` stays `a,b,c` in front of the existing chain)
+- `redirectTo(url=)` encodes `params` the same way `back=true` does
+- A blank string returned from a layout function uses the default layout, matching the documented contract

--- a/changelog.d/controller-hardener-shoulds.changed.md
+++ b/changelog.d/controller-hardener-shoulds.changed.md
@@ -1,0 +1,2 @@
+- `processAction()` returns `false` when a verification aborts or a before filter returns `false` (the halt signal was previously always `true`)
+- `processRequest()` accepts opt-in `csrf="exception"` / `csrf="abort"`; the historic test-helper default remains `ignore` and production `protectsFromForgery()` is unchanged

--- a/vendor/wheels/controller/filters.cfc
+++ b/vendor/wheels/controller/filters.cfc
@@ -44,8 +44,12 @@ component {
 			}
 			if (arguments.placement == "append") {
 				ArrayAppend(variables.$class.filters, local.filter);
+			} else if (!ArrayLen(variables.$class.filters)) {
+				ArrayAppend(variables.$class.filters, local.filter);
 			} else {
-				ArrayPrepend(variables.$class.filters, local.filter);
+				// Prepend the through-list as a block so "a,b,c" stays a,b,c
+				// in front of the existing chain (not c,b,a).
+				ArrayInsertAt(variables.$class.filters, local.i, local.filter);
 			}
 		}
 	}
@@ -86,14 +90,15 @@ component {
 		}
 
 		// Set all filters to be returned, or loop over them and set only those that match the supplied type to be returned.
+		// Always return a copy so callers cannot mutate the live $class.filters chain.
 		if (arguments.type == "all") {
-			local.rv = variables.$class.filters;
+			local.rv = Duplicate(variables.$class.filters);
 		} else {
 			local.rv = [];
 			local.iEnd = ArrayLen(variables.$class.filters);
 			for (local.i = 1; local.i <= local.iEnd; local.i++) {
 				if (LCase(variables.$class.filters[local.i].type) == LCase(arguments.type)) {
-					ArrayAppend(local.rv, variables.$class.filters[local.i]);
+					ArrayAppend(local.rv, Duplicate(variables.$class.filters[local.i]));
 				}
 			}
 		}

--- a/vendor/wheels/controller/layouts.cfc
+++ b/vendor/wheels/controller/layouts.cfc
@@ -80,11 +80,10 @@ component {
 	 */
 	public any function $useLayout(required string $action) {
 		local.rv = true;
-		local.layoutType = "template";
+		local.matched = false;
 
 		for (local.layout in variables.$class.layouts) {
-			local.rv = local.layout.useDefault;
-
+			local.layoutType = "template";
 			if (
 				(!StructKeyExists(local.layout, "except") || !ListFindNoCase(local.layout.except, arguments.$action))
 				&& (!StructKeyExists(local.layout, "only") || ListFindNoCase(local.layout.only, arguments.$action))
@@ -101,15 +100,24 @@ component {
 				) {
 					local.invokeArgs = {};
 					local.invokeArgs.action = arguments.$action;
+					StructDelete(local, "result");
 					local.result = $invoke(method = local.layout[local.layoutType], invokeArgs = local.invokeArgs);
 
 					// If the developer doesn't return anything from the function or if they return a blank string it should use the default layout still.
-					if (StructKeyExists(local, "result")) {
+					if (StructKeyExists(local, "result") && !(IsSimpleValue(local.result) && !Len(ToString(local.result)))) {
 						local.rv = local.result;
+					} else {
+						local.rv = local.layout.useDefault;
 					}
 				} else {
 					local.rv = local.layout[local.layoutType];
 				}
+				local.matched = true;
+			} else if (!local.matched) {
+				// Only apply this declaration's useDefault when no prior
+				// usesLayout has matched. A later non-match must not wipe a
+				// chosen layout (that was a silent bypass).
+				local.rv = local.layout.useDefault;
 			}
 		}
 		return local.rv;

--- a/vendor/wheels/controller/processing.cfc
+++ b/vendor/wheels/controller/processing.cfc
@@ -11,6 +11,10 @@ component {
 	public boolean function processAction(string includeFilters = true) {
 		$runCsrfProtection(action = variables.params.action);
 
+		// Completed is the halt signal: false when a verification aborted or a
+		// before filter returned false. Always-true used to make that signal dead.
+		local.completed = false;
+
 		// Check if action should be cached, and if so, cache statically or set the time to use later when caching just the action.
 		local.cache = 0;
 		if ($get("cacheActions") && $hasCachableActions() && flashIsEmpty() && StructIsEmpty(form)) {
@@ -116,9 +120,11 @@ component {
 			if ($get("showDebugInformation")) {
 				$debugPoint("afterFilters");
 			}
+
+			local.completed = local.runAction;
 		}
 
-		return true;
+		return local.completed;
 	}
 
 	/**
@@ -194,9 +200,9 @@ component {
 					& "/"
 					& LCase(arguments.action)
 					& ".cfm";
-					if (FileExists(ExpandPath(local.file))) {
-						Throw(object = e);
-					} else {
+					// Only remap genuine missing-view includes. A missing action.cfm
+					// used to turn every render/layout exception into ViewNotFound.
+					if ($isMissingViewException(e) && !FileExists(ExpandPath(local.file))) {
 						// For non-HTML formats, provide a more helpful error message
 						if (local.contentType != "html") {
 							$throwErrorOrShow404Page(
@@ -211,6 +217,8 @@ component {
 								extendedInfo = "Create a file named `#LCase(arguments.action)#.cfm` in the `app/views/#LCase(ListChangeDelims(variables.$class.name, '/', '.'))#` directory (create the directory as well if it doesn't already exist)."
 							);
 						}
+					} else {
+						Throw(object = e);
 					}
 				}
 			}
@@ -227,13 +235,30 @@ component {
 		required string category
 	) {
 		$callAction(action = arguments.action);
-		$addToCache(
-			key = arguments.key,
-			value = variables.$instance.response,
-			time = arguments.time,
-			category = arguments.category
-		);
+		// A redirect-only action has no body. Caching that empty string turns
+		// the next hit into a blank 200 with no redirect.
+		if (!$performedRedirect()) {
+			$addToCache(
+				key = arguments.key,
+				value = variables.$instance.response,
+				time = arguments.time,
+				category = arguments.category
+			);
+		}
 		return response();
+	}
+
+	/**
+	 * Internal function. True when an auto-render exception is a missing view
+	 * include rather than a layout/helper/runtime error that happened to fire
+	 * while action.cfm was also absent.
+	 */
+	public boolean function $isMissingViewException(required any exception) {
+		if ($isMissingMappedInclude(arguments.exception)) {
+			return true;
+		}
+		local.type = StructKeyExists(arguments.exception, "type") ? ToString(arguments.exception.type) : "";
+		return FindNoCase("MissingInclude", local.type) > 0 || local.type == "template";
 	}
 
 	/**

--- a/vendor/wheels/controller/processing.cfc
+++ b/vendor/wheels/controller/processing.cfc
@@ -58,53 +58,75 @@ component {
 			// Only proceed to call the action if a before filter has not
 			// returned false and has not already rendered content.
 			if (local.runAction && !$performedRenderOrRedirect()) {
-				// Get content from the cache if it exists there and set it to the request scope. If not, the $callActionAndAddToCache function will run, calling the controller action (which in turn sets the content to the request scope).
-				if (local.cache) {
-					local.category = "action";
+				// $callAction always Throws typed ViewNotFound for a genuine
+				// missing view. Catch it here and present the 404 page so HTTP
+				// dispatch keeps the existing production 404 (include+abort
+				// when showErrorInformation is off). Direct $callAction
+				// callers — including the B5 specs — still see the type.
+				// `var` (not local.) so the catch write survives on BoxLang.
+				var viewNotFound = {hit = false, message = "", extendedInfo = ""};
+				try {
+					// Get content from the cache if it exists there and set it to the request scope. If not, the $callActionAndAddToCache function will run, calling the controller action (which in turn sets the content to the request scope).
+					if (local.cache) {
+						local.category = "action";
 
-					// Create the key for the cache.
-					local.key = $hashedKey(variables.$class.name, variables.params);
+						// Create the key for the cache.
+						local.key = $hashedKey(variables.$class.name, variables.params);
 
-					// Evaluate variables and append to the cache key when specified.
-					// Missing or unresolvable items throw; they are never omitted,
-					// because a silent skip collapses distinct keys into one shared key.
-					if (Len(local.appendToKey)) {
-						local.scopeMap = {
-							"request": request,
-							"arguments": arguments,
-							"application": application,
-							"session": session,
-							"variables": variables
-						};
-						local.key = $appendToCacheKey(
-							key = local.key,
-							appendToKey = local.appendToKey,
-							scopeMap = local.scopeMap
+						// Evaluate variables and append to the cache key when specified.
+						// Missing or unresolvable items throw; they are never omitted,
+						// because a silent skip collapses distinct keys into one shared key.
+						if (Len(local.appendToKey)) {
+							local.scopeMap = {
+								"request": request,
+								"arguments": arguments,
+								"application": application,
+								"session": session,
+								"variables": variables
+							};
+							local.key = $appendToCacheKey(
+								key = local.key,
+								appendToKey = local.appendToKey,
+								scopeMap = local.scopeMap
+							);
+						}
+
+						local.conditionArgs = {};
+						local.conditionArgs.key = local.key;
+						local.conditionArgs.category = local.category;
+						local.executeArgs = {};
+						local.executeArgs.controller = variables.params.controller;
+						local.executeArgs.action = variables.params.action;
+						local.executeArgs.key = local.key;
+						local.executeArgs.time = local.cache;
+						local.executeArgs.category = local.category;
+						local.lockName = local.category & local.key & application.applicationName;
+						variables.$instance.response = $doubleCheckedLock(
+							name = local.lockName,
+							condition = "$getFromCache",
+							execute = "$callActionAndAddToCache",
+							conditionArgs = local.conditionArgs,
+							executeArgs = local.executeArgs
 						);
 					}
 
-					local.conditionArgs = {};
-					local.conditionArgs.key = local.key;
-					local.conditionArgs.category = local.category;
-					local.executeArgs = {};
-					local.executeArgs.controller = variables.params.controller;
-					local.executeArgs.action = variables.params.action;
-					local.executeArgs.key = local.key;
-					local.executeArgs.time = local.cache;
-					local.executeArgs.category = local.category;
-					local.lockName = local.category & local.key & application.applicationName;
-					variables.$instance.response = $doubleCheckedLock(
-						name = local.lockName,
-						condition = "$getFromCache",
-						execute = "$callActionAndAddToCache",
-						conditionArgs = local.conditionArgs,
-						executeArgs = local.executeArgs
-					);
+					// If we didn't render anything from a cached action, we call the action here.
+					if (!$performedRender()) {
+						$callAction(action = variables.params.action);
+					}
+				} catch (Wheels.ViewNotFound e) {
+					viewNotFound.hit = true;
+					viewNotFound.message = e.message;
+					if (StructKeyExists(e, "extendedInfo")) {
+						viewNotFound.extendedInfo = e.extendedInfo;
+					}
 				}
-
-				// If we didn't render anything from a cached action, we call the action here.
-				if (!$performedRender()) {
-					$callAction(action = variables.params.action);
+				if (viewNotFound.hit) {
+					$throwErrorOrShow404Page(
+						type = "Wheels.ViewNotFound",
+						message = viewNotFound.message,
+						extendedInfo = viewNotFound.extendedInfo
+					);
 				}
 			}
 
@@ -203,20 +225,24 @@ component {
 					// Only remap genuine missing-view includes. A missing action.cfm
 					// used to turn every render/layout exception into ViewNotFound.
 					if ($isMissingViewException(e) && !FileExists(ExpandPath(local.file))) {
-						// For non-HTML formats, provide a more helpful error message
+						// Always throw a typed ViewNotFound. $throwErrorOrShow404Page
+						// include+aborts when showErrorInformation is off, which
+						// hides the type from callers and from TestBox toThrow.
+						// processAction catches this and presents the 404 page so
+						// HTTP 404 for apps is unchanged.
 						if (local.contentType != "html") {
-							$throwErrorOrShow404Page(
-								type = "Wheels.ViewNotFound",
-								message = "No content was rendered for the `#arguments.action#` action in the `#variables.$class.name#` controller.",
-								extendedInfo = "For content type `#local.contentType#`, either: 1) Call a render function (renderText, renderWith, etc.) in your action, 2) Create a view template named `#LCase(arguments.action)#.#local.contentType#.cfm`, or 3) Use onlyProvides() to restrict acceptable formats."
-							);
+							local.viewNotFoundMessage = "No content was rendered for the `#arguments.action#` action in the `#variables.$class.name#` controller.";
+							local.viewNotFoundExtended = "For content type `#local.contentType#`, either: 1) Call a render function (renderText, renderWith, etc.) in your action, 2) Create a view template named `#LCase(arguments.action)#.#local.contentType#.cfm`, or 3) Use onlyProvides() to restrict acceptable formats.";
 						} else {
-							$throwErrorOrShow404Page(
-								type = "Wheels.ViewNotFound",
-								message = "Could not find the view page for the `#arguments.action#` action in the `#variables.$class.name#` controller.",
-								extendedInfo = "Create a file named `#LCase(arguments.action)#.cfm` in the `app/views/#LCase(ListChangeDelims(variables.$class.name, '/', '.'))#` directory (create the directory as well if it doesn't already exist)."
-							);
+							local.viewNotFoundMessage = "Could not find the view page for the `#arguments.action#` action in the `#variables.$class.name#` controller.";
+							local.viewNotFoundExtended = "Create a file named `#LCase(arguments.action)#.cfm` in the `app/views/#LCase(ListChangeDelims(variables.$class.name, '/', '.'))#` directory (create the directory as well if it doesn't already exist).";
 						}
+						$header(statusCode = 404);
+						Throw(
+							type = "Wheels.ViewNotFound",
+							message = local.viewNotFoundMessage,
+							extendedInfo = local.viewNotFoundExtended
+						);
 					} else {
 						Throw(object = e);
 					}

--- a/vendor/wheels/controller/redirection.cfc
+++ b/vendor/wheels/controller/redirection.cfc
@@ -136,11 +136,13 @@ component {
 			}
 			local.url = arguments.url;
 			if (Len(arguments.params)) {
+				local.params = $constructParams(params = arguments.params, encode = arguments.encode);
 				if (Find("?", arguments.url)) {
-					local.url = "#local.url#&#arguments.params#";
-				} else {
-					local.url = "#local.url#?#arguments.params#";
+					local.params = Replace(local.params, "?", "&");
+				} else if (Left(local.params, 1) == "&") {
+					local.params = Replace(local.params, "&", "?", "one");
 				}
+				local.url &= local.params;
 			}
 		} else {
 			local.url = uRLFor(argumentCollection = arguments);

--- a/vendor/wheels/events/init/functions.cfm
+++ b/vendor/wheels/events/init/functions.cfm
@@ -531,7 +531,7 @@
 			appendToLabel = "",
 			encode = true
 		};
-		application.$wheels.functions.processRequest = {method = "get", returnAs = "", rollback = false};
+		application.$wheels.functions.processRequest = {method = "get", returnAs = "", rollback = false, csrf = "ignore"};
 		application.$wheels.functions.protectsFromForgery = {with = "exception", only = "", except = ""};
 		application.$wheels.functions.radioButton = {
 			label = "useDefaultLabel",

--- a/vendor/wheels/global/request.cfm
+++ b/vendor/wheels/global/request.cfm
@@ -490,13 +490,15 @@
 	 * @returnAs Pass in `struct` to return all information about the request instead of just the final output (`body`).
 	 * @rollback Pass in `true` to roll back all database transactions made during the request.
 	 * @includeFilters Set to `before` to only execute "before" filters, `after` to only execute "after" filters or `false` to skip all filters.
+	 * @csrf CSRF handling for this request. Default `ignore` preserves the historic test helper. Pass `exception` or `abort` to enforce; this is opt-in and does not change the production `protectsFromForgery()` default.
 	 */
 	public any function processRequest(
 		required struct params,
 		string method,
 		string returnAs,
 		string rollback,
-		string includeFilters = true
+		string includeFilters = true,
+		string csrf = "ignore"
 	) {
 		$args(name = "processRequest", args = arguments);
 
@@ -528,8 +530,9 @@
 
 		local.controller = controller(name = arguments.params.controller, params = arguments.params);
 
-		// Set to ignore CSRF errors during testing.
-		local.controller.protectsFromForgery(with = "ignore");
+		// Historic test helper defaults to ignore. Opt in to exception/abort
+		// without flipping the production protectsFromForgery() default.
+		local.controller.protectsFromForgery(with = arguments.csrf);
 
 		local.controller.processAction(includeFilters = arguments.includeFilters);
 		local.response = local.controller.response();

--- a/vendor/wheels/global/routing.cfm
+++ b/vendor/wheels/global/routing.cfm
@@ -110,10 +110,18 @@
 		local.routePos = application.wheels.namedRoutePositions[arguments.route];
 		if (Find(",", local.routePos)) {
 			// there are several routes with this name so we need to figure out which one to use by checking the passed in arguments
+			local.foundRoute = false;
+			local.methodSpecified = StructKeyExists(arguments, "method") && Len(arguments.method);
 			local.iEnd = ListLen(local.routePos);
 			for (local.i = 1; local.i <= local.iEnd; local.i++) {
 				local.rv = application.wheels.routes[ListGetAt(local.routePos, local.i)];
-				local.foundRoute = StructKeyExists(arguments, "method") && local.rv.methods == arguments.method;
+				// Method is optional: URLFor / redirectTo do not pass it. When it
+				// is present it must match; when it is absent, variables decide.
+				local.foundRoute = !local.methodSpecified
+				|| (
+					StructKeyExists(local.rv, "methods")
+					&& ListFindNoCase(local.rv.methods, arguments.method)
+				);
 				local.jEnd = ListLen(local.rv.foundvariables);
 				for (local.j = 1; local.j <= local.jEnd; local.j++) {
 					local.variable = ListGetAt(local.rv.foundvariables, local.j);
@@ -124,6 +132,13 @@
 				if (local.foundRoute) {
 					break;
 				}
+			}
+			if (!local.foundRoute) {
+				$throwErrorOrShow404Page(
+					type = "Wheels.RouteNotFound",
+					message = "Could not find a `#arguments.route#` route that matched the supplied arguments.",
+					extendedInfo = "Same-named routes are distinguished by HTTP method and required path variables. Passing a method or variables that match none of the candidates is an error, not a fallback to the last declared route."
+				);
 			}
 		} else {
 			local.rv = application.wheels.routes[local.routePos];

--- a/vendor/wheels/tests/_assets/controllers/HardenerLifecycle.cfc
+++ b/vendor/wheels/tests/_assets/controllers/HardenerLifecycle.cfc
@@ -19,6 +19,26 @@ component extends="Controller" {
 		renderText(request.hardenerCachePayload);
 	}
 
+	function cachedRedirect() {
+		redirectTo(url = "/hardener-redirect-target", delay = true);
+	}
+
+	function noView() {
+		// Intentionally empty: $callAction auto-renders and there is no view file.
+	}
+
+	public any function explodingLayout() {
+		Throw(type = "Wheels.HardenerLayoutError", message = "layout exploded on purpose");
+	}
+
+	public any function blankLayout() {
+		return "";
+	}
+
+	public any function namedLayout() {
+		return "hardener_named_layout";
+	}
+
 	private function denyUnlessAllowed() {
 		request.hardenerDenyRan = true;
 		if (!StructKeyExists(request, "hardenerAllow") || !request.hardenerAllow) {

--- a/vendor/wheels/tests/specs/controller/renderingSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/renderingSpec.cfc
@@ -682,6 +682,10 @@ component extends="wheels.WheelsTest" {
 				request.cgi.http_x_requested_with = ""
 				params = {controller = "dummy", action = "index"}
 				_controller = application.wo.controller("dummy", params)
+				// usesLayout writes class-level state. Clear leftovers so each
+				// example tests one declaration instead of relying on the old
+				// $useLayout wipe of a prior match.
+				ArrayClear(_controller.$getControllerClassData().layouts)
 			})
 
 			it("is using method match", () => {

--- a/vendor/wheels/tests/specs/hardener/ControllerHardenerShouldSpec.cfc
+++ b/vendor/wheels/tests/specs/hardener/ControllerHardenerShouldSpec.cfc
@@ -13,6 +13,12 @@ component extends="wheels.WheelsTest" {
 		describe("B5 $callAction does not remap real render errors to ViewNotFound", () => {
 
 			beforeEach(() => {
+				// $throwErrorOrShow404Page only Throws when showErrorInformation
+				// is on; otherwise it renders the 404 page and abort — the catch
+				// never sees a typed Wheels.ViewNotFound. Pin the throw path so
+				// CI proves the types without changing production 404 behavior.
+				_priorShowError = application.wheels.showErrorInformation
+				application.wheels.showErrorInformation = true
 				params = {controller = "hardenerLifecycle", action = "noView"}
 				_controller = g.controller("hardenerLifecycle", params)
 				_classData = _controller.$getControllerClassData()
@@ -21,28 +27,27 @@ component extends="wheels.WheelsTest" {
 
 			afterEach(() => {
 				_classData.layouts = _priorLayouts
+				application.wheels.showErrorInformation = _priorShowError
 			})
 
 			it("still maps a genuine missing view to ViewNotFound", () => {
-				var thrown = {type = ""}
-				try {
+				expect(() => {
 					_controller.$callAction(action = "noView")
-				} catch (any e) {
-					thrown.type = e.type
-				}
-				expect(thrown.type).toBe("Wheels.ViewNotFound")
+				}).toThrow("Wheels.ViewNotFound")
 			})
 
 			it("preserves a layout function error when the action view is missing", () => {
+				// Bind the layout fn on this instance so usesLayout / $useLayout
+				// resolve it as a function (same pattern as renderingSpec).
+				var boom = function() {
+					Throw(type = "Wheels.HardenerLayoutError", message = "layout exploded on purpose");
+				};
+				_controller.explodingLayout = boom
 				_controller.usesLayout(template = "explodingLayout")
 
-				var thrown = {type = ""}
-				try {
+				expect(() => {
 					_controller.$callAction(action = "noView")
-				} catch (any e) {
-					thrown.type = e.type
-				}
-				expect(thrown.type).toBe("Wheels.HardenerLayoutError")
+				}).toThrow("Wheels.HardenerLayoutError")
 			})
 
 		})

--- a/vendor/wheels/tests/specs/hardener/ControllerHardenerShouldSpec.cfc
+++ b/vendor/wheels/tests/specs/hardener/ControllerHardenerShouldSpec.cfc
@@ -220,7 +220,9 @@ component extends="wheels.WheelsTest" {
 
 			it("percent-encodes query values appended to url=", () => {
 				_controller.redirectTo(url = "/hardener-target", params = "q=hello world", delay = true)
-				expect(_controller.getRedirect().url).toInclude("hello%20world")
+				var dest = _controller.getRedirect().url
+				expect(dest).notToInclude("hello world")
+				expect(ReFindNoCase("hello(%20|[+])world", dest) > 0).toBeTrue()
 			})
 
 		})

--- a/vendor/wheels/tests/specs/hardener/ControllerHardenerShouldSpec.cfc
+++ b/vendor/wheels/tests/specs/hardener/ControllerHardenerShouldSpec.cfc
@@ -1,0 +1,238 @@
+/**
+ * Hardener BLOCKERs B5–B6 and controller-lifecycle SHOULDs.
+ *
+ * Directory-scoped so `wheels test --core --ci --filter=hardener`
+ * discovers this folder (a single-file directory= scope finds 0 bundles).
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		g = application.wo
+
+		describe("B5 $callAction does not remap real render errors to ViewNotFound", () => {
+
+			beforeEach(() => {
+				params = {controller = "hardenerLifecycle", action = "noView"}
+				_controller = g.controller("hardenerLifecycle", params)
+				_classData = _controller.$getControllerClassData()
+				_priorLayouts = Duplicate(_classData.layouts)
+			})
+
+			afterEach(() => {
+				_classData.layouts = _priorLayouts
+			})
+
+			it("still maps a genuine missing view to ViewNotFound", () => {
+				var thrown = {type = ""}
+				try {
+					_controller.$callAction(action = "noView")
+				} catch (any e) {
+					thrown.type = e.type
+				}
+				expect(thrown.type).toBe("Wheels.ViewNotFound")
+			})
+
+			it("preserves a layout function error when the action view is missing", () => {
+				_controller.usesLayout(template = "explodingLayout")
+
+				var thrown = {type = ""}
+				try {
+					_controller.$callAction(action = "noView")
+				} catch (any e) {
+					thrown.type = e.type
+				}
+				expect(thrown.type).toBe("Wheels.HardenerLayoutError")
+			})
+
+		})
+
+		describe("B6 $useLayout later non-match does not wipe a prior match", () => {
+
+			beforeEach(() => {
+				params = {controller = "hardenerLifecycle", action = "secret"}
+				_controller = g.controller("hardenerLifecycle", params)
+				_classData = _controller.$getControllerClassData()
+				_priorLayouts = Duplicate(_classData.layouts)
+			})
+
+			afterEach(() => {
+				_classData.layouts = _priorLayouts
+			})
+
+			it("keeps the first matching usesLayout when a later only= does not apply", () => {
+				_controller.usesLayout(template = "admin", only = "secret")
+				_controller.usesLayout(template = "public", only = "index")
+
+				expect(_controller.$useLayout("secret")).toBe("admin")
+			})
+
+			it("lets a later matching usesLayout override an earlier match", () => {
+				_controller.usesLayout(template = "admin")
+				_controller.usesLayout(template = "special", only = "secret")
+
+				expect(_controller.$useLayout("secret")).toBe("special")
+				expect(_controller.$useLayout("index")).toBe("admin")
+			})
+
+			it("still uses useDefault when no usesLayout matches", () => {
+				_controller.usesLayout(template = "admin", only = "secret", useDefault = false)
+				_controller.usesLayout(template = "public", only = "index")
+
+				expect(_controller.$useLayout("list")).toBeTrue()
+			})
+
+		})
+
+		describe("SHOULD $callActionAndAddToCache does not cache a redirect-only response", () => {
+
+			beforeEach(() => {
+				_hadCacheActions = StructKeyExists(application.wheels, "cacheActions")
+				if (_hadCacheActions) {
+					_priorCacheActions = application.wheels.cacheActions
+				}
+				application.wheels.cacheActions = true
+				_originalForm = Duplicate(form)
+				StructClear(form)
+				_controller = g.controller("hardenerLifecycle", {controller = "hardenerLifecycle", action = "cachedRedirect"})
+				_controller.$clearCachableActions()
+				g.$clearCache("action")
+			})
+
+			afterEach(() => {
+				_controller.$clearCachableActions()
+				g.$clearCache("action")
+				StructClear(form)
+				StructAppend(form, _originalForm, false)
+				if (_hadCacheActions) {
+					application.wheels.cacheActions = _priorCacheActions
+				} else {
+					StructDelete(application.wheels, "cacheActions")
+				}
+			})
+
+			it("re-runs the redirect on a second request instead of serving a blank 200", () => {
+				_controller.caches(action = "cachedRedirect")
+
+				var first = g.controller("hardenerLifecycle", {controller = "hardenerLifecycle", action = "cachedRedirect"})
+				first.processAction()
+				expect(first.$performedRedirect()).toBeTrue()
+
+				var second = g.controller("hardenerLifecycle", {controller = "hardenerLifecycle", action = "cachedRedirect"})
+				second.processAction()
+				expect(second.$performedRedirect()).toBeTrue()
+				expect(second.getRedirect().url).toInclude("/hardener-redirect-target")
+			})
+
+		})
+
+		describe("SHOULD filterChain(all) returns a copy", () => {
+
+			beforeEach(() => {
+				params = {controller = "hardenerLifecycle", action = "secret"}
+				_controller = g.controller("hardenerLifecycle", params)
+				_classData = _controller.$getControllerClassData()
+				_priorFilters = Duplicate(_classData.filters)
+			})
+
+			afterEach(() => {
+				_classData.filters = _priorFilters
+			})
+
+			it("does not let callers mutate the live $class.filters array", () => {
+				var chain = _controller.filterChain("all")
+				var originalLen = ArrayLen(chain)
+				ArrayAppend(chain, {through = "hardenerMutated"})
+
+				expect(ArrayLen(_controller.filterChain("all"))).toBe(originalLen)
+			})
+
+		})
+
+		describe("SHOULD processAction returns false when a before filter halts", () => {
+
+			beforeEach(() => {
+				request.hardenerSecretRan = false
+				request.hardenerDenyRan = false
+				request.hardenerAllow = false
+				params = {controller = "hardenerLifecycle", action = "secret"}
+				_controller = g.controller("hardenerLifecycle", params)
+			})
+
+			it("returns false when a before filter returns false", () => {
+				expect(_controller.processAction()).toBeFalse()
+				expect(request.hardenerSecretRan).toBeFalse()
+			})
+
+			it("returns true when the action is allowed to run", () => {
+				request.hardenerAllow = true
+				expect(_controller.processAction()).toBeTrue()
+				expect(request.hardenerSecretRan).toBeTrue()
+			})
+
+		})
+
+		describe("SHOULD filters prepend keeps through order", () => {
+
+			beforeEach(() => {
+				params = {controller = "hardenerLifecycle", action = "secret"}
+				_controller = g.controller("hardenerLifecycle", params)
+				_classData = _controller.$getControllerClassData()
+				_priorFilters = Duplicate(_classData.filters)
+				_controller.setFilterChain([])
+			})
+
+			afterEach(() => {
+				_classData.filters = _priorFilters
+			})
+
+			it("prepends a multi-through list without reversing it", () => {
+				_controller.filters(through = "existing")
+				_controller.filters(through = "alpha,bravo,charlie", placement = "prepend")
+				var chain = _controller.filterChain("all")
+
+				expect(chain[1].through).toBe("alpha")
+				expect(chain[2].through).toBe("bravo")
+				expect(chain[3].through).toBe("charlie")
+				expect(chain[4].through).toBe("existing")
+			})
+
+		})
+
+		describe("SHOULD redirectTo(url=) encodes params like back=", () => {
+
+			beforeEach(() => {
+				params = {controller = "hardenerLifecycle", action = "secret"}
+				_controller = g.controller("hardenerLifecycle", params)
+			})
+
+			it("percent-encodes query values appended to url=", () => {
+				_controller.redirectTo(url = "/hardener-target", params = "q=hello world", delay = true)
+				expect(_controller.getRedirect().url).toInclude("hello%20world")
+			})
+
+		})
+
+		describe("SHOULD blank layout function return uses the default layout", () => {
+
+			beforeEach(() => {
+				params = {controller = "hardenerLifecycle", action = "noView"}
+				_controller = g.controller("hardenerLifecycle", params)
+				_classData = _controller.$getControllerClassData()
+				_priorLayouts = Duplicate(_classData.layouts)
+			})
+
+			afterEach(() => {
+				_classData.layouts = _priorLayouts
+			})
+
+			it("treats a blank string return as useDefault instead of no layout", () => {
+				_controller.usesLayout(template = "blankLayout")
+				expect(_controller.$useLayout("noView")).toBeTrue()
+			})
+
+		})
+
+	}
+
+}

--- a/vendor/wheels/tests/specs/hardener/ControllerHardenerShouldSpec.cfc
+++ b/vendor/wheels/tests/specs/hardener/ControllerHardenerShouldSpec.cfc
@@ -13,13 +13,24 @@ component extends="wheels.WheelsTest" {
 		describe("B5 $callAction does not remap real render errors to ViewNotFound", () => {
 
 			beforeEach(() => {
-				// $throwErrorOrShow404Page only Throws when showErrorInformation
-				// is on; otherwise it renders the 404 page and abort — the catch
-				// never sees a typed Wheels.ViewNotFound. Pin the throw path so
-				// CI proves the types without changing production 404 behavior.
-				_priorShowError = application.wheels.showErrorInformation
-				application.wheels.showErrorInformation = true
-				params = {controller = "hardenerLifecycle", action = "noView"}
+				// Full-suite leftover request.cgi.http_accept (providesSpec
+				// writes application/json / pdf onto the shared cgi struct)
+				// makes $requestContentType() non-html, so $callAction skips
+				// auto-render and both B5 its finish without throwing.
+				// Pin HTML on params AND Accept so the missing-view path runs.
+				_priorAccept = StructKeyExists(request, "cgi") && StructKeyExists(request.cgi, "http_accept")
+					? request.cgi.http_accept
+					: ""
+				if (!StructKeyExists(request, "cgi")) {
+					request.cgi = {}
+				}
+				request.cgi.http_accept = "text/html"
+				// Prove the production Throw, not the $throwErrorOrShow404Page
+				// showErrorInformation=true path. $get reads $appKey() so set()
+				// writes the key $callAction's siblings would consult.
+				_priorShowError = g.$get("showErrorInformation")
+				g.set(showErrorInformation = false)
+				params = {controller = "hardenerLifecycle", action = "noView", format = "html"}
 				_controller = g.controller("hardenerLifecycle", params)
 				_classData = _controller.$getControllerClassData()
 				_priorLayouts = Duplicate(_classData.layouts)
@@ -27,7 +38,10 @@ component extends="wheels.WheelsTest" {
 
 			afterEach(() => {
 				_classData.layouts = _priorLayouts
-				application.wheels.showErrorInformation = _priorShowError
+				g.set(showErrorInformation = _priorShowError)
+				if (StructKeyExists(request, "cgi")) {
+					request.cgi.http_accept = _priorAccept
+				}
 			})
 
 			it("still maps a genuine missing view to ViewNotFound", () => {

--- a/vendor/wheels/tests/specs/hardener/ControllerHardenerShouldSpec.cfc
+++ b/vendor/wheels/tests/specs/hardener/ControllerHardenerShouldSpec.cfc
@@ -111,6 +111,18 @@ component extends="wheels.WheelsTest" {
 				}
 			})
 
+			it("does not store a cache entry for a redirect-only action", () => {
+				var probeKey = "hardener-redirect-probe-key"
+				_controller.$callActionAndAddToCache(
+					action = "cachedRedirect",
+					time = 60,
+					key = probeKey,
+					category = "action"
+				)
+				expect(_controller.$performedRedirect()).toBeTrue()
+				expect(StructKeyExists(application.wheels.cache.action, probeKey)).toBeFalse()
+			})
+
 			it("re-runs the redirect on a second request instead of serving a blank 200", () => {
 				_controller.caches(action = "cachedRedirect")
 

--- a/vendor/wheels/tests/specs/hardener/DispatchHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/hardener/DispatchHardenerSpec.cfc
@@ -1,5 +1,5 @@
 /**
- * Hardener BLOCKERs B1–B3 (dispatch / request lifecycle).
+ * Hardener BLOCKERs B1–B3 plus request-lifecycle SHOULDs ($findRoute, processRequest CSRF).
  *
  * Directory-scoped so `wheels test --core --ci --filter=hardener`
  * discovers this folder (a single-file directory= scope finds 0 bundles).
@@ -219,6 +219,91 @@ component extends="wheels.WheelsTest" {
 				request.cgi["request_method"] = "POST"
 				form._method = "TRACE"
 				expect(dispatch.$getRequestMethod()).toBe("POST")
+			})
+
+		})
+
+		describe("SHOULD $findRoute multi-name does not fail open", () => {
+
+			beforeEach(() => {
+				_originalRoutes = Duplicate(application.wheels.routes)
+				_originalStaticRoutes = StructKeyExists(application.wheels, "staticRoutes") ? StructCopy(application.wheels.staticRoutes) : {}
+				_originalNamedRoutePositions = StructKeyExists(application.wheels, "namedRoutePositions") ? StructCopy(application.wheels.namedRoutePositions) : {}
+				application.wheels.routes = [
+					{
+						name = "hardenerWidget",
+						methods = "get",
+						foundvariables = "key",
+						controller = "dummy",
+						action = "show",
+						pattern = "hardener-widgets/[key]"
+					},
+					{
+						name = "hardenerWidget",
+						methods = "post",
+						foundvariables = "",
+						controller = "dummy",
+						action = "create",
+						pattern = "hardener-widgets"
+					}
+				]
+				application.wheels.namedRoutePositions = {hardenerWidget = "1,2"}
+			})
+
+			afterEach(() => {
+				application.wheels.routes = _originalRoutes
+				application.wheels.staticRoutes = _originalStaticRoutes
+				application.wheels.namedRoutePositions = _originalNamedRoutePositions
+			})
+
+			it("throws RouteNotFound when no same-named candidate matches the method", () => {
+				var thrown = {type = ""}
+				try {
+					g.$findRoute(route = "hardenerWidget", method = "delete")
+				} catch (any e) {
+					thrown.type = e.type
+				}
+				expect(thrown.type).toBe("Wheels.RouteNotFound")
+			})
+
+			it("selects the candidate whose variables and method match instead of the last name", () => {
+				var found = g.$findRoute(route = "hardenerWidget", method = "get", key = "1")
+				expect(found.action).toBe("show")
+				expect(found.methods).toBe("get")
+			})
+
+			it("still resolves a matching method when variables are empty", () => {
+				var found = g.$findRoute(route = "hardenerWidget", method = "post")
+				expect(found.action).toBe("create")
+			})
+
+		})
+
+		describe("SHOULD processRequest CSRF ignore is opt-in exception not a silent default flip", () => {
+
+			beforeEach(() => {
+				_originalCgiMethod = request.cgi.request_method
+			})
+
+			afterEach(() => {
+				request.cgi["request_method"] = _originalCgiMethod
+			})
+
+			it("keeps the historic processRequest default of CSRF ignore", () => {
+				var params = {controller = "csrfProtectedWithException", action = "create"}
+				var body = g.processRequest(params = params, method = "post")
+				expect(body).toBe("Create ran.")
+			})
+
+			it("enforces CSRF when processRequest is asked for exception mode", () => {
+				var params = {controller = "csrfProtectedWithException", action = "create"}
+				var thrown = {type = ""}
+				try {
+					g.processRequest(params = params, method = "post", csrf = "exception")
+				} catch (any e) {
+					thrown.type = e.type
+				}
+				expect(thrown.type).toBe("Wheels.InvalidAuthenticityToken")
 			})
 
 		})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Controller / request-lifecycle hardener slice on top of #3400 (B1–B4, B7–B8 already on develop). Draft for Lead/CoS review.

### BLOCKERs
- **B5** — `$callAction` auto-render catch mapped **any** exception to `Wheels.ViewNotFound` when `action.cfm` was missing, masking layout/render errors. Now only genuine missing-view includes (`$isMissingViewException` + missing file) become typed `Wheels.ViewNotFound`; other types are rethrown.
- **B6** — `$useLayout` reset `rv = useDefault` on every loop pass, so a later non-matching `usesLayout` wiped a prior match (silent layout bypass). Once a match is chosen, later non-matches leave it alone; a later match still overrides.

### SHOULDs touched
- **`$callActionAndAddToCache`** — does not store a cache entry for a redirect-only action (empty body / blank 200 on hit).
- **`filterChain("all")`** — returns a `Duplicate()` copy so callers cannot mutate the live `$class.filters` array.
- **`processAction` halt** — returns `false` when a verification aborts or a before filter returns `false`. Additive: success path is still `true`. Callers that ignore the return are unchanged.
- **`$findRoute` multi-name** — no longer fail-opens to the last same-named candidate. Selects the first candidate matching method (when supplied) and required variables; throws `Wheels.RouteNotFound` when none match.
- **`processRequest` CSRF ignore** — **default stays `ignore`** (historic test helper). Opt-in `csrf="exception"` / `csrf="abort"` enforces. Production `protectsFromForgery()` default is unchanged.
- **`filters(placement="prepend")` + multi-`through`** — `a,b,c` stays `a,b,c` in front of the existing chain (was reversed to `c,b,a`).
- **`redirectTo(url=)` params** — encoded via `$constructParams` like `back=true`.
- **Blank layout-function return** — treated as `useDefault` (matches the in-source contract / docs), not as “no layout”.

`renderingSpec` `specified_layouts` examples now clear dummy class layouts so they test one declaration at a time and no longer depend on the B6 wipe.

Lead accepted **(a)** on the three public flips (`$findRoute` RouteNotFound, `redirectTo(url=)` encode, blank layout-fn → default). Those stay as shipped.

### B5 — why `974b3645e` was UNPROVEN on LuCLI, and what `2f440a27e` changes

LuCLI 32721709696: both B5 its **did not throw**. The `showErrorInformation=true` pin was the wrong lever.

**Root cause (full-suite only):** `$callAction` skips auto-render when `$requestContentType()` is not `html` and the format is not in `$acceptableFormats`. Earlier bundles (`providesSpec`) write `request.cgi.http_accept` to `application/json` / `application/pdf` on the **shared** `request.cgi` struct (`$$oldCGIScope = request.cgi` is a reference, not a copy). After those specs, Accept is leftover non-html, auto-render never runs, `$useLayout` / exploding layout never run, both its finish cleanly. Isolated `filter=hardener` never loads `providesSpec`, so it stayed green.

`$throwErrorOrShow404Page` abort was a second swallow **if** the missing-view path was reached with `showErrorInformation` off.

**Production change (flagged — not a public HTTP 404 flip):**
- `$callAction` now **always Throws** typed `Wheels.ViewNotFound` for a genuine missing view (`$header(404)` then `Throw`). It no longer include+aborts via `$throwErrorOrShow404Page`.
- `processAction` (HTTP dispatch) **catches** `Wheels.ViewNotFound` and still calls `$throwErrorOrShow404Page`, so apps still get HTTP 404 + `onmissingtemplate` when `showErrorInformation` is off.
- Layout / other render errors still `Throw(object = e)` with their original type.

**Test change:** B5 pins `params.format=html` + `request.cgi.http_accept=text/html`, and sets `showErrorInformation=false` via `set()` so the typed Throw is proven — not the old throw-path pin.

## PROVEN / UNPROVEN

| Item | Status | Filter evidence |
|---|---|---|
| B5 ViewNotFound swallow | **PROVEN** | `wheels test --core --ci --filter=hardener` → 41 passed (showErrorInformation=false) |
| B6 `$useLayout` wipe | **PROVEN** | same |
| Redirect-only action cache | **PROVEN** | same (asserts no cache key written) |
| `filterChain("all")` copy | **PROVEN** | same |
| `processAction` halt return | **PROVEN** | same |
| `$findRoute` multi-name fail-open | **PROVEN** | same — Lead accepted (a) |
| `processRequest` CSRF **default flip** | **UNPROVEN / escalate** | Default remains `ignore`. Do not merge a silent flip. |
| `processRequest` CSRF **opt-in** `csrf="exception"` | **PROVEN** | same |
| prepend multi-through order | **PROVEN** | same |
| `redirectTo(url=)` encode | **PROVEN** | same (`%20` or `+`) — Lead accepted (a) |
| Blank layout-fn return | **PROVEN** | same — Lead accepted (a) |
| Missing `super.config()` CSRF | **UNPROVEN** | Already warn-only in development; fail-closed would be a default flip |
| URL scope wins over form | **UNPROVEN** | Documented contract in `$mergeUrlAndFormScopes` |
| CSRF header only copied on Ajax | **UNPROVEN** | Intentional form-field vs `X-CSRF-Token` header split |
| `verifies` handler fallthrough | **UNPROVEN (already on develop)** | `$runVerifications` already `redirectTo(back=true)` |
| `$currentUserForPolicy` catch → guest | **UNPROVEN (already on develop)** | Catch already falls through to guest |
| Silent double-render / redirect after render | **UNPROVEN** | Last-write-wins is current public API; throwing would be a default flip |
| `onlyProvides` unacceptable format → HTML | **UNPROVEN** | Documented 4.0.4 fallback |
| CSRF before before-filters | **UNPROVEN** | Reordering is a default flip; CSRF-first is fail-closed |
| Non-HTML auto-render skip → empty 200 | **UNPROVEN** | 406 would be a default flip |
| `only`+`except` OR semantics | **UNPROVEN** | Documented OR; AND would be a default flip |
| Filter type case-sensitivity | skipped | Already B8 on develop |

## Default-flip flags (Lead / CoS)

- **`processRequest` CSRF `with="ignore"` default: DO NOT MERGE a silent flip.** Opt-in `csrf="exception"` only. Production `protectsFromForgery()` remains `exception`.
- `processAction` returning `false` on halt is additive (was always `true`).
- `$findRoute` throwing `RouteNotFound` instead of returning the last same-named candidate is fail-closed. **Lead accepted (a).**
- **`$callAction` ViewNotFound is now always a typed Throw.** HTTP 404 via `processAction` is unchanged. Direct `$callAction` callers (tests / custom dispatch) no longer see include+abort when `showErrorInformation` is off.

## HEAD

`2f440a27e1f96069c527d67f4637177162d567b6`

## Test filters

```
wheels test --core --ci --filter=hardener
wheels test --core --ci --filter=controller
```

### Green counts (this HEAD)

| Filter | Result |
|---|---|
| `hardener` | **41 passed** (B5 its included; `showErrorInformation=false`) |
| `controller` | **550 passed** (processAction catch path) |

## Related

Follow-on to #3400. Does not re-do B1–B4 / B7–B8.

## Type of Change

- [x] Bug fix
- [x] Enhancement to existing feature

## Feature Completeness Checklist

- [x] **DCO sign-off**
- [x] **Tests**
- [ ] **Framework Docs** — no public default change; `processRequest(csrf=)` is test-helper opt-in
- [ ] **AI Reference Docs**
- [ ] **CLAUDE.md** — no convention change
- [x] **Changelog fragment** — `changelog.d/controller-hardener-b5-b6.fixed.md`, `changelog.d/controller-hardener-shoulds.changed.md`
- [x] **Test runner passes** — scoped `hardener` + `controller` on this HEAD

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dda74504-3b6f-4e88-bc1e-6fb2d15c27c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dda74504-3b6f-4e88-bc1e-6fb2d15c27c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

