### PR TITLE
fix(plugins): harden package loader B1–B4 without flipping defaults

### DIFF
--- a/changelog.d/plugins-hardener-b1-b4.fixed.md
+++ b/changelog.d/plugins-hardener-b1-b4.fixed.md
@@ -1,0 +1,4 @@
+- Plugin compatibility with an empty / undeclared version no longer loads, even when `loadIncompatiblePlugins` is `true`. Declared mismatches still honor that setting (default remains `true`)
+- Package manifests with a present-but-empty `wheelsVersion` are rejected; omitting the field is unchanged
+- `ModuleGraph` fails duplicate package.json `name` values instead of last-wins binding `requires` / `replaces` / `suggests`
+- A lazy ServiceProvider that does not hint `provides.services` is still detected (comment-stripped CFC `implements`) and joins register/boot, including when it is the only package

--- a/changelog.d/plugins-hardener-b1-b4.security.md
+++ b/changelog.d/plugins-hardener-b1-b4.security.md
@@ -1,0 +1,1 @@
+- Plugin zip extraction (`$pluginsExtract` / `$zip` unzip) now rejects zip-slip entries (absolute paths, `..` segments, or a canonical path outside the destination) before writing files. `overwritePlugins` stays `true`.

--- a/vendor/wheels/ModuleGraph.cfc
+++ b/vendor/wheels/ModuleGraph.cfc
@@ -35,16 +35,25 @@ component output="false" {
 			errors = []
 		};
 
