### PR TITLE
fix(view): harden view helper BLOCKERs B1–B5

### DIFF
--- a/changelog.d/view-helpers-hardener-b1-b5.added.md
+++ b/changelog.d/view-helpers-hardener-b1-b5.added.md
@@ -1,0 +1,1 @@
+- `linkTo(sanitizeHref=true)` blanks caller-supplied `javascript:` / `data:` hrefs. Default remains `false` (no public-behavior change)

--- a/changelog.d/view-helpers-hardener-b1-b5.security.md
+++ b/changelog.d/view-helpers-hardener-b1-b5.security.md
@@ -1,0 +1,3 @@
+- `labelPlacement="aroundRight"` now encodes the label under the existing `encode=true` default (`$formAfterElement` no longer raw-concats)
+- Date `<select>` helpers honor `encode="attributes"` the same way `select()` does (attribute values stay encoded)
+- `paginationLinks()` sanitizes `prependToPage` on first/last `alwaysShowAnchors` the same way as numbered pages

--- a/vendor/wheels/events/init/functions.cfm
+++ b/vendor/wheels/events/init/functions.cfm
@@ -224,7 +224,14 @@
 		application.$wheels.functions.imageTag = {onlyPath = true, host = "", protocol = "", port = 0, encode = true};
 		application.$wheels.functions.includePartial = {layout = "", spacer = "", dataFunction = true};
 		application.$wheels.functions.javaScriptIncludeTag = {type = "text/javascript", head = false, encode = true};
-		application.$wheels.functions.linkTo = {onlyPath = true, host = "", protocol = "", port = 0, encode = true};
+		application.$wheels.functions.linkTo = {
+			onlyPath = true,
+			host = "",
+			protocol = "",
+			port = 0,
+			encode = true,
+			sanitizeHref = false
+		};
 		application.$wheels.functions.mailTo = {encode = true};
 		application.$wheels.functions.maximum = {parameterize = true, ifNull = ""};
 		application.$wheels.functions.minimum = {parameterize = true, ifNull = ""};

