### PR TITLE
fix(migrator): harden schema BLOCKERs B1–B6 (announce, redo, FK, tenant, rename)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -716,7 +716,9 @@ am.writeMigration(d, "rename_name_field");
 
 _Auto-migration is currently CFC-only (`wheels.migrator.AutoMigrator`, shown above). There is no `wheels dbmigrate diff` CLI command — invoking it errors._
 
-Result struct: `{modelName, tableName, addColumns, removeColumns, changeColumns, renameColumns, suggestedRenames}`. Limits: PK renames not detected; rename + type change requires separate migrations; calculated properties excluded.
+Result struct: `{modelName, tableName, addColumns, removeColumns, changeColumns, renameColumns, suggestedRenames}`. Limits: PK renames not detected; rename + type change requires separate migrations; calculated properties excluded. `writeMigration()` / `generateMigrationCFC()` honor `suggestedRenames` as `renameColumn` instead of destructive remove+add.
+
+Announce-only `up()`/`down()` (the default "NOT IMPLEMENTED" stubs and the announce template) do not write `wheels_migrator_versions`. `redoMigration()` fails closed when `allowMigrationDown` is false — the framework default stays `false` (development still opts in to `true`). Default FK names are `FK_<table>_<refTable>_<column>` so two FKs to the same reference table do not collide.
 
 ### Seeding
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -718,7 +718,7 @@ _Auto-migration is currently CFC-only (`wheels.migrator.AutoMigrator`, shown abo
 
 Result struct: `{modelName, tableName, addColumns, removeColumns, changeColumns, renameColumns, suggestedRenames}`. Limits: PK renames not detected; rename + type change requires separate migrations; calculated properties excluded. `writeMigration()` / `generateMigrationCFC()` honor `suggestedRenames` as `renameColumn` instead of destructive remove+add.
 
-Announce-only `up()`/`down()` (the default "NOT IMPLEMENTED" stubs and the announce template) do not write `wheels_migrator_versions`. `redoMigration()` fails closed when `allowMigrationDown` is false — the framework default stays `false` (development still opts in to `true`). Default FK names are `FK_<table>_<refTable>_<column>` so two FKs to the same reference table do not collide.
+Announce-only `up()`/`down()` (the default "NOT IMPLEMENTED" stubs and the announce template) do not write `wheels_migrator_versions`. `announce()` plus ORM persist (`model().create()` / `save()` / `delete()` with no `$execute`) still marks or unmarks the version. `redoMigration()` fails closed when `allowMigrationDown` is false — the framework default stays `false` (development still opts in to `true`). Default FK names are `FK_<table>_<refTable>_<column>` so two FKs to the same reference table do not collide.
 
 ### Seeding
 

--- a/changelog.d/migrator-hardener-b1-b6.fixed.md
+++ b/changelog.d/migrator-hardener-b1-b6.fixed.md
@@ -1,4 +1,4 @@
-- Announce-only migrations (default `up()`/`down()` stubs and the announce template) no longer mark or unmark versions in `wheels_migrator_versions`
+- Announce-only migrations (default `up()`/`down()` stubs and the announce template) no longer mark or unmark versions in `wheels_migrator_versions`. `announce()` plus ORM persist (`model().create()` / `save()` / `delete()` with no `$execute`) still marks or unmarks the version
 - `redoMigration()` fails closed when `allowMigrationDown` is false instead of skipping `down()` and re-running `up()` (the `allowMigrationDown` default is unchanged)
 - CREATE TABLE foreign keys now emit `ON UPDATE` / `ON DELETE`; default FK names include the column so two FKs to the same table do not collide
 - `TenantMigrator` no longer mutates `application.wheels.dataSourceName`; tenant runs use a request-scoped datasource

--- a/changelog.d/migrator-hardener-b1-b6.fixed.md
+++ b/changelog.d/migrator-hardener-b1-b6.fixed.md
@@ -1,0 +1,5 @@
+- Announce-only migrations (default `up()`/`down()` stubs and the announce template) no longer mark or unmark versions in `wheels_migrator_versions`
+- `redoMigration()` fails closed when `allowMigrationDown` is false instead of skipping `down()` and re-running `up()` (the `allowMigrationDown` default is unchanged)
+- CREATE TABLE foreign keys now emit `ON UPDATE` / `ON DELETE`; default FK names include the column so two FKs to the same table do not collide
+- `TenantMigrator` no longer mutates `application.wheels.dataSourceName`; tenant runs use a request-scoped datasource
+- `AutoMigrator.generateMigrationCFC()` honors `suggestedRenames` as `renameColumn` instead of destructive remove+add

--- a/vendor/wheels/Migrator.cfc
+++ b/vendor/wheels/Migrator.cfc
@@ -352,15 +352,23 @@ component output="false" extends="wheels.Global"{
 	) {
 		local.appKey = $appKey();
 		local.result = {success = true, output = ""};
+		// Fail-closed redo: if down cannot run, do not run up (that would
+		// double-apply) and do not change version tracking.
+		if (arguments.direction == "redo" && !application[local.appKey].allowMigrationDown) {
+			local.result.success = false;
+			local.result.output = "#arguments.errorLabel# #arguments.migration.version#.#Chr(13) & Chr(10)#Cannot redo migration: allowMigrationDown is false. Running up() without down() would double-apply.#Chr(13) & Chr(10)#";
+			return local.result;
+		}
 		local.divider = arguments.direction == "up" ? "--------" : "-------";
 		transaction action="begin" {
 			try {
 				// Test query to establish datasource for BoxLang compatibility
 				if (structKeyExists(server, "boxlang")) {
-					$query(datasource = application[local.appKey].dataSourceName, sql = "SELECT 1 as test");
+					$query(datasource = $migratorDataSource(), sql = "SELECT 1 as test");
 				}
 				local.result.output &= "#Chr(13) & Chr(10)##local.divider# " & arguments.migration.cfcfile & " #RepeatString("-", Max(5, 50 - Len(arguments.migration.cfcfile)))##Chr(13) & Chr(10)#";
 				request.$wheelsMigrationOutput = "";
+				request.$wheelsMigrationDidExecute = false;
 				request.$wheelsMigrationSQLFile = "#this.paths.sql#/#arguments.migration.cfcfile#_#arguments.direction#.sql";
 				if (application[local.appKey].writeMigratorSQLFiles) {
 					$writeMigrationFile(request.$wheelsMigrationSQLFile, "");
@@ -370,17 +378,19 @@ component output="false" extends="wheels.Global"{
 				if (arguments.direction == "down") {
 					arguments.migration.cfc.down();
 					local.result.output &= request.$wheelsMigrationOutput;
-					$removeVersionAsMigrated(arguments.migration.version);
-				} else if (arguments.direction == "redo") {
-					if (application[local.appKey].allowMigrationDown) {
-						arguments.migration.cfc.down();
+					if (request.$wheelsMigrationDidExecute) {
+						$removeVersionAsMigrated(arguments.migration.version);
 					}
+				} else if (arguments.direction == "redo") {
+					arguments.migration.cfc.down();
 					arguments.migration.cfc.up();
 					local.result.output &= request.$wheelsMigrationOutput;
 				} else {
 					arguments.migration.cfc.up();
 					local.result.output &= request.$wheelsMigrationOutput;
-					$setVersionAsMigrated(arguments.migration.version, arguments.migration.name);
+					if (request.$wheelsMigrationDidExecute) {
+						$setVersionAsMigrated(arguments.migration.version, arguments.migration.name);
+					}
 				}
 			} catch (any e) {
 				local.result.success = false;
@@ -449,7 +459,7 @@ component output="false" extends="wheels.Global"{
 			}
 		}
 		$query(
-			datasource = application[local.appKey].dataSourceName,
+			datasource = $migratorDataSource(),
 			sql = "INSERT INTO #application[local.appKey].migratorTableName# (#local.cols#) VALUES (#local.vals#)"
 		);
 	}
@@ -461,7 +471,7 @@ component output="false" extends="wheels.Global"{
 		local.appKey = $appKey();
 		if (!StructKeyExists(request, "$wheelsDebugSQL"))
 			$query(
-				datasource = application[local.appKey].dataSourceName,
+				datasource = $migratorDataSource(),
 				sql = "DELETE FROM #application[local.appKey].migratorTableName# WHERE version = '#$sanitiseVersion(arguments.version)#'"
 			);
 	}
@@ -549,7 +559,7 @@ component output="false" extends="wheels.Global"{
 
 		try {
 			local.migratedVersions = $query(
-				datasource = application[local.appKey].dataSourceName,
+				datasource = $migratorDataSource(),
 				sql = "SELECT version FROM #application[local.appKey].migratorTableName# WHERE core_level = #application[local.appKey].migrationLevel# ORDER BY version ASC"
 			);
 		} catch (any e) {
@@ -560,11 +570,11 @@ component output="false" extends="wheels.Global"{
 			// table present but unreadable) is rethrown rather than being
 			// misread as an empty migration history.
 			var probeState = {fresh = false};
-			if (!$migratorTableExists(application[local.appKey].dataSourceName, application[local.appKey].migratorTableName)) {
+			if (!$migratorTableExists($migratorDataSource(), application[local.appKey].migratorTableName)) {
 				try {
 					$dbinfo(
 						type = "version",
-						datasource = application[local.appKey].dataSourceName,
+						datasource = $migratorDataSource(),
 						username = application.wheels.dataSourceUserName,
 						password = application.wheels.dataSourcePassword
 					);
@@ -641,7 +651,7 @@ component output="false" extends="wheels.Global"{
 			return;
 		}
 
-		local.dsn = application[local.appKey].dataSourceName;
+		local.dsn = $migratorDataSource();
 		local.levelsTable = application[local.appKey].levelsTableName;
 		local.versionsTable = application[local.appKey].migratorTableName;
 
@@ -888,7 +898,7 @@ component output="false" extends="wheels.Global"{
 		try {
 			local.versionsQuoted = "'" & ArrayToList(local.bareOrphans, "','") & "'";
 			local.rows = $query(
-				datasource = application[local.appKey].dataSourceName,
+				datasource = $migratorDataSource(),
 				sql = "SELECT version, name, applied_at FROM #application[local.appKey].migratorTableName# "
 					& "WHERE version IN (#local.versionsQuoted#) "
 					& "AND core_level = #application[local.appKey].migrationLevel# "
@@ -1188,7 +1198,7 @@ component output="false" extends="wheels.Global"{
 		// own `arguments` scope (CFML closures don't inherit the parent's
 		// `arguments` struct), so we need to pull the value out by reference
 		// before the closure sees it.
-		var dsn = application[arguments.appKey].dataSourceName;
+		var dsn = $migratorDataSource();
 
 		// Always probe with a no-rows query so we don't load data unnecessarily.
 		// `WHERE 1=0` is portable across every adapter we support.
@@ -1262,7 +1272,7 @@ component output="false" extends="wheels.Global"{
 			sql: []
 		};
 		var appKey = $appKey();
-		var dsn = application[appKey].dataSourceName;
+		var dsn = $migratorDataSource();
 
 		// Inline probe (CFML closures don't inherit parent `arguments`, so
 		// `dsn` is captured via lexical scope — see $detectSystemTables for
@@ -1413,7 +1423,7 @@ component output="false" extends="wheels.Global"{
 	public struct function $ensureTrackingColumns(boolean addMissing = true) {
 		var rv = {hasName: false, hasAppliedAt: false, added: [], errors: []};
 		var appKey = $appKey();
-		var dsn = application[appKey].dataSourceName;
+		var dsn = $migratorDataSource();
 		var tableName = application[appKey].migratorTableName;
 
 		try {

--- a/vendor/wheels/Migrator.cfc
+++ b/vendor/wheels/Migrator.cfc
@@ -370,6 +370,7 @@ component output="false" extends="wheels.Global"{
 				request.$wheelsMigrationOutput = "";
 				request.$wheelsMigrationDidExecute = false;
 				request.$wheelsMigrationDidAnnounce = false;
+				request.$wheelsMigrationDidWork = false;
 				request.$wheelsMigrationSQLFile = "#this.paths.sql#/#arguments.migration.cfcfile#_#arguments.direction#.sql";
 				if (application[local.appKey].writeMigratorSQLFiles) {
 					$writeMigrationFile(request.$wheelsMigrationSQLFile, "");
@@ -408,19 +409,26 @@ component output="false" extends="wheels.Global"{
 	}
 
 	/**
-	 * True when the just-run up()/down() did real work. Announce-only
-	 * steps (default stubs, announce template) must not update the
-	 * version table. ORM-only migrations (model().create() with no
-	 * $execute) still count — they are not announce-only.
+	 * True when the just-run up()/down() did real work. Skip version
+	 * tracking only when the step is truly announce-only: announced,
+	 * no $execute, and no ORM/other persist work. announce() plus
+	 * model().create()/save()/delete() still counts.
 	 */
 	private boolean function $migrationStepMutatedSchema() {
-		if (request.$wheelsMigrationDidExecute) {
-			return true;
+		if (!StructKeyExists(request, "$wheelsMigrationDidExecute")) {
+			request.$wheelsMigrationDidExecute = false;
 		}
-		if (request.$wheelsMigrationDidAnnounce) {
-			return false;
+		if (!StructKeyExists(request, "$wheelsMigrationDidAnnounce")) {
+			request.$wheelsMigrationDidAnnounce = false;
 		}
-		return true;
+		if (!StructKeyExists(request, "$wheelsMigrationDidWork")) {
+			request.$wheelsMigrationDidWork = false;
+		}
+		return !(
+			request.$wheelsMigrationDidAnnounce
+			&& !request.$wheelsMigrationDidExecute
+			&& !request.$wheelsMigrationDidWork
+		);
 	}
 
 	/**

--- a/vendor/wheels/Migrator.cfc
+++ b/vendor/wheels/Migrator.cfc
@@ -369,6 +369,7 @@ component output="false" extends="wheels.Global"{
 				local.result.output &= "#Chr(13) & Chr(10)##local.divider# " & arguments.migration.cfcfile & " #RepeatString("-", Max(5, 50 - Len(arguments.migration.cfcfile)))##Chr(13) & Chr(10)#";
 				request.$wheelsMigrationOutput = "";
 				request.$wheelsMigrationDidExecute = false;
+				request.$wheelsMigrationDidAnnounce = false;
 				request.$wheelsMigrationSQLFile = "#this.paths.sql#/#arguments.migration.cfcfile#_#arguments.direction#.sql";
 				if (application[local.appKey].writeMigratorSQLFiles) {
 					$writeMigrationFile(request.$wheelsMigrationSQLFile, "");
@@ -378,7 +379,7 @@ component output="false" extends="wheels.Global"{
 				if (arguments.direction == "down") {
 					arguments.migration.cfc.down();
 					local.result.output &= request.$wheelsMigrationOutput;
-					if (request.$wheelsMigrationDidExecute) {
+					if ($migrationStepMutatedSchema()) {
 						$removeVersionAsMigrated(arguments.migration.version);
 					}
 				} else if (arguments.direction == "redo") {
@@ -388,7 +389,7 @@ component output="false" extends="wheels.Global"{
 				} else {
 					arguments.migration.cfc.up();
 					local.result.output &= request.$wheelsMigrationOutput;
-					if (request.$wheelsMigrationDidExecute) {
+					if ($migrationStepMutatedSchema()) {
 						$setVersionAsMigrated(arguments.migration.version, arguments.migration.name);
 					}
 				}
@@ -404,6 +405,22 @@ component output="false" extends="wheels.Global"{
 			transaction action="commit";
 		}
 		return local.result;
+	}
+
+	/**
+	 * True when the just-run up()/down() did real work. Announce-only
+	 * steps (default stubs, announce template) must not update the
+	 * version table. ORM-only migrations (model().create() with no
+	 * $execute) still count — they are not announce-only.
+	 */
+	private boolean function $migrationStepMutatedSchema() {
+		if (request.$wheelsMigrationDidExecute) {
+			return true;
+		}
+		if (request.$wheelsMigrationDidAnnounce) {
+			return false;
+		}
+		return true;
 	}
 
 	/**

--- a/vendor/wheels/global/util.cfm
+++ b/vendor/wheels/global/util.cfm
@@ -602,6 +602,22 @@
 		return local.rv;
 	}
 
+	/**
+	 * Datasource the migrator should use for this request.
+	 * Prefer a request-scoped override (TenantMigrator) so tenant runs do
+	 * not mutate application.wheels.dataSourceName, which concurrent
+	 * requests read without the tenant lock.
+	 */
+	public string function $migratorDataSource() {
+		if (IsDefined("request.wheels.migratorDataSource") && Len(ToString(request.wheels.migratorDataSource))) {
+			return ToString(request.wheels.migratorDataSource);
+		}
+		if (IsDefined("request.wheels.tenant.dataSource") && Len(ToString(request.wheels.tenant.dataSource))) {
+			return ToString(request.wheels.tenant.dataSource);
+		}
+		return application[$appKey()].dataSourceName;
+	}
+
 
 	/**
 	 * Generates a 36-character UUID compatible with SQL Server's uniqueidentifier.

--- a/vendor/wheels/migrator/AutoMigrator.cfc
+++ b/vendor/wheels/migrator/AutoMigrator.cfc
@@ -49,7 +49,7 @@ component extends="wheels.migrator.Base" {
 		local.dbColumns = $dbinfo(
 			type = "columns",
 			table = local.tableName,
-			datasource = application[local.appKey].dataSourceName,
+			datasource = $migratorDataSource(),
 			username = application[local.appKey].dataSourceUserName,
 			password = application[local.appKey].dataSourcePassword
 		);
@@ -252,10 +252,26 @@ component extends="wheels.migrator.Base" {
 		local.upBody = "";
 		local.downBody = "";
 
-		// Emit renameColumns first in up(); reversed renames go last in down()
+		// Emit renameColumns first in up(); reversed renames go last in down().
+		// Honor suggestedRenames as renames too — leaving them as remaining
+		// add/remove would emit destructive drop+add.
 		local.renameColumns = StructKeyExists(arguments.diffResult, "renameColumns")
-			? arguments.diffResult.renameColumns
+			? Duplicate(arguments.diffResult.renameColumns)
 			: [];
+		local.suggestedRenames = StructKeyExists(arguments.diffResult, "suggestedRenames")
+			? arguments.diffResult.suggestedRenames
+			: [];
+		local.skipAdd = {};
+		local.skipRemove = {};
+		for (local.s in local.suggestedRenames) {
+			ArrayAppend(local.renameColumns, local.s);
+			local.skipRemove[LCase(local.s.from)] = true;
+			local.skipAdd[LCase(local.s.to)] = true;
+		}
+		for (local.r in local.renameColumns) {
+			local.skipRemove[LCase(local.r.from)] = true;
+			local.skipAdd[LCase(local.r.to)] = true;
+		}
 		local.iEnd = ArrayLen(local.renameColumns);
 		for (local.i = 1; local.i <= local.iEnd; local.i++) {
 			local.r = local.renameColumns[local.i];
@@ -268,6 +284,9 @@ component extends="wheels.migrator.Base" {
 		local.iEnd = ArrayLen(arguments.diffResult.addColumns);
 		for (local.i = 1; local.i <= local.iEnd; local.i++) {
 			local.col = arguments.diffResult.addColumns[local.i];
+			if (StructKeyExists(local.skipAdd, LCase(local.col.name))) {
+				continue;
+			}
 			local.upBody &= local.tab & local.tab
 				& 'addColumn(table="' & arguments.diffResult.tableName
 				& '", columnType="' & local.col.type
@@ -282,6 +301,9 @@ component extends="wheels.migrator.Base" {
 		local.iEnd = ArrayLen(arguments.diffResult.removeColumns);
 		for (local.i = 1; local.i <= local.iEnd; local.i++) {
 			local.col = arguments.diffResult.removeColumns[local.i];
+			if (StructKeyExists(local.skipRemove, LCase(local.col.name))) {
+				continue;
+			}
 			local.upBody &= local.tab & local.tab
 				& 'removeColumn(table="' & arguments.diffResult.tableName
 				& '", columnName="' & local.col.name & '");' & local.nl;

--- a/vendor/wheels/migrator/Base.cfc
+++ b/vendor/wheels/migrator/Base.cfc
@@ -10,6 +10,7 @@ component extends="wheels.Global"{
 	public function announce(required string message) {
 		param name="request.$wheelsMigrationOutput" default="";
 		request.$wheelsMigrationOutput = request.$wheelsMigrationOutput & arguments.message & Chr(13) & Chr(10);
+		request.$wheelsMigrationDidAnnounce = true;
 	}
 
 	public string function $getDBType(string dataSource = "") {

--- a/vendor/wheels/migrator/Base.cfc
+++ b/vendor/wheels/migrator/Base.cfc
@@ -14,7 +14,7 @@ component extends="wheels.Global"{
 
 	public string function $getDBType(string dataSource = "") {
 		local.appKey = $appKey();
-		local.dsName = Len(arguments.dataSource) ? arguments.dataSource : application[local.appKey].dataSourceName;
+		local.dsName = Len(arguments.dataSource) ? arguments.dataSource : $migratorDataSource();
 
 		// Memoize the resolved adapter name per datasource: engine identity is
 		// stable for the life of the application, and discovery paths (e.g.
@@ -121,7 +121,7 @@ component extends="wheels.Global"{
 		local.quotedTable = this.adapter.quoteTableName(arguments.table);
 		try {
 			$query(
-				datasource = application[local.appKey].dataSourceName,
+				datasource = $migratorDataSource(),
 				sql = "SELECT 1 FROM #local.quotedTable# WHERE 1=0"
 			);
 		} catch (any e) {
@@ -131,7 +131,7 @@ component extends="wheels.Global"{
 			local.foreignKeys = $dbinfo(
 				type = "foreignkeys",
 				table = arguments.table,
-				datasource = application[local.appKey].dataSourceName,
+				datasource = $migratorDataSource(),
 				username = application[local.appKey].dataSourceUserName,
 				password = application[local.appKey].dataSourcePassword
 			);
@@ -152,7 +152,7 @@ component extends="wheels.Global"{
 			return;
 		}
 		local.appKey = $appKey();
-		local.dsName = Len(arguments.dataSource) ? arguments.dataSource : application[local.appKey].dataSourceName;
+		local.dsName = Len(arguments.dataSource) ? arguments.dataSource : $migratorDataSource();
 		// Executed statements may change the schema — drop the request-scoped
 		// column cache so the next $getColumns() re-probes.
 		StructDelete(request, "$wheelsMigratorColumns");
@@ -167,7 +167,7 @@ component extends="wheels.Global"{
 	 */
 	private void function $executeWithParams(required string sql, required array params, string dataSource = "") {
 		local.appKey = $appKey();
-		local.dsName = Len(arguments.dataSource) ? arguments.dataSource : application[local.appKey].dataSourceName;
+		local.dsName = Len(arguments.dataSource) ? arguments.dataSource : $migratorDataSource();
 		local.prepared = $prepareMigrationSql(sql = arguments.sql, dsName = local.dsName);
 		if (!local.prepared.captured) {
 			queryExecute(local.prepared.sql, arguments.params, {datasource: local.dsName});
@@ -205,6 +205,8 @@ component extends="wheels.Global"{
 			}
 			ArrayAppend(request.$wheelsDebugSQLResult, local.sql);
 		}
+		// Any real SQL (including debug capture) means this step is not announce-only.
+		request.$wheelsMigrationDidExecute = true;
 		return {sql: local.sql, captured: local.captured};
 	}
 
@@ -218,7 +220,7 @@ component extends="wheels.Global"{
 		// Key on the VERBATIM table name: the $dbinfo probe below uses original
 		// case, so case-folding the key would let `Authors` and `authors` share
 		// one slot on case-sensitive databases (#2937 review, #2977).
-		local.cacheKey = application[local.appKey].dataSourceName & "|" & arguments.tableName;
+		local.cacheKey = $migratorDataSource() & "|" & arguments.tableName;
 		if (
 			StructKeyExists(request, "$wheelsMigratorColumns")
 			&& StructKeyExists(request.$wheelsMigratorColumns, local.cacheKey)
@@ -226,7 +228,7 @@ component extends="wheels.Global"{
 			return request.$wheelsMigratorColumns[local.cacheKey];
 		}
 		local.columns = $dbinfo(
-			datasource = application[local.appKey].dataSourceName,
+			datasource = $migratorDataSource(),
 			username = application[local.appKey].dataSourceUserName,
 			password = application[local.appKey].dataSourcePassword,
 			type = "columns",
@@ -281,7 +283,7 @@ component extends="wheels.Global"{
 	private string function $getColumnDefinition(required string tableName, required string columnName) {
 		local.appKey = $appKey();
 		local.columns = $dbinfo(
-			datasource = application[local.appKey].dataSourceName,
+			datasource = $migratorDataSource(),
 			username = application[local.appKey].dataSourceUserName,
 			password = application[local.appKey].dataSourcePassword,
 			type = "columns",

--- a/vendor/wheels/migrator/CLAUDE.md
+++ b/vendor/wheels/migrator/CLAUDE.md
@@ -69,6 +69,16 @@ Two caches introduced in #2937 — know their scopes before adding probes:
 - `application[appKey].$migratorAdapterNames` — application-scoped, keyed by datasource name. Memoized migrator adapter name, written by `Base.cfc::$getDBType()`. Survives requests; rebuilt on reload (a datasource's driver can't change without one).
 - `request.$wheelsMigratorColumns` — request-scoped, keyed by `dsName|tableName` (table name VERBATIM — no case folding, since the `$dbinfo` probe uses original case and case-sensitive databases can host `Authors` and `authors` separately). Column list per table, written by `Base.cfc::$getColumns()`, dropped wholesale by `$execute()` so DDL in the same request is reflected on the next read.
 
+## Constraint names and tenant isolation
+
+Default foreign-key names are `FK_<table>_<refTable>_<column>` so two FKs from the same table to the same reference table do not collide. `dropReference()` builds the same name (column suffix follows `useUnderscoreReferenceColumns`). Existing constraints created as `FK_<table>_<refTable>` must be dropped with an explicit `dropForeignKey(keyName=)`.
+
+CREATE TABLE inlines FKs via `toForeignKeySQL()`, which preserves `onUpdate` / `onDelete` (same mapping as `Abstract.foreignKeySQL`). ALTER ADD uses `toSQL()`.
+
+`TenantMigrator` isolates the tenant datasource on `request.wheels.migratorDataSource` (read by `$migratorDataSource()`). It must not swap `application.wheels.dataSourceName`.
+
+Announce-only `up()`/`down()` do not write the version table. `redoMigration()` fails closed when `allowMigrationDown` is false — do not flip that default to `true`.
+
 ## Tests
 
 Specs live in `vendor/wheels/tests/specs/migrator/`. `referencesSpec.cfc` exercises `TableDefinition::references()` (the `columnNames` alias plus the suffix flag) at the unit layer — inspecting `t.columns` / `t.foreignKeys` directly without `t.create()` so the assertions are adapter-independent. `primaryKeySpec.cfc` mirrors that shape for `TableDefinition::primaryKey()` — the `columnName` / `columnNames` aliases plus precedence semantics (#2803). `migrationSpec.cfc` covers Migration.cfc command-version helpers via real DDL roundtrips — its "Tests addReference" describe block guards the `useUnderscoreReferenceColumns` path on `Migration.cfc::addReference()`. Most FK-related tests in `migrationSpec.cfc` skip on SQLite (which doesn't support altering CONSTRAINTS) but run on every other engine in CI.

--- a/vendor/wheels/migrator/CLAUDE.md
+++ b/vendor/wheels/migrator/CLAUDE.md
@@ -77,7 +77,7 @@ CREATE TABLE inlines FKs via `toForeignKeySQL()`, which preserves `onUpdate` / `
 
 `TenantMigrator` isolates the tenant datasource on `request.wheels.migratorDataSource` (read by `$migratorDataSource()`). It must not swap `application.wheels.dataSourceName`.
 
-Announce-only `up()`/`down()` do not write the version table. `redoMigration()` fails closed when `allowMigrationDown` is false — do not flip that default to `true`.
+Announce-only `up()`/`down()` do not write the version table. `announce()` plus ORM persist (`model().create()` / `save()` / `delete()` with no `$execute`) still marks or unmarks the version. `redoMigration()` fails closed when `allowMigrationDown` is false — do not flip that default to `true`.
 
 ## Tests
 

--- a/vendor/wheels/migrator/ForeignKeyDefinition.cfc
+++ b/vendor/wheels/migrator/ForeignKeyDefinition.cfc
@@ -21,8 +21,20 @@ component extends="Base" {
 				this[local.argumentName] = arguments[local.argumentName];
 			}
 		}
-		this.name = "FK_#objectCase(this.table)#_#objectCase(this.referenceTable)#";
+		this.name = $defaultForeignKeyName(this.table, this.referenceTable, this.column);
 		return this;
+	}
+
+	/**
+	 * Default constraint name. Includes the column so two FKs from the same
+	 * table to the same reference table do not collide.
+	 */
+	public string function $defaultForeignKeyName(
+		required string table,
+		required string referenceTable,
+		required string column
+	) {
+		return "FK_#objectCase(arguments.table)#_#objectCase(arguments.referenceTable)#_#objectCase(arguments.column)#";
 	}
 
 	public string function toSQL() {
@@ -55,6 +67,30 @@ component extends="Base" {
 			}
 		}
 		arguments.sql = this.adapter.addForeignKeyOptions(sql = arguments.sql, options = local.options);
+		// CREATE TABLE uses this path; ALTER ADD uses toSQL()/foreignKeySQL().
+		// Adapters historically dropped onUpdate/onDelete here.
+		return $appendReferentialActions(arguments.sql);
+	}
+
+	/**
+	 * Appends ON UPDATE / ON DELETE using the same mapping as Abstract.foreignKeySQL.
+	 */
+	public string function $appendReferentialActions(required string sql) {
+		for (local.item in ListToArray("onUpdate,onDelete")) {
+			if (StructKeyExists(this, local.item) && Len(this[local.item])) {
+				switch (this[local.item]) {
+					case "none":
+						arguments.sql &= " " & UCase(humanize(local.item)) & " NO ACTION";
+						break;
+					case "null":
+						arguments.sql &= " " & UCase(humanize(local.item)) & " SET NULL";
+						break;
+					default:
+						arguments.sql &= " " & UCase(humanize(local.item)) & " CASCADE";
+						break;
+				}
+			}
+		}
 		return arguments.sql;
 	}
 

--- a/vendor/wheels/migrator/Migration.cfc
+++ b/vendor/wheels/migrator/Migration.cfc
@@ -383,7 +383,13 @@ component extends="Base" {
 		// addReference for the same pattern.
 		$combineArguments(args = arguments, combine = "referenceName,columnName", required = false);
 		$combineArguments(args = arguments, combine = "referenceName,columnNames", required = true);
-		dropForeignKey(arguments.table, "FK_#arguments.table#_#pluralize(arguments.referenceName)#");
+		local.idSuffix = $get("useUnderscoreReferenceColumns") ? "_id" : "id";
+		local.column = arguments.referenceName & local.idSuffix;
+		local.refTable = pluralize(arguments.referenceName);
+		dropForeignKey(
+			arguments.table,
+			"FK_#objectCase(arguments.table)#_#objectCase(local.refTable)#_#objectCase(local.column)#"
+		);
 	}
 
 	/**

--- a/vendor/wheels/migrator/TenantMigrator.cfc
+++ b/vendor/wheels/migrator/TenantMigrator.cfc
@@ -142,11 +142,11 @@ component {
 
 	/**
 	 * Runs a single migration action against one tenant datasource.
-	 * Holds an exclusive named lock for the FULL run: the migrator reads
-	 * `application.wheels.dataSourceName` lazily at query time, so the
-	 * application-wide datasource is swapped to the tenant's for the whole
-	 * action and only restored once it completes. The lock prevents
-	 * concurrent tenant migrations from interleaving datasource swaps.
+	 * Isolates the tenant DS on the request (`request.wheels.migratorDataSource`)
+	 * instead of mutating `application.wheels.dataSourceName`. Concurrent
+	 * requests read the application key without this lock, so swapping it
+	 * would route their queries at the tenant. Per-datasource lock serializes
+	 * two runs against the same tenant without blocking other tenants.
 	 */
 	public any function $runForTenant(
 		required string action,
@@ -154,16 +154,32 @@ component {
 		required string migratePath,
 		required string sqlPath
 	) {
-		local.appKey = "wheels";
+		if (!Len(Trim(arguments.dataSource))) {
+			Throw(
+				type = "Wheels.TenantMigrator.InvalidDataSource",
+				message = "Tenant migration requires a non-empty dataSource."
+			);
+		}
 
-		lock name="wheels_tenant_migrator" type="exclusive" timeout="300" {
-			local.originalDataSourceName = application[local.appKey].dataSourceName;
-			application[local.appKey].dataSourceName = arguments.dataSource;
-			try {
+		if (!StructKeyExists(request, "wheels")) {
+			request.wheels = {};
+		}
+		local.hadOverride = StructKeyExists(request.wheels, "migratorDataSource");
+		if (local.hadOverride) {
+			local.priorOverride = request.wheels.migratorDataSource;
+		}
+		request.wheels.migratorDataSource = arguments.dataSource;
+
+		try {
+			lock name="wheels_tenant_migrator_#arguments.dataSource#" type="exclusive" timeout="300" {
 				local.migrator = $newMigrator(migratePath = arguments.migratePath, sqlPath = arguments.sqlPath);
 				return $executeAction(migrator = local.migrator, action = arguments.action);
-			} finally {
-				application[local.appKey].dataSourceName = local.originalDataSourceName;
+			}
+		} finally {
+			if (local.hadOverride) {
+				request.wheels.migratorDataSource = local.priorOverride;
+			} else {
+				StructDelete(request.wheels, "migratorDataSource");
 			}
 		}
 	}

--- a/vendor/wheels/model/bulk.cfc
+++ b/vendor/wheels/model/bulk.cfc
@@ -60,6 +60,7 @@ component {
 			local.totalInserted += (local.batchEnd - local.batchStart + 1);
 		}
 
+		$markMigrationDidWork();
 		$clearRequestCache();
 		return {insertedCount: local.totalInserted};
 	}
@@ -150,6 +151,7 @@ component {
 			local.totalUpserted += (local.batchEnd - local.batchStart + 1);
 		}
 
+		$markMigrationDidWork();
 		$clearRequestCache();
 		return {upsertedCount: local.totalUpserted};
 	}

--- a/vendor/wheels/model/create.cfc
+++ b/vendor/wheels/model/create.cfc
@@ -311,6 +311,7 @@ component {
 			sql = local.sql,
 			$primaryKey = local.pks
 		);
+		$markMigrationDidWork();
 		$clearRequestCache();
 		local.generatedKey = variables.wheels.class.adapter.$generatedKey();
 		if (StructKeyExists(local.inserted.result, local.generatedKey)) {

--- a/vendor/wheels/model/delete.cfc
+++ b/vendor/wheels/model/delete.cfc
@@ -196,6 +196,7 @@ component {
 	 */
 	public numeric function $deleteAll() {
 		local.deleted = variables.wheels.class.adapter.$querySetup(sql = arguments.sql, parameterize = arguments.parameterize);
+		$markMigrationDidWork();
 		$clearRequestCache();
 		return local.deleted.result.recordCount;
 	}
@@ -219,6 +220,7 @@ component {
 				sql = arguments.sql,
 				parameterize = arguments.parameterize
 			);
+			$markMigrationDidWork();
 			$clearRequestCache();
 			if (local.deleted.result.recordCount == 1 && $callback("afterDelete", arguments.callbacks)) {
 				local.rv = true;

--- a/vendor/wheels/model/miscellaneous.cfc
+++ b/vendor/wheels/model/miscellaneous.cfc
@@ -29,6 +29,15 @@ component {
 	}
 
 	/**
+	 * Marks the current migrator step as having done ORM persist work
+	 * (create / save / update / delete) so announce() alone does not
+	 * disqualify the step from version tracking.
+	 */
+	public void function $markMigrationDidWork() {
+		request.$wheelsMigrationDidWork = true;
+	}
+
+	/**
 	 * Use this method to override the data source connection information for this model.
 	 *
 	 * [section: Model Configuration]

--- a/vendor/wheels/model/update.cfc
+++ b/vendor/wheels/model/update.cfc
@@ -292,6 +292,7 @@ component {
 	 **/
 	public numeric function $updateAll() {
 		local.updated = variables.wheels.class.adapter.$querySetup(parameterize = arguments.parameterize, sql = arguments.sql);
+		$markMigrationDidWork();
 		$clearRequestCache();
 		return local.updated.result.recordCount;
 	}
@@ -323,6 +324,7 @@ component {
 				ArrayDeleteAt(local.sql, ArrayLen(local.sql));
 				local.sql = $addKeyWhereClause(sql = local.sql);
 				variables.wheels.class.adapter.$querySetup(sql = local.sql, parameterize = arguments.parameterize);
+				$markMigrationDidWork();
 				$clearRequestCache();
 			}
 		}

--- a/vendor/wheels/tests/_assets/migrator/SpyTenantMigrator.cfc
+++ b/vendor/wheels/tests/_assets/migrator/SpyTenantMigrator.cfc
@@ -1,0 +1,20 @@
+/**
+ * Test double for TenantMigrator hardener B5.
+ * Captures application.wheels.dataSourceName (and any request-scoped override)
+ * at the start of $executeAction — after $runForTenant has entered its lock.
+ */
+component extends="wheels.migrator.TenantMigrator" {
+
+	public any function $executeAction(required any migrator, required string action) {
+		request.hardenerTenantMigratorAppDs = application.wheels.dataSourceName;
+		if (IsDefined("request.wheels.migratorDataSource") && Len(ToString(request.wheels.migratorDataSource))) {
+			request.hardenerTenantMigratorOverrideDs = request.wheels.migratorDataSource;
+		} else if (IsDefined("request.wheels.tenant.dataSource") && Len(ToString(request.wheels.tenant.dataSource))) {
+			request.hardenerTenantMigratorOverrideDs = request.wheels.tenant.dataSource;
+		} else {
+			request.hardenerTenantMigratorOverrideDs = "";
+		}
+		return super.$executeAction(argumentCollection = arguments);
+	}
+
+}

--- a/vendor/wheels/tests/_assets/migrator/announceonly/90000000000001_announce_only.cfc
+++ b/vendor/wheels/tests/_assets/migrator/announceonly/90000000000001_announce_only.cfc
@@ -1,0 +1,11 @@
+component extends="wheels.migrator.Migration" hint="announce-only up/down — hardener B1" {
+
+	function up() {
+		announce("announce only up");
+	}
+
+	function down() {
+		announce("announce only down");
+	}
+
+}

--- a/vendor/wheels/tests/_assets/migrator/announceorm/90000000000003_announce_then_orm.cfc
+++ b/vendor/wheels/tests/_assets/migrator/announceorm/90000000000003_announce_then_orm.cfc
@@ -1,0 +1,17 @@
+component extends="wheels.migrator.Migration" hint="announce then ORM persist — hardener B1 hole" {
+
+	function up() {
+		announce("seeding via ORM");
+		model("Tag").create(name = "hardener_b1_announce_then_orm");
+	}
+
+	function down() {
+		announce("removing via ORM");
+		// Instance delete — not removeRecord(), which goes through $execute.
+		var tag = model("Tag").findOne(where = "name = 'hardener_b1_announce_then_orm'");
+		if (IsObject(tag)) {
+			tag.delete();
+		}
+	}
+
+}

--- a/vendor/wheels/tests/_assets/migrator/defaultstubs/90000000000002_default_stubs.cfc
+++ b/vendor/wheels/tests/_assets/migrator/defaultstubs/90000000000002_default_stubs.cfc
@@ -1,0 +1,2 @@
+component extends="wheels.migrator.Migration" hint="inherits default announce-only up/down — hardener B1" {
+}

--- a/vendor/wheels/tests/specs/hardener/MigratorHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/hardener/MigratorHardenerSpec.cfc
@@ -1,0 +1,399 @@
+/**
+ * Hardener BLOCKERs B1–B6 (migrator / schema).
+ *
+ * Directory-scoped so `wheels test --core --ci --filter=hardener`
+ * discovers this folder (a single-file directory= scope finds 0 bundles).
+ */
+component extends="wheels.WheelsTest" {
+
+	include "../migrator/helperFunctions.cfm";
+
+	function beforeAll() {
+		variables.g = application.wo;
+		variables.migration = CreateObject("component", "wheels.migrator.Migration").init();
+		variables.announceMigrator = CreateObject("component", "wheels.Migrator").init(
+			migratePath = "/wheels/tests/_assets/migrator/announceonly/",
+			sqlPath = "/wheels/tests/_assets/migrator/sql_hardener_announce/"
+		);
+		variables.stubMigrator = CreateObject("component", "wheels.Migrator").init(
+			migratePath = "/wheels/tests/_assets/migrator/defaultstubs/",
+			sqlPath = "/wheels/tests/_assets/migrator/sql_hardener_stubs/"
+		);
+		variables.wrapperMigrator = CreateObject("component", "wheels.Migrator").init(
+			migratePath = "/wheels/tests/_assets/migrator/migrations_2789/",
+			sqlPath = "/wheels/tests/_assets/migrator/sql_2789/"
+		);
+		variables.sqlMigrator = CreateObject("component", "wheels.Migrator").init(
+			migratePath = "/wheels/tests/_assets/migrator/migrations/",
+			sqlPath = "/wheels/tests/_assets/migrator/sql/"
+		);
+		variables.autoMigrator = CreateObject("component", "wheels.migrator.AutoMigrator");
+		variables.fkAdapter = variables.migration.adapter;
+	}
+
+	function run() {
+
+		var _isCockroachDB = CreateObject("component", "wheels.migrator.Migration").init().adapter.adapterName() == "CockroachDB";
+
+		describe("B1 announce-only migrations do not update the version table", () => {
+
+			beforeEach(() => {
+				deleteMigratorVersions(2);
+				StructDelete(request, "$wheelsDebugSQL");
+				StructDelete(request, "$wheelsMigrationDidExecute");
+			});
+
+			afterEach(() => {
+				deleteMigratorVersions(2);
+				StructDelete(request, "$wheelsDebugSQL");
+				StructDelete(request, "$wheelsMigrationDidExecute");
+			});
+
+			it("does not mark an announce-only up() as migrated", () => {
+				if (_isCockroachDB) return;
+				variables.announceMigrator.migrateTo("90000000000001");
+				var rows = queryExecute(
+					"SELECT version FROM #application.wheels.migratorTableName# WHERE version = '90000000000001'",
+					{},
+					{datasource: application.wheels.dataSourceName}
+				);
+				expect(rows.recordCount).toBe(
+					0,
+					"Announce-only up() must not INSERT into the migrator versions table."
+				);
+			});
+
+			it("does not mark the default announce-only Migration.up() stub as migrated", () => {
+				if (_isCockroachDB) return;
+				variables.stubMigrator.migrateTo("90000000000002");
+				var rows = queryExecute(
+					"SELECT version FROM #application.wheels.migratorTableName# WHERE version = '90000000000002'",
+					{},
+					{datasource: application.wheels.dataSourceName}
+				);
+				expect(rows.recordCount).toBe(
+					0,
+					"Default up() that only announces NOT IMPLEMENTED must not mark the version migrated."
+				);
+			});
+
+			it("does not remove a tracking row when down() is announce-only", () => {
+				if (_isCockroachDB) return;
+				var priorDown = application.wheels.allowMigrationDown;
+				application.wheels.allowMigrationDown = true;
+				try {
+					// Ensure the tracking table exists without relying on up()
+					// to write the row (that write is the bug under test).
+					variables.announceMigrator.migrateTo("90000000000001");
+					queryExecute(
+						"DELETE FROM #application.wheels.migratorTableName# WHERE version = '90000000000001'",
+						{},
+						{datasource: application.wheels.dataSourceName}
+					);
+					queryExecute(
+						"INSERT INTO #application.wheels.migratorTableName# (version, core_level) VALUES ('90000000000001', #application.wheels.migrationLevel#)",
+						{},
+						{datasource: application.wheels.dataSourceName}
+					);
+					variables.announceMigrator.migrateTo("0");
+					var rows = queryExecute(
+						"SELECT version FROM #application.wheels.migratorTableName# WHERE version = '90000000000001'",
+						{},
+						{datasource: application.wheels.dataSourceName}
+					);
+					expect(rows.recordCount).toBe(
+						1,
+						"Announce-only down() must not DELETE the migrator versions row."
+					);
+				} finally {
+					application.wheels.allowMigrationDown = priorDown;
+				}
+			});
+
+			it("still records a version when up() actually executes SQL", () => {
+				if (_isCockroachDB) return;
+				try {
+					variables.migration.dropTable("c_o_r_e_bunyips");
+				} catch (any e) {}
+				variables.sqlMigrator.migrateTo("001");
+				var rows = queryExecute(
+					"SELECT version FROM #application.wheels.migratorTableName# WHERE version = '001'",
+					{},
+					{datasource: application.wheels.dataSourceName}
+				);
+				try {
+					variables.migration.dropTable("c_o_r_e_bunyips");
+				} catch (any e) {}
+				expect(rows.recordCount).toBe(
+					1,
+					"A migration that executes SQL must still be recorded as migrated."
+				);
+			});
+
+		});
+
+		describe("B2 redo fails closed when allowMigrationDown is false", () => {
+
+			beforeEach(() => {
+				deleteMigratorVersions(2);
+				try {
+					queryExecute(
+						"DELETE FROM c_o_r_e_tags WHERE name = 'issue2789_via_model_create'",
+						{},
+						{datasource: application.wheels.dataSourceName}
+					);
+				} catch (any e) {}
+				StructDelete(request, "$issue2789FlagDuringUp");
+				StructDelete(request, "$wheelsTransactionWrapper");
+			});
+
+			afterEach(() => {
+				deleteMigratorVersions(2);
+				try {
+					queryExecute(
+						"DELETE FROM c_o_r_e_tags WHERE name = 'issue2789_via_model_create'",
+						{},
+						{datasource: application.wheels.dataSourceName}
+					);
+				} catch (any e) {}
+				StructDelete(request, "$issue2789FlagDuringUp");
+				StructDelete(request, "$wheelsTransactionWrapper");
+			});
+
+			it("does not re-run up() when down is blocked by the default allowMigrationDown=false", () => {
+				if (_isCockroachDB) return;
+				var priorDown = application.wheels.allowMigrationDown;
+				application.wheels.allowMigrationDown = true;
+				try {
+					variables.wrapperMigrator.migrateTo("001");
+				} finally {
+					application.wheels.allowMigrationDown = priorDown;
+				}
+				var before = queryExecute(
+					"SELECT id FROM c_o_r_e_tags WHERE name = 'issue2789_via_model_create'",
+					{},
+					{datasource: application.wheels.dataSourceName}
+				);
+				expect(before.recordCount).toBeGT(0);
+
+				application.wheels.allowMigrationDown = false;
+				try {
+					var output = variables.wrapperMigrator.redoMigration("001");
+					var after = queryExecute(
+						"SELECT id FROM c_o_r_e_tags WHERE name = 'issue2789_via_model_create'",
+						{},
+						{datasource: application.wheels.dataSourceName}
+					);
+					expect(after.recordCount).toBe(
+						before.recordCount,
+						"redo must not re-run up() when down is blocked — that double-applies."
+					);
+					expect(output).toInclude("allowMigrationDown");
+					var versions = queryExecute(
+						"SELECT version FROM #application.wheels.migratorTableName# WHERE version = '001'",
+						{},
+						{datasource: application.wheels.dataSourceName}
+					);
+					expect(versions.recordCount).toBe(
+						1,
+						"Fail-closed redo must leave the version tracking row in place."
+					);
+				} finally {
+					application.wheels.allowMigrationDown = priorDown;
+				}
+			});
+
+			it("does not flip the allowMigrationDown framework default", () => {
+				var src = FileRead(ExpandPath("/wheels/events/onapplicationstart.cfc"));
+				expect(src).toInclude("application.$wheels.allowMigrationDown = false");
+			});
+
+		});
+
+		describe("B3 CREATE FK path preserves onUpdate and onDelete", () => {
+
+			it("includes ON UPDATE / ON DELETE in toForeignKeySQL() used by CREATE TABLE", () => {
+				var fk = CreateObject("component", "wheels.migrator.ForeignKeyDefinition").init(
+					adapter = variables.fkAdapter,
+					table = "posts",
+					referenceTable = "users",
+					column = "userid",
+					referenceColumn = "id",
+					onUpdate = "cascade",
+					onDelete = "null"
+				);
+				var sql = fk.toForeignKeySQL();
+				expect(sql).toInclude("ON UPDATE CASCADE");
+				expect(sql).toInclude("ON DELETE SET NULL");
+			});
+
+			it("includes ON UPDATE / ON DELETE in adapter.createTable() SQL", () => {
+				var fk = CreateObject("component", "wheels.migrator.ForeignKeyDefinition").init(
+					adapter = variables.fkAdapter,
+					table = "posts",
+					referenceTable = "users",
+					column = "authorid",
+					referenceColumn = "id",
+					onUpdate = "none",
+					onDelete = "cascade"
+				);
+				var sql = variables.fkAdapter.createTable(
+					name = "posts",
+					columns = [],
+					primaryKeys = [],
+					foreignKeys = [fk]
+				);
+				expect(sql).toInclude("ON UPDATE NO ACTION");
+				expect(sql).toInclude("ON DELETE CASCADE");
+			});
+
+		});
+
+		describe("B4 default FK name includes the column so two FKs to the same table do not collide", () => {
+
+			it("names two FKs to the same reference table differently", () => {
+				var authorFk = CreateObject("component", "wheels.migrator.ForeignKeyDefinition").init(
+					adapter = variables.fkAdapter,
+					table = "posts",
+					referenceTable = "users",
+					column = "authorid",
+					referenceColumn = "id"
+				);
+				var editorFk = CreateObject("component", "wheels.migrator.ForeignKeyDefinition").init(
+					adapter = variables.fkAdapter,
+					table = "posts",
+					referenceTable = "users",
+					column = "editorid",
+					referenceColumn = "id"
+				);
+				expect(authorFk.name).notToBe(
+					editorFk.name,
+					"Default FK name must include the column (or otherwise be unique per column)."
+				);
+				expect(authorFk.name).toInclude("authorid");
+				expect(editorFk.name).toInclude("editorid");
+			});
+
+			it("still includes table and reference table in the default name", () => {
+				var fk = CreateObject("component", "wheels.migrator.ForeignKeyDefinition").init(
+					adapter = variables.fkAdapter,
+					table = "posts",
+					referenceTable = "users",
+					column = "userid",
+					referenceColumn = "id"
+				);
+				expect(fk.name).toInclude("posts");
+				expect(fk.name).toInclude("users");
+				expect(fk.name).toInclude("userid");
+			});
+
+		});
+
+		describe("B5 TenantMigrator does not mutate shared application.wheels.dataSourceName", () => {
+
+			afterEach(() => {
+				if (StructKeyExists(request, "wheels")) {
+					StructDelete(request.wheels, "tenant");
+					StructDelete(request.wheels, "migratorDataSource");
+				}
+				StructDelete(request, "hardenerTenantMigratorAppDs");
+				StructDelete(request, "hardenerTenantMigratorOverrideDs");
+			});
+
+			it("leaves application.wheels.dataSourceName unchanged while a tenant action runs", () => {
+				var original = application.wheels.dataSourceName;
+				var spy = CreateObject("component", "wheels.tests._assets.migrator.SpyTenantMigrator").init();
+				spy.migrateAll(
+					action = "info",
+					tenants = [{id = "probe", dataSource = "wheels_hardener_tenant_ds_probe"}],
+					stopOnError = false,
+					migratePath = "/wheels/tests/_assets/migrator/migrations/",
+					sqlPath = "/wheels/tests/_assets/migrator/sql/"
+				);
+				expect(StructKeyExists(request, "hardenerTenantMigratorAppDs")).toBeTrue(
+					"$executeAction must run so the spec can observe the datasource in the lock."
+				);
+				expect(request.hardenerTenantMigratorAppDs).toBe(
+					original,
+					"TenantMigrator must not swap application.wheels.dataSourceName — concurrent requests read that key without the tenant lock."
+				);
+				expect(application.wheels.dataSourceName).toBe(original);
+			});
+
+			it("isolates the tenant datasource on the request instead of application scope", () => {
+				var original = application.wheels.dataSourceName;
+				var spy = CreateObject("component", "wheels.tests._assets.migrator.SpyTenantMigrator").init();
+				spy.migrateAll(
+					action = "info",
+					tenants = [{id = "probe", dataSource = "wheels_hardener_tenant_ds_probe"}],
+					stopOnError = false,
+					migratePath = "/wheels/tests/_assets/migrator/migrations/",
+					sqlPath = "/wheels/tests/_assets/migrator/sql/"
+				);
+				expect(request.hardenerTenantMigratorOverrideDs).toBe("wheels_hardener_tenant_ds_probe");
+				expect(application.wheels.dataSourceName).toBe(original);
+			});
+
+		});
+
+		describe("B6 AutoMigrator honors suggestedRenames instead of remove+add", () => {
+
+			it("emits renameColumn for suggestedRenames and does not emit destructive remove+add for those columns", () => {
+				var diffResult = {
+					modelName: "TestModel",
+					tableName: "test_models",
+					addColumns: [{name: "emailAddress", type: "string", nullable: true, "default": ""}],
+					removeColumns: [{name: "email_addr"}],
+					changeColumns: [],
+					renameColumns: [],
+					suggestedRenames: [
+						{
+							from: "email_addr",
+							to: "emailAddress",
+							type: "string",
+							confidence: 0.82,
+							ambiguous: false
+						}
+					]
+				};
+				var cfc = variables.autoMigrator.generateMigrationCFC(diffResult, "honor_suggested");
+				expect(cfc).toInclude('renameColumn(table="test_models", columnName="email_addr", newColumnName="emailAddress")');
+				expect(Find('removeColumn(table="test_models", columnName="email_addr"', cfc)).toBe(
+					0,
+					"suggestedRenames must not be emitted as removeColumn."
+				);
+				expect(Find('addColumn(table="test_models"', cfc)).toBe(
+					0,
+					"suggestedRenames must not be emitted as addColumn."
+				);
+			});
+
+			it("does not drop a suggested-rename source column even when it is also listed in removeColumns", () => {
+				var diffResult = {
+					modelName: "TestModel",
+					tableName: "test_models",
+					addColumns: [{name: "fullName", type: "string", nullable: true, "default": ""}],
+					removeColumns: [{name: "full_name"}, {name: "legacy_unused"}],
+					changeColumns: [],
+					renameColumns: [],
+					suggestedRenames: [
+						{
+							from: "full_name",
+							to: "fullName",
+							type: "string",
+							confidence: 0.9,
+							ambiguous: false
+						}
+					]
+				};
+				var cfc = variables.autoMigrator.generateMigrationCFC(diffResult, "honor_suggested_mixed");
+				expect(cfc).toInclude('renameColumn(table="test_models", columnName="full_name", newColumnName="fullName")');
+				expect(Find('removeColumn(table="test_models", columnName="full_name"', cfc)).toBe(0);
+				expect(cfc).toInclude('removeColumn(table="test_models", columnName="legacy_unused")');
+			});
+
+		});
+
+	}
+
+}

--- a/vendor/wheels/tests/specs/hardener/MigratorHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/hardener/MigratorHardenerSpec.cfc
@@ -23,6 +23,10 @@ component extends="wheels.WheelsTest" {
 			migratePath = "/wheels/tests/_assets/migrator/migrations_2789/",
 			sqlPath = "/wheels/tests/_assets/migrator/sql_2789/"
 		);
+		variables.ormMigrator = CreateObject("component", "wheels.Migrator").init(
+			migratePath = "/wheels/tests/_assets/migrator/announceorm/",
+			sqlPath = "/wheels/tests/_assets/migrator/sql_hardener_announceorm/"
+		);
 		variables.sqlMigrator = CreateObject("component", "wheels.Migrator").init(
 			migratePath = "/wheels/tests/_assets/migrator/migrations/",
 			sqlPath = "/wheels/tests/_assets/migrator/sql/"
@@ -41,12 +45,30 @@ component extends="wheels.WheelsTest" {
 				deleteMigratorVersions(2);
 				StructDelete(request, "$wheelsDebugSQL");
 				StructDelete(request, "$wheelsMigrationDidExecute");
+				StructDelete(request, "$wheelsMigrationDidAnnounce");
+				StructDelete(request, "$wheelsMigrationDidWork");
+				try {
+					queryExecute(
+						"DELETE FROM c_o_r_e_tags WHERE name = 'hardener_b1_announce_then_orm'",
+						{},
+						{datasource: application.wheels.dataSourceName}
+					);
+				} catch (any e) {}
 			});
 
 			afterEach(() => {
 				deleteMigratorVersions(2);
 				StructDelete(request, "$wheelsDebugSQL");
 				StructDelete(request, "$wheelsMigrationDidExecute");
+				StructDelete(request, "$wheelsMigrationDidAnnounce");
+				StructDelete(request, "$wheelsMigrationDidWork");
+				try {
+					queryExecute(
+						"DELETE FROM c_o_r_e_tags WHERE name = 'hardener_b1_announce_then_orm'",
+						{},
+						{datasource: application.wheels.dataSourceName}
+					);
+				} catch (any e) {}
 			});
 
 			it("does not mark an announce-only up() as migrated", () => {
@@ -104,6 +126,62 @@ component extends="wheels.WheelsTest" {
 					expect(rows.recordCount).toBe(
 						1,
 						"Announce-only down() must not DELETE the migrator versions row."
+					);
+				} finally {
+					application.wheels.allowMigrationDown = priorDown;
+				}
+			});
+
+			it("still marks a version migrated when up() announces then creates via ORM without $execute", () => {
+				if (_isCockroachDB) return;
+				variables.ormMigrator.migrateTo("90000000000003");
+				var rows = queryExecute(
+					"SELECT version FROM #application.wheels.migratorTableName# WHERE version = '90000000000003'",
+					{},
+					{datasource: application.wheels.dataSourceName}
+				);
+				expect(rows.recordCount).toBe(
+					1,
+					"announce() then model().create() with no $execute must still INSERT the migrator versions row."
+				);
+			});
+
+			it("still removes a tracking row when down() announces then deletes via ORM without $execute", () => {
+				if (_isCockroachDB) return;
+				var priorDown = application.wheels.allowMigrationDown;
+				application.wheels.allowMigrationDown = true;
+				try {
+					// Ensure the tracking table exists. up() may or may not
+					// write the row (that write is the sibling hole); the
+					// row is forced present so down() is actually invoked.
+					variables.ormMigrator.migrateTo("90000000000003");
+					queryExecute(
+						"DELETE FROM #application.wheels.migratorTableName# WHERE version = '90000000000003'",
+						{},
+						{datasource: application.wheels.dataSourceName}
+					);
+					queryExecute(
+						"INSERT INTO #application.wheels.migratorTableName# (version, core_level) VALUES ('90000000000003', #application.wheels.migrationLevel#)",
+						{},
+						{datasource: application.wheels.dataSourceName}
+					);
+					var existing = queryExecute(
+						"SELECT id FROM c_o_r_e_tags WHERE name = 'hardener_b1_announce_then_orm'",
+						{},
+						{datasource: application.wheels.dataSourceName}
+					);
+					if (existing.recordCount == 0) {
+						model("Tag").create(name = "hardener_b1_announce_then_orm");
+					}
+					variables.ormMigrator.migrateTo("0");
+					var rows = queryExecute(
+						"SELECT version FROM #application.wheels.migratorTableName# WHERE version = '90000000000003'",
+						{},
+						{datasource: application.wheels.dataSourceName}
+					);
+					expect(rows.recordCount).toBe(
+						0,
+						"announce() then model delete with no $execute must still DELETE the migrator versions row."
 					);
 				} finally {
 					application.wheels.allowMigrationDown = priorDown;

--- a/vendor/wheels/tests/specs/migrator/MigratorRobustnessSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/MigratorRobustnessSpec.cfc
@@ -130,7 +130,13 @@ component extends="wheels.WheelsTest" {
 
 			it("sets request.$wheelsTransactionWrapper for the duration of up()", () => {
 				if (_isCockroachDB) return;
-				wrapperMigrator.redoMigration("001");
+				var priorDown = application.wheels.allowMigrationDown;
+				application.wheels.allowMigrationDown = true;
+				try {
+					wrapperMigrator.redoMigration("001");
+				} finally {
+					application.wheels.allowMigrationDown = priorDown;
+				}
 				expect(request.$issue2789FlagDuringUp).toBeTrue(
 					"redoMigration() must set request.$wheelsTransactionWrapper while the "
 					& "migration runs (issue ##2789), like every other migration path."
@@ -139,7 +145,13 @@ component extends="wheels.WheelsTest" {
 
 			it("rolls back DML written by up() when the redo fails", () => {
 				if (_isCockroachDB) return;
-				var output = errorPathMigrator.redoMigration("005");
+				var priorDown = application.wheels.allowMigrationDown;
+				application.wheels.allowMigrationDown = true;
+				try {
+					var output = errorPathMigrator.redoMigration("005");
+				} finally {
+					application.wheels.allowMigrationDown = priorDown;
+				}
 				expect(output).toInclude("Error re-running 005");
 				expect(output).toInclude("synthetic failure after DML");
 				var found = queryExecute(

--- a/vendor/wheels/tests/specs/migrator/migrationCommandsSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/migrationCommandsSpec.cfc
@@ -100,7 +100,7 @@ component extends="wheels.WheelsTest" {
 
 			it("dropReference accepts columnName alias for the legacy referenceName parameter", () => {
 				// dropReference resolves to dropForeignKey by name pattern
-				// (FK_<table>_<pluralized-reference>). If no such FK exists,
+				// (FK_<table>_<pluralized-reference>_<column>). If no such FK exists,
 				// dropForeignKey errors at the SQL layer — that's fine here;
 				// we only care that the alias resolved before SQL ran.
 				var aliasAccepted = true;

--- a/vendor/wheels/tests/specs/migrator/migrationSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/migrationSpec.cfc
@@ -1091,7 +1091,7 @@ component extends="wheels.WheelsTest" {
 
 				created = g.$query(query = info, dbtype = "query", sql = sql)
 
-				migration.dropForeignKey(table = tableName, keyName = "FK_#tableName#_#referenceTableName#")
+				migration.dropForeignKey(table = tableName, keyName = "FK_#tableName#_#referenceTableName#_barid")
 				info = g.$dbinfo(datasource = application.wheels.dataSourceName, table = referenceTableName, type = "foreignkeys")
 				dropped = g.$query(query = info, dbtype = "query", sql = sql)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Hardener slice for migrator/schema BLOCKERs B1–B6. Started from develop tip `324efe28a11426d8cc9b5cc72469e4e8d54cb666`.

## Summary

### B1 — Announce-only up/down still updated the version table
Default `Migration.up()`/`down()` and the announce template only call `announce()`, but `$runMigrationStep` still called `$setVersionAsMigrated` / `$removeVersionAsMigrated`. Announce-only steps no longer write `wheels_migrator_versions`. SQL via `$execute` still records. ORM-only steps (`model().create()` with no `$execute`) still record — they are not announce-only.

**Hole on `4c2f11e8`:** `announce()` plus ORM persist (`model().create()` / `delete()`) with no `$execute` set `DidAnnounce` and never `DidExecute`, so the step was treated as announce-only and **never marked migrated**. Killing spec (`0362b3672`) failed on that tip. Fix (`ead7a1602`): mark migrated unless truly announce-only (`DidAnnounce && !DidExecute && !DidWork`).

### B2 — `redo` + `allowMigrationDown=false` skipped down and still ran up
**`allowMigrationDown` default is unchanged (`false`; development still opts in to `true`).** Redo now fails closed when down cannot run: it does not call `up()`, does not change version tracking, and returns an error that names `allowMigrationDown`. Existing redo transaction specs explicitly opt in to `allowMigrationDown=true`.

### B3 — CREATE FK path dropped `onUpdate` / `onDelete`
`toSQL()` (ALTER ADD) already passed referential actions; `toForeignKeySQL()` (CREATE TABLE) did not. CREATE TABLE SQL now appends `ON UPDATE` / `ON DELETE` using the same mapping as `Abstract.foreignKeySQL`.

### B4 — Default FK name `FK_table_refTable` ignored the column
Two FKs from the same table to the same reference table collided. Default names are now `FK_<table>_<refTable>_<column>`. `dropReference()` builds the same name. Existing constraints created as `FK_<table>_<refTable>` must be dropped with an explicit `dropForeignKey(keyName=)`.

### B5 — `TenantMigrator` mutated `application.wheels.dataSourceName` under a weak lock
The exclusive lock did not protect concurrent requests that read the application datasource without taking it. Tenant runs now set `request.wheels.migratorDataSource` and a per-datasource lock. `$migratorDataSource()` is the migrator read path. Application scope is not swapped.

### B6 — `AutoMigrator` ignored `suggestedRenames` and emitted remove+add
`generateMigrationCFC()` only consumed `renameColumns`. Suggested pairs stayed in add/remove and became destructive drop+add. Suggested renames now emit `renameColumn` and are excluded from add/remove.

## PROVEN / UNPROVEN

| ID | Status | Filter evidence |
|---|---|---|
| B1 | **PROVEN (announce-only vs announce+ORM)** | Announce-only: no version write. Announce+ORM (`announce()` then `model().create()`/`delete()`, no `$execute`): **must** set/remove the versions row. RED (`0362b3672` on tip `4c2f11e8`): 55 passed, 2 failed (up `Expected [1] Actual [0]`, down `Expected [0] Actual [1]`). GREEN (`ead7a1602`): 57 passed. Skip only `DidAnnounce && !DidExecute && !DidWork`. |
| B2 | **PROVEN** | RED: redo with `allowMigrationDown=false` double-applied (`Expected [1] Actual [2]`). GREEN: fail-closed, version row left in place. Default not flipped (source assertion). |
| B3 | **PROVEN** | RED: `toForeignKeySQL()` / `createTable()` omitted `ON UPDATE` / `ON DELETE`. GREEN: clauses present. |
| B4 | **PROVEN** | RED: both FKs named `FK_posts_users`. GREEN: names include `authorid` / `editorid`. |
| B5 | **PROVEN** | RED: `$executeAction` saw `application.wheels.dataSourceName` swapped to the tenant probe DS. GREEN: application key unchanged; tenant DS on the request. |
| B6 | **PROVEN** | RED: `generateMigrationCFC()` emitted `addColumn`+`removeColumn` for suggested pairs. GREEN: `renameColumn` only. |

No other public default flips. **`allowMigrationDown` remains `false`** (development still opts in to `true`).

## HEAD

`ead7a1602314a498fe841b415cbe6018c25f32d3`

## Test driver

```
wheels test --core --ci --filter=hardener
wheels test --core --ci --filter=migrator
```

Red → green on `filter=hardener`:

- RED (`0c848520e`): 44 passed, 11 failed, 55 specs (`MigratorHardenerSpec` 3 pass / 11 fail)
- GREEN (`4c2f11e8b`): 55 passed, 0 failed
- `filter=migrator` after GREEN: 292 passed
- B1 hole RED (`0362b3672` on `4c2f11e8`): 55 passed, 2 failed, 57 specs — announce+ORM up/down
- B1 hole GREEN (`ead7a1602`): **57 passed** (`wheels test --core --ci --filter=hardener`)

## Type of Change

- [x] Bug fix
- [x] DCO sign-off on every commit
- [x] Tests (prove-red then green)
- [x] Changelog fragment (`changelog.d/migrator-hardener-b1-b6.fixed.md`)
- [x] CLAUDE.md / `vendor/wheels/migrator/CLAUDE.md` for public migrator behavior

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d4ebe5c-ac6d-4ece-858c-4b767a060743?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d4ebe5c-ac6d-4ece-858c-4b767a060743&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

