### PR TITLE
fix(auth): harden auth SHOULDs S1–S8 without flipping JWT defaults

### DIFF
--- a/changelog.d/auth-hardener-shoulds.changed.md
+++ b/changelog.d/auth-hardener-shoulds.changed.md
@@ -1,0 +1,1 @@
+- `JwtService` accepts opt-in `maxRefreshAge` (refresh window after `exp`) and `requireExpiry` (reject tokens with no `exp`). Defaults stay `0` / `false` — unbounded refresh and missing-exp accept are unchanged

--- a/changelog.d/auth-hardener-shoulds.changed.md
+++ b/changelog.d/auth-hardener-shoulds.changed.md
@@ -1,1 +1,1 @@
-- `JwtService` accepts opt-in `maxRefreshAge` (refresh window after `exp`) and `requireExpiry` (reject tokens with no `exp`). Defaults stay `0` / `false` — unbounded refresh and missing-exp accept are unchanged
+- `JwtService.decode()` now requires an `exp` claim by default (`requireExpiry=true`). Pass `requireExpiry=false` to accept signed tokens with no expiry. `maxRefreshAge` stays `0` (unbounded refresh) unless a positive window is set

--- a/changelog.d/auth-hardener-shoulds.security.md
+++ b/changelog.d/auth-hardener-shoulds.security.md
@@ -2,3 +2,4 @@
 - `authenticateWith()` fails closed when the restriction list includes any unregistered strategy name, instead of silently skipping typos
 - `TokenStrategy` usage sample binds the token through the 2-arg query builder instead of interpolating it into `where=`
 - `JwtStrategy` catch-all returns a generic 401 and no longer concatenates `e.message` into the response
+- `JwtService.decode()` fails closed on a missing `exp` claim by default (`requireExpiry=true`; opt out with `requireExpiry=false`)

--- a/changelog.d/auth-hardener-shoulds.security.md
+++ b/changelog.d/auth-hardener-shoulds.security.md
@@ -1,0 +1,4 @@
+- `SessionStrategy.login()` / `logout()` rotate or invalidate the session ID and no longer swallow rotate failures in a catch-all
+- `authenticateWith()` fails closed when the restriction list includes any unregistered strategy name, instead of silently skipping typos
+- `TokenStrategy` usage sample binds the token through the 2-arg query builder instead of interpolating it into `where=`
+- `JwtStrategy` catch-all returns a generic 401 and no longer concatenates `e.message` into the response