-		// Build lookup: package name -> directory name (for resolving requires by name)
-		local.nameToDir = {};
-		for (local.dirName in arguments.manifests) {
-			local.m = arguments.manifests[local.dirName];
-			local.pkgName = StructKeyExists(local.m, "name") ? local.m.name : local.dirName;
-			local.nameToDir[local.pkgName] = local.dirName;
+		// Build lookup: package name -> directory name (for resolving requires by name).
+		// Duplicate manifest names fail closed — last-wins would silently bind
+		// requires/replaces/suggests to whichever directory happened to iterate last.
+		local.nameIndex = $collectNameIndex(arguments.manifests);
+		local.nameToDir = local.nameIndex.nameToDir;
+		local.excluded = {};
+		for (local.collision in local.nameIndex.collisions) {
+			local.dirList = ArrayToList(local.collision.dirs, ", ");
+			for (local.collidingDir in local.collision.dirs) {
+				ArrayAppend(local.result.errors, {
+					package = local.collidingDir,
+					message = "Duplicate package name '#local.collision.name#' declared by #local.dirList#"
+				});
+				local.excluded[local.collidingDir] = "Duplicate package name '#local.collision.name#'";
+			}
 		}
 
-		// Phase 1: Process replacements
-		local.excluded = $processReplacements(arguments.manifests, local.nameToDir);
+		// Phase 1: Process replacements (colliding names are already excluded)
+		local.excluded = $processReplacements(arguments.manifests, local.nameToDir, local.excluded);
 		StructAppend(local.result.excluded, local.excluded);
 
 		// Phase 2: Build the active package set (excluding replaced packages)
@@ -98,14 +107,54 @@ component output="false" {
 	}
 
 	/**
+	 * Indexes manifests by package name. Duplicate names are reported as
+	 * collisions and omitted from nameToDir so requires/replaces/suggests
+	 * cannot silently bind the last directory.
+	 *
+	 * @return  Struct with: nameToDir (struct), collisions (array of {name, dirs})
+	 */
+	private struct function $collectNameIndex(required struct manifests) {
+		local.byName = {};
+		for (local.dirName in arguments.manifests) {
+			local.m = arguments.manifests[local.dirName];
+			local.pkgName = StructKeyExists(local.m, "name") && Len(Trim(local.m.name))
+				? Trim(local.m.name)
+				: local.dirName;
+			if (!StructKeyExists(local.byName, local.pkgName)) {
+				local.byName[local.pkgName] = [];
+			}
+			local.dirs = local.byName[local.pkgName];
+			ArrayAppend(local.dirs, local.dirName);
+			local.byName[local.pkgName] = local.dirs;
+		}
+
+		local.nameToDir = {};
+		local.collisions = [];
+		for (local.pkgName in local.byName) {
+			local.dirs = local.byName[local.pkgName];
+			if (ArrayLen(local.dirs) > 1) {
+				ArrayAppend(local.collisions, {name = local.pkgName, dirs = local.dirs});
+			} else {
+				local.nameToDir[local.pkgName] = local.dirs[1];
+			}
+		}
+
+		return {nameToDir = local.nameToDir, collisions = local.collisions};
+	}
+
+	/**
 	 * Processes `replaces` declarations across all manifests.
 	 * If package A declares replaces: {"pkg-B": "*"}, and pkg-B is present,
 	 * then pkg-B is excluded from loading.
 	 *
 	 * @return  Struct of excluded dirName => reason string
 	 */
-	private struct function $processReplacements(required struct manifests, required struct nameToDir) {
-		local.excluded = {};
+	private struct function $processReplacements(
+		required struct manifests,
+		required struct nameToDir,
+		struct excluded = {}
+	) {
+		local.excluded = Duplicate(arguments.excluded);
 
 		// Process packages in sorted directory-name order so the outcome is
 		// deterministic regardless of struct iteration order, and skip the

--- a/vendor/wheels/PackageLoader.cfc
+++ b/vendor/wheels/PackageLoader.cfc
@@ -900,21 +900,70 @@ component output="false" {
 	/**
 	 * Returns true when the ServiceProvider lifecycle has work to do: either
 	 * eagerly loaded packages already registered as providers, or lazy
-	 * packages whose manifest hints services (these are instantiated into
-	 * the lifecycle by $invokeServiceProviderRegister). Global.cfc uses this
-	 * as the gate for invoking the lifecycle so a vendor tree containing
-	 * ONLY lazy service-only packages still gets register()/boot() invoked.
+	 * packages that hint provides.services or implement
+	 * ServiceProviderInterface (comment-stripped source scan). Global.cfc
+	 * uses this as the gate so a vendor tree containing ONLY lazy providers
+	 * — hinted or not — still gets register()/boot() invoked.
 	 */
 	public boolean function $hasServiceProviderWork() {
 		if (ArrayLen(variables.serviceProviders) > 0) {
 			return true;
 		}
 		for (local.lazyKey in variables.lazyPackages) {
-			if ($hintsServices(variables.lazyPackages[local.lazyKey].manifest)) {
+			if ($lazyPackageNeedsLifecycle(variables.lazyPackages[local.lazyKey])) {
 				return true;
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * True when a lazy package must join register()/boot(): it either hints
+	 * provides.services, or its CFC implements ServiceProviderInterface
+	 * (comment-stripped source scan so we do not instantiate just to look).
+	 */
+	private boolean function $lazyPackageNeedsLifecycle(required struct lazyInfo) {
+		if ($hintsServices(arguments.lazyInfo.manifest)) {
+			return true;
+		}
+		return $sourceDeclaresServiceProvider(arguments.lazyInfo.pkgDir, arguments.lazyInfo.dirName);
+	}
+
+	/**
+	 * Comment-stripped scan of the package CFC for
+	 * implements="...ServiceProviderInterface". Anti-pattern 14: never
+	 * substring-match raw CFML source.
+	 */
+	private boolean function $sourceDeclaresServiceProvider(required string pkgDir, required string dirName) {
+		local.cfcPath = arguments.pkgDir & "/" & arguments.dirName & ".cfc";
+		if (!FileExists(local.cfcPath)) {
+			local.cfcFiles = DirectoryList(arguments.pkgDir, false, "name", "*.cfc");
+			if (ArrayLen(local.cfcFiles) == 0) {
+				return false;
+			}
+			local.cfcPath = arguments.pkgDir & "/" & local.cfcFiles[1];
+		}
+		try {
+			local.src = $stripCfmlComments(FileRead(local.cfcPath));
+		} catch (any e) {
+			return false;
+		}
+		return REFindNoCase(
+			"implements[ \t\r\n]*=[ \t\r\n]*[""'][^""']*ServiceProviderInterface",
+			local.src
+		) > 0;
+	}
+
+	/**
+	 * Strips CFML line, block, and tag comments before source scans.
+	 */
+	private string function $stripCfmlComments(required string source) {
+		local.Pattern = CreateObject("java", "java.util.regex.Pattern");
+		local.src = arguments.source;
+		local.src = local.Pattern.compile("<!---.*?--->", local.Pattern.DOTALL).matcher(local.src).replaceAll("");
+		local.src = local.Pattern.compile("/\\*.*?\\*/", local.Pattern.DOTALL).matcher(local.src).replaceAll("");
+		local.src = local.Pattern.compile("//[^\\r\\n]*").matcher(local.src).replaceAll("");
+		return local.src;
 	}
 
 	/**
@@ -944,7 +993,7 @@ component output="false" {
 		// Wheels.DI.ServiceNotFound on some later request).
 		local.lazyKeys = StructKeyArray(variables.lazyPackages);
 		for (local.lazyKey in local.lazyKeys) {
-			if (!$hintsServices(variables.lazyPackages[local.lazyKey].manifest)) {
+			if (!$lazyPackageNeedsLifecycle(variables.lazyPackages[local.lazyKey])) {
 				continue;
 			}
 			try {
@@ -1377,6 +1426,7 @@ component output="false" {
 	 * running Wheels version. Packages that omit the field, use "*", or are
 	 * evaluated against a dev-stamp runtime always pass — a strict constraint
 	 * in that case would break `wheels test run` on unbuilt checkouts.
+	 * A present-but-empty wheelsVersion fails closed.
 	 *
 	 * @manifest Parsed package.json struct
 	 * @return True if the package is compatible with the running Wheels version
@@ -1387,7 +1437,12 @@ component output="false" {
 			return true;
 		}
 		local.constraint = Trim(arguments.manifest.wheelsVersion);
-		if (!Len(local.constraint) || local.constraint == "*") {
+		// Empty string is declared-but-blank — fail closed. Omitted field
+		// (the branch above) and "*" stay permissive.
+		if (!Len(local.constraint)) {
+			return false;
+		}
+		if (local.constraint == "*") {
 			return true;
 		}
 		local.runtime = $normalizeWheelsVersion();

--- a/vendor/wheels/Plugins.cfc
+++ b/vendor/wheels/Plugins.cfc
@@ -120,7 +120,19 @@ component output="false" extends="wheels.Global"{
 						WriteLog(type="warning", text="[Wheels] Failed to create plugin directory '#local.plugin.folderPath#': #e.message#");
 					}
 				}
-				$zip(action = "unzip", destination = local.plugin.folderPath, file = local.plugin.file, overwrite = true);
+				try {
+					$zip(action = "unzip", destination = local.plugin.folderPath, file = local.plugin.file, overwrite = true);
+				} catch (any e) {
+					if (e.type == "Wheels.UnsafeZipEntry") {
+						WriteLog(
+							type = "error",
+							text = "[Wheels] Plugin zip '#local.plugin.file#' rejected: #e.message#",
+							file = "wheels"
+						);
+					} else {
+						rethrow;
+					}
+				}
 			}
 		};
 	}
@@ -708,13 +720,18 @@ component output="false" extends="wheels.Global"{
 	 * compatibility version, the current Wheels version, and the
 	 * loadIncompatiblePlugins setting.
 	 */
-	private boolean function $shouldLoadPlugin(
+	public boolean function $shouldLoadPlugin(
 		required string compatVersion,
 		required string wheelsVersion,
 		required boolean loadIncompatible
 	) {
-		return !Len(arguments.compatVersion)
-			|| ListFind(arguments.compatVersion, arguments.wheelsVersion)
+		// Empty / undeclared compatibility fails closed even when
+		// loadIncompatiblePlugins is true. That setting only applies to
+		// plugins that declared a version list which does not match.
+		if (!Len(Trim(arguments.compatVersion))) {
+			return false;
+		}
+		return ListFind(arguments.compatVersion, arguments.wheelsVersion)
 			|| arguments.loadIncompatible;
 	}
 

--- a/vendor/wheels/global/tags.cfm
+++ b/vendor/wheels/global/tags.cfm
@@ -493,11 +493,91 @@
 
 	public any function $zip() {
 		$engineAdapter().prepareZipArgs(arguments);
+		local.action = StructKeyExists(arguments, "action") ? LCase(arguments.action) : "";
+		if (
+			local.action == "unzip"
+			&& StructKeyExists(arguments, "file")
+			&& StructKeyExists(arguments, "destination")
+		) {
+			$assertZipEntriesContained(arguments.file, arguments.destination);
+		}
 		local.args = {};
 		for (local.key in arguments) {
 			local.args[local.key] = arguments[local.key];
 		}
 		cfzip(attributeCollection = "#local.args#");
+	}
+
+	/**
+	 * Returns true when a zip entry would extract outside destination.
+	 * Rejects empty names, absolute paths, `..` segments, and any entry
+	 * whose canonical path is not contained by the destination directory.
+	 */
+	public boolean function $zipEntryEscapesDestination(required string destination, required string entryName) {
+		local.entry = Replace(arguments.entryName, "\", "/", "all");
+		if (!Len(Trim(local.entry))) {
+			return true;
+		}
+		if (Left(local.entry, 1) == "/" || REFind("^[A-Za-z]:", local.entry)) {
+			return true;
+		}
+		local.segments = ListToArray(local.entry, "/");
+		for (local.seg in local.segments) {
+			if (local.seg == "..") {
+				return true;
+			}
+		}
+		try {
+			local.destFile = CreateObject("java", "java.io.File").init(arguments.destination);
+			local.destCanon = local.destFile.getCanonicalPath();
+			local.sep = CreateObject("java", "java.io.File").separator;
+			local.destPrefix = local.destCanon;
+			if (Right(local.destPrefix, 1) != local.sep) {
+				local.destPrefix = local.destPrefix & local.sep;
+			}
+			local.target = CreateObject("java", "java.io.File").init(local.destFile, local.entry);
+			local.targetCanon = local.target.getCanonicalPath();
+			if (local.targetCanon == local.destCanon) {
+				return false;
+			}
+			return CompareNoCase(Left(local.targetCanon, Len(local.destPrefix)), local.destPrefix) != 0;
+		} catch (any e) {
+			return true;
+		}
+	}
+
+	/**
+	 * Lists entry names in a zip via java.util.zip.ZipFile so every engine
+	 * sees the same names before cfzip writes anything.
+	 */
+	public array function $zipEntryNames(required string zipFile) {
+		local.names = [];
+		local.zf = CreateObject("java", "java.util.zip.ZipFile").init(arguments.zipFile);
+		try {
+			local.entries = local.zf.entries();
+			while (local.entries.hasMoreElements()) {
+				local.entry = local.entries.nextElement();
+				ArrayAppend(local.names, local.entry.getName());
+			}
+		} finally {
+			local.zf.close();
+		}
+		return local.names;
+	}
+
+	/**
+	 * Throws Wheels.UnsafeZipEntry when any entry would escape destination.
+	 */
+	public void function $assertZipEntriesContained(required string zipFile, required string destination) {
+		local.names = $zipEntryNames(arguments.zipFile);
+		for (local.entry in local.names) {
+			if ($zipEntryEscapesDestination(arguments.destination, local.entry)) {
+				Throw(
+					type = "Wheels.UnsafeZipEntry",
+					message = "Zip entry '#local.entry#' escapes destination '#arguments.destination#'"
+				);
+			}
+		}
 	}
 
 

--- a/vendor/wheels/tests/_assets/packages_hardener_emptycompat/emptycompat/Emptycompat.cfc
+++ b/vendor/wheels/tests/_assets/packages_hardener_emptycompat/emptycompat/Emptycompat.cfc
@@ -1,0 +1,8 @@
+component {
+
+	public any function init() {
+		this.version = "1.0.0";
+		return this;
+	}
+
+}

--- a/vendor/wheels/tests/_assets/packages_hardener_emptycompat/emptycompat/package.json
+++ b/vendor/wheels/tests/_assets/packages_hardener_emptycompat/emptycompat/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "wheels-emptycompat",
+	"version": "1.0.0",
+	"description": "Hardener B2 fixture: empty wheelsVersion string must fail closed",
+	"wheelsVersion": "",
+	"provides": {
+		"mixins": "none"
+	}
+}

--- a/vendor/wheels/tests/_assets/packages_lazy_sp_solo/solounhinted/Solounhinted.cfc
+++ b/vendor/wheels/tests/_assets/packages_lazy_sp_solo/solounhinted/Solounhinted.cfc
@@ -1,0 +1,23 @@
+/**
+ * Hardener B4 fixture: the only package in this vendor tree. Lazy, implements
+ * ServiceProviderInterface, and does NOT hint provides.services. The loader
+ * must still detect ServiceProvider work so register()/boot() run.
+ */
+component implements="wheels.ServiceProviderInterface" {
+
+	public any function init() {
+		this.version = "1.0.0";
+		this.registerCalled = false;
+		this.bootCalled = false;
+		return this;
+	}
+
+	public void function register(required any container) {
+		this.registerCalled = true;
+	}
+
+	public void function boot(required struct app) {
+		this.bootCalled = true;
+	}
+
+}

--- a/vendor/wheels/tests/_assets/packages_lazy_sp_solo/solounhinted/package.json
+++ b/vendor/wheels/tests/_assets/packages_lazy_sp_solo/solounhinted/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "wheels-solounhinted",
+	"version": "1.0.0",
+	"description": "Hardener B4 fixture: solo unhinted lazy ServiceProvider — no provides.services",
+	"lazy": true,
+	"provides": {
+		"mixins": "none"
+	}
+}

--- a/vendor/wheels/tests/_assets/plugins/hardener_emptycompat/EmptyCompatPlugin/EmptyCompatPlugin.cfc
+++ b/vendor/wheels/tests/_assets/plugins/hardener_emptycompat/EmptyCompatPlugin/EmptyCompatPlugin.cfc
@@ -1,0 +1,12 @@
+/**
+ * Hardener B2 fixture: plugin with no this.version and no plugin.json
+ * wheelsVersion. Empty compatibility must fail closed even when
+ * loadIncompatiblePlugins stays true.
+ */
+component {
+
+	public any function init() {
+		return this;
+	}
+
+}

--- a/vendor/wheels/tests/specs/hardener/PluginsHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/hardener/PluginsHardenerSpec.cfc
@@ -1,0 +1,304 @@
+/**
+ * Hardener BLOCKERs B1–B4 (plugins / package loader).
+ *
+ * Directory-scoped so `wheels test --core --ci --filter=hardener`
+ * discovers this folder (a single-file directory= scope finds 0 bundles).
+ *
+ * Public defaults stay true (CoS lock): overwritePlugins,
+ * loadIncompatiblePlugins, deletePluginDirectories. Fixes are fail-closed
+ * containment / detection under those defaults.
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		g = application.wo
+
+		describe("CoS lock: plugin public defaults stay true", () => {
+
+			it("keeps overwritePlugins true", () => {
+				expect(application.wheels.overwritePlugins).toBeTrue();
+			});
+
+			it("keeps loadIncompatiblePlugins true", () => {
+				expect(application.wheels.loadIncompatiblePlugins).toBeTrue();
+			});
+
+			it("keeps deletePluginDirectories true", () => {
+				expect(application.wheels.deletePluginDirectories).toBeTrue();
+			});
+
+		});
+
+		describe("B1 zip slip: unzip stays inside destination", () => {
+
+			beforeEach(() => {
+				slipRoot = ExpandPath("/wheels/tests/_assets/plugins/hardener_zipslip_runtime");
+				$resetDir(slipRoot);
+				destDir = slipRoot & "/dest";
+				DirectoryCreate(destDir);
+				zipPath = slipRoot & "/Slip-1.0.zip";
+				escapedSibling = slipRoot & "/escaped-sibling.txt";
+				escapedPluginTree = ExpandPath("/wheels/tests/_assets/plugins/hardener-b1-pwned.txt");
+			});
+
+			afterEach(() => {
+				$resetDir(slipRoot);
+				if (FileExists(escapedPluginTree)) {
+					FileDelete(escapedPluginTree);
+				}
+			});
+
+			it("does not write a ../ zip entry outside the unzip destination", () => {
+				$writeZipWithEntries(zipPath, {
+					"../escaped-sibling.txt" = "pwned-sibling",
+					"safe.txt" = "contained"
+				});
+
+				try {
+					g.$zip(action = "unzip", destination = destDir, file = zipPath, overwrite = true);
+				} catch (any e) {
+					// fail-closed throw is allowed; the escaped file must not land
+				}
+
+				expect(FileExists(escapedSibling)).toBeFalse();
+			});
+
+			it("does not write a ../../ zip entry into the plugins tree", () => {
+				$writeZipWithEntries(zipPath, {
+					"../../hardener-b1-pwned.txt" = "pwned-tree",
+					"safe.txt" = "contained"
+				});
+
+				try {
+					g.$zip(action = "unzip", destination = destDir, file = zipPath, overwrite = true);
+				} catch (any e) {
+				}
+
+				expect(FileExists(escapedPluginTree)).toBeFalse();
+			});
+
+			it("does not extract a zip-slip plugin archive when overwritePlugins is true", () => {
+				originalPluginComponentPath = application.wheels.pluginComponentPath;
+				application.wheels.pluginComponentPath = "/wheels/tests/_assets/plugins/hardener_zipslip_runtime";
+
+				$writeZipWithEntries(zipPath, {
+					"../escaped-sibling.txt" = "pwned-extract",
+					"../../hardener-b1-pwned.txt" = "pwned-tree"
+				});
+
+				var config = {
+					path = "wheels",
+					fileName = "Plugins",
+					method = "$init",
+					pluginPath = "/wheels/tests/_assets/plugins/hardener_zipslip_runtime",
+					deletePluginDirectories = true,
+					overwritePlugins = true,
+					loadIncompatiblePlugins = true
+				};
+
+				try {
+					$pluginObj(config);
+				} catch (any e) {
+					// extract must fail closed without leaving escaped files
+				}
+
+				application.wheels.pluginComponentPath = originalPluginComponentPath;
+
+				expect(FileExists(escapedSibling)).toBeFalse();
+				expect(FileExists(escapedPluginTree)).toBeFalse();
+			});
+
+			it("rejects an absolute zip entry path", () => {
+				var absEscape = slipRoot & "/abs-escaped.txt";
+				if (FileExists(absEscape)) {
+					FileDelete(absEscape);
+				}
+				var absEntry = {};
+				absEntry[Replace(absEscape, "\", "/", "all")] = "pwned-abs";
+				$writeZipWithEntries(zipPath, absEntry);
+
+				try {
+					g.$zip(action = "unzip", destination = destDir, file = zipPath, overwrite = true);
+				} catch (any e) {
+				}
+
+				expect(FileExists(absEscape)).toBeFalse();
+			});
+
+		});
+
+		describe("B2 version gate: empty compat fails closed", () => {
+
+			it("does not load a plugin with empty compatibility when loadIncompatiblePlugins is true", () => {
+				originalPluginComponentPath = application.wheels.pluginComponentPath;
+				application.wheels.pluginComponentPath = "/wheels/tests/_assets/plugins/hardener_emptycompat";
+
+				var config = {
+					path = "wheels",
+					fileName = "Plugins",
+					method = "$init",
+					pluginPath = "/wheels/tests/_assets/plugins/hardener_emptycompat",
+					deletePluginDirectories = true,
+					overwritePlugins = true,
+					loadIncompatiblePlugins = true,
+					wheelsVersion = "4.0.0"
+				};
+				var pluginObj = $pluginObj(config);
+				var plugins = pluginObj.getPlugins();
+
+				application.wheels.pluginComponentPath = originalPluginComponentPath;
+
+				expect(plugins).notToHaveKey("EmptyCompatPlugin");
+			});
+
+			it("still loads a declared mismatch when loadIncompatiblePlugins is true", () => {
+				originalPluginComponentPath = application.wheels.pluginComponentPath;
+				application.wheels.pluginComponentPath = "/wheels/tests/_assets/plugins/standard";
+
+				var config = {
+					path = "wheels",
+					fileName = "Plugins",
+					method = "$init",
+					pluginPath = "/wheels/tests/_assets/plugins/standard",
+					deletePluginDirectories = false,
+					overwritePlugins = false,
+					loadIncompatiblePlugins = true,
+					wheelsVersion = "99.9.9"
+				};
+				var pluginObj = $pluginObj(config);
+				var plugins = pluginObj.getPlugins();
+
+				application.wheels.pluginComponentPath = originalPluginComponentPath;
+
+				expect(plugins).toHaveKey("TestIncompatableVersion");
+			});
+
+			it("does not load a package whose wheelsVersion is an empty string", () => {
+				var loader = new wheels.PackageLoader(
+					vendorPath = ExpandPath("/wheels/tests/_assets/packages_hardener_emptycompat"),
+					componentPrefix = "wheels.tests._assets.packages_hardener_emptycompat",
+					wheelsVersion = "4.0.0"
+				);
+
+				expect(loader.getPackages()).notToHaveKey("emptycompat");
+				expect(loader.getPackageMeta()).notToHaveKey("emptycompat");
+
+				var foundEmpty = false;
+				for (var failed in loader.getFailedPackages()) {
+					if (failed.name == "emptycompat") {
+						foundEmpty = true;
+					}
+				}
+				expect(foundEmpty).toBeTrue();
+			});
+
+		});
+
+		describe("B3 duplicate package manifest name is not last-wins", () => {
+
+			it("fails both packages that declare the same manifest name", () => {
+				var graph = new wheels.ModuleGraph();
+				var manifests = {
+					pkgFirst = {name = "wheels-dup", version = "1.0.0"},
+					pkgSecond = {name = "wheels-dup", version = "2.0.0"}
+				};
+				var result = graph.resolve(manifests);
+
+				expect(ArrayFind(result.loadOrder, "pkgFirst")).toBe(0);
+				expect(ArrayFind(result.loadOrder, "pkgSecond")).toBe(0);
+
+				var foundDup = false;
+				for (var err in result.errors) {
+					if (FindNoCase("duplicate", err.message) && FindNoCase("wheels-dup", err.message)) {
+						foundDup = true;
+					}
+				}
+				expect(foundDup).toBeTrue();
+			});
+
+			it("does not resolve requires against a collided name", () => {
+				var graph = new wheels.ModuleGraph();
+				var manifests = {
+					pkgFirst = {name = "wheels-dup", version = "1.0.0"},
+					pkgSecond = {name = "wheels-dup", version = "2.0.0"},
+					pkgConsumer = {
+						name = "wheels-consumer",
+						version = "1.0.0",
+						requires = {"wheels-dup" = "*"}
+					}
+				};
+				var result = graph.resolve(manifests);
+
+				expect(ArrayFind(result.loadOrder, "pkgConsumer")).toBe(0);
+				expect(ArrayFind(result.loadOrder, "pkgFirst")).toBe(0);
+				expect(ArrayFind(result.loadOrder, "pkgSecond")).toBe(0);
+			});
+
+		});
+
+		describe("B4 solo unhinted lazy ServiceProvider still boots", () => {
+
+			beforeEach(() => {
+				soloPath = ExpandPath("/wheels/tests/_assets/packages_lazy_sp_solo");
+				soloPrefix = "wheels.tests._assets.packages_lazy_sp_solo";
+			});
+
+			it("reports ServiceProvider work when the only package is an unhinted lazy provider", () => {
+				var loader = new wheels.PackageLoader(
+					vendorPath = soloPath,
+					componentPrefix = soloPrefix
+				);
+
+				expect(loader.getPackages()).notToHaveKey("solounhinted");
+				expect(loader.$hasServiceProviderWork()).toBeTrue();
+			});
+
+			it("invokes register() and boot() on a solo unhinted lazy ServiceProvider", () => {
+				var loader = new wheels.PackageLoader(
+					vendorPath = soloPath,
+					componentPrefix = soloPrefix
+				);
+				var fakeContainer = CreateObject(
+					"component",
+					"wheels.tests._assets.plugins.serviceprovider.FakeContainer"
+				).init();
+
+				loader.$invokeServiceProviderRegister(fakeContainer);
+				loader.$invokeServiceProviderBoot({});
+
+				var pkgs = loader.getPackages();
+				expect(pkgs).toHaveKey("solounhinted");
+				expect(pkgs.solounhinted.registerCalled).toBeTrue();
+				expect(pkgs.solounhinted.bootCalled).toBeTrue();
+			});
+
+		});
+
+	}
+
+	function $pluginObj(required struct config) {
+		return g.$createObjectFromRoot(argumentCollection = arguments.config);
+	}
+
+	public void function $resetDir(required string path) {
+		if (DirectoryExists(arguments.path)) {
+			DirectoryDelete(arguments.path, true);
+		}
+		DirectoryCreate(arguments.path);
+	}
+
+	public void function $writeZipWithEntries(required string zipPath, required struct entries) {
+		var fos = CreateObject("java", "java.io.FileOutputStream").init(arguments.zipPath);
+		var zos = CreateObject("java", "java.util.zip.ZipOutputStream").init(fos);
+		for (var name in arguments.entries) {
+			var entry = CreateObject("java", "java.util.zip.ZipEntry").init(name);
+			zos.putNextEntry(entry);
+			var bytes = CreateObject("java", "java.lang.String").init(arguments.entries[name]).getBytes("UTF-8");
+			zos.write(bytes);
+			zos.closeEntry();
+		}
+		zos.close();
+	}
+
+}

--- a/vendor/wheels/tests/specs/hardener/PluginsHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/hardener/PluginsHardenerSpec.cfc
@@ -49,6 +49,14 @@ component extends="wheels.WheelsTest" {
 				}
 			});
 
+			it("classifies traversal and absolute entries as escaping", () => {
+				expect(g.$zipEntryEscapesDestination(destDir, "../escaped-sibling.txt")).toBeTrue();
+				expect(g.$zipEntryEscapesDestination(destDir, "../../hardener-b1-pwned.txt")).toBeTrue();
+				expect(g.$zipEntryEscapesDestination(destDir, "/tmp/abs-escaped.txt")).toBeTrue();
+				expect(g.$zipEntryEscapesDestination(destDir, "safe.txt")).toBeFalse();
+				expect(g.$zipEntryEscapesDestination(destDir, "nested/safe.txt")).toBeFalse();
+			});
+
 			it("does not write a ../ zip entry outside the unzip destination", () => {
 				$writeZipWithEntries(zipPath, {
 					"../escaped-sibling.txt" = "pwned-sibling",
@@ -130,6 +138,15 @@ component extends="wheels.WheelsTest" {
 
 		describe("B2 version gate: empty compat fails closed", () => {
 
+			it("empty compat fails closed even when loadIncompatible is true", () => {
+				var pm = CreateObject("component", "wheels.Plugins");
+				expect(pm.$shouldLoadPlugin("", "4.0.0", true)).toBeFalse();
+				expect(pm.$shouldLoadPlugin("   ", "4.0.0", true)).toBeFalse();
+				expect(pm.$shouldLoadPlugin("1.0", "4.0.0", true)).toBeTrue();
+				expect(pm.$shouldLoadPlugin("1.0", "4.0.0", false)).toBeFalse();
+				expect(pm.$shouldLoadPlugin("4.0.0", "4.0.0", false)).toBeTrue();
+			});
+
 			it("does not load a plugin with empty compatibility when loadIncompatiblePlugins is true", () => {
 				originalPluginComponentPath = application.wheels.pluginComponentPath;
 				application.wheels.pluginComponentPath = "/wheels/tests/_assets/plugins/hardener_emptycompat";
@@ -200,8 +217,8 @@ component extends="wheels.WheelsTest" {
 			it("fails both packages that declare the same manifest name", () => {
 				var graph = new wheels.ModuleGraph();
 				var manifests = {
-					pkgFirst = {name = "wheels-dup", version = "1.0.0"},
-					pkgSecond = {name = "wheels-dup", version = "2.0.0"}
+					"pkgFirst" = {name = "wheels-dup", version = "1.0.0"},
+					"pkgSecond" = {name = "wheels-dup", version = "2.0.0"}
 				};
 				var result = graph.resolve(manifests);
 
@@ -220,9 +237,9 @@ component extends="wheels.WheelsTest" {
 			it("does not resolve requires against a collided name", () => {
 				var graph = new wheels.ModuleGraph();
 				var manifests = {
-					pkgFirst = {name = "wheels-dup", version = "1.0.0"},
-					pkgSecond = {name = "wheels-dup", version = "2.0.0"},
-					pkgConsumer = {
+					"pkgFirst" = {name = "wheels-dup", version = "1.0.0"},
+					"pkgSecond" = {name = "wheels-dup", version = "2.0.0"},
+					"pkgConsumer" = {
 						name = "wheels-consumer",
 						version = "1.0.0",
 						requires = {"wheels-dup" = "*"}

--- a/vendor/wheels/tests/specs/packages/LazyServiceProviderSpec.cfc
+++ b/vendor/wheels/tests/specs/packages/LazyServiceProviderSpec.cfc
@@ -10,8 +10,9 @@
  *
  * Fixtures live in /wheels/tests/_assets/packages_lazy_sp:
  * - lazysvc:  lazy + provides.services hint — must join the lifecycle at boot.
- * - lazylate: lazy, no services hint — stays lazy through boot; register()/
- *             boot() must run when getPackage() instantiates it afterwards.
+ * - lazylate: lazy, no services hint, but implements ServiceProviderInterface
+ *             — pulled into register()/boot() at lifecycle time (same as a
+ *             solo unhinted provider).
  */
 component extends="wheels.WheelsTest" {
 
@@ -59,7 +60,7 @@ component extends="wheels.WheelsTest" {
 				expect(pkgs.lazysvc.bootCalled).toBeTrue();
 			});
 
-			it("leaves a lazy provider without a services hint un-instantiated through boot", () => {
+			it("invokes register() and boot() on an unhinted lazy ServiceProvider", () => {
 				var loader = new wheels.PackageLoader(
 					vendorPath = lazyFixturesPath,
 					componentPrefix = lazyFixturesPrefix
@@ -72,9 +73,10 @@ component extends="wheels.WheelsTest" {
 				loader.$invokeServiceProviderRegister(fakeContainer);
 				loader.$invokeServiceProviderBoot({});
 
-				// Unhinted lazy packages keep their laziness.
-				expect(loader.getPackages()).notToHaveKey("lazylate");
-				expect(loader.isPackageLoaded("lazylate")).toBeTrue();
+				var pkgs = loader.getPackages();
+				expect(pkgs).toHaveKey("lazylate");
+				expect(pkgs.lazylate.registerCalled).toBeTrue();
+				expect(pkgs.lazylate.bootCalled).toBeTrue();
 			});
 
 			it("invokes register()/boot() when an unhinted lazy provider is instantiated after boot", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardener Coder for plugins / package-loader. Desk lock: **do not flip** `overwritePlugins`, `loadIncompatiblePlugins`, or `deletePluginDirectories` (all stay `true`). Fail-closed under those defaults.

## BLOCKERs

| ID | Status | What was proven |
|---|---|---|
| **B1** Zip slip | **PROVEN** | `$zip` lists entries first and rejects `../` / absolute / canonical-escape paths (`Wheels.UnsafeZipEntry`) before `cfzip` writes. `$pluginsExtract` logs and skips that zip (does not abort boot). Integration: slip zip extracts 0 files; destination parent stays intact. Unit: `$zipEntryEscapesDestination` covers `..`, absolute, nested `..`. |
| **B2** Version gate fail-open | **PROVEN** | Empty / whitespace `compatibility` / `wheelsVersion` → `$shouldLoadPlugin` returns `false` even when `loadIncompatible=true`. Declared mismatch (`1.x` vs `3.0.0`) still loads when `loadIncompatible=true` (default unchanged). Package `$isCompatibleVersion`: present-but-empty `wheelsVersion` fails closed; omitted / `"*"` still pass. |
| **B3** Duplicate package `name` | **PROVEN** | Two dirs with `name: "dup-pkg"`: both excluded from load order, `nameToDir` has no `"dup-pkg"` key, `errors` has a uniqueness message. `$processReplacements` receives the collision set so `replaces` cannot fire from a colliding name. |
| **B4** Solo unhinted lazy ServiceProvider | **PROVEN** | Fixture `packages_lazy_sp_solo` has no `provides.services` but implements `ServiceProviderInterface`. `$sourceDeclaresServiceProvider` (comment-stripped scan) is true; `$hasServiceProviderWork` is true; `$invokeServiceProviderRegister` + `$bootServiceProviders` increment register/boot. |
| Defaults stay `true` | **PROVEN** | Guard spec asserts `overwritePlugins`, `deletePluginDirectories`, `loadIncompatiblePlugins` remain `true`. |
| Flip `loadIncompatiblePlugins` | **UNPROVEN** | Escalated to Lead→CoS. Not flipped. |

## SHOULDs

Desk did not attach S1–S15 text. **Deferred**, not invented.

## Local proof (wheels CLI, Lucee 7)

Driver: `wheels test --core --ci --filter=…` (never CommandBox).

| Filter | Result |
|---|---|
| `--filter=hardener` RED (`a302254e2`) | 103 pass / **5 fail** (B2×2, B3, B4×2). B1 integration already held on Lucee `cfzip`. |
| `--filter=hardener` GREEN | **110 passed** |
| `--filter=packages` | **136 passed** |
| `--filter=global` | **199 passed** |
| `--filter=plugins` | 0 bundles (no `specs/plugins/` dir). Plugin load covered by hardener B2. |

## CI (GREEN push `44ec9e18`)

- Lucee 7 + SQLite (LuCLI) core tests: **passed**
- Smoke: production (Lucee 7), testing (Adobe 2023), production (Adobe 2023): **passed**
- Smoke: testing (Lucee 7): **infra flake** — LuCLI `Cannot start server - port conflicts detected` while downloading Lucee Express. Died **before** the app or tests ran. Same job **passed** on the RED push (`32729487934`). Not a loader regression.

## Inferred follow-ups (not in this PR)

- Overwrite-on-reload as opt-in (keep default `true` until CoS lock lifts)
- Mismatch-load as opt-in (same)
- `deletePluginDirectories` behaviour

## Test plan

- [x] RED then GREEN `wheels test --core --ci --filter=hardener`
- [x] `wheels test --core --ci --filter=packages`
- [x] `wheels test --core --ci --filter=global`
- [ ] Human: Adobe 2023 `$zip` containment (Lucee `cfzip` already refused `..` on RED)
- [ ] Human: re-run Smoke testing (Lucee 7) if the port-conflict flake needs a green check

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60dacea5-f300-43b4-801b-faff6a5a9565?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60dacea5-f300-43b4-801b-faff6a5a9565&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

