### PR TITLE
fix(migrator): harden schema SHOULDs S1–S20

### DIFF
--- a/changelog.d/migrator-hardener-shoulds.changed.md
+++ b/changelog.d/migrator-hardener-shoulds.changed.md
@@ -1,0 +1,4 @@
+- `updateRecord()` / `removeRecord()` accept `all=true` for an intentional full-table write; empty `where` now throws
+- `AutoMigrator.diff()` accepts `allowColumnRemoval=false` and reports leftover columns on `unmappedColumns` instead of scheduling drops
+- `t.references()` accepts `referenceColumn` (default remains `"id"`)
+- Tenant structs may pass `userName` / `password` for per-tenant migrator credentials

--- a/changelog.d/migrator-hardener-shoulds.fixed.md
+++ b/changelog.d/migrator-hardener-shoulds.fixed.md
@@ -1,0 +1,6 @@
+- Migrator down no longer reports a successful rollback when `allowMigrationDown` is false; the default stays `false`
+- Adobe `dropTable()` now drops foreign keys by `FK_NAME` instead of `FKCOLUMN_NAME`
+- New `wheels_migrator_versions` tables use a PRIMARY KEY on `version`; existing tables get a best-effort unique index
+- `updateRecord()` / `removeRecord()` require a `where` clause or explicit `all=true` instead of touching every row
+- Migrations that fail to load are not run; MySQL/Oracle failures warn that DDL is not rolled back
+- AutoMigrator rejects unsafe identifiers, restores typed dropped columns in `down()`, and can opt out of destructive unmapped-column drops via `allowColumnRemoval=false`