--- a/vendor/wheels/auth/Authenticator.cfc
+++ b/vendor/wheels/auth/Authenticator.cfc
@@ -103,11 +103,9 @@ component implements="wheels.auth.AuthenticatorInterface" output="false" {
 		// Determine which strategies to try and in what order
 		if (ArrayLen(local.filter)) {
 			// Restricted: try only the named strategies, in the caller's order.
-			// Unknown names are skipped so a list mixing a typo with a valid
-			// name still authenticates — but when the restriction leaves
-			// nothing to try AND unknown names were given, surface the wiring
-			// bug (misspelled name or registerStrategy() never ran) instead of
-			// a generic 401.
+			// Unknown names fail closed even when other listed names are
+			// registered — a typo in "token,jwtt" must not silently degrade
+			// to token-only.
 			local.toTry = [];
 			local.unknown = [];
 			for (local.name in local.filter) {
@@ -122,7 +120,7 @@ component implements="wheels.auth.AuthenticatorInterface" output="false" {
 				}
 			}
 
-			if (ArrayLen(local.toTry) == 0 && ArrayLen(local.unknown)) {
+			if (ArrayLen(local.unknown)) {
 				local.unknownList = ArrayToList(local.unknown, ", ");
 				local.registeredList = ArrayToList(getStrategyNames(), ", ");
 				return $authResult(

--- a/vendor/wheels/auth/JwtService.cfc
+++ b/vendor/wheels/auth/JwtService.cfc
@@ -23,7 +23,7 @@ component output="false" {
 	 * @issuer Default issuer claim (iss). Empty string means no iss claim added and no iss validation on decode.
 	 * @allowedClockSkew Seconds of clock skew tolerance for expiry checks (default 0).
 	 * @maxRefreshAge Seconds after exp during which refresh() still accepts an expired token. 0 (default) keeps the historic unbounded refresh. Set a positive bound to fail closed.
-	 * @requireExpiry When true, decode() rejects a signed token that has no exp claim. Default false keeps the historic fail-open.
+	 * @requireExpiry When true (the default), decode() rejects a signed token that has no exp claim. Pass false to opt out.
 	 */
 	public JwtService function init(
 		required string secretKey,
@@ -31,7 +31,7 @@ component output="false" {
 		string issuer = "",
 		numeric allowedClockSkew = 0,
 		numeric maxRefreshAge = 0,
-		boolean requireExpiry = false
+		boolean requireExpiry = true
 	) {
 		// Fail fast on missing or weak secrets — a short HMAC key makes every issued token brute-forceable
 		if (!Len(arguments.secretKey)) {
@@ -106,8 +106,8 @@ component output="false" {
 	 *
 	 * Verifies the signature and checks expiry/nbf claims. When an issuer was
 	 * configured, the iss claim must be present and match it (case-sensitive).
-	 * When requireExpiry is true, a missing exp claim is rejected. Throws on
-	 * invalid token, bad signature, wrong issuer, or expired token.
+	 * A missing exp claim is rejected by default (requireExpiry=true). Throws on
+	 * invalid token, bad signature, wrong issuer, missing exp, or expired token.
 	 *
 	 * @token The JWT token string to decode.
 	 * @ignoreExpiry If true, skip expiry validation (used for refresh). Default false.

--- a/vendor/wheels/auth/JwtService.cfc
+++ b/vendor/wheels/auth/JwtService.cfc
@@ -22,12 +22,16 @@ component output="false" {
 	 * @defaultExpiry Default token lifetime in seconds (default 3600 = 1 hour).
 	 * @issuer Default issuer claim (iss). Empty string means no iss claim added and no iss validation on decode.
 	 * @allowedClockSkew Seconds of clock skew tolerance for expiry checks (default 0).
+	 * @maxRefreshAge Seconds after exp during which refresh() still accepts an expired token. 0 (default) keeps the historic unbounded refresh. Set a positive bound to fail closed.
+	 * @requireExpiry When true, decode() rejects a signed token that has no exp claim. Default false keeps the historic fail-open.
 	 */
 	public JwtService function init(
 		required string secretKey,
 		numeric defaultExpiry = 3600,
 		string issuer = "",
-		numeric allowedClockSkew = 0
+		numeric allowedClockSkew = 0,
+		numeric maxRefreshAge = 0,
+		boolean requireExpiry = false
 	) {
 		// Fail fast on missing or weak secrets — a short HMAC key makes every issued token brute-forceable
 		if (!Len(arguments.secretKey)) {
@@ -49,6 +53,8 @@ component output="false" {
 		variables.defaultExpiry = arguments.defaultExpiry;
 		variables.issuer = arguments.issuer;
 		variables.allowedClockSkew = arguments.allowedClockSkew;
+		variables.maxRefreshAge = arguments.maxRefreshAge;
+		variables.requireExpiry = arguments.requireExpiry;
 
 		// Cache the Java class handles used on the per-request encode/decode paths
 		variables.messageDigest = CreateObject("java", "java.security.MessageDigest");
@@ -100,7 +106,8 @@ component output="false" {
 	 *
 	 * Verifies the signature and checks expiry/nbf claims. When an issuer was
 	 * configured, the iss claim must be present and match it (case-sensitive).
-	 * Throws on invalid token, bad signature, wrong issuer, or expired token.
+	 * When requireExpiry is true, a missing exp claim is rejected. Throws on
+	 * invalid token, bad signature, wrong issuer, or expired token.
 	 *
 	 * @token The JWT token string to decode.
 	 * @ignoreExpiry If true, skip expiry validation (used for refresh). Default false.
@@ -159,6 +166,13 @@ component output="false" {
 			}
 		}
 
+		if (variables.requireExpiry && !StructKeyExists(local.claims, "exp")) {
+			throw(
+				type = "Wheels.Auth.JWT.MissingExpiry",
+				message = "JWT token is missing a required exp claim"
+			);
+		}
+
 		// Validate time-based claims
 		if (!arguments.ignoreExpiry) {
 			local.now = $epochSeconds();
@@ -207,6 +221,10 @@ component output="false" {
 	 * existing claims but updates iat and exp. The jti claim is removed
 	 * so callers can assign a new one if needed.
 	 *
+	 * When maxRefreshAge is 0 (default), any expired-but-validly-signed token
+	 * can be refreshed. When maxRefreshAge is positive, tokens whose exp is
+	 * older than now - maxRefreshAge are rejected.
+	 *
 	 * @token The existing JWT token to refresh.
 	 * @expiry New token lifetime in seconds. Uses defaultExpiry if not provided.
 	 * @return New signed JWT token string.
@@ -214,6 +232,22 @@ component output="false" {
 	public string function refresh(required string token, numeric expiry = 0) {
 		// Decode with ignoreExpiry=true to allow refreshing expired tokens
 		local.claims = decode(token = arguments.token, ignoreExpiry = true);
+
+		if (variables.maxRefreshAge > 0) {
+			if (!StructKeyExists(local.claims, "exp")) {
+				throw(
+					type = "Wheels.Auth.JWT.RefreshWindowExceeded",
+					message = "JWT token cannot be refreshed because it has no exp claim"
+				);
+			}
+			local.now = $epochSeconds();
+			if (local.claims.exp + variables.maxRefreshAge < local.now) {
+				throw(
+					type = "Wheels.Auth.JWT.RefreshWindowExceeded",
+					message = "JWT token is too old to refresh"
+				);
+			}
+		}
 
 		// Remove time-based claims so encode() regenerates them
 		StructDelete(local.claims, "iat");

--- a/vendor/wheels/auth/JwtStrategy.cfc
+++ b/vendor/wheels/auth/JwtStrategy.cfc
@@ -98,9 +98,27 @@ component implements="wheels.auth.AuthStrategy" output="false" {
 				statusCode = 401,
 				strategy = getName()
 			);
+		} catch ("Wheels.Auth.JWT.InvalidAlgorithm" e) {
+			return variables.authResult.failure(
+				error = "Invalid JWT algorithm",
+				statusCode = 401,
+				strategy = getName()
+			);
+		} catch ("Wheels.Auth.JWT.InvalidIssuer" e) {
+			return variables.authResult.failure(
+				error = "JWT issuer validation failed",
+				statusCode = 401,
+				strategy = getName()
+			);
+		} catch ("Wheels.Auth.JWT.MissingExpiry" e) {
+			return variables.authResult.failure(
+				error = "JWT token is missing expiry",
+				statusCode = 401,
+				strategy = getName()
+			);
 		} catch (any e) {
 			return variables.authResult.failure(
-				error = "JWT authentication error: " & e.message,
+				error = "JWT authentication failed",
 				statusCode = 401,
 				strategy = getName()
 			);

--- a/vendor/wheels/auth/SessionStrategy.cfc
+++ b/vendor/wheels/auth/SessionStrategy.cfc
@@ -14,11 +14,11 @@
  *   var sessionAuth = new wheels.auth.SessionStrategy();
  *   authenticator.registerStrategy(name="session", strategy=sessionAuth);
  *
- *   // After verifying credentials in a login action:
- *   sessionAuth.login(principal={id=user.id, role=user.role});
- *
- *   // In a logout action:
- *   sessionAuth.logout();
+	 *   // After verifying credentials in a login action (rotates the SID):
+	 *   sessionAuth.login(principal={id=user.id, role=user.role});
+	 *
+	 *   // In a logout action (clears the principal and rotates the SID):
+	 *   sessionAuth.logout();
  *
  * [section: Authentication]
  * [category: Strategies]
@@ -97,13 +97,8 @@ component implements="wheels.auth.AuthStrategy" output="false" {
 	 * @principal Struct representing the authenticated identity (user id, roles, etc.).
 	 */
 	public void function login(required struct principal) {
-		// Regenerate session ID to prevent session fixation attacks
-		try {
-			sessionRotate();
-		} catch (any e) {
-			writeLog(text="sessionRotate() unavailable: #e.message#", type="warning", file="wheels_auth");
-		}
-
+		// Rotate first so a failed rotate cannot leave a principal on the old SID.
+		$rotateSession();
 		$setSessionPrincipal(arguments.principal);
 
 		if (IsCustomFunction(variables.onLogin) || IsClosure(variables.onLogin)) {
@@ -114,15 +109,39 @@ component implements="wheels.auth.AuthStrategy" output="false" {
 	/**
 	 * Destroy the authenticated session.
 	 *
-	 * Clears the principal from the session scope and optionally
-	 * invokes the onLogout callback.
+	 * Clears the principal, rotates or invalidates the session ID so the
+	 * old cookie cannot be reused, and optionally invokes onLogout.
 	 */
 	public void function logout() {
 		$clearSessionPrincipal();
+		$rotateSession();
 
 		if (IsCustomFunction(variables.onLogout) || IsClosure(variables.onLogout)) {
 			variables.onLogout();
 		}
+	}
+
+	/**
+	 * Rotate or invalidate the current session ID.
+	 *
+	 * Prefers sessionRotate() (Lucee). Falls back to sessionInvalidate()
+	 * when that BIF is absent (Adobe CF). Does not catch-all: a rotate
+	 * failure must surface so login/logout cannot silently keep the old SID.
+	 */
+	public void function $rotateSession() {
+		local.functions = GetFunctionList();
+		if (StructKeyExists(local.functions, "sessionRotate")) {
+			sessionRotate();
+			return;
+		}
+		if (StructKeyExists(local.functions, "sessionInvalidate")) {
+			sessionInvalidate();
+			return;
+		}
+		throw(
+			type = "Wheels.Auth.SessionRotateUnavailable",
+			message = "Session ID rotation is required at login/logout but neither sessionRotate() nor sessionInvalidate() is available."
+		);
 	}
 
 	/**

--- a/vendor/wheels/auth/TokenStrategy.cfc
+++ b/vendor/wheels/auth/TokenStrategy.cfc
@@ -16,12 +16,14 @@
  *   {"my-api-key": {id: 1, role: "admin"}, "other-key": {id: 2, role: "reader"}}
  *
  * Usage:
- *   // With a validator callback
- *   var strategy = new wheels.auth.TokenStrategy(validator=function(token) {
- *       var key = model("ApiKey").findOne(where="token='#token#' AND active=1");
+ *   // With a validator callback — hoist the closure (Adobe invariant 5)
+ *   // and bind the token via the 2-arg query builder (never interpolate).
+ *   var tokenValidator = function(token) {
+ *       var key = model("ApiKey").where("token", arguments.token).where("active", 1).findOne();
  *       if (isObject(key)) return {id: key.userId, role: key.role};
  *       return false;
- *   });
+ *   };
+ *   var strategy = new wheels.auth.TokenStrategy(validator=tokenValidator);
  *
  *   // With a static token map
  *   var strategy = new wheels.auth.TokenStrategy(tokens={"abc-123": {id: 1, role: "admin"}});

--- a/vendor/wheels/tests/_assets/auth/CountingRotateSessionStrategy.cfc
+++ b/vendor/wheels/tests/_assets/auth/CountingRotateSessionStrategy.cfc
@@ -1,0 +1,26 @@
+/**
+ * SessionStrategy test double that counts $rotateSession invocations.
+ * Used by AuthHardenerShouldSpec S1/S2 to prove login and logout
+ * go through the rotation helper rather than a silent no-op.
+ */
+component extends="wheels.auth.SessionStrategy" output="false" {
+
+	public CountingRotateSessionStrategy function init(
+		string sessionKey = "wheels.auth",
+		any onLogin = "",
+		any onLogout = ""
+	) {
+		super.init(argumentCollection = arguments);
+		variables.rotateCalls = 0;
+		return this;
+	}
+
+	public numeric function $rotateCount() {
+		return variables.rotateCalls;
+	}
+
+	public void function $rotateSession() {
+		variables.rotateCalls = variables.rotateCalls + 1;
+	}
+
+}

--- a/vendor/wheels/tests/_assets/auth/ThrowingRotateSessionStrategy.cfc
+++ b/vendor/wheels/tests/_assets/auth/ThrowingRotateSessionStrategy.cfc
@@ -1,0 +1,15 @@
+/**
+ * SessionStrategy test double whose $rotateSession always throws.
+ * Used by AuthHardenerShouldSpec S1 to prove login/logout do not
+ * swallow rotation failures.
+ */
+component extends="wheels.auth.SessionStrategy" output="false" {
+
+	public void function $rotateSession() {
+		throw(
+			type = "Wheels.Auth.SessionRotateFailed",
+			message = "forced rotate failure for hardener S1"
+		);
+	}
+
+}

--- a/vendor/wheels/tests/specs/auth/AuthMiddlewareSpec.cfc
+++ b/vendor/wheels/tests/specs/auth/AuthMiddlewareSpec.cfc
@@ -129,7 +129,7 @@ component extends="wheels.WheelsTest" {
 					expect(captured.strategy).toBe("alwaysPass");
 				});
 
-				it("skips unregistered strategies gracefully", function() {
+				it("fails closed when the restriction list mixes a typo with a known name", function() {
 					var auth = new wheels.auth.Authenticator();
 					auth.registerStrategy(name = "pass", strategy = new wheels.tests._assets.auth.AlwaysPassStrategy());
 
@@ -137,10 +137,13 @@ component extends="wheels.WheelsTest" {
 					var pipeline = new wheels.middleware.Pipeline(middleware = [mw]);
 
 					var result = pipeline.run(request = {}, coreHandler = function(required struct request) {
-						return "OK";
+						return "should not reach";
 					});
 
-					expect(result).toBe("OK");
+					var parsed = DeserializeJSON(result);
+					expect(parsed.status).toBe(401);
+					expect(parsed.error).toInclude("nonexistent");
+					expect(parsed.error).toInclude("unregistered strategy");
 				});
 
 				it("surfaces a wiring error when restricted to only unregistered strategies", function() {

--- a/vendor/wheels/tests/specs/auth/AuthenticatorSpec.cfc
+++ b/vendor/wheels/tests/specs/auth/AuthenticatorSpec.cfc
@@ -170,11 +170,14 @@ component extends="wheels.WheelsTest" {
 					expect(result.strategy).toBe("alwaysPass");
 				});
 
-				it("skips unknown names when a registered strategy can still authenticate", function() {
+				it("fails closed when the restriction list includes an unknown name", function() {
 					auth.registerStrategy(name = "pass", strategy = new wheels.tests._assets.auth.AlwaysPassStrategy());
 
 					var result = auth.authenticateWith(request = {}, strategies = "ghost,pass");
-					expect(result.success).toBeTrue();
+					expect(result.success).toBeFalse();
+					expect(result.statusCode).toBe(401);
+					expect(result.error).toInclude("ghost");
+					expect(result.error).toInclude("unregistered strategy");
 				});
 
 				it("surfaces a wiring diagnostic when restricted to only unregistered names", function() {

--- a/vendor/wheels/tests/specs/auth/JwtServiceSpec.cfc
+++ b/vendor/wheels/tests/specs/auth/JwtServiceSpec.cfc
@@ -196,6 +196,32 @@ component extends="wheels.WheelsTest" {
 					}).toThrow("Wheels.Auth.JWT.InvalidSignature");
 				});
 
+				it("throws MissingExpiry for a signed token with no exp by default", function() {
+					var token = _signHs256(
+						"test-secret-key-for-jwt-specs-padded-to-32-bytes",
+						"{""alg"":""HS256"",""typ"":""JWT""}",
+						"{""sub"":1,""iat"":1000}"
+					);
+					expect(function() {
+						jwt.decode(token);
+					}).toThrow("Wheels.Auth.JWT.MissingExpiry");
+				});
+
+				it("accepts a signed token with no exp when requireExpiry is false", function() {
+					var openJwt = new wheels.auth.JwtService(
+						secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes",
+						requireExpiry = false
+					);
+					var token = _signHs256(
+						"test-secret-key-for-jwt-specs-padded-to-32-bytes",
+						"{""alg"":""HS256"",""typ"":""JWT""}",
+						"{""sub"":1,""iat"":1000}"
+					);
+					var claims = openJwt.decode(token);
+					expect(claims.sub).toBe(1);
+					expect(StructKeyExists(claims, "exp")).toBeFalse();
+				});
+
 			});
 
 			describe("issuer validation", function() {
@@ -484,6 +510,22 @@ component extends="wheels.WheelsTest" {
 		b64 = Replace(b64, "/", "_", "all");
 		b64 = REReplace(b64, "=+$", "");
 		return b64;
+	}
+
+	/**
+	 * Craft a valid HS256 JWT from JSON strings (used to omit exp).
+	 */
+	private string function _signHs256(required string secret, required string headerJson, required string payloadJson) {
+		var headerB64 = _base64UrlEncode(arguments.headerJson);
+		var payloadB64 = _base64UrlEncode(arguments.payloadJson);
+		var input = headerB64 & "." & payloadB64;
+		var hmacHex = HMac(input, arguments.secret, "HMACSHA256", "UTF-8");
+		var hmacBinary = BinaryDecode(hmacHex, "hex");
+		var b64 = BinaryEncode(hmacBinary, "base64");
+		b64 = Replace(b64, "+", "-", "all");
+		b64 = Replace(b64, "/", "_", "all");
+		b64 = REReplace(b64, "=+$", "");
+		return input & "." & b64;
 	}
 
 }

--- a/vendor/wheels/tests/specs/auth/SessionStrategySpec.cfc
+++ b/vendor/wheels/tests/specs/auth/SessionStrategySpec.cfc
@@ -103,12 +103,12 @@ component extends="wheels.WheelsTest" {
 					expect(captured.principal.id).toBe(99);
 				});
 
-				it("does not error when sessionRotate is called during login", function() {
-					// sessionRotate() is wrapped in try/catch so login works
-					// even on engines that don't support it
+				it("rotates the session identity on login", function() {
+					var beforeId = $sessionIdentityToken();
 					strategy.login(principal = {id = 42});
 					expect(strategy.isLoggedIn()).toBeTrue();
 					expect(strategy.currentUser().id).toBe(42);
+					expect($sessionIdentityToken()).notToBe(beforeId);
 				});
 
 				it("creates intermediate session structs for nested keys", function() {
@@ -128,6 +128,14 @@ component extends="wheels.WheelsTest" {
 					strategy.logout();
 
 					expect(strategy.isLoggedIn()).toBeFalse();
+				});
+
+				it("rotates the session identity on logout", function() {
+					strategy.login(principal = {id = 7});
+					var beforeId = $sessionIdentityToken();
+					strategy.logout();
+					expect(strategy.isLoggedIn()).toBeFalse();
+					expect($sessionIdentityToken()).notToBe(beforeId);
 				});
 
 				it("authenticate fails after logout", function() {
@@ -257,6 +265,18 @@ component extends="wheels.WheelsTest" {
 
 		});
 
+	}
+
+	private string function $sessionIdentityToken() {
+		if (StructKeyExists(session, "sessionid") && Len(ToString(session.sessionid))) {
+			return ToString(session.sessionid);
+		}
+		if (StructKeyExists(session, "cfid") || StructKeyExists(session, "cftoken")) {
+			var cfid = StructKeyExists(session, "cfid") ? ToString(session.cfid) : "";
+			var cftoken = StructKeyExists(session, "cftoken") ? ToString(session.cftoken) : "";
+			return cfid & ":" & cftoken;
+		}
+		return "";
 	}
 
 }

--- a/vendor/wheels/tests/specs/hardener/AuthHardenerShouldSpec.cfc
+++ b/vendor/wheels/tests/specs/hardener/AuthHardenerShouldSpec.cfc
@@ -1,0 +1,400 @@
+/**
+ * Hardener SHOULDs S1–S8 (auth).
+ *
+ * Directory-scoped so `wheels test --core --ci --filter=hardener`
+ * discovers this folder (a single-file directory= scope finds 0 bundles).
+ *
+ * Escalations (no silent public default/API flips):
+ *   S6 JwtService.refresh() default stays ignoreExpiry-forever (maxRefreshAge=0).
+ *   S7 JwtService.decode() default stays fail-open for missing exp (requireExpiry=false).
+ *
+ * CoS lock: allowedClockSkew=0, issuer="", queryParam="", iterations=600000.
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("CoS lock: auth public defaults stay conservative", function() {
+
+			it("keeps JwtService clock skew 0 and issuer empty", function() {
+				var jwt = new wheels.auth.JwtService(
+					secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes"
+				);
+				var token = jwt.encode(claims = {sub = 1});
+				var claims = jwt.decode(token);
+				expect(StructKeyExists(claims, "iss")).toBeFalse();
+
+				var now = Int(CreateObject("java", "java.lang.System").currentTimeMillis() / 1000);
+				var expired = jwt.encode(claims = {sub = 1, iat = now - 10, exp = now - 1});
+				expect(function() {
+					jwt.decode(expired);
+				}).toThrow("Wheels.Auth.JWT.TokenExpired");
+			});
+
+			it("keeps TokenStrategy and JwtStrategy queryParam disabled", function() {
+				var jwt = new wheels.auth.JwtService(
+					secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes"
+				);
+				var tokenStrategy = new wheels.auth.TokenStrategy();
+				expect(tokenStrategy.supports(request = {params = {api_key = "x"}})).toBeFalse();
+
+				var jwtStrategy = new wheels.auth.JwtStrategy(jwtService = jwt);
+				var token = jwt.encode(claims = {sub = 1});
+				expect(
+					jwtStrategy.supports(request = {headers = {}, params = {token = token}})
+				).toBeFalse();
+			});
+
+			it("keeps PasswordHasher iterations at 600000", function() {
+				var hasher = new wheels.auth.PasswordHasher();
+				var digest = hasher.hash("hardener-cos-lock");
+				expect(digest).toInclude("$i=600000$");
+			});
+
+		});
+
+		describe("S1 SessionStrategy login does not swallow rotate failures", function() {
+
+			it("surfaces a $rotateSession failure instead of logging in on the old SID", function() {
+				var strategy = new wheels.tests._assets.auth.ThrowingRotateSessionStrategy();
+				var state = {threw = false, type = ""};
+				try {
+					strategy.login(principal = {id = 1});
+				} catch (any e) {
+					state.threw = true;
+					state.type = e.type;
+				}
+				expect(state.threw).toBeTrue();
+				expect(state.type).toBe("Wheels.Auth.SessionRotateFailed");
+				expect(strategy.isLoggedIn()).toBeFalse();
+			});
+
+			it("login invokes $rotateSession", function() {
+				var strategy = new wheels.tests._assets.auth.CountingRotateSessionStrategy();
+				strategy.login(principal = {id = 7});
+				expect(strategy.$rotateCount()).toBe(1);
+				expect(strategy.isLoggedIn()).toBeTrue();
+			});
+
+			it("SessionStrategy.cfc has no catch-any around session rotation", function() {
+				var src = FileRead(ExpandPath("/wheels/auth/SessionStrategy.cfc"));
+				expect(FindNoCase("catch (any", src)).toBe(
+					0,
+					"sessionRotate/sessionInvalidate must not be wrapped in catch-any"
+				);
+			});
+
+		});
+
+		describe("S2 logout rotates or invalidates the SID", function() {
+
+			beforeEach(function() {
+				StructDelete(session, "wheels");
+			});
+
+			afterEach(function() {
+				StructDelete(session, "wheels");
+			});
+
+			it("logout invokes $rotateSession after clearing the principal", function() {
+				var strategy = new wheels.tests._assets.auth.CountingRotateSessionStrategy();
+				strategy.login(principal = {id = 7});
+				expect(strategy.$rotateCount()).toBe(1);
+				strategy.logout();
+				expect(strategy.isLoggedIn()).toBeFalse();
+				expect(strategy.$rotateCount()).toBe(2);
+			});
+
+			it("logout changes the session identity", function() {
+				var strategy = new wheels.auth.SessionStrategy();
+				strategy.login(principal = {id = 7});
+				var before = $sessionIdentity();
+				expect($sessionIdentityPresent(before)).toBeTrue();
+				strategy.logout();
+				var after = $sessionIdentity();
+				expect($sessionIdentityChanged(before, after)).toBeTrue();
+				expect(strategy.isLoggedIn()).toBeFalse();
+			});
+
+			it("surfaces a $rotateSession failure on logout", function() {
+				var strategy = new wheels.tests._assets.auth.ThrowingRotateSessionStrategy();
+				session.wheels = {auth = {id = 9}};
+				var state = {threw = false, type = ""};
+				try {
+					strategy.logout();
+				} catch (any e) {
+					state.threw = true;
+					state.type = e.type;
+				}
+				expect(state.threw).toBeTrue();
+				expect(state.type).toBe("Wheels.Auth.SessionRotateFailed");
+			});
+
+		});
+
+		describe("S3 authenticateWith does not skip unknown names", function() {
+
+			it("fails closed when the restriction list mixes a typo with a known name", function() {
+				var auth = new wheels.auth.Authenticator();
+				auth.registerStrategy(
+					name = "pass",
+					strategy = new wheels.tests._assets.auth.AlwaysPassStrategy()
+				);
+				var result = auth.authenticateWith(request = {}, strategies = "ghost,pass");
+				expect(result.success).toBeFalse();
+				expect(result.statusCode).toBe(401);
+				expect(result.error).toInclude("ghost");
+				expect(result.error).toInclude("unregistered strategy");
+			});
+
+			it("fails closed for an array filter that includes an unknown name", function() {
+				var auth = new wheels.auth.Authenticator();
+				auth.registerStrategy(
+					name = "pass",
+					strategy = new wheels.tests._assets.auth.AlwaysPassStrategy()
+				);
+				var result = auth.authenticateWith(request = {}, strategies = ["ghost", "pass"]);
+				expect(result.success).toBeFalse();
+				expect(result.error).toInclude("ghost");
+			});
+
+			it("still authenticates when every listed name is registered", function() {
+				var auth = new wheels.auth.Authenticator();
+				auth.registerStrategy(
+					name = "pass",
+					strategy = new wheels.tests._assets.auth.AlwaysPassStrategy()
+				);
+				var result = auth.authenticateWith(request = {}, strategies = "pass");
+				expect(result.success).toBeTrue();
+			});
+
+		});
+
+		describe("S4 TokenStrategy docs do not interpolate tokens into SQL", function() {
+
+			it("TokenStrategy.cfc usage sample has no interpolated where= token", function() {
+				var src = FileRead(ExpandPath("/wheels/auth/TokenStrategy.cfc"));
+				// Build the forbidden interpolation without putting a raw ## pair
+				// that CFML would treat as an empty expression in this spec.
+				var interpolatedWhere = "token=" & Chr(39) & "##token##" & Chr(39);
+				expect(FindNoCase(interpolatedWhere, src)).toBe(
+					0,
+					"TokenStrategy docs must not show where=""token='##token##'"""
+				);
+			});
+
+		});
+
+		describe("S5 login changes the session identity", function() {
+
+			beforeEach(function() {
+				StructDelete(session, "wheels");
+			});
+
+			afterEach(function() {
+				StructDelete(session, "wheels");
+			});
+
+			it("login rotates the SID, not just stores the principal", function() {
+				var strategy = new wheels.auth.SessionStrategy();
+				var before = $sessionIdentity();
+				expect($sessionIdentityPresent(before)).toBeTrue();
+				strategy.login(principal = {id = 42, role = "admin"});
+				var after = $sessionIdentity();
+				expect(strategy.isLoggedIn()).toBeTrue();
+				expect(strategy.currentUser().id).toBe(42);
+				expect($sessionIdentityChanged(before, after)).toBeTrue();
+			});
+
+		});
+
+		describe("S6 JwtService.refresh max-age contract (escalated default)", function() {
+
+			it("default maxRefreshAge=0 still refreshes a token expired years ago", function() {
+				var jwt = new wheels.auth.JwtService(
+					secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes"
+				);
+				var now = Int(CreateObject("java", "java.lang.System").currentTimeMillis() / 1000);
+				var ancient = jwt.encode(
+					claims = {sub = 1, iat = now - (10 * 365 * 86400), exp = now - (10 * 365 * 86400) + 3600}
+				);
+				var refreshed = jwt.refresh(ancient);
+				expect(jwt.verify(refreshed)).toBeTrue();
+			});
+
+			it("rejects refresh when maxRefreshAge is set and the token is older than that window", function() {
+				var jwt = new wheels.auth.JwtService(
+					secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes",
+					maxRefreshAge = 86400
+				);
+				var now = Int(CreateObject("java", "java.lang.System").currentTimeMillis() / 1000);
+				var ancient = jwt.encode(
+					claims = {sub = 1, iat = now - (10 * 365 * 86400), exp = now - (10 * 365 * 86400) + 3600}
+				);
+				expect(function() {
+					jwt.refresh(ancient);
+				}).toThrow("Wheels.Auth.JWT.RefreshWindowExceeded");
+			});
+
+			it("still refreshes a recently expired token when maxRefreshAge is set", function() {
+				var jwt = new wheels.auth.JwtService(
+					secretKey = "test-secret-key-for-jwt-specs-padded-to-32-bytes",
+					maxRefreshAge = 86400
+				);
+				var now = Int(CreateObject("java", "java.lang.System").currentTimeMillis() / 1000);
+				var recent = jwt.encode(claims = {sub = 9, iat = now - 7200, exp = now - 30});
+				var refreshed = jwt.refresh(recent);
+				var claims = jwt.decode(refreshed);
+				expect(claims.sub).toBe(9);
+			});
+
+		});
+
+		describe("S7 JwtService.decode missing exp (escalated default)", function() {
+
+			it("default requireExpiry=false still accepts a signed token with no exp", function() {
+				var secret = "test-secret-key-for-jwt-specs-padded-to-32-bytes";
+				var jwt = new wheels.auth.JwtService(secretKey = secret);
+				var token = $signHs256(
+					secret,
+					"{""alg"":""HS256"",""typ"":""JWT""}",
+					"{""sub"":1,""iat"":1000}"
+				);
+				var claims = jwt.decode(token);
+				expect(claims.sub).toBe(1);
+				expect(StructKeyExists(claims, "exp")).toBeFalse();
+			});
+
+			it("rejects a signed token with no exp when requireExpiry is true", function() {
+				var secret = "test-secret-key-for-jwt-specs-padded-to-32-bytes";
+				var jwt = new wheels.auth.JwtService(secretKey = secret, requireExpiry = true);
+				var token = $signHs256(
+					secret,
+					"{""alg"":""HS256"",""typ"":""JWT""}",
+					"{""sub"":1,""iat"":1000}"
+				);
+				expect(function() {
+					jwt.decode(token);
+				}).toThrow("Wheels.Auth.JWT.MissingExpiry");
+			});
+
+		});
+
+		describe("S8 JwtStrategy catch-all does not leak exception messages", function() {
+
+			beforeEach(function() {
+				jwtService = new wheels.auth.JwtService(
+					secretKey = "test-secret-for-strategy-specs-padded-to-32"
+				);
+				strategy = new wheels.auth.JwtStrategy(jwtService = jwtService);
+			});
+
+			it("returns a generic 401 for an unexpected JWT error", function() {
+				var headerB64 = $base64UrlEncode("{""alg"":""none"",""typ"":""JWT""}");
+				var payloadB64 = $base64UrlEncode("{""sub"":1,""iat"":999999999,""exp"":999999999}");
+				var fakeToken = headerB64 & "." & payloadB64 & ".fakesig";
+				var req = {headers = {authorization = "Bearer " & fakeToken}};
+				var result = strategy.authenticate(req);
+				expect(result.success).toBeFalse();
+				expect(result.statusCode).toBe(401);
+				expect(result.error).notToInclude("JWT authentication error:");
+				expect(FindNoCase("substitution", result.error)).toBe(0);
+				expect(FindNoCase("none", result.error)).toBe(0);
+				expect(result.error).notToInclude("fakesig");
+			});
+
+			it("does not leak InvalidIssuer details through the catch-all", function() {
+				var issuerService = new wheels.auth.JwtService(
+					secretKey = "test-secret-for-strategy-specs-padded-to-32",
+					issuer = "expected-issuer"
+				);
+				var issuerStrategy = new wheels.auth.JwtStrategy(jwtService = issuerService);
+				var otherService = new wheels.auth.JwtService(
+					secretKey = "test-secret-for-strategy-specs-padded-to-32",
+					issuer = "other-issuer"
+				);
+				var token = otherService.encode(claims = {sub = 1});
+				var req = {headers = {authorization = "Bearer " & token}};
+				var result = issuerStrategy.authenticate(req);
+				expect(result.success).toBeFalse();
+				expect(result.statusCode).toBe(401);
+				expect(result.error).notToInclude("JWT authentication error:");
+				expect(result.error).notToInclude(token);
+			});
+
+		});
+
+	}
+
+	/**
+	 * Snapshot identifying session fields so SID rotation can be asserted
+	 * without depending on a single engine-specific key.
+	 */
+	private struct function $sessionIdentity() {
+		var id = {};
+		if (StructKeyExists(session, "sessionid") && Len(ToString(session.sessionid))) {
+			id.sessionid = ToString(session.sessionid);
+		}
+		if (StructKeyExists(session, "cfid") && Len(ToString(session.cfid))) {
+			id.cfid = ToString(session.cfid);
+		}
+		if (StructKeyExists(session, "cftoken") && Len(ToString(session.cftoken))) {
+			id.cftoken = ToString(session.cftoken);
+		}
+		if (StructKeyExists(session, "urltoken") && Len(ToString(session.urltoken))) {
+			id.urltoken = ToString(session.urltoken);
+		}
+		var javaId = "";
+		try {
+			var ctx = GetPageContext();
+			var sess = ctx.getSession();
+			if (!IsNull(sess)) {
+				javaId = ToString(sess.getId());
+			}
+		} catch (any e) {
+			javaId = "";
+		}
+		if (Len(javaId)) {
+			id.javaId = javaId;
+		}
+		return id;
+	}
+
+	private boolean function $sessionIdentityPresent(required struct identity) {
+		return !StructIsEmpty(arguments.identity);
+	}
+
+	private boolean function $sessionIdentityChanged(required struct before, required struct after) {
+		for (var key in arguments.before) {
+			if (StructKeyExists(arguments.after, key) && arguments.after[key] != arguments.before[key]) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Craft a valid HS256 JWT from JSON strings (used to omit exp).
+	 */
+	private string function $signHs256(required string secret, required string headerJson, required string payloadJson) {
+		var headerB64 = $base64UrlEncode(arguments.headerJson);
+		var payloadB64 = $base64UrlEncode(arguments.payloadJson);
+		var input = headerB64 & "." & payloadB64;
+		var hmacHex = HMac(input, arguments.secret, "HMACSHA256", "UTF-8");
+		var hmacBinary = BinaryDecode(hmacHex, "hex");
+		var b64 = BinaryEncode(hmacBinary, "base64");
+		b64 = Replace(b64, "+", "-", "all");
+		b64 = Replace(b64, "/", "_", "all");
+		b64 = REReplace(b64, "=+$", "");
+		return input & "." & b64;
+	}
+
+	private string function $base64UrlEncode(required string value) {
+		var b64 = ToBase64(arguments.value);
+		b64 = Replace(b64, "+", "-", "all");
+		b64 = Replace(b64, "/", "_", "all");
+		b64 = REReplace(b64, "=+$", "");
+		return b64;
+	}
+
+}

--- a/vendor/wheels/tests/specs/hardener/AuthHardenerShouldSpec.cfc
+++ b/vendor/wheels/tests/specs/hardener/AuthHardenerShouldSpec.cfc
@@ -6,8 +6,8 @@
  *
  * Escalations (no silent public default/API flips):
  *   S6 JwtService.refresh() default stays ignoreExpiry-forever (maxRefreshAge=0).
- *   S7 JwtService.decode() default stays fail-open for missing exp (requireExpiry=false).
  *
+ * S7 JwtService.decode() default is requireExpiry=true (missing exp fails closed).
  * CoS lock: allowedClockSkew=0, issuer="", queryParam="", iterations=600000.
  */
 component extends="wheels.WheelsTest" {
@@ -250,24 +250,11 @@ component extends="wheels.WheelsTest" {
 
 		});
 
-		describe("S7 JwtService.decode missing exp (escalated default)", function() {
+		describe("S7 JwtService.decode missing exp fails closed by default", function() {
 
-			it("default requireExpiry=false still accepts a signed token with no exp", function() {
+			it("default requireExpiry=true rejects a signed token with no exp", function() {
 				var secret = "test-secret-key-for-jwt-specs-padded-to-32-bytes";
 				var jwt = new wheels.auth.JwtService(secretKey = secret);
-				var token = $signHs256(
-					secret,
-					"{""alg"":""HS256"",""typ"":""JWT""}",
-					"{""sub"":1,""iat"":1000}"
-				);
-				var claims = jwt.decode(token);
-				expect(claims.sub).toBe(1);
-				expect(StructKeyExists(claims, "exp")).toBeFalse();
-			});
-
-			it("rejects a signed token with no exp when requireExpiry is true", function() {
-				var secret = "test-secret-key-for-jwt-specs-padded-to-32-bytes";
-				var jwt = new wheels.auth.JwtService(secretKey = secret, requireExpiry = true);
 				var token = $signHs256(
 					secret,
 					"{""alg"":""HS256"",""typ"":""JWT""}",
@@ -276,6 +263,19 @@ component extends="wheels.WheelsTest" {
 				expect(function() {
 					jwt.decode(token);
 				}).toThrow("Wheels.Auth.JWT.MissingExpiry");
+			});
+
+			it("still accepts a signed token with no exp when requireExpiry is false", function() {
+				var secret = "test-secret-key-for-jwt-specs-padded-to-32-bytes";
+				var jwt = new wheels.auth.JwtService(secretKey = secret, requireExpiry = false);
+				var token = $signHs256(
+					secret,
+					"{""alg"":""HS256"",""typ"":""JWT""}",
+					"{""sub"":1,""iat"":1000}"
+				);
+				var claims = jwt.decode(token);
+				expect(claims.sub).toBe(1);
+				expect(StructKeyExists(claims, "exp")).toBeFalse();
 			});
 
 		});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Auth hardener SHOULDs S1–S8 on develop tip `efe289e6509865c14945348cd468651dd0838174`, plus Peter's S7 default flip.

| # | Finding | Resolution |
|---|---|---|
| **S1** | `SessionStrategy.login()` wrapped `sessionRotate()` in `catch (any)` and continued. | `$rotateSession()` with no catch-all. |
| **S2** | `logout()` cleared the principal only. | Clear then `$rotateSession()`. |
| **S3** | `authenticateWith("ghost,pass")` skipped unknown names. | Fail closed on any unknown name. |
| **S4** | `TokenStrategy` sample interpolated `where="token='#token#'"`. | 2-arg query builder + hoisted validator. |
| **S5** | Specs asserted login, not SID change. | SID change asserted on login and logout. |
| **S6** | `refresh()` `ignoreExpiry` unbounded — **KEEP default**. | Opt-in `maxRefreshAge` only. Default stays `0`. |
| **S7** | `decode()` missing `exp` fail-open — **FLIPPED**. | Default is now `requireExpiry=true`. Opt out with `requireExpiry=false`. |
| **S8** | `JwtStrategy` catch-all leaked `e.message`. | Generic 401. |

## S6 / S7 status (Lead)

- **S6 KEEP:** `maxRefreshAge=0` unbounded refresh stays. Do not flip.
- **S7 FLIPPED:** `requireExpiry` default is `true`. Missing `exp` fails closed. `requireExpiry=false` remains the opt-out.

## Defaults not weakened (except the agreed S7 flip)

`allowedClockSkew=0`, `issuer=""`, `queryParam=""` (Token + JWT), `PasswordHasher` iterations `600000`, `maxRefreshAge=0`. Only `requireExpiry` changed (`false` → `true`).

## PROVEN / UNPROVEN

S7 prove-red (`e99a24738`, default still `false`):

```
wheels test --core --ci --filter=hardener  →  218 passed, 1 failed
  FAIL: default requireExpiry=true rejects a signed token with no exp
```

GREEN (`623b2c2af`):

```
wheels test --core --ci --filter=hardener  →  219 passed (0.56s)
wheels test --core --ci --filter=auth      →  202 passed (0.25s)
```

| # | Status | Filter evidence |
|---|---|---|
| S1 | **PROVEN** | `filter=hardener` 219 |
| S2 | **PROVEN** | `filter=hardener` 219 |
| S3 | **PROVEN** | `filter=hardener` 219; `filter=auth` 202 |
| S4 | **PROVEN** | `filter=hardener` 219 |
| S5 | **PROVEN** | `filter=hardener` 219; `filter=auth` 202 |
| S6 default unbounded refresh | **PROVEN KEEP** | 10-year-expired token still refreshes at `maxRefreshAge=0` |
| S6 opt-in bound | **PROVEN** | `maxRefreshAge=86400` → `RefreshWindowExceeded` |
| S6 default flip | **UNPROVEN / KEPT** | not flipped |
| S7 default missing-exp fail-closed | **PROVEN FLIP** | RED: default decode accepted no-`exp`. GREEN: default throws `MissingExpiry`; `requireExpiry=false` still accepts |
| S8 | **PROVEN** | `filter=hardener` 219 |

## Test plan

```bash
wheels test --core --ci --filter=hardener
wheels test --core --ci --filter=auth
```

Driver is Wheels CLI only (no CommandBox).

## HEAD

`623b2c2afae2eb263f6402c83b6569d21e74cbfa`

## Type of Change

- [x] Bug fix
- [x] Enhancement to existing feature
- [x] Documentation update

## Feature Completeness Checklist

- [x] **DCO sign-off**
- [x] **Tests**
- [ ] **Framework Docs** — not required for this hardening slice
- [ ] **AI Reference Docs** — not required
- [ ] **CLAUDE.md** — unchanged
- [x] **Changelog fragment** — notes the `requireExpiry=true` public default flip
- [x] **Test runner passes** — `filter=hardener` 219; `filter=auth` 202

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0598c134-c169-4bab-9f59-dbd78cc4d0cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0598c134-c169-4bab-9f59-dbd78cc4d0cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