--- a/vendor/wheels/tests/specs/hardener/ViewHelpersHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/hardener/ViewHelpersHardenerSpec.cfc
@@ -1,0 +1,234 @@
+/**
+ * Hardener BLOCKERs B1–B5 (view helpers: form labels, date select encode,
+ * linkTo href schemes, paginationLinks anchors, $element assertion).
+ *
+ * Directory-scoped so `wheels test --core --ci --filter=hardener`
+ * discovers this folder (a single-file directory= scope finds 0 bundles).
+ *
+ * encode defaults stay true. B3 default deny of javascript:/data: is
+ * ESCALATED — this spec proves an opt-in fail-closed path only.
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		g = application.wo
+
+		describe("CoS lock: encode defaults stay true", () => {
+
+			it("keeps encode=true on textFieldTag, dateSelect, linkTo, and paginationLinks", () => {
+				expect(application.wheels.functions.textFieldTag.encode).toBeTrue()
+				expect(application.wheels.functions.dateSelect.encode).toBeTrue()
+				expect(application.wheels.functions.linkTo.encode).toBeTrue()
+				expect(application.wheels.functions.paginationLinks.encode).toBeTrue()
+			})
+
+		})
+
+		describe("B1 aroundRight encodes the label under encode=true", () => {
+
+			beforeEach(() => {
+				_controller = g.controller(name = "dummy")
+				g.set(functionName = "textFieldTag", encode = true)
+			})
+
+			afterEach(() => {
+				g.set(functionName = "textFieldTag", encode = true)
+			})
+
+			it("does not emit a raw XSS label when labelPlacement is aroundRight", () => {
+				result = _controller.textFieldTag(
+					name = "username",
+					label = "<img src=x onerror=alert(1)>",
+					labelPlacement = "aroundRight",
+					encode = true
+				)
+
+				expect(result).notToInclude("<img")
+				expect(result).notToInclude("onerror")
+				expect(result).toInclude("&lt;img")
+			})
+
+			it("still encodes aroundLeft labels so the placements stay aligned", () => {
+				result = _controller.textFieldTag(
+					name = "username",
+					label = "<img src=x onerror=alert(1)>",
+					labelPlacement = "aroundLeft",
+					encode = true
+				)
+
+				expect(result).notToInclude("<img")
+				expect(result).notToInclude("onerror")
+				expect(result).toInclude("&lt;img")
+			})
+
+			it("leaves the label raw only when encode is explicitly false", () => {
+				result = _controller.textFieldTag(
+					name = "username",
+					label = "<img src=x onerror=alert(1)>",
+					labelPlacement = "aroundRight",
+					encode = false
+				)
+
+				expect(result).toInclude("<img src=x onerror=alert(1)>")
+			})
+
+		})
+
+		describe("B2 date select honors encode=attributes like select()", () => {
+
+			beforeEach(() => {
+				_controller = g.controller(name = "dummy")
+			})
+
+			it("encodes a breaking class on yearSelectTag when encode is attributes", () => {
+				result = _controller.yearSelectTag(
+					name = "y",
+					selected = 2020,
+					startYear = 2020,
+					endYear = 2020,
+					includeBlank = false,
+					label = "",
+					encode = "attributes",
+					class = 'x" onclick="alert(1)'
+				)
+
+				expect(result).notToInclude('onclick="alert(1)"')
+				expect(result).toInclude("select")
+			})
+
+			it("does not coerce encode=attributes to false on the date select helper", () => {
+				result = _controller.$yearMonthHourMinuteSecondSelectTag(
+					name = "y",
+					value = "2020",
+					includeBlank = false,
+					label = "",
+					labelPlacement = "around",
+					prepend = "",
+					append = "",
+					prependToLabel = "",
+					appendToLabel = "",
+					$type = "year",
+					$loopFrom = 2020,
+					$loopTo = 2020,
+					$id = "y",
+					$step = 1,
+					encode = "attributes",
+					class = 'x" onclick="alert(1)',
+					objectName = {},
+					property = "y"
+				)
+
+				expect(result).notToInclude('onclick="alert(1)"')
+			})
+
+		})
+
+		describe("B3 linkTo href javascript:/data: gate is opt-in", () => {
+
+			beforeEach(() => {
+				_controller = g.controller(name = "dummy")
+				g.set(functionName = "linkTo", encode = true)
+				g.set(functionName = "linkTo", sanitizeHref = false)
+			})
+
+			afterEach(() => {
+				g.set(functionName = "linkTo", encode = true)
+				g.set(functionName = "linkTo", sanitizeHref = false)
+			})
+
+			it("keeps sanitizeHref false so default public href behavior is unchanged", () => {
+				if (StructKeyExists(application.wheels.functions.linkTo, "sanitizeHref")) {
+					expect(application.wheels.functions.linkTo.sanitizeHref).toBeFalse()
+				} else {
+					expect(true).toBeTrue()
+				}
+			})
+
+			it("still emits javascript: hrefs under the default sanitizeHref=false", () => {
+				result = _controller.linkTo(href = "javascript:alert(1)", text = "x")
+
+				expect(result).toInclude("javascript:")
+			})
+
+			it("strips javascript: hrefs when sanitizeHref is true", () => {
+				result = _controller.linkTo(href = "javascript:alert(1)", text = "x", sanitizeHref = true)
+
+				expect(result).notToInclude("javascript:")
+				expect(result).toInclude("<a")
+			})
+
+			it("strips DATA: hrefs when sanitizeHref is true", () => {
+				result = _controller.linkTo(
+					href = "DATA:text/html,<script>alert(1)</script>",
+					text = "x",
+					sanitizeHref = true
+				)
+
+				expect(result).notToInclude("data:")
+				expect(result).notToInclude("DATA:")
+				expect(result).notToInclude("<script>")
+			})
+
+			it("leaves https hrefs intact when sanitizeHref is true", () => {
+				result = _controller.linkTo(href = "https://example.com/ok", text = "x", sanitizeHref = true)
+
+				expect(result).toInclude("https://example.com/ok")
+			})
+
+		})
+
+		describe("B4 paginationLinks sanitizes prependToPage on first/last anchors", () => {
+
+			beforeEach(() => {
+				_controller = g.controller(name = "dummy")
+				g.set(functionName = "linkTo", encode = false)
+				g.set(functionName = "paginationLinks", encode = "attributes")
+			})
+
+			afterEach(() => {
+				g.set(functionName = "linkTo", encode = true)
+				g.set(functionName = "paginationLinks", encode = true)
+			})
+
+			it("does not emit onmouseover from prependToPage on alwaysShowAnchors", () => {
+				authors = g.model("author").findAll(page = 2, perPage = 3, order = "lastName")
+				result = _controller.paginationLinks(
+					windowSize = 0,
+					alwaysShowAnchors = true,
+					prependOnAnchor = true,
+					prependToPage = '<li class="page-item" onmouseover="alert(1)">',
+					appendToPage = "</li>",
+					encode = "attributes"
+				)
+
+				expect(result).notToInclude("onmouseover")
+				expect(result).notToInclude("alert(1)")
+				expect(result).toInclude("page-item")
+			})
+
+		})
+
+		describe("B5 $element assertion is not a tautology", () => {
+
+			it("renders a textarea with the supplied attributes and content", () => {
+				_controller = g.controller(name = "dummy")
+				args = {}
+				args.name = "textarea"
+				args.attributes = {}
+				args.attributes.rows = 10
+				args.attributes.cols = 40
+				args.attributes.name = "textareatest"
+				args.content = "this is a test to see if textarea renders"
+
+				e = _controller.$element(argumentCollection = args)
+				r = '<textarea cols="40" name="textareatest" rows="10">this is a test to see if textarea renders</textarea>'
+
+				expect(e).toBe(r)
+			})
+
+		})
+
+	}
+
+}

--- a/vendor/wheels/tests/specs/hardener/ViewHelpersHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/hardener/ViewHelpersHardenerSpec.cfc
@@ -58,7 +58,6 @@ component extends="wheels.WheelsTest" {
 				)
 
 				expect(result).notToInclude("<img")
-				expect(result).notToInclude("onerror")
 				expect(result).toInclude("&lt;img")
 			})
 
@@ -129,32 +128,29 @@ component extends="wheels.WheelsTest" {
 			beforeEach(() => {
 				_controller = g.controller(name = "dummy")
 				g.set(functionName = "linkTo", encode = true)
-				g.set(functionName = "linkTo", sanitizeHref = false)
 			})
 
 			afterEach(() => {
 				g.set(functionName = "linkTo", encode = true)
-				g.set(functionName = "linkTo", sanitizeHref = false)
 			})
 
 			it("keeps sanitizeHref false so default public href behavior is unchanged", () => {
-				if (StructKeyExists(application.wheels.functions.linkTo, "sanitizeHref")) {
-					expect(application.wheels.functions.linkTo.sanitizeHref).toBeFalse()
-				} else {
-					expect(true).toBeTrue()
-				}
+				expect(application.wheels.functions.linkTo.sanitizeHref).toBeFalse()
 			})
 
 			it("still emits javascript: hrefs under the default sanitizeHref=false", () => {
 				result = _controller.linkTo(href = "javascript:alert(1)", text = "x")
+				decoded = _controller.$decodeHtmlEntities(result)
 
-				expect(result).toInclude("javascript:")
+				expect(decoded).toInclude("javascript:")
 			})
 
 			it("strips javascript: hrefs when sanitizeHref is true", () => {
 				result = _controller.linkTo(href = "javascript:alert(1)", text = "x", sanitizeHref = true)
+				decoded = _controller.$decodeHtmlEntities(result)
 
-				expect(result).notToInclude("javascript:")
+				expect(decoded).notToInclude("javascript:")
+				expect(result).notToInclude("sanitizehref")
 				expect(result).toInclude("<a")
 			})
 
@@ -164,16 +160,17 @@ component extends="wheels.WheelsTest" {
 					text = "x",
 					sanitizeHref = true
 				)
+				decoded = _controller.$decodeHtmlEntities(result)
 
-				expect(result).notToInclude("data:")
-				expect(result).notToInclude("DATA:")
+				expect(decoded).notToInclude("data:")
 				expect(result).notToInclude("<script>")
 			})
 
 			it("leaves https hrefs intact when sanitizeHref is true", () => {
 				result = _controller.linkTo(href = "https://example.com/ok", text = "x", sanitizeHref = true)
+				decoded = _controller.$decodeHtmlEntities(result)
 
-				expect(result).toInclude("https://example.com/ok")
+				expect(decoded).toInclude("https://example.com/ok")
 			})
 
 		})

--- a/vendor/wheels/tests/specs/hardener/ViewHelpersHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/hardener/ViewHelpersHardenerSpec.cfc
@@ -45,7 +45,6 @@ component extends="wheels.WheelsTest" {
 				)
 
 				expect(result).notToInclude("<img")
-				expect(result).notToInclude("onerror")
 				expect(result).toInclude("&lt;img")
 			})
 

--- a/vendor/wheels/tests/specs/view/miscellaneousSpec.cfc
+++ b/vendor/wheels/tests/specs/view/miscellaneousSpec.cfc
@@ -21,9 +21,9 @@ component extends="wheels.WheelsTest" {
 				args.content = "this is a test to see if textarea renders"
 
 				e = _controller.$element(argumentcollection = args)
-				r = '<textare cols="40" name="textareatest" rows="10">this is a test to see if textare renders</textarea>'
+				r = '<textarea cols="40" name="textareatest" rows="10">this is a test to see if textarea renders</textarea>'
 
-				expect(r).toBe(r)
+				expect(e).toBe(r)
 			})
 		})
 

--- a/vendor/wheels/view/forms.cfc
+++ b/vendor/wheels/view/forms.cfc
@@ -479,8 +479,14 @@ component {
 				// if the label should be placed after the tag we return the entire label tag
 				local.rv &= $createLabel(argumentCollection = arguments);
 			} else if (arguments.labelPlacement == "aroundRight") {
-				// if the text should be placed to the right of the form input we return both the text and the closing tag
-				local.rv &= arguments.label & "</label>";
+				// Match $createLabel / $element: encode label text when encode=true.
+				// aroundRight used to concat arguments.label raw, so XSS labels
+				// skipped the encode=true path that around / aroundLeft / after use.
+				local.labelText = arguments.label;
+				if (IsBoolean(arguments.encode) && arguments.encode && $get("encodeHtmlTags")) {
+					local.labelText = EncodeForHTML($canonicalize(arguments.label));
+				}
+				local.rv &= local.labelText & "</label>";
 			} else {
 				// the label argument is either "around" or "aroundLeft" so we only have to return the closing label tag
 				local.rv &= "</label>";

--- a/vendor/wheels/view/formsdate.cfc
+++ b/vendor/wheels/view/formsdate.cfc
@@ -319,7 +319,9 @@ component {
 				local.content &= $yearMonthHourMinuteSecondSelectTagContent(argumentCollection = local.args);
 			}
 		}
-		local.encode = IsBoolean(arguments.encode) && arguments.encode ? "attributes" : false;
+		// Match select(): encode="attributes" (non-boolean) must still encode
+		// attribute values. `IsBoolean && encode` coerced that string to false.
+		local.encode = IsBoolean(arguments.encode) && !arguments.encode ? false : "attributes";
 		return local.before & $element(
 			name = "select",
 			skip = "objectName,property,label,labelPlacement,prepend,append,prependToLabel,appendToLabel,errorElement,errorClass,value,includeBlank,order,separator,startYear,endYear,monthDisplay,monthNames,monthAbbreviations,dateSeparator,dateOrder,timeSeparator,timeOrder,minuteStep,secondStep,association,position,twelveHour,encode",

--- a/vendor/wheels/view/links.cfc
+++ b/vendor/wheels/view/links.cfc
@@ -20,6 +20,7 @@ component {
 	 * @port Set this to override the current port number.
 	 * @href Pass a link to an external site here if you want to bypass the Wheels routing system altogether and link to an external URL.
 	 * @encode [see:styleSheetLinkTag].
+	 * @sanitizeHref When true, blank out caller-supplied `javascript:` / `data:` hrefs. Default false (B3: default deny is a public-behavior change).
 	 */
 	public string function linkTo(
 		string text,
@@ -34,7 +35,8 @@ component {
 		string protocol,
 		numeric port,
 		string href,
-		any encode
+		any encode,
+		boolean sanitizeHref
 	) {
 		$args(name = "linkTo", args = arguments);
 
@@ -60,11 +62,15 @@ component {
 			}
 			arguments.href = uRLFor(argumentCollection = local.args);
 			local.encodeExcept = "href";
+		} else if (IsBoolean(arguments.sanitizeHref) && arguments.sanitizeHref) {
+			// Opt-in fail-closed gate. Default sanitizeHref=false keeps
+			// javascript:/data: hrefs working (B3 public-behavior escalation).
+			arguments.href = $sanitizeLinkToHref(arguments.href);
 		}
 		if (!StructKeyExists(arguments, "text")) {
 			arguments.text = arguments.href;
 		}
-		local.skip = "text,route,controller,action,key,params,anchor,onlyPath,host,protocol,port,encode";
+		local.skip = "text,route,controller,action,key,params,anchor,onlyPath,host,protocol,port,encode,sanitizeHref";
 		if (Len(arguments.route)) {
 			// variables passed in as route arguments should not be added to the html element
 			local.skip = ListAppend(local.skip, $routeVariables(argumentCollection = arguments));
@@ -77,6 +83,19 @@ component {
 			encode = arguments.encode,
 			encodeExcept = local.encodeExcept
 		);
+	}
+
+	/**
+	 * Opt-in fail-closed href gate for `linkTo(href=)`. Strips javascript:
+	 * and data: schemes (case-insensitive, optional whitespace before `:`).
+	 * Default `sanitizeHref=false` leaves those hrefs unchanged.
+	 */
+	public string function $sanitizeLinkToHref(required string href) {
+		local.trimmed = Trim(arguments.href);
+		if (ReFindNoCase("^(javascript|data)\s*:", local.trimmed)) {
+			return "";
+		}
+		return arguments.href;
 	}
 
 	/**
@@ -301,6 +320,9 @@ component {
 			if (Len(arguments.prepend)) {
 				local.start &= arguments.prepend;
 			}
+			// Sanitize prependToPage before first/last anchors AND the middle
+			// loop. alwaysShowAnchors previously concatenated the raw string.
+			local.sanitizedPrepend = $paginationSanitizeWrapper(arguments.prependToPage);
 			if (arguments.alwaysShowAnchors) {
 				if ((local.currentPage - arguments.windowSize) > 1) {
 					local.pageNumber = 1;
@@ -314,7 +336,7 @@ component {
 					}
 					local.linkToArguments.text = NumberFormat(local.pageNumber);
 					if (Len(arguments.prependToPage) && arguments.prependOnAnchor) {
-						local.start &= arguments.prependToPage;
+						local.start &= local.sanitizedPrepend;
 					}
 					local.start &= linkTo(argumentCollection = local.linkToArguments);
 					if (Len(local.sanitizedAppend) && arguments.appendOnAnchor) {
@@ -322,15 +344,6 @@ component {
 					}
 					local.start &= arguments.anchorDivider;
 				}
-			}
-			// Sanitize prependToPage once before the loop (input doesn't change per iteration).
-			// First decode HTML numeric entities so that encoded payloads like &#111;nmouseover
-			// are normalised before the regex strips event handlers and javascript: URIs.
-			if (Len(arguments.prependToPage)) {
-				local.decodedPrepend = $decodeHtmlEntities(arguments.prependToPage);
-				local.sanitizedPrepend = reReplaceNoCase(local.decodedPrepend, '\s+on\w+\s*=\s*([''"])[^''"]*\1', '', 'all');
-				local.sanitizedPrepend = reReplaceNoCase(local.sanitizedPrepend, '\s+on\w+\s*=\s*[^\s>]+', '', 'all');
-				local.sanitizedPrepend = reReplaceNoCase(local.sanitizedPrepend, 'javascript\s*:', '', 'all');
 			}
 
 			local.middle = "";
@@ -422,7 +435,7 @@ component {
 					local.linkToArguments.text = NumberFormat(local.totalPages);
 					local.end &= arguments.anchorDivider;
 					if (Len(arguments.prependToPage) && arguments.prependOnAnchor) {
-						local.end &= arguments.prependToPage;
+						local.end &= local.sanitizedPrepend;
 					}
 					local.end &= linkTo(argumentCollection = local.linkToArguments);
 					if (Len(local.sanitizedAppend) && arguments.appendOnAnchor) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

View-helper hardener for BLOCKERs B1–B5. Started from develop tip `faa0a158d00cfbd287d8f5cab4afb66243b65470`.

### B1 — `labelPlacement="aroundRight"` skips label encoding — **PROVEN, fixed**

`$formAfterElement` concatenated `arguments.label` raw for `aroundRight`. `$createLabel` / `$formBeforeElement` already encode under `encode=true`. RED: `textFieldTag(..., label="<img src=x onerror=alert(1)>", labelPlacement="aroundRight")` emitted the raw `<img>` after the input. GREEN: same path now uses `EncodeForHTML($canonicalize(label))` when `encode=true`. `encode=false` still leaves the label raw.

### B2 — Date `<select>`: `encode="attributes"` coerced to false — **PROVEN, fixed**

`$yearMonthHourMinuteSecondSelectTag` used `IsBoolean(encode) && encode ? "attributes" : false`. The string `"attributes"` is not boolean, so attribute encoding turned off. RED: `yearSelectTag(..., encode="attributes", class='x" onclick="alert(1)')` emitted raw `onclick="alert(1)"`. GREEN: same ternary as `select()` — `IsBoolean(encode) && !encode ? false : "attributes"`.

### B3 — `linkTo(href=)` has no `javascript:` / `data:` gate — **ESCALATED**

Caller-supplied `href` bypasses `URLFor`. `EncodeForHTMLAttribute` encodes `:` to `&#x3a;` but browsers decode that back to `javascript:` / `data:`.

**Escalation:** default-deny would change public behavior (`javascript:void(0)` etc.). This PR does **not** deny by default.

- Default `sanitizeHref=false` — decoded markup still contains `javascript:` (**UNPROVEN** as a default deny; documented on purpose)
- Opt-in `linkTo(href=..., sanitizeHref=true)` blanks `javascript:` / `data:` schemes (fail-closed path)

S14 open-redirect parity and S20 `formHelperDataAutoId` default were **not** touched.

### B4 — `paginationLinks` `alwaysShowAnchors` uses raw `prependToPage` — **PROVEN, fixed**

RED: with `windowSize=0` and `encode="attributes"`, first/last anchors kept `onmouseover="alert(1)"` while numbered pages were sanitized. GREEN: `$paginationSanitizeWrapper()` runs before first/last concat.

### B5 — `miscellaneousSpec` `$element` tautology — **PROVEN, fixed (test-only)**

`expect(r).toBe(r)` against a corrupted expected (`<textare` / `textare renders`). Replaced with `expect(e).toBe(r)` and the real `<textarea>` markup.

## Constraints

- **encode defaults are NOT flipped.** `textFieldTag`, `dateSelect`, `linkTo`, and `paginationLinks` stay `encode=true`.
- B3 default deny is escalated / not applied.
- SHOULDs deferred (Desk can send the S-list).

## PROVEN / UNPROVEN

Driver: `wheels test --core --ci --filter=hardener` → `wheels.tests.specs.hardener` (8 bundles).

RED (test-only `f7db5ba39b0d0683b6e5d0e3ce87bc64867c6972`): `bundles=8 pass=153 fail=7 error=0`.

GREEN (`d23eb7e9381f11850d9a0bce50b58953097f96ed`):

```
wheels test --core --ci --filter=hardener
Scope: wheels.tests.specs.hardener
bundlesDiscovered=8 pass=160 fail=0 error=0

wheels test --core --ci --filter=view
Scope: wheels.tests.specs.view
bundlesDiscovered=33 pass=581 fail=0 error=0
```

| ID | Status | Filter evidence |
|---|---|---|
| B1 | **PROVEN** | `--filter=hardener` — aroundRight XSS label encoded under encode=true |
| B2 | **PROVEN** | `--filter=hardener` — yearSelectTag / `$yearMonthHourMinuteSecondSelectTag` encode=attributes |
| B3 | **UNPROVEN** (default deny) / **PROVEN** (opt-in) | default still allows decoded `javascript:`; `sanitizeHref=true` blanks javascript:/data: |
| B4 | **PROVEN** | `--filter=hardener` — alwaysShowAnchors first/last prependToPage sanitized |
| B5 | **PROVEN** | tautology removed; `--filter=hardener` + `--filter=view` assert `$element` output |

## Type of Change

- [x] Bug fix
- [x] Enhancement to existing feature

## Feature Completeness Checklist

- [x] **DCO sign-off**
- [x] **Tests**
- [ ] **Framework Docs** — no new public default; B3 opt-in documented here
- [ ] **AI Reference Docs**
- [ ] **CLAUDE.md**
- [x] **Changelog fragment** — `changelog.d/view-helpers-hardener-b1-b5.security.md` + `.added.md`
- [x] **Test runner passes** — hardener 160/0/0, view 581/0/0

## Test Plan

1. `wheels test --core --ci --filter=hardener` — green
2. `wheels test --core --ci --filter=view` — green (regression)
3. encode defaults remain true
4. B3 default still emits decoded `javascript:` unless `sanitizeHref=true`

## HEAD

`d23eb7e9381f11850d9a0bce50b58953097f96ed`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adcc6392-80af-48f8-8f06-dd52ed643bb9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adcc6392-80af-48f8-8f06-dd52ed643bb9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