--- a/vendor/wheels/Migrator.cfc
+++ b/vendor/wheels/Migrator.cfc
@@ -113,6 +113,12 @@ component output="false" extends="wheels.Global"{
 				DirectoryCreate(this.paths.sql);
 			}
 			if (local.currentVersion > arguments.version && arguments.missingMigFlag == false) {
+				// S1: do not print a successful "Migrating … down" banner when
+				// down is blocked — that reads as a completed rollback.
+				if (!application[local.appKey].allowMigrationDown) {
+					local.rv &= "Cannot migrate down from #local.currentVersion# to #arguments.version#: allowMigrationDown is false.#Chr(13) & Chr(10)#";
+					return local.rv;
+				}
 				local.rv &= "Migrating from #local.currentVersion# down to #arguments.version#.#Chr(13) & Chr(10)#";
 				for (local.i = ArrayLen(local.migrations); local.i >= 1; local.i--) {
 					local.migration = local.migrations[local.i];
@@ -359,6 +365,17 @@ component output="false" extends="wheels.Global"{
 			local.result.output = "#arguments.errorLabel# #arguments.migration.version#.#Chr(13) & Chr(10)#Cannot redo migration: allowMigrationDown is false. Running up() without down() would double-apply.#Chr(13) & Chr(10)#";
 			return local.result;
 		}
+		// S5: a CFC that failed to load must not reach .up()/.down().
+		if (StructKeyExists(arguments.migration, "loadError") && Len(ToString(arguments.migration.loadError))) {
+			local.result.success = false;
+			local.result.output = "#arguments.errorLabel# #arguments.migration.version#.#Chr(13) & Chr(10)#Migration failed to load: #arguments.migration.loadError##Chr(13) & Chr(10)#";
+			return local.result;
+		}
+		if (!StructKeyExists(arguments.migration, "cfc")) {
+			local.result.success = false;
+			local.result.output = "#arguments.errorLabel# #arguments.migration.version#.#Chr(13) & Chr(10)#Migration CFC was not loaded.#Chr(13) & Chr(10)#";
+			return local.result;
+		}
 		local.divider = arguments.direction == "up" ? "--------" : "-------";
 		transaction action="begin" {
 			try {
@@ -397,6 +414,9 @@ component output="false" extends="wheels.Global"{
 			} catch (any e) {
 				local.result.success = false;
 				local.result.output &= "#arguments.errorLabel# #arguments.migration.version#.#Chr(13) & Chr(10)##e.message##Chr(13) & Chr(10)##e.detail##Chr(13) & Chr(10)#";
+				if ($ddlAutoCommits()) {
+					local.result.output &= "Warning: this database auto-commits DDL. The per-migration transaction did not roll back schema changes.#Chr(13) & Chr(10)#";
+				}
 				transaction action="rollback";
 				StructDelete(request, "$wheelsTransactionWrapper");
 				// Skip the commit below — rollback already closed the transaction.
@@ -597,11 +617,12 @@ component output="false" extends="wheels.Global"{
 			var probeState = {fresh = false};
 			if (!$migratorTableExists($migratorDataSource(), application[local.appKey].migratorTableName)) {
 				try {
+					local.creds = $migratorDataSourceCredentials();
 					$dbinfo(
 						type = "version",
 						datasource = $migratorDataSource(),
-						username = application.wheels.dataSourceUserName,
-						password = application.wheels.dataSourcePassword
+						username = local.creds.username,
+						password = local.creds.password
 					);
 					probeState.fresh = true;
 				} catch (any datasourceError) {
@@ -719,11 +740,12 @@ component output="false" extends="wheels.Global"{
 
 			// Version tracking table.
 			if (!$migratorTableExists(local.dsn, local.versionsTable)) {
+				local.creds = $migratorDataSourceCredentials();
 				local.info = $dbinfo(
 					type = "version",
 					datasource = local.dsn,
-					username = application.wheels.dataSourceUserName,
-					password = application.wheels.dataSourcePassword
+					username = local.creds.username,
+					password = local.creds.password
 				);
 				local.dbType = local.info.database_productname;
 				// FK constraint name follows the levels-table prefix so a
@@ -740,7 +762,7 @@ component output="false" extends="wheels.Global"{
 							datasource = local.dsn,
 							sql = "
 								CREATE TABLE #local.versionsTable# (
-									version VARCHAR(25),
+									version VARCHAR(25) PRIMARY KEY,
 									core_level INT NOT NULL DEFAULT 1,
 									CONSTRAINT #local.fkName# FOREIGN KEY (core_level) REFERENCES #local.levelsTable#(id)
 								)
@@ -776,9 +798,9 @@ component output="false" extends="wheels.Global"{
 				} else {
 					// Fresh database — create the tracking table.
 					if (FindNoCase("Oracle", local.dbType)) {
-						local.createSQL = "CREATE TABLE #local.versionsTable# (version VARCHAR2(25), core_level NUMBER DEFAULT 1 NOT NULL)";
+						local.createSQL = "CREATE TABLE #local.versionsTable# (version VARCHAR2(25) PRIMARY KEY, core_level NUMBER DEFAULT 1 NOT NULL)";
 					} else {
-						local.createSQL = "CREATE TABLE #local.versionsTable# (version VARCHAR(25), core_level INT NOT NULL DEFAULT 1)";
+						local.createSQL = "CREATE TABLE #local.versionsTable# (version VARCHAR(25) PRIMARY KEY, core_level INT NOT NULL DEFAULT 1)";
 					}
 					try {
 						$query(datasource = local.dsn, sql = local.createSQL);
@@ -793,11 +815,54 @@ component output="false" extends="wheels.Global"{
 					}
 				}
 			}
+			// S3: existing tables created before the PRIMARY KEY DDL still
+			// need a uniqueness constraint. Best-effort — duplicates or
+			// engines that already have the PK land in the catch.
+			$ensureVersionUniqueness(
+				dsn = local.dsn,
+				versionsTable = local.versionsTable
+			);
 		}
 
 		// Table guaranteed present — add the enriched name + applied_at
 		// columns when missing so $setVersionAsMigrated can write them.
 		$maybeEnsureTrackingColumns(local.appKey);
+	}
+
+	/**
+	 * True when the current migrator datasource auto-commits DDL so a
+	 * cftransaction rollback cannot undo CREATE/ALTER/DROP. MySQL (implicit
+	 * commit) and Oracle (DDL auto-commit) are the known cases. Used to
+	 * warn after a failed migration step — full DDL rollback is not possible
+	 * on these engines.
+	 */
+	public boolean function $ddlAutoCommits() {
+		local.appKey = $appKey();
+		local.dbType = "";
+		if (StructKeyExists(application[local.appKey], "$migratorDbType")) {
+			local.dbType = application[local.appKey].$migratorDbType;
+		}
+		return (
+			FindNoCase("MySQL", local.dbType)
+			|| FindNoCase("MariaDB", local.dbType)
+			|| FindNoCase("Oracle", local.dbType)
+		);
+	}
+
+	/**
+	 * Best-effort UNIQUE/PK on the version column for tables created before
+	 * the PRIMARY KEY DDL. A JVM-local lock cannot stop a second process
+	 * inserting a duplicate version row.
+	 */
+	public void function $ensureVersionUniqueness(required string dsn, required string versionsTable) {
+		try {
+			$query(
+				datasource = arguments.dsn,
+				sql = "CREATE UNIQUE INDEX #arguments.versionsTable#_version_uidx ON #arguments.versionsTable# (version)"
+			);
+		} catch (any e) {
+			// Index already present, PK already exists, or duplicate rows.
+		}
 	}
 
 	/**
@@ -1344,11 +1409,12 @@ component output="false" extends="wheels.Global"{
 		// renamed first so any FK constraint pointing at c_o_r_e_levels
 		// follows naturally when levels is renamed last (every supported
 		// engine auto-updates FK references on table rename).
+		var creds = $migratorDataSourceCredentials();
 		var info = $dbinfo(
 			type = "version",
 			datasource = dsn,
-			username = application.wheels.dataSourceUserName,
-			password = application.wheels.dataSourcePassword
+			username = creds.username,
+			password = creds.password
 		);
 		var dbType = info.database_productname;
 
@@ -1481,11 +1547,12 @@ component output="false" extends="wheels.Global"{
 		// can't DEFAULT a TIMESTAMP on ALTER ADD COLUMN). Guarded so it
 		// fires at most once per app process.
 		if (!StructKeyExists(application[appKey], "$migratorDbType")) {
+			var creds = $migratorDataSourceCredentials();
 			var info = $dbinfo(
 				type = "version",
 				datasource = dsn,
-				username = application.wheels.dataSourceUserName,
-				password = application.wheels.dataSourcePassword
+				username = creds.username,
+				password = creds.password
 			);
 			application[appKey].$migratorDbType = info.database_productname;
 		}

--- a/vendor/wheels/databaseAdapters/Abstract.cfc
+++ b/vendor/wheels/databaseAdapters/Abstract.cfc
@@ -260,6 +260,24 @@ component extends="wheels.migrator.Base"{
 	}
 
 	/**
+	 * Inline CREATE TABLE foreign-key fragment. Quotes identifiers through
+	 * the adapter so reserved/mixed-case names stay valid.
+	 */
+	public string function addForeignKeyOptions(required string sql, struct options = {}) {
+		if (StructKeyExists(arguments.options, "column")) {
+			arguments.sql = arguments.sql & " FOREIGN KEY (" & quoteColumnName(arguments.options.column) & ")";
+		}
+		if (
+			StructKeyExists(arguments.options, "referenceTable")
+			&& StructKeyExists(arguments.options, "referenceColumn")
+		) {
+			arguments.sql = arguments.sql & " REFERENCES " & quoteTableName(arguments.options.referenceTable);
+			arguments.sql = arguments.sql & " (" & quoteColumnName(arguments.options.referenceColumn) & ")";
+		}
+		return arguments.sql;
+	}
+
+	/**
 	 * generates sql for foreign key constraint
 	 */
 	public string function foreignKeySQL(
@@ -271,7 +289,7 @@ component extends="wheels.migrator.Base"{
 		string onUpdate = "",
 		string onDelete = ""
 	) {
-		local.sql = "CONSTRAINT #quoteTableName(arguments.name)# FOREIGN KEY (#quoteColumnName(arguments.column)#) REFERENCES #objectCase(arguments.referenceTable)#(#quoteColumnName(arguments.referenceColumn)#)";
+		local.sql = "CONSTRAINT #quoteTableName(arguments.name)# FOREIGN KEY (#quoteColumnName(arguments.column)#) REFERENCES #quoteTableName(arguments.referenceTable)#(#quoteColumnName(arguments.referenceColumn)#)";
 		for (local.item in ListToArray("onUpdate,onDelete")) {
 			if (Len(arguments[local.item])) {
 				switch (arguments[local.item]) {

--- a/vendor/wheels/databaseAdapters/CockroachDB/CockroachDBMigrator.cfc
+++ b/vendor/wheels/databaseAdapters/CockroachDB/CockroachDBMigrator.cfc
@@ -13,6 +13,7 @@ component extends="wheels.databaseAdapters.PostgreSQL.PostgreSQLMigrator" {
 	variables.sqlTypes['text'] = {name = 'STRING'};
 	variables.sqlTypes['time'] = {name = 'TIME'};
 	variables.sqlTypes['timestamp'] = {name = 'TIMESTAMP'};
+	variables.sqlTypes['char'] = {name = 'CHAR', limit = 1};
 	variables.sqlTypes['uuid'] = {name = 'UUID'};
 
 	/**

--- a/vendor/wheels/databaseAdapters/MicrosoftSQLServer/MicrosoftSQLServerMigrator.cfc
+++ b/vendor/wheels/databaseAdapters/MicrosoftSQLServer/MicrosoftSQLServerMigrator.cfc
@@ -2,6 +2,7 @@ component extends="wheels.databaseAdapters.Abstract" {
 
 	variables.sqlTypes = {};
 	variables.sqlTypes['primaryKey'] = "int NOT NULL IDENTITY (1, 1)";
+	variables.sqlTypes['biginteger'] = {name = 'BIGINT'};
 	variables.sqlTypes['binary'] = {name = 'IMAGE'};
 	variables.sqlTypes['boolean'] = {name = 'BIT'};
 	variables.sqlTypes['date'] = {name = 'date'};
@@ -21,12 +22,12 @@ component extends="wheels.databaseAdapters.Abstract" {
 	}
 
 	public string function addForeignKeyOptions(required string sql, struct options = {}) {
-		arguments.sql = arguments.sql & " FOREIGN KEY (" & arguments.options.column & ")";
+		arguments.sql = arguments.sql & " FOREIGN KEY (" & quoteColumnName(arguments.options.column) & ")";
 		if (StructKeyExists(arguments.options, "referenceTable")) {
 			if (StructKeyExists(arguments.options, "referenceColumn")) {
 				arguments.sql = arguments.sql & " REFERENCES ";
-				arguments.sql = arguments.sql & arguments.options.referenceTable;
-				arguments.sql = arguments.sql & " (" & arguments.options.referenceColumn & ")";
+				arguments.sql = arguments.sql & quoteTableName(arguments.options.referenceTable);
+				arguments.sql = arguments.sql & " (" & quoteColumnName(arguments.options.referenceColumn) & ")";
 			}
 		}
 		return arguments.sql;
@@ -103,20 +104,16 @@ component extends="wheels.databaseAdapters.Abstract" {
 	 * generates sql to change an existing column in a table
 	 */
 	public string function changeColumnInTable(required string name, required any column) {
-		local.sql = "";
-		for (local.i in ["default", "allowNull", "afterColumn"]) {
-			if (StructKeyExists(arguments.column, local.i)) {
-				local.opts = {};
-				local.opts.type = arguments.column.type;
-				local.opts[local.i] = arguments.column[local.i];
-				local.columnSQL = addColumnOptions(sql = "", options = local.opts, alter = true);
-				if (local.i == "allowNull") {
-					local.sql = local.sql & "ALTER TABLE #quoteTableName(arguments.name)# ALTER COLUMN #objectCase(arguments.column.name)# #arguments.column.sqlType()# #local.columnSQL#;";
-				} else if (local.i == "default") {
-					// SQL server will throw an exception if a default constraint exists
-					local.sql = local.sql & "ALTER TABLE #quoteTableName(arguments.name)# ADD CONSTRAINT DF_#objectCase(arguments.column.name)# #local.columnSQL# FOR #objectCase(arguments.column.name)#;";
-				}
-			}
+		local.nullSQL = "";
+		if (StructKeyExists(arguments.column, "allowNull")) {
+			local.opts = {type = arguments.column.type, allowNull = arguments.column.allowNull};
+			local.nullSQL = addColumnOptions(sql = "", options = local.opts, alter = true);
+		}
+		local.sql = "ALTER TABLE #quoteTableName(arguments.name)# ALTER COLUMN #quoteColumnName(arguments.column.name)# #arguments.column.sqlType()# #local.nullSQL#;";
+		if (StructKeyExists(arguments.column, "default")) {
+			local.opts = {type = arguments.column.type, "default" = arguments.column["default"]};
+			local.columnSQL = addColumnOptions(sql = "", options = local.opts, alter = true);
+			local.sql = local.sql & "ALTER TABLE #quoteTableName(arguments.name)# ADD CONSTRAINT DF_#objectCase(arguments.column.name)# #local.columnSQL# FOR #quoteColumnName(arguments.column.name)#;";
 		}
 		return local.sql;
 	}

--- a/vendor/wheels/databaseAdapters/MySQL/MySQLMigrator.cfc
+++ b/vendor/wheels/databaseAdapters/MySQL/MySQLMigrator.cfc
@@ -25,12 +25,12 @@ component extends="wheels.databaseAdapters.Abstract" {
 	}
 
 	public string function addForeignKeyOptions(required string sql, struct options = {}) {
-		arguments.sql = arguments.sql & " FOREIGN KEY (" & arguments.options.column & ")";
+		arguments.sql = arguments.sql & " FOREIGN KEY (" & quoteColumnName(arguments.options.column) & ")";
 		if (StructKeyExists(arguments.options, "referenceTable")) {
 			if (StructKeyExists(arguments.options, "referenceColumn")) {
 				arguments.sql = arguments.sql & " REFERENCES ";
-				arguments.sql = arguments.sql & arguments.options.referenceTable;
-				arguments.sql = arguments.sql & " (" & arguments.options.referenceColumn & ")";
+				arguments.sql = arguments.sql & quoteTableName(arguments.options.referenceTable);
+				arguments.sql = arguments.sql & " (" & quoteColumnName(arguments.options.referenceColumn) & ")";
 			}
 		}
 		return arguments.sql;

--- a/vendor/wheels/databaseAdapters/Oracle/OracleMigrator.cfc
+++ b/vendor/wheels/databaseAdapters/Oracle/OracleMigrator.cfc
@@ -221,12 +221,12 @@ component extends="wheels.databaseAdapters.Abstract" {
         required string sql,
         struct options = {}
     ) {
-        arguments.sql &= " FOREIGN KEY (" & arguments.options.column & ")";
+        arguments.sql &= " FOREIGN KEY (" & quoteColumnName(arguments.options.column) & ")";
 
         if (StructKeyExists(arguments.options, "referenceTable")) {
             if (StructKeyExists(arguments.options, "referenceColumn")) {
-                arguments.sql &= " REFERENCES " & arguments.options.referenceTable;
-                arguments.sql &= " (" & arguments.options.referenceColumn & ")";
+                arguments.sql &= " REFERENCES " & quoteTableName(arguments.options.referenceTable);
+                arguments.sql &= " (" & quoteColumnName(arguments.options.referenceColumn) & ")";
             }
         }
 

--- a/vendor/wheels/databaseAdapters/PostgreSQL/PostgreSQLMigrator.cfc
+++ b/vendor/wheels/databaseAdapters/PostgreSQL/PostgreSQLMigrator.cfc
@@ -1,7 +1,9 @@
 component extends="wheels.databaseAdapters.Abstract" {
 
 	variables.sqlTypes = {};
+	variables.sqlTypes['biginteger'] = {name = 'BIGINT'};
 	variables.sqlTypes['binary'] = {name = 'BYTEA'};
+	variables.sqlTypes['char'] = {name = 'CHAR', limit = 1};
 	variables.sqlTypes['boolean'] = {name = 'BOOLEAN'};
 	variables.sqlTypes['date'] = {name = 'DATE'};
 	variables.sqlTypes['datetime'] = {name = 'TIMESTAMP'};
@@ -27,12 +29,12 @@ component extends="wheels.databaseAdapters.Abstract" {
 	 * or scaffold `--belongsTo=` on PostgreSQL throws at migrate time. See #2876.
 	 */
 	public string function addForeignKeyOptions(required string sql, struct options = {}) {
-		arguments.sql = arguments.sql & " FOREIGN KEY (" & arguments.options.column & ")";
+		arguments.sql = arguments.sql & " FOREIGN KEY (" & quoteColumnName(arguments.options.column) & ")";
 		if (StructKeyExists(arguments.options, "referenceTable")) {
 			if (StructKeyExists(arguments.options, "referenceColumn")) {
 				arguments.sql = arguments.sql & " REFERENCES ";
-				arguments.sql = arguments.sql & arguments.options.referenceTable;
-				arguments.sql = arguments.sql & " (" & arguments.options.referenceColumn & ")";
+				arguments.sql = arguments.sql & quoteTableName(arguments.options.referenceTable);
+				arguments.sql = arguments.sql & " (" & quoteColumnName(arguments.options.referenceColumn) & ")";
 			}
 		}
 		return arguments.sql;
@@ -126,20 +128,18 @@ component extends="wheels.databaseAdapters.Abstract" {
 	 * Rails adaptor appears to be applying default/nulls in separate queries
 	 */
 	public string function changeColumnInTable(required string name, required any column) {
+		local.sql = "ALTER TABLE #quoteTableName(objectCase(arguments.name))# ALTER COLUMN #quoteColumnName(arguments.column.name)# TYPE #arguments.column.sqlType()#";
 		for (local.i in ["default", "allowNull", "afterColumn"]) {
 			if (StructKeyExists(arguments.column, local.i)) {
 				local.opts = {};
 				local.opts.type = arguments.column.type;
 				local.opts[local.i] = arguments.column[local.i];
 				local.columnSQL = addColumnOptions(
-					sql = " ALTER COLUMN #arguments.column.name#",
+					sql = " ALTER COLUMN #quoteColumnName(arguments.column.name)#",
 					options = local.opts,
 					alter = true
 				);
-				if (!StructKeyExists(local, "sql")) {
-					local.sql = "ALTER TABLE #quoteTableName(objectCase(arguments.name))# ALTER COLUMN #objectCase(arguments.column.name)# TYPE #arguments.column.sqlType()#";
-				}
-				if (Len(arguments.column[local.i])) {
+				if (local.i == "allowNull" || Len(ToString(arguments.column[local.i]))) {
 					local.sql = ListAppend(local.sql, local.columnSQL, ",#Chr(13)##Chr(10)#");
 				}
 			}

--- a/vendor/wheels/databaseAdapters/SQLite/SQLiteMigrator.cfc
+++ b/vendor/wheels/databaseAdapters/SQLite/SQLiteMigrator.cfc
@@ -29,9 +29,9 @@ component extends="wheels.databaseAdapters.Abstract" {
 	 * SQLite supports inline foreign key definitions
 	 */
 	public string function addForeignKeyOptions(required string sql, struct options = {}) {
-		arguments.sql &= " REFERENCES " & arguments.options.referenceTable;
+		arguments.sql &= " REFERENCES " & quoteTableName(arguments.options.referenceTable);
 		if (StructKeyExists(arguments.options, "referenceColumn")) {
-			arguments.sql &= " (" & arguments.options.referenceColumn & ")";
+			arguments.sql &= " (" & quoteColumnName(arguments.options.referenceColumn) & ")";
 		}
 		// Add ON DELETE / ON UPDATE if provided
 		if (StructKeyExists(arguments.options, "onDelete")) {

--- a/vendor/wheels/global/util.cfm
+++ b/vendor/wheels/global/util.cfm
@@ -618,6 +618,26 @@
 		return application[$appKey()].dataSourceName;
 	}
 
+	/**
+	 * Username/password the migrator should use for $dbinfo probes.
+	 * TenantMigrator may set request-scoped overrides so a tenant DS
+	 * with its own credentials does not silently reuse the app DS user.
+	 */
+	public struct function $migratorDataSourceCredentials() {
+		var creds = {username = "", password = ""};
+		if (IsDefined("request.wheels.migratorDataSourceUserName")) {
+			creds.username = ToString(request.wheels.migratorDataSourceUserName);
+			if (IsDefined("request.wheels.migratorDataSourcePassword")) {
+				creds.password = ToString(request.wheels.migratorDataSourcePassword);
+			}
+			return creds;
+		}
+		var appKey = $appKey();
+		creds.username = application[appKey].dataSourceUserName;
+		creds.password = application[appKey].dataSourcePassword;
+		return creds;
+	}
+
 
 	/**
 	 * Generates a 36-character UUID compatible with SQL Server's uniqueidentifier.

--- a/vendor/wheels/migrator/AutoMigrator.cfc
+++ b/vendor/wheels/migrator/AutoMigrator.cfc
@@ -46,12 +46,13 @@ component extends="wheels.migrator.Base" {
 		}
 
 		local.appKey = $appKey();
+		local.creds = $migratorDataSourceCredentials();
 		local.dbColumns = $dbinfo(
 			type = "columns",
 			table = local.tableName,
 			datasource = $migratorDataSource(),
-			username = application[local.appKey].dataSourceUserName,
-			password = application[local.appKey].dataSourcePassword
+			username = local.creds.username,
+			password = local.creds.password
 		);
 
 		local.actualColumns = {};
@@ -72,6 +73,13 @@ component extends="wheels.migrator.Base" {
 		local.addColumns = [];
 		local.removeColumns = [];
 		local.changeColumns = [];
+		local.unmappedColumns = [];
+		// S9: destructive unmapped→remove stays the default. Opt out with
+		// options.allowColumnRemoval=false (fail-closed listing only).
+		local.allowColumnRemoval = true;
+		if (StructKeyExists(arguments.options, "allowColumnRemoval")) {
+			local.allowColumnRemoval = arguments.options.allowColumnRemoval;
+		}
 
 		for (local.colName in local.expectedColumns) {
 			if (!StructKeyExists(local.actualColumns, local.colName)) {
@@ -92,9 +100,14 @@ component extends="wheels.migrator.Base" {
 				if (IsBoolean(local.actual.isPrimaryKey) && local.actual.isPrimaryKey) {
 					continue;
 				}
-				ArrayAppend(local.removeColumns, {
-					name: local.colName
-				});
+				local.unmapped = {
+					name: local.colName,
+					type: $dbTypeToMigrationType(local.actual.typeName)
+				};
+				ArrayAppend(local.unmappedColumns, local.unmapped);
+				if (local.allowColumnRemoval) {
+					ArrayAppend(local.removeColumns, local.unmapped);
+				}
 			}
 		}
 
@@ -110,11 +123,37 @@ component extends="wheels.migrator.Base" {
 				local.expectedMigType = $cfSqlTypeToMigrationType(local.expected.type);
 				local.actualMigType = $dbTypeToMigrationType(local.actual.typeName);
 
-				if (local.expectedMigType != local.actualMigType && local.actualMigType != "unknown") {
+				local.typeChanged = (local.expectedMigType != local.actualMigType && local.actualMigType != "unknown");
+				local.sizeChanged = (
+					Len(ToString(local.expected.size))
+					&& IsNumeric(local.expected.size)
+					&& Val(local.expected.size) != Val(local.actual.size)
+				);
+				local.scaleChanged = (
+					Len(ToString(local.expected.scale))
+					&& IsNumeric(local.expected.scale)
+					&& Val(local.expected.scale) != Val(local.actual.decimalDigits)
+				);
+				local.nullChanged = (
+					IsBoolean(local.expected.nullable)
+					&& IsBoolean(local.actual.nullable)
+					&& local.expected.nullable != local.actual.nullable
+				);
+				if (local.typeChanged || local.sizeChanged || local.scaleChanged || local.nullChanged) {
 					ArrayAppend(local.changeColumns, {
 						name: local.colName,
-						from: {type: local.actualMigType},
-						to: {type: local.expectedMigType}
+						from: {
+							type: local.actualMigType,
+							size: local.actual.size,
+							scale: local.actual.decimalDigits,
+							nullable: local.actual.nullable
+						},
+						to: {
+							type: local.expectedMigType,
+							size: local.expected.size,
+							scale: local.expected.scale,
+							nullable: local.expected.nullable
+						}
 					});
 				}
 			}
@@ -159,7 +198,8 @@ component extends="wheels.migrator.Base" {
 			removeColumns: local.detection.remainingRemoves,
 			changeColumns: local.changeColumns,
 			renameColumns: local.detection.confirmedRenames,
-			suggestedRenames: local.detection.suggestedRenames
+			suggestedRenames: local.detection.suggestedRenames,
+			unmappedColumns: local.unmappedColumns
 		};
 	}
 
@@ -201,6 +241,9 @@ component extends="wheels.migrator.Base" {
 
 					// Build this model's options: {renames, heuristicThreshold}
 					local.modelOptions = {heuristicThreshold: local.threshold};
+					if (StructKeyExists(arguments.options, "allowColumnRemoval")) {
+						local.modelOptions.allowColumnRemoval = arguments.options.allowColumnRemoval;
+					}
 					if (StructKeyExists(local.perModelHints, local.modelName)
 						&& StructKeyExists(local.perModelHints[local.modelName], "renames")) {
 						local.modelOptions.renames = local.perModelHints[local.modelName].renames;
@@ -251,6 +294,8 @@ component extends="wheels.migrator.Base" {
 		local.tab = Chr(9);
 		local.upBody = "";
 		local.downBody = "";
+		local.tableName = $escapeCfcIdentifier(arguments.diffResult.tableName);
+		local.safeHint = $escapeCfcHint(arguments.migrationName);
 
 		// Emit renameColumns first in up(); reversed renames go last in down().
 		// Honor suggestedRenames as renames too — leaving them as remaining
@@ -276,9 +321,9 @@ component extends="wheels.migrator.Base" {
 		for (local.i = 1; local.i <= local.iEnd; local.i++) {
 			local.r = local.renameColumns[local.i];
 			local.upBody &= local.tab & local.tab
-				& 'renameColumn(table="' & arguments.diffResult.tableName
-				& '", columnName="' & local.r.from
-				& '", newColumnName="' & local.r.to & '");' & local.nl;
+				& 'renameColumn(table="' & local.tableName
+				& '", columnName="' & $escapeCfcIdentifier(local.r.from)
+				& '", newColumnName="' & $escapeCfcIdentifier(local.r.to) & '");' & local.nl;
 		}
 
 		local.iEnd = ArrayLen(arguments.diffResult.addColumns);
@@ -288,14 +333,14 @@ component extends="wheels.migrator.Base" {
 				continue;
 			}
 			local.upBody &= local.tab & local.tab
-				& 'addColumn(table="' & arguments.diffResult.tableName
-				& '", columnType="' & local.col.type
-				& '", columnName="' & local.col.name & '"'
+				& 'addColumn(table="' & local.tableName
+				& '", columnType="' & $escapeCfcIdentifier(local.col.type)
+				& '", columnName="' & $escapeCfcIdentifier(local.col.name) & '"'
 				& ', allowNull=' & (IsBoolean(local.col.nullable) && local.col.nullable ? "true" : "false")
 				& ');' & local.nl;
 			local.downBody &= local.tab & local.tab
-				& 'removeColumn(table="' & arguments.diffResult.tableName
-				& '", columnName="' & local.col.name & '");' & local.nl;
+				& 'removeColumn(table="' & local.tableName
+				& '", columnName="' & $escapeCfcIdentifier(local.col.name) & '");' & local.nl;
 		}
 
 		local.iEnd = ArrayLen(arguments.diffResult.removeColumns);
@@ -305,32 +350,51 @@ component extends="wheels.migrator.Base" {
 				continue;
 			}
 			local.upBody &= local.tab & local.tab
-				& 'removeColumn(table="' & arguments.diffResult.tableName
-				& '", columnName="' & local.col.name & '");' & local.nl;
-			local.downBody &= local.tab & local.tab
-				& '// TODO: restore column "' & local.col.name & '" — original type unknown' & local.nl;
+				& 'removeColumn(table="' & local.tableName
+				& '", columnName="' & $escapeCfcIdentifier(local.col.name) & '");' & local.nl;
+			if (StructKeyExists(local.col, "type") && Len(local.col.type) && local.col.type != "unknown") {
+				local.downBody &= local.tab & local.tab
+					& 'addColumn(table="' & local.tableName
+					& '", columnType="' & $escapeCfcIdentifier(local.col.type)
+					& '", columnName="' & $escapeCfcIdentifier(local.col.name) & '");' & local.nl;
+			} else {
+				local.downBody &= local.tab & local.tab
+					& '// TODO: restore column "' & $escapeCfcIdentifier(local.col.name) & '" — original type unknown' & local.nl;
+			}
 		}
 
 		local.iEnd = ArrayLen(arguments.diffResult.changeColumns);
 		for (local.i = 1; local.i <= local.iEnd; local.i++) {
 			local.col = arguments.diffResult.changeColumns[local.i];
-			local.upBody &= local.tab & local.tab
-				& 'changeColumn(table="' & arguments.diffResult.tableName
-				& '", columnName="' & local.col.name
-				& '", columnType="' & local.col.to.type & '");' & local.nl;
-			local.downBody &= local.tab & local.tab
-				& 'changeColumn(table="' & arguments.diffResult.tableName
-				& '", columnName="' & local.col.name
-				& '", columnType="' & local.col.from.type & '");' & local.nl;
+			local.upArgs = 'changeColumn(table="' & local.tableName
+				& '", columnName="' & $escapeCfcIdentifier(local.col.name)
+				& '", columnType="' & $escapeCfcIdentifier(local.col.to.type) & '"';
+			if (StructKeyExists(local.col.to, "size") && Len(ToString(local.col.to.size)) && IsNumeric(local.col.to.size)) {
+				local.upArgs &= ', limit=' & Val(local.col.to.size);
+			}
+			if (StructKeyExists(local.col.to, "nullable") && IsBoolean(local.col.to.nullable)) {
+				local.upArgs &= ', allowNull=' & (local.col.to.nullable ? "true" : "false");
+			}
+			local.upBody &= local.tab & local.tab & local.upArgs & ');' & local.nl;
+			local.downArgs = 'changeColumn(table="' & local.tableName
+				& '", columnName="' & $escapeCfcIdentifier(local.col.name)
+				& '", columnType="' & $escapeCfcIdentifier(local.col.from.type) & '"';
+			if (StructKeyExists(local.col.from, "size") && Len(ToString(local.col.from.size)) && IsNumeric(local.col.from.size)) {
+				local.downArgs &= ', limit=' & Val(local.col.from.size);
+			}
+			if (StructKeyExists(local.col.from, "nullable") && IsBoolean(local.col.from.nullable)) {
+				local.downArgs &= ', allowNull=' & (local.col.from.nullable ? "true" : "false");
+			}
+			local.downBody &= local.tab & local.tab & local.downArgs & ');' & local.nl;
 		}
 
 		// Append reversed renames to down() (after other reversals)
 		for (local.i = 1; local.i <= ArrayLen(local.renameColumns); local.i++) {
 			local.r = local.renameColumns[local.i];
 			local.downBody &= local.tab & local.tab
-				& 'renameColumn(table="' & arguments.diffResult.tableName
-				& '", columnName="' & local.r.to
-				& '", newColumnName="' & local.r.from & '");' & local.nl;
+				& 'renameColumn(table="' & local.tableName
+				& '", columnName="' & $escapeCfcIdentifier(local.r.to)
+				& '", newColumnName="' & $escapeCfcIdentifier(local.r.from) & '");' & local.nl;
 		}
 
 		if (!Len(Trim(local.upBody))) {
@@ -340,7 +404,7 @@ component extends="wheels.migrator.Base" {
 			local.downBody = local.tab & local.tab & '// No changes to reverse' & local.nl;
 		}
 
-		local.content = 'component extends="wheels.migrator.Migration" hint="' & arguments.migrationName & '" {' & local.nl;
+		local.content = 'component extends="wheels.migrator.Migration" hint="' & local.safeHint & '" {' & local.nl;
 		local.content &= local.nl;
 		local.content &= local.tab & 'public void function up() {' & local.nl;
 		local.content &= local.upBody;
@@ -391,6 +455,31 @@ component extends="wheels.migrator.Base" {
 	 * Sanitizes a string for use as a filename component.
 	 * Lowercases, collapses non-alphanumeric chars to underscores, and trims edge underscores.
 	 */
+	/**
+	 * Fail-closed identifier for generated CFC source. Rejects quotes,
+	 * hashes, and other CFML/SQL metacharacters so a table/column name
+	 * cannot close a string and inject tags.
+	 */
+	public string function $escapeCfcIdentifier(required string name) {
+		if (!ReFindNoCase("^[A-Za-z_][A-Za-z0-9_]*$", arguments.name)) {
+			Throw(
+				type = "Wheels.Migrator.InvalidIdentifier",
+				message = "Unsafe identifier for generated migration CFC: `#arguments.name#`. Use letters, digits, and underscore only."
+			);
+		}
+		return arguments.name;
+	}
+
+	/**
+	 * Hint attributes are quoted strings. Strip `"` and escape `#` so a
+	 * migration name cannot break out of the generated component tag.
+	 */
+	public string function $escapeCfcHint(required string name) {
+		local.safe = Replace(arguments.name, '"', "", "all");
+		local.safe = Replace(local.safe, "##", "####", "all");
+		return local.safe;
+	}
+
 	public string function $sanitizeFileName(required string name) {
 		local.safe = LCase(arguments.name);
 		local.safe = ReReplace(local.safe, "[^a-z0-9_]+", "_", "all");

--- a/vendor/wheels/migrator/Base.cfc
+++ b/vendor/wheels/migrator/Base.cfc
@@ -29,11 +29,12 @@ component extends="wheels.Global"{
 			return application[local.appKey].$migratorAdapterNames[local.dsName];
 		}
 
+		local.creds = $migratorDataSourceCredentials();
 		local.info = $dbinfo(
 			type = "version",
 			datasource = local.dsName,
-			username = application[local.appKey].dataSourceUserName,
-			password = application[local.appKey].dataSourcePassword
+			username = local.creds.username,
+			password = local.creds.password
 		);
 		local.adapterName = "";
 		if (
@@ -129,16 +130,35 @@ component extends="wheels.Global"{
 			local.state.tableExists = false;
 		}
 		if (local.state.tableExists) {
+			local.creds = $migratorDataSourceCredentials();
 			local.foreignKeys = $dbinfo(
 				type = "foreignkeys",
 				table = arguments.table,
 				datasource = $migratorDataSource(),
-				username = application[local.appKey].dataSourceUserName,
-				password = application[local.appKey].dataSourcePassword
+				username = local.creds.username,
+				password = local.creds.password
 			);
-			local.foreignKeyList = ValueList(local.foreignKeys.FKCOLUMN_NAME);
+			// S2: FKCOLUMN_NAME is the local column, not the constraint name.
+			// Adobe dropTable() fed that list to dropForeignKey(keyname=).
+			local.foreignKeyList = $foreignKeyConstraintNames(local.foreignKeys);
 		}
 		return local.foreignKeyList;
+	}
+
+	/**
+	 * Constraint names from a cfdbinfo(type="foreignkeys") query.
+	 * Prefers FK_NAME. Never falls back to FKCOLUMN_NAME — that is the
+	 * referencing column, and using it as a constraint name breaks DROP
+	 * on Adobe / non-SQLite.
+	 */
+	public string function $foreignKeyConstraintNames(required query foreignKeys) {
+		if (
+			IsQuery(arguments.foreignKeys)
+			&& ListFindNoCase(arguments.foreignKeys.columnList, "FK_NAME")
+		) {
+			return ValueList(arguments.foreignKeys.FK_NAME);
+		}
+		return "";
 	}
 
 	private void function $execute(required any sql, string dataSource = "") {
@@ -228,10 +248,11 @@ component extends="wheels.Global"{
 		) {
 			return request.$wheelsMigratorColumns[local.cacheKey];
 		}
+		local.creds = $migratorDataSourceCredentials();
 		local.columns = $dbinfo(
 			datasource = $migratorDataSource(),
-			username = application[local.appKey].dataSourceUserName,
-			password = application[local.appKey].dataSourcePassword,
+			username = local.creds.username,
+			password = local.creds.password,
 			type = "columns",
 			table = arguments.tableName
 		);
@@ -283,10 +304,11 @@ component extends="wheels.Global"{
 
 	private string function $getColumnDefinition(required string tableName, required string columnName) {
 		local.appKey = $appKey();
+		local.creds = $migratorDataSourceCredentials();
 		local.columns = $dbinfo(
 			datasource = $migratorDataSource(),
-			username = application[local.appKey].dataSourceUserName,
-			password = application[local.appKey].dataSourcePassword,
+			username = local.creds.username,
+			password = local.creds.password,
 			type = "columns",
 			table = arguments.tableName
 		);

--- a/vendor/wheels/migrator/CLAUDE.md
+++ b/vendor/wheels/migrator/CLAUDE.md
@@ -75,9 +75,11 @@ Default foreign-key names are `FK_<table>_<refTable>_<column>` so two FKs from t
 
 CREATE TABLE inlines FKs via `toForeignKeySQL()`, which preserves `onUpdate` / `onDelete` (same mapping as `Abstract.foreignKeySQL`). ALTER ADD uses `toSQL()`.
 
-`TenantMigrator` isolates the tenant datasource on `request.wheels.migratorDataSource` (read by `$migratorDataSource()`). It must not swap `application.wheels.dataSourceName`.
+`TenantMigrator` isolates the tenant datasource on `request.wheels.migratorDataSource` (read by `$migratorDataSource()`). It must not swap `application.wheels.dataSourceName`. Optional per-tenant `userName` / `password` land on `request.wheels.migratorDataSourceUserName` / `migratorDataSourcePassword` (`$migratorDataSourceCredentials()`).
 
-Announce-only `up()`/`down()` do not write the version table. `announce()` plus ORM persist (`model().create()` / `save()` / `delete()` with no `$execute`) still marks or unmarks the version. `redoMigration()` fails closed when `allowMigrationDown` is false — do not flip that default to `true`.
+Announce-only `up()`/`down()` do not write the version table. `announce()` plus ORM persist (`model().create()` / `save()` / `delete()` with no `$execute`) still marks or unmarks the version. `redoMigration()` and `migrateTo` down fail closed when `allowMigrationDown` is false — do not flip that default to `true`.
+
+`updateRecord()` / `removeRecord()` require a `where` clause or explicit `all=true`. AutoMigrator unmapped columns still become `removeColumns` by default; pass `allowColumnRemoval=false` to list them on `unmappedColumns` only. `t.references(referenceColumn=)` defaults to `"id"`. `t.timestamp()` defaults to `columnType="datetime"`. `t.float()` keeps `default=""` / `allowNull=true`.
 
 ## Tests
 

--- a/vendor/wheels/migrator/ForeignKeyDefinition.cfc
+++ b/vendor/wheels/migrator/ForeignKeyDefinition.cfc
@@ -50,7 +50,7 @@ component extends="Base" {
 	}
 
 	public string function toForeignKeySQL() {
-		local.sql = "CONSTRAINT " & this.name;
+		local.sql = "CONSTRAINT " & this.adapter.quoteTableName(this.name);
 		local.sql = addForeignKeyOptions(local.sql);
 		return local.sql;
 	}

--- a/vendor/wheels/migrator/Migration.cfc
+++ b/vendor/wheels/migrator/Migration.cfc
@@ -543,9 +543,16 @@ component extends="Base" {
 	 * [category: Migration Functions]
 	 *
 	 * @table The table name where the record is
-	 * @where The where clause, i.e admin = 1
+	 * @where The where clause, i.e admin = 1. Raw SQL — callers must supply a predicate or all=true.
+	 * @all When true, an empty where updates every row. Default false (fail-closed).
 	 */
-	public void function updateRecord(required string table, string where = "") {
+	public void function updateRecord(required string table, string where = "", boolean all = false) {
+		if (!Len(Trim(arguments.where)) && !arguments.all) {
+			Throw(
+				type = "Wheels.Migrator.MissingWhere",
+				message = "updateRecord() requires a where clause or all=true. An empty where would update every row."
+			);
+		}
 		local.appKey = $appKey();
 		local.setClauses = "";
 		local.params = [];
@@ -556,7 +563,7 @@ component extends="Base" {
 			arguments[application[local.appKey].timeStampOnUpdateProperty] = $timestamp();
 		}
 		for (local.key in arguments) {
-			if (local.key neq "table" && local.key neq "where") {
+			if (local.key neq "table" && local.key neq "where" && local.key neq "all") {
 				local.setClauses = ListAppend(local.setClauses, "#this.adapter.quoteColumnName(local.key)# = ?");
 				local.value = arguments[local.key];
 				// Strip wrapping single quotes if present (legacy convention)
@@ -594,9 +601,16 @@ component extends="Base" {
 	 * [category: Migration Functions]
 	 *
 	 * @table The table name to remove the record from
-	 * @where The where clause, i.e id = 123
+	 * @where The where clause, i.e id = 123. Raw SQL — callers must supply a predicate or all=true.
+	 * @all When true, an empty where deletes every row. Default false (fail-closed).
 	 */
-	public void function removeRecord(required string table, string where = "") {
+	public void function removeRecord(required string table, string where = "", boolean all = false) {
+		if (!Len(Trim(arguments.where)) && !arguments.all) {
+			Throw(
+				type = "Wheels.Migrator.MissingWhere",
+				message = "removeRecord() requires a where clause or all=true. An empty where would delete every row."
+			);
+		}
 		local.sql = 'DELETE FROM #this.adapter.quoteTableName(arguments.table)#';
 		local.message = 'Removed record(s) from table #arguments.table#';
 		if (arguments.where != '') {

--- a/vendor/wheels/migrator/TableDefinition.cfc
+++ b/vendor/wheels/migrator/TableDefinition.cfc
@@ -51,6 +51,7 @@ component extends="Base" {
 		numeric precision,
 		numeric scale,
 		string references,
+		string referenceColumn = "id",
 		string onUpdate = "",
 		string onDelete = ""
 	) {
@@ -78,7 +79,7 @@ component extends="Base" {
 				table = this.name,
 				referenceTable = local.referenceTable,
 				column = arguments.name,
-				referenceColumn = "id",
+				referenceColumn = arguments.referenceColumn,
 				onUpdate = arguments.onUpdate,
 				onDelete = arguments.onDelete
 			);
@@ -334,6 +335,7 @@ component extends="Base" {
 	 * @foreignKey If true (default), registers a foreign key on the generated column. Ignored when `polymorphic=true`.
 	 * @onUpdate Foreign-key ON UPDATE clause. Engine-specific values; common: `"cascade"`, `"null"`, `"none"`.
 	 * @onDelete Foreign-key ON DELETE clause. Same value set as `onUpdate`.
+	 * @referenceColumn Referenced PK column. Default remains `"id"` (public API — do not flip).
 	 */
 	public any function references(
 		string referenceNames,
@@ -343,7 +345,8 @@ component extends="Base" {
 		boolean polymorphic = "false",
 		boolean foreignKey = "true",
 		string onUpdate = "",
-		string onDelete = ""
+		string onDelete = "",
+		string referenceColumn = "id"
 	) {
 		$combineArguments(args = arguments, combine = "referenceNames,columnNames", required = true);
 		local.idSuffix = $get("useUnderscoreReferenceColumns") ? "_id" : "id";
@@ -372,7 +375,7 @@ component extends="Base" {
 					table = this.name,
 					referenceTable = local.referenceTable,
 					column = "#local.referenceName##local.idSuffix#",
-					referenceColumn = "id",
+					referenceColumn = arguments.referenceColumn,
 					onUpdate = arguments.onUpdate,
 					onDelete = arguments.onDelete
 				);

--- a/vendor/wheels/migrator/TenantMigrator.cfc
+++ b/vendor/wheels/migrator/TenantMigrator.cfc
@@ -111,7 +111,9 @@ component {
 						action = arguments.action,
 						dataSource = local.tenant.dataSource,
 						migratePath = arguments.migratePath,
-						sqlPath = arguments.sqlPath
+						sqlPath = arguments.sqlPath,
+						userName = StructKeyExists(local.tenant, "userName") ? local.tenant.userName : "",
+						password = StructKeyExists(local.tenant, "password") ? local.tenant.password : ""
 					);
 
 					ArrayAppend(local.results.success, {
@@ -152,7 +154,9 @@ component {
 		required string action,
 		required string dataSource,
 		required string migratePath,
-		required string sqlPath
+		required string sqlPath,
+		string userName = "",
+		string password = ""
 	) {
 		if (!Len(Trim(arguments.dataSource))) {
 			Throw(
@@ -169,6 +173,17 @@ component {
 			local.priorOverride = request.wheels.migratorDataSource;
 		}
 		request.wheels.migratorDataSource = arguments.dataSource;
+		local.hadUser = StructKeyExists(request.wheels, "migratorDataSourceUserName");
+		if (local.hadUser) {
+			local.priorUser = request.wheels.migratorDataSourceUserName;
+			local.priorPassword = StructKeyExists(request.wheels, "migratorDataSourcePassword")
+				? request.wheels.migratorDataSourcePassword
+				: "";
+		}
+		if (Len(Trim(arguments.userName))) {
+			request.wheels.migratorDataSourceUserName = arguments.userName;
+			request.wheels.migratorDataSourcePassword = arguments.password;
+		}
 
 		try {
 			lock name="wheels_tenant_migrator_#arguments.dataSource#" type="exclusive" timeout="300" {
@@ -180,6 +195,13 @@ component {
 				request.wheels.migratorDataSource = local.priorOverride;
 			} else {
 				StructDelete(request.wheels, "migratorDataSource");
+			}
+			if (local.hadUser) {
+				request.wheels.migratorDataSourceUserName = local.priorUser;
+				request.wheels.migratorDataSourcePassword = local.priorPassword;
+			} else {
+				StructDelete(request.wheels, "migratorDataSourceUserName");
+				StructDelete(request.wheels, "migratorDataSourcePassword");
 			}
 		}
 	}

--- a/vendor/wheels/migrator/templates/create-record.cfc
+++ b/vendor/wheels/migrator/templates/create-record.cfc
@@ -33,7 +33,7 @@ component extends="[extends]" hint="[description]" {
 		var state = {};
 		transaction {
 			try {
-				removeRecord(table = 'tableName', where = '');
+				removeRecord(table = 'tableName', where = 'id = 1');
 			} catch (any e) {
 				state.exception = e;
 			}

--- a/vendor/wheels/migrator/templates/remove-record.cfc
+++ b/vendor/wheels/migrator/templates/remove-record.cfc
@@ -15,7 +15,7 @@ component extends="[extends]" hint="[description]" {
 		var state = {};
 		transaction {
 			try {
-				removeRecord(table = 'tableName', where = '');
+				removeRecord(table = 'tableName', where = 'id = 1');
 			} catch (any e) {
 				state.exception = e;
 			}

--- a/vendor/wheels/migrator/templates/update-record.cfc
+++ b/vendor/wheels/migrator/templates/update-record.cfc
@@ -16,7 +16,7 @@ component extends="[extends]" hint="[description]" {
 		var state = {};
 		transaction {
 			try {
-				updateRecord(table = 'tableName', where = '');
+				updateRecord(table = 'tableName', where = 'id = 1');
 			} catch (any e) {
 				state.exception = e;
 			}
@@ -34,7 +34,7 @@ component extends="[extends]" hint="[description]" {
 		var state = {};
 		transaction {
 			try {
-				updateRecord(table = 'tableName', where = '');
+				updateRecord(table = 'tableName', where = 'id = 1');
 			} catch (any e) {
 				state.exception = e;
 			}

--- a/vendor/wheels/tests/_assets/migrator/SpyTenantMigrator.cfc
+++ b/vendor/wheels/tests/_assets/migrator/SpyTenantMigrator.cfc
@@ -14,6 +14,11 @@ component extends="wheels.migrator.TenantMigrator" {
 		} else {
 			request.hardenerTenantMigratorOverrideDs = "";
 		}
+		if (IsDefined("request.wheels.migratorDataSourceUserName")) {
+			request.hardenerTenantMigratorOverrideUser = request.wheels.migratorDataSourceUserName;
+		} else {
+			request.hardenerTenantMigratorOverrideUser = "";
+		}
 		return super.$executeAction(argumentCollection = arguments);
 	}
 

--- a/vendor/wheels/tests/_assets/migrator/loaderror/90000000000004_broken_init.cfc
+++ b/vendor/wheels/tests/_assets/migrator/loaderror/90000000000004_broken_init.cfc
@@ -1,0 +1,15 @@
+component extends="wheels.migrator.Migration" hint="intentional load failure for S5" {
+
+	public any function init() {
+		Throw(type = "Wheels.HardenerLoadError", message = "intentional load failure for S5");
+	}
+
+	public void function up() {
+		announce("must not run after loadError");
+	}
+
+	public void function down() {
+		announce("must not run after loadError");
+	}
+
+}

--- a/vendor/wheels/tests/specs/hardener/MigratorHardenerShouldSpec.cfc
+++ b/vendor/wheels/tests/specs/hardener/MigratorHardenerShouldSpec.cfc
@@ -1,0 +1,547 @@
+/**
+ * Hardener SHOULDs S1–S20 (migrator / schema).
+ *
+ * Directory-scoped so `wheels test --core --ci --filter=hardener`
+ * discovers this folder (a single-file directory= scope finds 0 bundles).
+ *
+ * Escalations (no silent public default/API flips): S9, S15, S16, S17, S20.
+ * allowMigrationDown default stays false.
+ */
+component extends="wheels.WheelsTest" {
+
+	include "../migrator/helperFunctions.cfm";
+
+	function beforeAll() {
+		variables.g = application.wo;
+		variables.migration = CreateObject("component", "wheels.migrator.Migration").init();
+		variables.sqlMigrator = CreateObject("component", "wheels.Migrator").init(
+			migratePath = "/wheels/tests/_assets/migrator/migrations/",
+			sqlPath = "/wheels/tests/_assets/migrator/sql/"
+		);
+		variables.loadErrorMigrator = CreateObject("component", "wheels.Migrator").init(
+			migratePath = "/wheels/tests/_assets/migrator/loaderror/",
+			sqlPath = "/wheels/tests/_assets/migrator/sql_hardener_loaderror/"
+		);
+		variables.autoMigrator = CreateObject("component", "wheels.migrator.AutoMigrator");
+		variables.isCockroachDB = variables.migration.adapter.adapterName() == "CockroachDB";
+	}
+
+	function run() {
+
+		describe("S1 migrateTo down does not look successful when allowMigrationDown is false", () => {
+
+			beforeEach(() => {
+				deleteMigratorVersions(2);
+				try {
+					variables.migration.dropTable("c_o_r_e_bunyips");
+				} catch (any e) {}
+			});
+
+			afterEach(() => {
+				deleteMigratorVersions(2);
+				try {
+					variables.migration.dropTable("c_o_r_e_bunyips");
+				} catch (any e) {}
+			});
+
+			it("refuses down with an explicit allowMigrationDown message instead of a no-op success banner", () => {
+				if (variables.isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
+				var priorDown = application.wheels.allowMigrationDown;
+				application.wheels.allowMigrationDown = true;
+				try {
+					variables.sqlMigrator.migrateTo("001");
+				} finally {
+					application.wheels.allowMigrationDown = priorDown;
+				}
+				application.wheels.allowMigrationDown = false;
+				try {
+					var output = variables.sqlMigrator.migrateTo("0");
+					expect(output).toInclude("allowMigrationDown");
+					expect(FindNoCase("Migrating from", output)).toBe(
+						0,
+						"Blocked down must not print the successful Migrating-from-X-down banner."
+					);
+					var rows = queryExecute(
+						"SELECT version FROM #application.wheels.migratorTableName# WHERE version = '001'",
+						{},
+						{datasource: application.wheels.dataSourceName}
+					);
+					expect(rows.recordCount).toBe(1, "Blocked down must leave the version row in place.");
+				} finally {
+					application.wheels.allowMigrationDown = priorDown;
+				}
+			});
+
+			it("does not flip the allowMigrationDown framework default", () => {
+				var src = FileRead(ExpandPath("/wheels/events/onapplicationstart.cfc"));
+				expect(src).toInclude("application.$wheels.allowMigrationDown = false");
+			});
+
+		});
+
+		describe("S2 $getForeignKeys uses FK_NAME not FKCOLUMN_NAME", () => {
+
+			it("reads constraint names from FK_NAME", () => {
+				var q = QueryNew("FK_NAME,FKCOLUMN_NAME", "varchar,varchar");
+				QueryAddRow(q);
+				QuerySetCell(q, "FK_NAME", "FK_posts_users_userid", 1);
+				QuerySetCell(q, "FKCOLUMN_NAME", "userid", 1);
+				expect(variables.migration.$foreignKeyConstraintNames(q)).toBe("FK_posts_users_userid");
+			});
+
+			it("does not fall back to FKCOLUMN_NAME when FK_NAME is absent", () => {
+				var q = QueryNew("FKCOLUMN_NAME", "varchar");
+				QueryAddRow(q);
+				QuerySetCell(q, "FKCOLUMN_NAME", "userid", 1);
+				expect(variables.migration.$foreignKeyConstraintNames(q)).toBe("");
+			});
+
+		});
+
+		describe("S3 versions table uniqueness is not JVM-lock-only", () => {
+
+			it("creates the versions table with a PRIMARY KEY on version", () => {
+				var src = FileRead(ExpandPath("/wheels/Migrator.cfc"));
+				expect(src).toInclude("version VARCHAR(25) PRIMARY KEY");
+				expect(src).toInclude("version VARCHAR2(25) PRIMARY KEY");
+			});
+
+			it("attempts a unique index on existing version tables", () => {
+				var src = FileRead(ExpandPath("/wheels/Migrator.cfc"));
+				expect(src).toInclude("$ensureVersionUniqueness");
+				expect(src).toInclude("_version_uidx");
+			});
+
+		});
+
+		describe("S4 updateRecord/removeRecord empty where is fail-closed", () => {
+
+			it("throws when updateRecord is called with an empty where", () => {
+				expect(() => {
+					variables.migration.updateRecord(table = "c_o_r_e_tags", status = "x");
+				}).toThrow("Wheels.Migrator.MissingWhere");
+			});
+
+			it("throws when removeRecord is called with an empty where", () => {
+				expect(() => {
+					variables.migration.removeRecord(table = "c_o_r_e_tags");
+				}).toThrow("Wheels.Migrator.MissingWhere");
+			});
+
+			it("allows an explicit all=true wipe", () => {
+				if (variables.isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
+				var tableName = "dbm_hardener_s4_all";
+				try {
+					variables.migration.dropTable(tableName);
+				} catch (any e) {}
+				var t = variables.migration.createTable(name = tableName, force = true);
+				t.string(columnNames = "label", allowNull = true);
+				t.create();
+				variables.migration.addRecord(table = tableName, label = "a");
+				variables.migration.addRecord(table = tableName, label = "b");
+				variables.migration.removeRecord(table = tableName, all = true);
+				var rows = queryExecute(
+					"SELECT * FROM #tableName#",
+					{},
+					{datasource: application.wheels.dataSourceName}
+				);
+				try {
+					variables.migration.dropTable(tableName);
+				} catch (any e2) {}
+				expect(rows.recordCount).toBe(0);
+			});
+
+		});
+
+		describe("S5 loadError is checked before up/down", () => {
+
+			it("does not invoke up() on a migration that failed to load", () => {
+				if (variables.isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
+				var output = variables.loadErrorMigrator.migrateTo("90000000000004");
+				expect(output).toInclude("failed to load");
+				expect(output).toInclude("intentional load failure for S5");
+				expect(FindNoCase("must not run after loadError", output)).toBe(0);
+			});
+
+		});
+
+		describe("S6 per-migration txn warns when DDL auto-commits", () => {
+
+			it("flags MySQL and Oracle as DDL auto-commit engines", () => {
+				var prior = application.wheels.$migratorDbType ?: "";
+				var had = StructKeyExists(application.wheels, "$migratorDbType");
+				try {
+					application.wheels.$migratorDbType = "MySQL";
+					expect(variables.sqlMigrator.$ddlAutoCommits()).toBeTrue();
+					application.wheels.$migratorDbType = "Oracle";
+					expect(variables.sqlMigrator.$ddlAutoCommits()).toBeTrue();
+					application.wheels.$migratorDbType = "SQLite";
+					expect(variables.sqlMigrator.$ddlAutoCommits()).toBeFalse();
+				} finally {
+					if (had) {
+						application.wheels.$migratorDbType = prior;
+					} else {
+						StructDelete(application.wheels, "$migratorDbType");
+					}
+				}
+			});
+
+			it("documents that full DDL rollback is not implemented on those engines", () => {
+				var src = FileRead(ExpandPath("/wheels/Migrator.cfc"));
+				expect(src).toInclude("this database auto-commits DDL");
+			});
+
+		});
+
+		describe("S7 Cockroach early return without skip is rejected", () => {
+
+			it("does not use a bare Cockroach return in hardener or migrator specs", () => {
+				var roots = [
+					ExpandPath("/wheels/tests/specs/hardener"),
+					ExpandPath("/wheels/tests/specs/migrator")
+				];
+				var offenders = [];
+				for (var root in roots) {
+					var files = DirectoryList(root, true, "path", "*Spec.cfc");
+					for (var filePath in files) {
+						var src = FileRead(filePath);
+						if (ReFind("if\s*\((?:_isCockroachDB|isCockroachDB|ctx\.isCockroachDB)\)\s*return\s*;", src)) {
+							ArrayAppend(offenders, filePath);
+						}
+					}
+				}
+				expect(ArrayLen(offenders)).toBe(
+					0,
+					"Bare Cockroach return marks the it() green: " & ArrayToList(offenders)
+				);
+			});
+
+		});
+
+		describe("S8 changeColumn default assertion matches the value written", () => {
+
+			it("expects foo not bar for the changeColumn default", () => {
+				var src = FileRead(ExpandPath("/wheels/tests/specs/migrator/migrationSpec.cfc"));
+				expect(src).toInclude('expect(actual.default_value).toInclude("foo")');
+				expect(Find('expect(actual.default_value).toInclude("bar")', src)).toBe(0);
+			});
+
+		});
+
+		describe("S9 AutoMigrator unmapped columns stay opt-in for removal", () => {
+
+			it("still emits removeColumns by default (no silent default flip)", () => {
+				var result = variables.autoMigrator.diff("Author");
+				expect(result).toHaveKey("unmappedColumns");
+				expect(result).toHaveKey("removeColumns");
+			});
+
+			it("omits removeColumns when allowColumnRemoval is false", () => {
+				var result = variables.autoMigrator.diff("Author", {allowColumnRemoval: false});
+				expect(ArrayLen(result.removeColumns)).toBe(
+					0,
+					"allowColumnRemoval=false must not schedule destructive drops."
+				);
+			});
+
+		});
+
+		describe("S10 generateMigrationCFC rejects unsafe identifiers", () => {
+
+			it("throws when a table name would break out of a CFML string", () => {
+				var diffResult = {
+					modelName: "TestModel",
+					tableName: 'users"; announce("pwned"); //',
+					addColumns: [],
+					removeColumns: [],
+					changeColumns: [],
+					renameColumns: []
+				};
+				expect(() => {
+					variables.autoMigrator.generateMigrationCFC(diffResult, "inject");
+				}).toThrow("Wheels.Migrator.InvalidIdentifier");
+			});
+
+			it("strips quotes from the generated hint attribute", () => {
+				var diffResult = {
+					modelName: "TestModel",
+					tableName: "test_models",
+					addColumns: [],
+					removeColumns: [],
+					changeColumns: [],
+					renameColumns: []
+				};
+				var cfc = variables.autoMigrator.generateMigrationCFC(diffResult, 'x" hint="evil');
+				expect(Find('hint="evil', cfc)).toBe(0);
+			});
+
+		});
+
+		describe("S11 auto-remove down() restores a typed column", () => {
+
+			it("emits addColumn in down when the removed column type is known", () => {
+				var diffResult = {
+					modelName: "TestModel",
+					tableName: "test_models",
+					addColumns: [],
+					removeColumns: [{name: "legacy_field", type: "string"}],
+					changeColumns: [],
+					renameColumns: []
+				};
+				var cfc = variables.autoMigrator.generateMigrationCFC(diffResult, "restore_typed");
+				expect(cfc).toInclude('removeColumn(table="test_models", columnName="legacy_field")');
+				expect(cfc).toInclude('addColumn(table="test_models", columnType="string", columnName="legacy_field")');
+			});
+
+			it("keeps the TODO when type is unknown", () => {
+				var diffResult = {
+					modelName: "TestModel",
+					tableName: "test_models",
+					addColumns: [],
+					removeColumns: [{name: "legacy_field"}],
+					changeColumns: [],
+					renameColumns: []
+				};
+				var cfc = variables.autoMigrator.generateMigrationCFC(diffResult, "restore_unknown");
+				expect(cfc).toInclude("TODO: restore column");
+			});
+
+		});
+
+		describe("S12 changeColumns includes size scale and null", () => {
+
+			it("emits limit and allowNull when the diff carries them", () => {
+				var diffResult = {
+					modelName: "TestModel",
+					tableName: "test_models",
+					addColumns: [],
+					removeColumns: [],
+					changeColumns: [
+						{
+							name: "title",
+							from: {type: "string", size: 10, nullable: true},
+							to: {type: "string", size: 50, nullable: false}
+						}
+					],
+					renameColumns: []
+				};
+				var cfc = variables.autoMigrator.generateMigrationCFC(diffResult, "size_null");
+				expect(cfc).toInclude("limit=50");
+				expect(cfc).toInclude("allowNull=false");
+			});
+
+		});
+
+		describe("S13 TenantMigrator credentials are request-scoped not hardcoded appKey", () => {
+
+			afterEach(() => {
+				if (StructKeyExists(request, "wheels")) {
+					StructDelete(request.wheels, "migratorDataSourceUserName");
+					StructDelete(request.wheels, "migratorDataSourcePassword");
+					StructDelete(request.wheels, "migratorDataSource");
+					StructDelete(request.wheels, "tenant");
+				}
+				StructDelete(request, "hardenerTenantMigratorOverrideUser");
+			});
+
+			it("does not hardcode application.wheels for migrator $dbinfo credentials", () => {
+				var src = FileRead(ExpandPath("/wheels/Migrator.cfc"));
+				expect(Find("application.wheels.dataSourceUserName", src)).toBe(
+					0,
+					"Migrator $dbinfo must use $appKey() / $migratorDataSourceCredentials()."
+				);
+			});
+
+			it("honors a request-scoped tenant username", () => {
+				if (!StructKeyExists(request, "wheels")) {
+					request.wheels = {};
+				}
+				request.wheels.migratorDataSourceUserName = "tenant_probe_user";
+				request.wheels.migratorDataSourcePassword = "tenant_probe_pass";
+				var creds = variables.g.$migratorDataSourceCredentials();
+				expect(creds.username).toBe("tenant_probe_user");
+				expect(creds.password).toBe("tenant_probe_pass");
+			});
+
+			it("passes tenant userName onto the request during a tenant action", () => {
+				var spy = CreateObject("component", "wheels.tests._assets.migrator.SpyTenantMigrator").init();
+				spy.migrateAll(
+					action = "info",
+					tenants = [
+						{
+							id = "probe",
+							dataSource = "wheels_hardener_tenant_ds_probe",
+							userName = "tenant_ds_user"
+						}
+					],
+					stopOnError = false,
+					migratePath = "/wheels/tests/_assets/migrator/migrations/",
+					sqlPath = "/wheels/tests/_assets/migrator/sql/"
+				);
+				expect(request.hardenerTenantMigratorOverrideUser).toBe("tenant_ds_user");
+			});
+
+		});
+
+		describe("S14 bigInteger and char have types on PG and MSSQL", () => {
+
+			it("maps biginteger and char on PostgreSQL", () => {
+				var pg = CreateObject("component", "wheels.databaseAdapters.PostgreSQL.PostgreSQLMigrator");
+				expect(pg.typeToSQL(type = "biginteger")).toBe("BIGINT");
+				expect(pg.typeToSQL(type = "char")).toInclude("CHAR");
+			});
+
+			it("maps biginteger on Microsoft SQL Server", () => {
+				var mssql = CreateObject("component", "wheels.databaseAdapters.MicrosoftSQLServer.MicrosoftSQLServerMigrator");
+				expect(mssql.typeToSQL(type = "biginteger")).toBe("BIGINT");
+			});
+
+		});
+
+		describe("S15 references default PK stays id (escalated public API)", () => {
+
+			it("still defaults referenceColumn to id", () => {
+				var prior = application.wheels.useUnderscoreReferenceColumns ?: false;
+				application.wheels.useUnderscoreReferenceColumns = false;
+				try {
+					var t = variables.migration.createTable(name = "dbm_hardener_s15", force = true);
+					t.references(columnNames = "user");
+					expect(t.foreignKeys[1].referenceColumn).toBe("id");
+				} finally {
+					application.wheels.useUnderscoreReferenceColumns = prior;
+				}
+			});
+
+			it("accepts an opt-in referenceColumn", () => {
+				var prior = application.wheels.useUnderscoreReferenceColumns ?: false;
+				application.wheels.useUnderscoreReferenceColumns = false;
+				try {
+					var t = variables.migration.createTable(name = "dbm_hardener_s15_opt", force = true);
+					t.references(columnNames = "user", referenceColumn = "uuid");
+					expect(t.foreignKeys[1].referenceColumn).toBe("uuid");
+				} finally {
+					application.wheels.useUnderscoreReferenceColumns = prior;
+				}
+			});
+
+		});
+
+		describe("S16 composite PK columnNames literal stays (escalated public API)", () => {
+
+			it("still treats columnNames as a literal single PK name", () => {
+				var t = variables.migration.createTable(name = "dbm_hardener_s16", id = false, force = true);
+				t.primaryKey(columnNames = "a,b");
+				expect(ArrayLen(t.primaryKeys)).toBe(1);
+				expect(t.primaryKeys[1].name).toBe("a,b");
+			});
+
+			it("emits a composite PRIMARY KEY via multiple primaryKey() calls", () => {
+				var t = variables.migration.createTable(name = "dbm_hardener_s16_comp", id = false, force = true);
+				t.primaryKey(columnNames = "firstId");
+				t.primaryKey(columnNames = "secondId");
+				var sql = variables.migration.adapter.createTable(
+					name = "dbm_hardener_s16_comp",
+					columns = t.columns,
+					primaryKeys = t.primaryKeys,
+					foreignKeys = []
+				);
+				expect(sql).toInclude("PRIMARY KEY");
+				expect(sql).toInclude("firstId");
+				expect(sql).toInclude("secondId");
+			});
+
+		});
+
+		describe("S17 timestamp() default stays datetime (escalated public API)", () => {
+
+			it("defaults columnType to datetime", () => {
+				var t = variables.migration.createTable(name = "dbm_hardener_s17", force = true);
+				t.timestamp(columnNames = "publishedAt");
+				expect(t.columns[1].type).toBe("datetime");
+			});
+
+			it("still allows columnType=timestamp as an opt-in", () => {
+				var t = variables.migration.createTable(name = "dbm_hardener_s17_opt", force = true);
+				t.timestamp(columnNames = "publishedAt", columnType = "timestamp");
+				expect(t.columns[1].type).toBe("timestamp");
+			});
+
+		});
+
+		describe("S18 CREATE FK quotes identifiers", () => {
+
+			it("quotes the constraint name and referenced table in toForeignKeySQL", () => {
+				var fk = CreateObject("component", "wheels.migrator.ForeignKeyDefinition").init(
+					adapter = variables.migration.adapter,
+					table = "posts",
+					referenceTable = "users",
+					column = "userid",
+					referenceColumn = "id"
+				);
+				var sql = fk.toForeignKeySQL();
+				var quotedName = variables.migration.adapter.quoteTableName(fk.name);
+				var quotedRef = variables.migration.adapter.quoteTableName("users");
+				expect(sql).toInclude(quotedName);
+				expect(sql).toInclude(quotedRef);
+			});
+
+		});
+
+		describe("S19 changeColumnInTable always emits a type change", () => {
+
+			it("PostgreSQL emits TYPE even when only limit is set", () => {
+				var pg = CreateObject("component", "wheels.databaseAdapters.PostgreSQL.PostgreSQLMigrator");
+				var col = CreateObject("component", "wheels.migrator.ColumnDefinition").init(
+					adapter = pg,
+					name = "title",
+					type = "string",
+					limit = 50
+				);
+				var sql = pg.changeColumnInTable(name = "posts", column = col);
+				expect(sql).toInclude("TYPE");
+				expect(sql).toInclude("VARCHAR");
+			});
+
+			it("MSSQL emits ALTER COLUMN even when only limit is set", () => {
+				var mssql = CreateObject("component", "wheels.databaseAdapters.MicrosoftSQLServer.MicrosoftSQLServerMigrator");
+				var col = CreateObject("component", "wheels.migrator.ColumnDefinition").init(
+					adapter = mssql,
+					name = "title",
+					type = "string",
+					limit = 50
+				);
+				var sql = mssql.changeColumnInTable(name = "posts", column = col);
+				expect(sql).toInclude("ALTER COLUMN");
+				expect(sql).toInclude("VARCHAR");
+			});
+
+		});
+
+		describe("S20 float() public defaults stay empty / true (escalated)", () => {
+
+			it("keeps default empty string and allowNull true", () => {
+				var t = variables.migration.createTable(name = "dbm_hardener_s20", force = true);
+				t.float(columnNames = "ratio");
+				expect(t.columns[1]["default"]).toBe("");
+				expect(t.columns[1].allowNull).toBeTrue();
+			});
+
+			it("does not change the declared parameter defaults in source", () => {
+				var src = FileRead(ExpandPath("/wheels/migrator/TableDefinition.cfc"));
+				expect(src).toInclude('function float(string columnNames, default = "", boolean allowNull = "true")');
+			});
+
+		});
+
+	}
+
+}

--- a/vendor/wheels/tests/specs/hardener/MigratorHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/hardener/MigratorHardenerSpec.cfc
@@ -72,7 +72,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("does not mark an announce-only up() as migrated", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				variables.announceMigrator.migrateTo("90000000000001");
 				var rows = queryExecute(
 					"SELECT version FROM #application.wheels.migratorTableName# WHERE version = '90000000000001'",
@@ -86,7 +89,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("does not mark the default announce-only Migration.up() stub as migrated", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				variables.stubMigrator.migrateTo("90000000000002");
 				var rows = queryExecute(
 					"SELECT version FROM #application.wheels.migratorTableName# WHERE version = '90000000000002'",
@@ -100,7 +106,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("does not remove a tracking row when down() is announce-only", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				var priorDown = application.wheels.allowMigrationDown;
 				application.wheels.allowMigrationDown = true;
 				try {
@@ -133,7 +142,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("still marks a version migrated when up() announces then creates via ORM without $execute", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				variables.ormMigrator.migrateTo("90000000000003");
 				var rows = queryExecute(
 					"SELECT version FROM #application.wheels.migratorTableName# WHERE version = '90000000000003'",
@@ -147,7 +159,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("still removes a tracking row when down() announces then deletes via ORM without $execute", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				var priorDown = application.wheels.allowMigrationDown;
 				application.wheels.allowMigrationDown = true;
 				try {
@@ -189,7 +204,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("still records a version when up() actually executes SQL", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				try {
 					variables.migration.dropTable("c_o_r_e_bunyips");
 				} catch (any e) {}
@@ -239,7 +257,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("does not re-run up() when down is blocked by the default allowMigrationDown=false", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				var priorDown = application.wheels.allowMigrationDown;
 				application.wheels.allowMigrationDown = true;
 				try {

--- a/vendor/wheels/tests/specs/migrator/MigrateIndividualErrorPathSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/MigrateIndividualErrorPathSpec.cfc
@@ -35,7 +35,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("returns normally when the migration's up() throws", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				var rv = "";
 				var threw = false;
 				var thrownMessage = "";
@@ -54,7 +57,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("does not record a tracking row when the migration throws", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateIndividual("004");
 				var versions = queryExecute(
 					"SELECT version FROM #application.wheels.migratorTableName# WHERE version = '004'",

--- a/vendor/wheels/tests/specs/migrator/MigratorInfoSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/MigratorInfoSpec.cfc
@@ -39,7 +39,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("$buildInfoOutput returns expected lines for a clean state", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("002");
 				var lines = migrator.$buildInfoOutput();
 				expect(lines).toBeArray();
@@ -51,7 +54,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("$buildInfoOutput marks orphan versions with [?] and NO FILE", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				insertOrphan("999");
 				var lines = migrator.$buildInfoOutput();
@@ -61,7 +67,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("$buildInfoOutput summary counts orphans separately", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				insertOrphan("999");
 				var lines = migrator.$buildInfoOutput();
@@ -70,7 +79,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("$buildInfoOutput omits orphan summary line when no orphans exist", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				var lines = migrator.$buildInfoOutput();
 				var joined = ArrayToList(lines, Chr(10));

--- a/vendor/wheels/tests/specs/migrator/MigratorOuterTransactionSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/MigratorOuterTransactionSpec.cfc
@@ -47,7 +47,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("model.create() inside up() persists after the outer transaction commits", () => {
-				if (ctx.isCockroachDB) return;
+				if (ctx.isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				var found = queryExecute(
 					"SELECT id FROM c_o_r_e_tags WHERE name = 'issue2789_via_model_create'",
@@ -58,19 +61,28 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("sets request.$wheelsTransactionWrapper for the duration of up()", () => {
-				if (ctx.isCockroachDB) return;
+				if (ctx.isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				expect(request.$issue2789FlagDuringUp).toBeTrue();
 			});
 
 			it("clears request.$wheelsTransactionWrapper after up() returns", () => {
-				if (ctx.isCockroachDB) return;
+				if (ctx.isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				expect(StructKeyExists(request, "$wheelsTransactionWrapper")).toBeFalse();
 			});
 
 			it("clears request.$wheelsTransactionWrapper after down() returns", () => {
-				if (ctx.isCockroachDB) return;
+				if (ctx.isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				migrator.migrateTo("0");
 				expect(StructKeyExists(request, "$wheelsTransactionWrapper")).toBeFalse();

--- a/vendor/wheels/tests/specs/migrator/MigratorReconciliationSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/MigratorReconciliationSpec.cfc
@@ -41,7 +41,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("returns a clean health struct when DB and files match", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("003");
 				var report = migrator.doctor();
 				expect(report).toBeStruct();
@@ -53,7 +56,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("flags orphans as unhealthy", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				insertOrphan("999");
 				var report = migrator.doctor();
@@ -63,7 +69,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("flags pending local migrations", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				var report = migrator.doctor();
 				expect(report.healthy).toBeFalse();
@@ -71,7 +80,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("includes a human-readable summary message", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				insertOrphan("999");
 				var report = migrator.doctor();
@@ -100,7 +112,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("removes an orphan version from the tracking table", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				insertOrphan("999");
 				var result = migrator.forgetVersion("999");
@@ -110,7 +125,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("refuses to forget a version that has a local file", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("002");
 				var result = migrator.forgetVersion("002");
 				expect(result.success).toBeFalse();
@@ -118,14 +136,20 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("refuses to forget a version that is not in the tracking table", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				var result = migrator.forgetVersion("999");
 				expect(result.success).toBeFalse();
 				expect(result.message).toInclude("not found");
 			});
 
 			it("returns a failure for invalid version input", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				var result = migrator.forgetVersion("abc");
 				expect(result.success).toBeFalse();
 				expect(result.message).toInclude("Invalid version");
@@ -152,7 +176,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("records a version as applied without running its up()", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				var result = migrator.pretendVersion("001");
 				expect(result.success).toBeTrue();
 				expect(result.recorded).toBe("001");
@@ -167,7 +194,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("refuses to pretend a version that is already applied", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				var result = migrator.pretendVersion("001");
 				expect(result.success).toBeFalse();
@@ -175,14 +205,20 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("refuses to pretend a version that has no local file", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				var result = migrator.pretendVersion("999");
 				expect(result.success).toBeFalse();
 				expect(result.message).toInclude("no matching file");
 			});
 
 			it("returns a failure for invalid version input", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				var result = migrator.pretendVersion("abc");
 				expect(result.success).toBeFalse();
 				expect(result.message).toInclude("Invalid version");

--- a/vendor/wheels/tests/specs/migrator/MigratorRobustnessSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/MigratorRobustnessSpec.cfc
@@ -45,7 +45,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("keeps the enriched name on the top version row after a missingMigFlag run", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("003");
 				// Simulate a "missing" gap migration: remove 002's tracking row
 				// and its table so the file counts as pending again.
@@ -72,7 +75,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("does not insert a bogus '0' row when run against an empty tracking table", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001", true);
 				var rows = queryExecute(
 					"SELECT version FROM #application.wheels.migratorTableName# WHERE version = '0'",
@@ -129,7 +135,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("sets request.$wheelsTransactionWrapper for the duration of up()", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				var priorDown = application.wheels.allowMigrationDown;
 				application.wheels.allowMigrationDown = true;
 				try {
@@ -144,7 +153,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("rolls back DML written by up() when the redo fails", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				var priorDown = application.wheels.allowMigrationDown;
 				application.wheels.allowMigrationDown = true;
 				try {
@@ -200,7 +212,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("doctor() reports state without bootstrapping the tracking table", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				var report = migrator.doctor();
 				expect(report.healthy).toBeFalse();
 				expect(report.summary.pending).toBe(3);
@@ -216,7 +231,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("getCurrentMigrationVersion() reports 0 without bootstrapping", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				expect(migrator.getCurrentMigrationVersion()).toBe("0");
 				var info = application.wo.$dbinfo(
 					datasource = application.wheels.dataSourceName,
@@ -227,7 +245,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("migrateTo() still bootstraps the tables that reads left alone", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.doctor();
 				migrator.migrateTo("001");
 				var info = application.wo.$dbinfo(

--- a/vendor/wheels/tests/specs/migrator/OrphanDetectionSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/OrphanDetectionSpec.cfc
@@ -41,7 +41,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("returns empty array when DB and files match", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				var orphans = migrator.$getOrphanVersions();
 				expect(orphans).toBeArray();
@@ -49,7 +52,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("returns the orphan when DB has a version with no matching file", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				insertOrphan("999");
 				var orphans = migrator.$getOrphanVersions();
@@ -58,7 +64,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("returns multiple orphans sorted ascending", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				insertOrphan("999");
 				insertOrphan("998");
@@ -69,7 +78,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("ignores the sentinel '0' returned by empty tracking table", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				var orphans = migrator.$getOrphanVersions();
 				expect(ArrayLen(orphans)).toBe(0);
 			});
@@ -95,7 +107,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("does not take the down branch when only orphans separate current from target", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				insertOrphan("999");
 				var output = migrator.migrateTo("003");
@@ -103,7 +118,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("applies pending local migrations when only orphans separate current from target", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				insertOrphan("999");
 				migrator.migrateTo("003");
@@ -114,7 +132,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("emits a warning naming the orphan version(s)", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				insertOrphan("999");
 				var output = migrator.migrateTo("003");
@@ -123,7 +144,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("prints a clear nothing-to-do message when no pending local migrations exist", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("003");
 				insertOrphan("999");
 				var output = migrator.migrateToLatest();
@@ -133,7 +157,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("still allows legitimate down-migration when down target has a local file", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("002");
 				var output = migrator.migrateTo("001");
 				expect(output).toInclude("down to 001");
@@ -142,7 +169,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("warns about orphans and still runs the down branch when both are present above target", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("002");
 				insertOrphan("999");
 				var output = migrator.migrateTo("001");

--- a/vendor/wheels/tests/specs/migrator/SchemaEnrichmentSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/SchemaEnrichmentSpec.cfc
@@ -41,7 +41,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("adds name and applied_at columns to the tracking table on first call", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				// Force tracking table to be created via migrateTo
 				migrator.migrateTo("001");
 				// First call should add the columns (the migrator may have already
@@ -55,7 +58,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("is idempotent — second call adds nothing", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				migrator.$ensureTrackingColumns();
 				var result = migrator.$ensureTrackingColumns();
@@ -65,7 +71,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("populates the name column for newly applied migrations", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				// The name column should now contain "create_bunyips_table" for version 001
 				var rows = queryExecute(
@@ -82,7 +91,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("populates applied_at for newly applied migrations", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				// applied_at is the column-DEFAULT CURRENT_TIMESTAMP on most
 				// engines; SQLite gets an explicit CFML-side Now() because it
@@ -98,7 +110,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("re-runs ALTER when the tracking table is dropped+recreated (regression)", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				// First run: applies a migration, schema gets enriched,
 				// and both app-scope caches are set.
 				migrator.migrateTo("001");
@@ -131,7 +146,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("populates applied_at across app restarts (regression for round-2 C2)", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				// First "app run": migrate 001, which adds the enriched
 				// columns and caches $migratorDbType + $trackingColumnsEnsured.
 				migrator.migrateTo("001");

--- a/vendor/wheels/tests/specs/migrator/TenantMigratorSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/TenantMigratorSpec.cfc
@@ -39,7 +39,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("action=latest migrates the tenant datasource to the latest fixture version", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				var results = tenantMigrator.migrateAll(
 					action = "latest",
 					tenants = [{id = "t1", dataSource = application.wheels.dataSourceName}],
@@ -53,7 +56,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("action=up applies exactly one pending migration", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				var results = tenantMigrator.migrateAll(
 					action = "up",
 					tenants = [{id = "t1", dataSource = application.wheels.dataSourceName}],
@@ -66,7 +72,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("action=down rolls back one version", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("002");
 				var results = tenantMigrator.migrateAll(
 					action = "down",
@@ -80,7 +89,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("action=info returns output without mutating the version", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo("001");
 				var results = tenantMigrator.migrateAll(
 					action = "info",
@@ -95,7 +107,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("restores the application datasource and a pre-existing request tenant context", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				var originalDataSourceName = application.wheels.dataSourceName;
 				if (!StructKeyExists(request, "wheels")) {
 					request.wheels = {};
@@ -114,7 +129,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("records the failure and continues when stopOnError=false", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				var results = tenantMigrator.migrateAll(
 					action = "info",
 					tenants = [
@@ -133,7 +151,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("stops after the first failure when stopOnError=true", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				var results = tenantMigrator.migrateAll(
 					action = "info",
 					tenants = [
@@ -162,7 +183,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("resolves tenants from a tenantProvider closure", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				// Hoisted before the named-arg call (Adobe CF chokes on inline
 				// closures passed as named arguments). Reads the application
 				// scope directly rather than capturing an outer local var.

--- a/vendor/wheels/tests/specs/migrator/migrationSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/migrationSpec.cfc
@@ -807,7 +807,10 @@ component extends="wheels.WheelsTest" {
 				if (isACF2016 && isPostgres) {
 					return
 				}
-				if (isCockroachDB) return;
+				if (isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 
 				tableName = "dbm_addindex_tests"
 				indexName = "idx_to_add"
@@ -832,7 +835,10 @@ component extends="wheels.WheelsTest" {
 				if (isACF2016 && isPostgres) {
 					return
 				}
-				if (isCockroachDB) return;
+				if (isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 
 				tableName = "dbm_addindex_tests"
 				indexName = "idx_to_add_to_multiple_columns"
@@ -947,7 +953,10 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("is changing column", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				if(get("adapterName") eq 'SQLiteModel') {
 					skip("SQLite changeColumn is covered by the SQLite-specific spec above.")
 				}
@@ -980,7 +989,7 @@ component extends="wheels.WheelsTest" {
 					expect(actual.nullable).toBeFalse()
 				}
 				if (ListFindNoCase(actual.columnList, "default_value")) {
-					expect(actual.default_value).toInclude("bar")
+					expect(actual.default_value).toInclude("foo")
 				} else if (structKeyExists(server, "boxlang")) {
 					expect(actual.COLUMN_DEF).toInclude("foo")
 				} else {
@@ -1253,7 +1262,10 @@ component extends="wheels.WheelsTest" {
 				if (isACF2016 && isPostgres) {
 					return
 				}
-				if (isCockroachDB) return;
+				if (isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				tableName = "dbm_removeindex_tests"
 				indexName = "idx_to_remove"
 				t = migration.createTable(name = tableName, force = true)

--- a/vendor/wheels/tests/specs/migrator/migratorSpec.cfc
+++ b/vendor/wheels/tests/specs/migrator/migratorSpec.cfc
@@ -39,7 +39,10 @@ component extends="wheels.WheelsTest" {
 		describe("Tests that getCurrentMigrationVersion", () => {
 
 			it("is returning expected value", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				for (local.table in ["c_o_r_e_bunyips", "c_o_r_e_dropbears", "c_o_r_e_hoopsnakes"]) {
 					migration.dropTable(local.table)
 				}
@@ -84,7 +87,10 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("is migrating up from 0 to 001", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo(001)
 				info = g.$dbinfo(datasource = application.wheels.dataSourceName, type = "tables", pattern = "c_o_r_e_bunyips")
 
@@ -95,7 +101,10 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("is migrating up from 0 to 003", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo(003)
 				info1 = g.$dbinfo(datasource = application.wheels.dataSourceName, type = "tables", pattern = "c_o_r_e_bunyips")
 				info2 = g.$dbinfo(datasource = application.wheels.dataSourceName, type = "tables", pattern = "c_o_r_e_dropbears")
@@ -110,7 +119,10 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("is migrating down from 003 to 001", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				migrator.migrateTo(003)
 				migrator.migrateTo(001)
 				info1 = g.$dbinfo(datasource = application.wheels.dataSourceName, type = "tables", pattern = "c_o_r_e_bunyips")
@@ -126,7 +138,10 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("generates sql files", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				application.wheels.writeMigratorSQLFiles = true
 
 				migrator.migrateTo(002)
@@ -203,7 +218,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("creates wheels_levels and wheels_migrator_versions on a fresh DB", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				application.wheels.migratorTableName = "wheels_migrator_versions";
 				application.wheels.levelsTableName = "wheels_levels";
 				application.wheels.createMigratorTable = true;
@@ -225,7 +243,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("falls back to c_o_r_e_levels when only legacy tables exist", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				application.wheels.migratorTableName = "wheels_migrator_versions";
 				application.wheels.levelsTableName = "wheels_levels";
 				application.wheels.createMigratorTable = true;
@@ -280,7 +301,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("returns a no-op result when neither legacy nor new tables exist", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 				application.wheels.levelsTableName = "wheels_levels";
 				application.wheels.migratorTableName = "wheels_migrator_versions";
 
@@ -291,7 +315,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("renames c_o_r_e_levels -> wheels_levels and c_o_r_e_migrator_versions -> wheels_migrator_versions", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 
 				// Pre-create both legacy tables so renameSystemTables has work to do.
 				queryExecute(
@@ -336,7 +363,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("refuses to rename when both legacy and new tables exist (partial-rename safeguard)", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 
 				// Simulate a half-renamed state: both versions of the levels
 				// table coexist. This shouldn't happen in practice but guards
@@ -363,7 +393,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("dryRun=true returns the SQL list without executing", () => {
-				if (_isCockroachDB) return;
+				if (_isCockroachDB) {
+					skip("CockroachDB is skipped for this migrator assertion; a bare return would mark it green.");
+					return;
+				}
 
 				queryExecute(
 					"CREATE TABLE c_o_r_e_levels (id INT PRIMARY KEY, name VARCHAR(50))",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardener SHOULDs for migrator/schema on top of #3402 (B1–B6). **B1–B6 are not re-done.** `allowMigrationDown` default remains **`false`**.

| # | Change |
|---|---|
| S1 | `migrateTo` down returns an explicit `allowMigrationDown is false` error instead of a successful “Migrating … down” banner that no-ops |
| S2 | `$getForeignKeys` / `dropTable` use `FK_NAME` (constraint), never `FKCOLUMN_NAME` |
| S3 | New versions tables get `PRIMARY KEY (version)`; existing tables get a best-effort unique index (JVM lock is not enough) |
| S4 | `updateRecord` / `removeRecord` require `where` or `all=true`; empty where throws `Wheels.Migrator.MissingWhere`. `where` remains raw SQL (existing public API) |
| S5 | `$runMigrationStep` refuses `.up()` / `.down()` when `loadError` is set or `cfc` is missing |
| S6 | Failed steps on MySQL/Oracle/MariaDB append a DDL auto-commit warning. **Full DDL rollback is UNPROVEN** (engine limitation) |
| S7 | Migrator + hardener specs use `skip()` instead of `if (isCockroachDB) return` |
| S8 | `migrationSpec` changeColumn default assertion expects `foo` (the value written), not `bar` |
| S9 | **ESCALATED.** Default still emits `removeColumns` for unmapped DB columns. Opt-in: `allowColumnRemoval=false` → `unmappedColumns` only. Default flip UNPROVEN |
| S10 | `generateMigrationCFC` rejects unsafe identifiers (`Wheels.Migrator.InvalidIdentifier`) and strips `"` / `#` from hints |
| S11 | Typed `removeColumns` emit `addColumn` in `down()`; TODO remains only when type is unknown |
| S12 | `changeColumns` compares size / scale / null; generator emits `limit` / `allowNull` when present |
| S13 | `$migratorDataSourceCredentials()` via `$appKey()`; optional tenant `userName` / `password` on the request. No hardcoded `application.wheels` for `$dbinfo` creds |
| S14 | PostgreSQL `biginteger`/`char` and MSSQL `biginteger` `sqlTypes` (were empty) |
| S15 | **ESCALATED.** `references()` still defaults `referenceColumn="id"`. Opt-in `referenceColumn=` added. Default flip UNPROVEN |
| S16 | **ESCALATED.** `primaryKey(columnNames="a,b")` remains a literal single name (documented). Composite PK via multiple `primaryKey()` calls still emits `PRIMARY KEY`. Splitting `columnNames` UNPROVEN |
| S17 | **ESCALATED.** `timestamp()` still defaults to `columnType="datetime"` (MSSQL `timestamp` is rowversion). Opt-in `columnType="timestamp"` already existed. Default flip UNPROVEN |
| S18 | CREATE FK path quotes constraint / table / column via adapter quote helpers |
| S19 | PG / MSSQL `changeColumnInTable` always emit a type `ALTER` (not only when default/null/after are set) |
| S20 | **ESCALATED.** `float()` keeps `default=""` / `allowNull=true`. Default flip UNPROVEN |

## Escalations (Lead)

Do **not** silently flip these public defaults/APIs. This PR proves the current contract and adds opt-in / fail-closed paths where that is safe:

- **S9** — unmapped → `removeColumns` remains the default. Use `allowColumnRemoval=false` to fail closed.
- **S15** — `referenceColumn` default stays `"id"`.
- **S16** — `columnNames="a,b"` stays a literal (existing `primaryKeySpec`).
- **S17** — `timestamp()` default stays `datetime`.
- **S20** — `float()` `default=""` / `allowNull=true` unchanged.

S6 full DDL rollback on MySQL/Oracle is **UNPROVEN** (implicit commit / DDL auto-commit). Warning only.

## `allowMigrationDown`

**Unchanged.** Still `application.$wheels.allowMigrationDown = false` in `onapplicationstart.cfc`. S1 only makes a blocked down *look* like a block.

## PROVEN / UNPROVEN

Driver: `wheels test --core --ci --filter=…` (never CommandBox). Local Lucee 7 + SQLite:

```
wheels test --core --ci --filter=hardener   → 94 passed
wheels test --core --ci --filter=migrator   → 292 passed
```

| Item | Status | Evidence |
|---|---|---|
| S1 | **PROVEN** | `MigratorHardenerShouldSpec` S1 — hardener 94 passed |
| S2 | **PROVEN** | `$foreignKeyConstraintNames` unit its |
| S3 | **PROVEN** (DDL + helper) | `PRIMARY KEY` on create; `$ensureVersionUniqueness` best-effort on existing tables |
| S4 | **PROVEN** | empty where throws; `all=true` wipe |
| S5 | **PROVEN** | load-error asset is not executed |
| S6 | **PROVEN** warning / **UNPROVEN** rollback | `$ddlAutoCommits()` + warning string; no engine-level DDL undo |
| S7 | **PROVEN** | source-scan + skip() conversions; migrator 292 passed |
| S8 | **PROVEN** | assertion now `foo` |
| S9 | **PROVEN** opt-in / **UNPROVEN** default flip | `allowColumnRemoval=false`; default still removes |
| S10 | **PROVEN** | `Wheels.Migrator.InvalidIdentifier` |
| S11 | **PROVEN** | typed `addColumn` in `down()` |
| S12 | **PROVEN** (generator) | `limit` / `allowNull` emitted |
| S13 | **PROVEN** | credentials helper + tenant `userName` |
| S14 | **PROVEN** | `typeToSQL` on PG / MSSQL adapters |
| S15 | **PROVEN** opt-in / **UNPROVEN** default flip | default still `id` |
| S16 | **PROVEN** current contract / **UNPROVEN** split | literal + composite via two calls |
| S17 | **PROVEN** current contract / **UNPROVEN** default flip | still `datetime` |
| S18 | **PROVEN** | quoted `toForeignKeySQL()` |
| S19 | **PROVEN** | PG/MSSQL adapters emit TYPE/ALTER COLUMN with only `limit` |
| S20 | **PROVEN** current contract / **UNPROVEN** default flip | defaults pinned |

## Test Plan

```bash
wheels test --core --ci --filter=hardener
wheels test --core --ci --filter=migrator
```

## Feature Completeness Checklist

- [x] **DCO sign-off**
- [x] **Tests**
- [ ] **Framework Docs** — not a user-facing guide change; escalations called out here
- [x] **AI Reference Docs** — `vendor/wheels/migrator/CLAUDE.md`
- [x] **CLAUDE.md** — migrator notes
- [x] **Changelog fragment** — `changelog.d/migrator-hardener-shoulds.{fixed,changed}.md`
- [x] **Test runner** — `wheels test --core --ci --filter=hardener` (94 passed); `--filter=migrator` (292 passed)

## HEAD

`ef8c0750f23f545d2d87290da87ed21b03fc46ca`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a81c163-af5e-41fa-ba6f-524df5df09d1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a81c163-af5e-41fa-ba6f-524df5df09d1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

