### PR TITLE
fix(middleware): harden pipeline SHOULDs S1–S7 without flipping defaults

### DIFF
--- a/changelog.d/middleware-hardener-shoulds.changed.md
+++ b/changelog.d/middleware-hardener-shoulds.changed.md
@@ -1,0 +1,2 @@
+- `AuthMiddleware` accepts `genericErrors=true` to emit a generic `Unauthorized` JSON body; the default 401 still includes `authResult.error`
+- `TenantResolver` accepts `failClosed=true` to 403 unmatched tenants; unmatched requests still proceed on the default datasource unless opted in

--- a/changelog.d/middleware-hardener-shoulds.security.md
+++ b/changelog.d/middleware-hardener-shoulds.security.md
@@ -1,0 +1,6 @@
+- `Pipeline.getMiddleware()` returns a shallow copy so callers cannot mutate the live stack
+- `RateLimiter.$getClientIp()` honors `trustProxy` / `X-Forwarded-For` before a client-supplied `request.remoteAddr`
+- `MiddlewareOrderResolver` throws `Wheels.Middleware.CircularDependency` on a cycle instead of falling back to priority-only order
+- `Cors` no longer short-circuits OPTIONS or emits `Access-Control-Max-Age` when no `Access-Control-Allow-Origin` is set
+- `TenantResolver` usage sample binds the subdomain through the 2-arg query builder instead of interpolating it into `where=`
+- RateLimiter default-lock specs now observe fail-closed (`$handleError` on a default constructor) and the store-size / key-length / timestamp-per-key caps when those caps are hit, instead of `toBeInstanceOf`

--- a/vendor/wheels/middleware/AuthMiddleware.cfc
+++ b/vendor/wheels/middleware/AuthMiddleware.cfc
@@ -42,16 +42,21 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 	 * @allowAnonymous When true, failed authentication does not short-circuit the pipeline.
 	 *                 Instead, request.auth is set to the failure result and the next middleware runs.
 	 *                 Useful for routes that behave differently for authenticated vs anonymous users.
+	 * @genericErrors When true, the default JSON 401 body uses a generic "Unauthorized" message
+	 *                instead of authResult.error. Defaults to false so existing API clients keep
+	 *                the current response contract.
 	 */
 	public AuthMiddleware function init(
 		any authenticator = "",
 		any strategies = "",
 		any onFailure = "",
-		boolean allowAnonymous = false
+		boolean allowAnonymous = false,
+		boolean genericErrors = false
 	) {
 		variables.authenticator = arguments.authenticator;
 		variables.allowAnonymous = arguments.allowAnonymous;
 		variables.onFailure = arguments.onFailure;
+		variables.genericErrors = arguments.genericErrors;
 
 		// Normalize strategies to an array
 		if (IsArray(arguments.strategies)) {
@@ -148,8 +153,13 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 			}
 		}
 
+		local.errorMessage = arguments.authResult.error;
+		if (variables.genericErrors) {
+			local.errorMessage = "Unauthorized";
+		}
+
 		return SerializeJSON({
-			error = arguments.authResult.error,
+			error = local.errorMessage,
 			status = arguments.authResult.statusCode
 		});
 	}

--- a/vendor/wheels/middleware/Cors.cfc
+++ b/vendor/wheels/middleware/Cors.cfc
@@ -111,6 +111,11 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 			if (local.reflected) {
 				local.headers["Vary"] = "Origin";
 			}
+			// Max-Age is a preflight header. Only emit it when ACAO is present
+			// so a denied origin is not advertised as a cacheable success.
+			if (UCase($requestMethod(arguments.request)) == "OPTIONS") {
+				local.headers["Access-Control-Max-Age"] = variables.maxAge;
+			}
 		}
 
 		return local.headers;
@@ -126,7 +131,9 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 		} catch (any e) {
 		}
 
-		// Handle preflight OPTIONS request — return empty response immediately.
+		// Handle preflight OPTIONS request — return empty response immediately
+		// only when ACAO was emitted. A denied or unconfigured origin must not
+		// look like a successful preflight (empty 200 + Max-Age).
 		// Prefer the request struct passed to the middleware (the canonical
 		// per-request context, mirroring how RateLimiter resolves remote_addr
 		// from arguments.request.cgi) and fall back to the engine CGI scope
@@ -134,25 +141,26 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 		// scope is read-only on Lucee 7, so unit tests that need to exercise
 		// the OPTIONS branch must inject the verb through arguments.request.cgi
 		// — hence the lookup order.
-		local.requestMethod = "GET";
-		if (StructKeyExists(arguments.request, "cgi") && StructKeyExists(arguments.request.cgi, "request_method")) {
-			local.requestMethod = arguments.request.cgi.request_method;
-		} else {
-			try {
-				local.requestMethod = cgi.request_method;
-			} catch (any e) {
-			}
-		}
-
-		if (UCase(local.requestMethod) == "OPTIONS") {
-			try {
-				cfheader(name = "Access-Control-Max-Age", value = variables.maxAge);
-			} catch (any e) {
-			}
+		if (UCase($requestMethod(arguments.request)) == "OPTIONS" && StructKeyExists(local.headers, "Access-Control-Allow-Origin")) {
 			return "";
 		}
 
 		return arguments.next(arguments.request);
+	}
+
+	/**
+	 * Resolve the HTTP verb from the middleware request context, falling back
+	 * to the engine CGI scope. Shared by $headersFor() and handle().
+	 */
+	private string function $requestMethod(required struct request) {
+		if (StructKeyExists(arguments.request, "cgi") && StructKeyExists(arguments.request.cgi, "request_method")) {
+			return arguments.request.cgi.request_method;
+		}
+		try {
+			return cgi.request_method;
+		} catch (any e) {
+		}
+		return "GET";
 	}
 
 }

--- a/vendor/wheels/middleware/MiddlewareOrderResolver.cfc
+++ b/vendor/wheels/middleware/MiddlewareOrderResolver.cfc
@@ -198,7 +198,8 @@ component output="false" {
 	/**
 	 * Kahn's algorithm with priority tiebreaker.
 	 * When multiple nodes have in-degree 0, lower priority runs first.
-	 * Falls back to priority-only sort if a cycle is detected.
+	 * Throws Wheels.Middleware.CircularDependency if a cycle is detected
+	 * (fail-closed — a cycle is a misconfiguration, not a recoverable order).
 	 */
 	private array function $topologicalSort(required array named, required struct graph) {
 		local.adjacency = arguments.graph.adjacency;
@@ -245,12 +246,11 @@ component output="false" {
 
 		// Cycle detection: not all nodes visited.
 		if (local.visited < ArrayLen(arguments.named)) {
-			WriteLog(
-				type = "warning",
-				text = "Wheels middleware ordering: circular dependency detected among plugin middleware. "
-					& "Falling back to priority-only ordering. Review before/after constraints."
+			throw(
+				type = "Wheels.Middleware.CircularDependency",
+				message = "Circular before/after constraint detected among plugin middleware. "
+					& "Review before/after constraints. Wheels will not guess an order."
 			);
-			return $fallbackPrioritySort(arguments.named);
 		}
 
 		return local.sorted;
@@ -274,21 +274,6 @@ component output="false" {
 		local.result = [];
 		for (local.pair in local.pairs) {
 			ArrayAppend(local.result, local.pair.key);
-		}
-		return local.result;
-	}
-
-	/**
-	 * Fallback: sort entries by priority only (ignoring constraints).
-	 */
-	private array function $fallbackPrioritySort(required array named) {
-		local.copy = Duplicate(arguments.named);
-		ArraySort(local.copy, function(a, b) {
-			return a.priority - b.priority;
-		});
-		local.result = [];
-		for (local.item in local.copy) {
-			ArrayAppend(local.result, local.item.entry);
 		}
 		return local.result;
 	}

--- a/vendor/wheels/middleware/Pipeline.cfc
+++ b/vendor/wheels/middleware/Pipeline.cfc
@@ -39,10 +39,15 @@ component output="false" {
 	}
 
 	/**
-	 * Returns the current middleware stack (for inspection/testing).
+	 * Returns a shallow copy of the current middleware stack (for inspection/testing).
+	 * Callers that mutate the returned array cannot change the live pipeline.
 	 */
 	public array function getMiddleware() {
-		return variables.middleware;
+		local.copy = [];
+		if (ArrayLen(variables.middleware)) {
+			ArrayAppend(local.copy, variables.middleware, true);
+		}
+		return local.copy;
 	}
 
 	/**

--- a/vendor/wheels/middleware/RateLimiter.cfc
+++ b/vendor/wheels/middleware/RateLimiter.cfc
@@ -212,12 +212,8 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 	 * Get the client IP address from the request, respecting proxy headers if configured.
 	 */
 	private string function $getClientIp(required struct request) {
-		// Check request struct first (test-friendly).
-		if (StructKeyExists(arguments.request, "remoteAddr")) {
-			return arguments.request.remoteAddr;
-		}
-
-		// Trust proxy: check X-Forwarded-For header.
+		// Trust proxy first so a client-supplied request.remoteAddr cannot
+		// override X-Forwarded-For when the operator opted into proxy trust.
 		if (variables.trustProxy) {
 			try {
 				local.forwarded = "";
@@ -236,6 +232,11 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 			}
 		}
 
+		// Test-friendly override — only after the trustProxy gate.
+		if (StructKeyExists(arguments.request, "remoteAddr")) {
+			return arguments.request.remoteAddr;
+		}
+
 		// Fall back to CGI remote_addr.
 		try {
 			if (StructKeyExists(arguments.request, "cgi") && StructKeyExists(arguments.request.cgi, "remote_addr")) {
@@ -251,8 +252,10 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 	/**
 	 * Handle a rate limiter error (lock timeout or DB failure) according to the failOpen setting.
 	 * Returns a struct with `allowed` and `remaining` reflecting the decision.
+	 * Public so specs can observe fail-closed on a default constructor (hardener B1)
+	 * without reaching into the variables scope.
 	 */
-	private struct function $handleError(required string context, required string clientKey) {
+	public struct function $handleError(required string context, required string clientKey) {
 		local.mode = variables.failOpen ? "fail-open" : "fail-closed";
 		writeLog(
 			text = "Rate limiter #arguments.context# (#local.mode#) for key: #arguments.clientKey#",
@@ -535,6 +538,34 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 	 */
 	public numeric function $storeSize() {
 		return variables.storage == "memory" ? variables.store.size() : 0;
+	}
+
+	/**
+	 * Internal probes. Public ONLY so specs can observe the configured caps
+	 * (hardener B1) instead of asserting toBeInstanceOf on a constructed limiter.
+	 */
+	public numeric function $maxStoreSize() {
+		return variables.maxStoreSize;
+	}
+
+	public numeric function $maxKeyLength() {
+		return variables.maxKeyLength;
+	}
+
+	public numeric function $maxTimestampsPerKey() {
+		return variables.maxTimestampsPerKey;
+	}
+
+	/**
+	 * Sliding-window timestamp count for one client key. Public so specs can
+	 * observe the per-key cap being hit, not just that handle() still returns.
+	 */
+	public numeric function $slidingWindowSize(required string clientKey) {
+		if (variables.storage != "memory" || !variables.store.containsKey(arguments.clientKey)) {
+			return 0;
+		}
+		local.value = variables.store.get(arguments.clientKey);
+		return IsArray(local.value) ? ArrayLen(local.value) : 0;
 	}
 
 	/**

--- a/vendor/wheels/middleware/TenantResolver.cfc
+++ b/vendor/wheels/middleware/TenantResolver.cfc
@@ -10,7 +10,8 @@
  *     new wheels.middleware.TenantResolver(
  *       resolver = function(req) {
  *         var subdomain = ListFirst(cgi.server_name, ".");
- *         var t = model("Tenant").findOne(where="subdomain='#subdomain#'");
+ *         // 2-arg where binds the value — never interpolate request input into where=.
+ *         var t = model("Tenant").where("subdomain", subdomain).findOne();
  *         if (IsObject(t)) return {id: t.id, dataSource: t.dataSourceName, config: {}};
  *         return {};
  *       }
@@ -28,15 +29,20 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 	 * @resolver Closure that receives the request struct and returns a tenant struct ({id, dataSource, config}). Used when strategy is "custom".
 	 * @strategy Resolution strategy: "subdomain", "header", or "custom" (default).
 	 * @headerName HTTP header to read tenant ID from when strategy is "header".
+	 * @failClosed When true, an unmatched resolver (empty struct / missing dataSource) short-circuits
+	 *             with HTTP 403 instead of proceeding on the application default datasource.
+	 *             Defaults to false so existing apps keep the documented tenant-free fallback.
 	 */
 	public TenantResolver function init(
 		any resolver = "",
 		string strategy = "custom",
-		string headerName = "X-Tenant-ID"
+		string headerName = "X-Tenant-ID",
+		boolean failClosed = false
 	) {
 		variables.strategy = arguments.strategy;
 		variables.headerName = arguments.headerName;
 		variables.resolver = arguments.resolver;
+		variables.failClosed = arguments.failClosed;
 
 		return this;
 	}
@@ -83,19 +89,28 @@ component implements="wheels.middleware.MiddlewareInterface" output="false" {
 
 			// Set on the built-in request scope (where $performQuery reads it)
 			request.wheels.tenant = local.tenant;
-		} else if (IsDefined("request.wheels.tenant")) {
-			// The resolver found no match. Drop any value already sitting on the key so a stale
-			// or foreign one can't outlive resolution and be read downstream as a resolved
-			// tenant — an unresolved request must look unresolved for the whole request (#3336).
-			//
-			// Guard with IsDefined on the full path, matching the finally block below. A
-			// `StructKeyExists(request, "wheels")` guard is NOT equivalent here: this function
-			// takes a parameter named `request`, and on Adobe 2025 the bare `request` token
-			// resolves differently between the StructKeyExists argument and the `request.wheels`
-			// member-access expression, so the guard passed and the delete then threw
-			// `Element WHEELS is undefined in REQUEST`. IsDefined resolves the whole dotted path
-			// in one evaluation, so it cannot disagree with itself.
-			StructDelete(request.wheels, "tenant");
+		} else {
+			if (IsDefined("request.wheels.tenant")) {
+				// The resolver found no match. Drop any value already sitting on the key so a stale
+				// or foreign one can't outlive resolution and be read downstream as a resolved
+				// tenant — an unresolved request must look unresolved for the whole request (#3336).
+				//
+				// Guard with IsDefined on the full path, matching the finally block below. A
+				// `StructKeyExists(request, "wheels")` guard is NOT equivalent here: this function
+				// takes a parameter named `request`, and on Adobe 2025 the bare `request` token
+				// resolves differently between the StructKeyExists argument and the `request.wheels`
+				// member-access expression, so the guard passed and the delete then threw
+				// `Element WHEELS is undefined in REQUEST`. IsDefined resolves the whole dotted path
+				// in one evaluation, so it cannot disagree with itself.
+				StructDelete(request.wheels, "tenant");
+			}
+			if (variables.failClosed) {
+				try {
+					cfheader(statusCode = "403");
+				} catch (any e) {
+				}
+				return "Forbidden";
+			}
 		}
 
 		try {

--- a/vendor/wheels/tests/specs/hardener/MiddlewareHardenerShouldSpec.cfc
+++ b/vendor/wheels/tests/specs/hardener/MiddlewareHardenerShouldSpec.cfc
@@ -1,5 +1,5 @@
 /**
- * Hardener SHOULDs S1–S7 (middleware pipeline).
+ * Hardener SHOULDs S1–S7 and BLOCKER B1 (middleware pipeline).
  *
  * Directory-scoped so `wheels test --core --ci --filter=hardener`
  * discovers this folder (a single-file directory= scope finds 0 bundles).
@@ -9,6 +9,10 @@
  *      genericErrors=true is opt-in.
  *   S5 TenantResolver unmatched still proceeds on the default datasource.
  *      failClosed=true is opt-in.
+ *
+ * B1 RateLimiterSpec default-lock its must observe fail-closed and cap
+ * behavior, not toBeInstanceOf. PluginMiddlewarePipelineSpec instance-ofs
+ * are Dispatch leftovers and are out of scope.
  *
  * CoS lock: Cors allowOrigins="" / allowCredentials=false,
  * RateLimiter failOpen=false / trustProxy=false,
@@ -298,6 +302,89 @@ component extends="wheels.WheelsTest" {
 				}
 				expect(state.threw).toBeTrue();
 				expect(state.type).toBe("Wheels.Middleware.CircularDependency");
+			});
+
+		});
+
+		describe("B1 RateLimiter default locks are observed, not instance-of", function() {
+
+			it("default ctor $handleError is fail-closed", function() {
+				var limiter = new wheels.middleware.RateLimiter();
+				var outcome = limiter.$handleError("hardener-b1", "default-ctor");
+				expect(outcome.allowed).toBeFalse();
+				expect(outcome.remaining).toBe(0);
+			});
+
+			it("failOpen=true is observed on $handleError, not just accepted by init", function() {
+				var limiter = new wheels.middleware.RateLimiter(failOpen = true);
+				var outcome = limiter.$handleError("hardener-b1", "fail-open");
+				expect(outcome.allowed).toBeTrue();
+			});
+
+			it("default maxKeyLength hashes a 129-char key and shares the hashed bucket", function() {
+				var limiter = new wheels.middleware.RateLimiter(maxRequests = 1, windowSeconds = 60);
+				var nextFn = function(req) {
+					return "ok";
+				};
+				var longKey = RepeatString("H", 129);
+				var hashed = Hash(longKey, "SHA-256");
+				expect(limiter.handle(request = {remoteAddr: longKey}, next = nextFn)).toBe("ok");
+				expect(limiter.handle(request = {remoteAddr: hashed}, next = nextFn)).toInclude(
+					"Rate limit exceeded"
+				);
+			});
+
+			it("default maxKeyLength does not hash a 128-char key", function() {
+				var limiter = new wheels.middleware.RateLimiter(maxRequests = 1, windowSeconds = 60);
+				var nextFn = function(req) {
+					return "ok";
+				};
+				var exact = RepeatString("E", 128);
+				var hashed = Hash(exact, "SHA-256");
+				expect(limiter.handle(request = {remoteAddr: exact}, next = nextFn)).toBe("ok");
+				expect(limiter.handle(request = {remoteAddr: hashed}, next = nextFn)).toBe("ok");
+			});
+
+			it("default maxStoreSize is 100000 and a smaller cap is observed via $storeSize", function() {
+				var defaults = new wheels.middleware.RateLimiter();
+				expect(defaults.$maxStoreSize()).toBe(100000);
+
+				var limiter = new wheels.middleware.RateLimiter(
+					maxRequests = 1000,
+					windowSeconds = 60,
+					strategy = "fixedWindow",
+					maxStoreSize = 5
+				);
+				var nextFn = function(req) {
+					return "ok";
+				};
+				for (var i = 1; i <= 20; i++) {
+					limiter.handle(request = {remoteAddr: "b1-store-#i#"}, next = nextFn);
+					expect(limiter.$storeSize()).toBeLTE(5);
+				}
+			});
+
+			it("default maxTimestampsPerKey is maxRequests * 3 and a smaller cap is observed", function() {
+				var defaults = new wheels.middleware.RateLimiter(
+					maxRequests = 10,
+					strategy = "slidingWindow"
+				);
+				expect(defaults.$maxTimestampsPerKey()).toBe(30);
+
+				var limiter = new wheels.middleware.RateLimiter(
+					maxRequests = 1000,
+					windowSeconds = 60,
+					strategy = "slidingWindow",
+					maxTimestampsPerKey = 5
+				);
+				var nextFn = function(req) {
+					return "ok";
+				};
+				for (var i = 1; i <= 20; i++) {
+					limiter.handle(request = {remoteAddr: "b1-ts"}, next = nextFn);
+				}
+				expect(limiter.$slidingWindowSize("b1-ts")).toBeLTE(6);
+				expect(limiter.$slidingWindowSize("b1-ts")).toBeGT(0);
 			});
 
 		});

--- a/vendor/wheels/tests/specs/hardener/MiddlewareHardenerShouldSpec.cfc
+++ b/vendor/wheels/tests/specs/hardener/MiddlewareHardenerShouldSpec.cfc
@@ -1,0 +1,372 @@
+/**
+ * Hardener SHOULDs S1–S7 (middleware pipeline).
+ *
+ * Directory-scoped so `wheels test --core --ci --filter=hardener`
+ * discovers this folder (a single-file directory= scope finds 0 bundles).
+ *
+ * Escalations (no silent public default/API flips):
+ *   S2 AuthMiddleware default 401 body still emits authResult.error.
+ *      genericErrors=true is opt-in.
+ *   S5 TenantResolver unmatched still proceeds on the default datasource.
+ *      failClosed=true is opt-in.
+ *
+ * CoS lock: Cors allowOrigins="" / allowCredentials=false,
+ * RateLimiter failOpen=false / trustProxy=false,
+ * AuthMiddleware allowAnonymous=false,
+ * SecurityHeaders SAMEORIGIN + nosniff.
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("CoS lock: middleware public defaults stay conservative", function() {
+
+			it("keeps Cors allowOrigins empty and allowCredentials false", function() {
+				var src = FileRead(ExpandPath("/wheels/middleware/Cors.cfc"));
+				expect(FindNoCase("string allowOrigins = """"", src)).toBeGT(0);
+				expect(FindNoCase("boolean allowCredentials = false", src)).toBeGT(0);
+
+				var cors = new wheels.middleware.Cors();
+				expect(cors.$resolveAllowOrigin("https://evil.example")).toBe("");
+			});
+
+			it("keeps RateLimiter failOpen and trustProxy false", function() {
+				var src = FileRead(ExpandPath("/wheels/middleware/RateLimiter.cfc"));
+				expect(FindNoCase("boolean trustProxy = false", src)).toBeGT(0);
+				expect(FindNoCase("boolean failOpen = false", src)).toBeGT(0);
+			});
+
+			it("keeps AuthMiddleware allowAnonymous false", function() {
+				var src = FileRead(ExpandPath("/wheels/middleware/AuthMiddleware.cfc"));
+				expect(FindNoCase("boolean allowAnonymous = false", src)).toBeGT(0);
+			});
+
+			it("keeps SecurityHeaders SAMEORIGIN and nosniff", function() {
+				var mw = new wheels.middleware.SecurityHeaders();
+				var headers = mw.$headers();
+				expect(headers["X-Frame-Options"]).toBe("SAMEORIGIN");
+				expect(headers["X-Content-Type-Options"]).toBe("nosniff");
+			});
+
+		});
+
+		describe("S1 TenantResolver docs use 2-arg where", function() {
+
+			it("TenantResolver.cfc usage sample does not interpolate subdomain into SQL", function() {
+				var src = FileRead(ExpandPath("/wheels/middleware/TenantResolver.cfc"));
+				// Build the forbidden interpolation without putting a raw ## pair
+				// that CFML would treat as an empty expression in this spec.
+				var interpolatedWhere = "subdomain=" & Chr(39) & "##subdomain##" & Chr(39);
+				expect(FindNoCase(interpolatedWhere, src)).toBe(
+					0,
+					"TenantResolver docs must not show where=""subdomain='##subdomain##'"""
+				);
+			});
+
+			it("TenantResolver.cfc usage sample binds subdomain through 2-arg where", function() {
+				var src = FileRead(ExpandPath("/wheels/middleware/TenantResolver.cfc"));
+				expect(FindNoCase("where(""subdomain""", src)).toBeGT(
+					0,
+					"TenantResolver docs must show the 2-arg query builder where(""subdomain"", ...)"
+				);
+			});
+
+		});
+
+		describe("S2 AuthMiddleware JSON error is opt-in generic", function() {
+
+			it("default 401 body still emits authResult.error (no silent contract flip)", function() {
+				var auth = new wheels.auth.Authenticator();
+				auth.registerStrategy(name = "fail", strategy = new wheels.tests._assets.auth.AlwaysFailStrategy());
+				var mw = new wheels.middleware.AuthMiddleware(authenticator = auth);
+				var pipeline = new wheels.middleware.Pipeline(middleware = [mw]);
+				var result = pipeline.run(request = {}, coreHandler = function(required struct request) {
+					return "should-not-reach";
+				});
+				var parsed = DeserializeJSON(result);
+				expect(parsed.error).toBe("Invalid credentials");
+				expect(parsed.status).toBe(401);
+			});
+
+			it("genericErrors=true emits a generic Unauthorized body", function() {
+				var auth = new wheels.auth.Authenticator();
+				auth.registerStrategy(name = "fail", strategy = new wheels.tests._assets.auth.AlwaysFailStrategy());
+				var mw = new wheels.middleware.AuthMiddleware(
+					authenticator = auth,
+					genericErrors = true
+				);
+				var pipeline = new wheels.middleware.Pipeline(middleware = [mw]);
+				var result = pipeline.run(request = {}, coreHandler = function(required struct request) {
+					return "should-not-reach";
+				});
+				var parsed = DeserializeJSON(result);
+				expect(parsed.error).toBe("Unauthorized");
+				expect(parsed.status).toBe(401);
+				expect(FindNoCase("Invalid credentials", result)).toBe(0);
+			});
+
+			it("genericErrors=true does not leak unregistered-strategy diagnostics", function() {
+				var auth = new wheels.auth.Authenticator();
+				auth.registerStrategy(name = "pass", strategy = new wheels.tests._assets.auth.AlwaysPassStrategy());
+				var mw = new wheels.middleware.AuthMiddleware(
+					authenticator = auth,
+					strategies = "ghost,pass",
+					genericErrors = true
+				);
+				var pipeline = new wheels.middleware.Pipeline(middleware = [mw]);
+				var result = pipeline.run(request = {}, coreHandler = function(required struct request) {
+					return "should-not-reach";
+				});
+				var parsed = DeserializeJSON(result);
+				expect(parsed.error).toBe("Unauthorized");
+				expect(FindNoCase("ghost", result)).toBe(0);
+				expect(FindNoCase("unregistered strategy", result)).toBe(0);
+			});
+
+		});
+
+		describe("S3 Pipeline.getMiddleware() returns a copy", function() {
+
+			it("mutating the returned array does not change the live stack", function() {
+				var shared = {order = []};
+				var mwA = new wheels.tests.specs.middleware._helpers.TrackingMiddleware(id = "A", tracker = shared);
+				var pipeline = new wheels.middleware.Pipeline(middleware = [mwA]);
+				var exposed = pipeline.getMiddleware();
+				var leak = new wheels.tests.specs.middleware._helpers.TrackingMiddleware(id = "LEAK", tracker = shared);
+				ArrayAppend(exposed, leak);
+
+				var handler = function(required struct request) {
+					ArrayAppend(shared.order, "core");
+					return "ok";
+				};
+				pipeline.run(request = {}, coreHandler = handler);
+
+				expect(ArrayLen(pipeline.getMiddleware())).toBe(1);
+				expect(ArrayToList(shared.order)).toBe("before:A,core,after:A");
+			});
+
+			it("deleting from the returned array does not empty the live stack", function() {
+				var mw = new wheels.middleware.RequestId();
+				var pipeline = new wheels.middleware.Pipeline(middleware = [mw]);
+				var exposed = pipeline.getMiddleware();
+				ArrayDeleteAt(exposed, 1);
+				expect(ArrayLen(pipeline.getMiddleware())).toBe(1);
+			});
+
+		});
+
+		describe("S4 RateLimiter $getClientIp honors trustProxy before remoteAddr", function() {
+
+			it("does not let request.remoteAddr override X-Forwarded-For when trustProxy is true", function() {
+				var limiter = new wheels.middleware.RateLimiter(
+					maxRequests = 1,
+					windowSeconds = 60,
+					trustProxy = true
+				);
+				var nextFn = function(req) {
+					return "ok";
+				};
+				var req1 = {
+					remoteAddr: "spoof-1",
+					cgi: {
+						remote_addr: "10.0.0.1",
+						http_x_forwarded_for: "203.0.113.10"
+					}
+				};
+				var req2 = {
+					remoteAddr: "spoof-2",
+					cgi: {
+						remote_addr: "10.0.0.1",
+						http_x_forwarded_for: "203.0.113.10"
+					}
+				};
+				expect(limiter.handle(request = req1, next = nextFn)).toBe("ok");
+				expect(limiter.handle(request = req2, next = nextFn)).toInclude("Rate limit exceeded");
+			});
+
+			it("still uses request.remoteAddr when trustProxy is false", function() {
+				var limiter = new wheels.middleware.RateLimiter(maxRequests = 1, windowSeconds = 60);
+				var nextFn = function(req) {
+					return "ok";
+				};
+				var req1 = {
+					remoteAddr: "test-a",
+					cgi: {remote_addr: "10.0.0.1", http_x_forwarded_for: "1.1.1.1"}
+				};
+				var req2 = {
+					remoteAddr: "test-b",
+					cgi: {remote_addr: "10.0.0.1", http_x_forwarded_for: "1.1.1.1"}
+				};
+				expect(limiter.handle(request = req1, next = nextFn)).toBe("ok");
+				expect(limiter.handle(request = req2, next = nextFn)).toBe("ok");
+			});
+
+		});
+
+		describe("S5 TenantResolver unmatched fail-closed is opt-in", function() {
+
+			afterEach(function() {
+				if (IsDefined("request.wheels.tenant")) {
+					StructDelete(request.wheels, "tenant");
+				}
+			});
+
+			it("default unmatched still proceeds on the default datasource", function() {
+				var emptyResolver = function(req) {
+					return {};
+				};
+				var mw = new wheels.middleware.TenantResolver(resolver = emptyResolver);
+				var pipeline = new wheels.middleware.Pipeline(middleware = [mw]);
+				var result = {called = false, hasTenant = false};
+				var handler = function(required struct request) {
+					result.called = true;
+					result.hasTenant = IsDefined("request.wheels.tenant");
+					return "proceeded";
+				};
+				var body = pipeline.run(request = {cgi = {}}, coreHandler = handler);
+				expect(body).toBe("proceeded");
+				expect(result.called).toBeTrue();
+				expect(result.hasTenant).toBeFalse();
+			});
+
+			it("failClosed=true short-circuits unmatched tenants with 403", function() {
+				var emptyResolver = function(req) {
+					return {};
+				};
+				var mw = new wheels.middleware.TenantResolver(
+					resolver = emptyResolver,
+					failClosed = true
+				);
+				var pipeline = new wheels.middleware.Pipeline(middleware = [mw]);
+				var result = {called = false};
+				var handler = function(required struct request) {
+					result.called = true;
+					return "should-not-reach";
+				};
+				var body = pipeline.run(request = {cgi = {}}, coreHandler = handler);
+				expect(result.called).toBeFalse();
+				expect(body).toBe("Forbidden");
+			});
+
+			it("failClosed=true still proceeds when a tenant resolves", function() {
+				var matchedResolver = function(req) {
+					return {id = "t1", dataSource = "tenant_one_ds"};
+				};
+				var mw = new wheels.middleware.TenantResolver(
+					resolver = matchedResolver,
+					failClosed = true
+				);
+				var pipeline = new wheels.middleware.Pipeline(middleware = [mw]);
+				var result = {called = false, tenantId = ""};
+				var handler = function(required struct request) {
+					result.called = true;
+					if (IsDefined("request.wheels.tenant")) {
+						result.tenantId = request.wheels.tenant.id;
+					}
+					return "ok";
+				};
+				var body = pipeline.run(request = {cgi = {}}, coreHandler = handler);
+				expect(body).toBe("ok");
+				expect(result.called).toBeTrue();
+				expect(result.tenantId).toBe("t1");
+			});
+
+		});
+
+		describe("S6 MiddlewareOrderResolver cycle fails closed", function() {
+
+			it("throws instead of falling back to priority-only order", function() {
+				var resolver = new wheels.middleware.MiddlewareOrderResolver();
+				var entries = [
+					{
+						middleware = "test.middleware.A",
+						options = {name = "A", priority = 1, before = "B"},
+						pluginName = "pluginA"
+					},
+					{
+						middleware = "test.middleware.B",
+						options = {name = "B", priority = 2, before = "A"},
+						pluginName = "pluginB"
+					}
+				];
+				var state = {threw = false, type = ""};
+				try {
+					resolver.resolve(entries);
+				} catch (any e) {
+					state.threw = true;
+					state.type = e.type;
+				}
+				expect(state.threw).toBeTrue();
+				expect(state.type).toBe("Wheels.Middleware.CircularDependency");
+			});
+
+		});
+
+		describe("S7 Cors OPTIONS without ACAO is not a cached success", function() {
+
+			it("default allowOrigins does not short-circuit OPTIONS as empty success", function() {
+				var cors = new wheels.middleware.Cors();
+				var reqCtx = {cgi = {request_method = "OPTIONS", http_origin = "https://evil.example"}};
+				var result = cors.handle(
+					request = reqCtx,
+					next = function(required struct request) {
+						return "passthrough";
+					}
+				);
+				expect(result).toBe("passthrough");
+			});
+
+			it("unmatched origin does not short-circuit OPTIONS as empty success", function() {
+				var cors = new wheels.middleware.Cors(allowOrigins = "https://myapp.example");
+				var reqCtx = {cgi = {request_method = "OPTIONS", http_origin = "https://evil.example"}};
+				var result = cors.handle(
+					request = reqCtx,
+					next = function(required struct request) {
+						return "passthrough";
+					}
+				);
+				expect(result).toBe("passthrough");
+			});
+
+			it("matched origin still short-circuits OPTIONS with an empty body", function() {
+				var cors = new wheels.middleware.Cors(allowOrigins = "https://myapp.example");
+				var reqCtx = {cgi = {request_method = "OPTIONS", http_origin = "https://myapp.example"}};
+				var result = cors.handle(
+					request = reqCtx,
+					next = function(required struct request) {
+						return "should-not-reach";
+					}
+				);
+				expect(result).toBe("");
+			});
+
+			it("emits Max-Age on OPTIONS only when ACAO is present", function() {
+				var cors = new wheels.middleware.Cors(allowOrigins = "https://myapp.example");
+				var allowed = cors.$headersFor(
+					request = {cgi = {request_method = "OPTIONS", http_origin = "https://myapp.example"}}
+				);
+				expect(allowed).toHaveKey("Access-Control-Allow-Origin");
+				expect(allowed).toHaveKey("Access-Control-Max-Age");
+				expect(allowed["Access-Control-Max-Age"]).toBe(86400);
+
+				var denied = cors.$headersFor(
+					request = {cgi = {request_method = "OPTIONS", http_origin = "https://evil.example"}}
+				);
+				expect(denied).notToHaveKey("Access-Control-Allow-Origin");
+				expect(denied).notToHaveKey("Access-Control-Max-Age");
+			});
+
+			it("does not emit Max-Age on a non-OPTIONS request", function() {
+				var cors = new wheels.middleware.Cors(allowOrigins = "https://myapp.example");
+				var headers = cors.$headersFor(
+					request = {cgi = {request_method = "GET", http_origin = "https://myapp.example"}}
+				);
+				expect(headers).toHaveKey("Access-Control-Allow-Origin");
+				expect(headers).notToHaveKey("Access-Control-Max-Age");
+			});
+
+		});
+
+	}
+
+}

--- a/vendor/wheels/tests/specs/middleware/CorsPreflightDispatchSpec.cfc
+++ b/vendor/wheels/tests/specs/middleware/CorsPreflightDispatchSpec.cfc
@@ -20,6 +20,8 @@ component extends="wheels.WheelsTest" {
 				_savedStaticRoutes = StructKeyExists(application.wheels, "staticRoutes")
 					? Duplicate(application.wheels.staticRoutes) : {};
 				_savedCgiMethod = request.cgi.request_method;
+				_hadCgiOrigin = StructKeyExists(request.cgi, "http_origin");
+				_savedCgiOrigin = _hadCgiOrigin ? request.cgi.http_origin : "";
 				application.wheels.routes = [];
 				application.wheels.staticRoutes = {};
 			});
@@ -29,6 +31,11 @@ component extends="wheels.WheelsTest" {
 				application.wheels.routes = _savedRoutes;
 				application.wheels.staticRoutes = _savedStaticRoutes;
 				request.cgi["request_method"] = _savedCgiMethod;
+				if (_hadCgiOrigin) {
+					request.cgi["http_origin"] = _savedCgiOrigin;
+				} else {
+					StructDelete(request.cgi, "http_origin");
+				}
 			});
 
 			it("does not 404 on OPTIONS preflight when CORS middleware is registered", () => {
@@ -44,6 +51,9 @@ component extends="wheels.WheelsTest" {
 					new wheels.middleware.Cors(allowOrigins = "https://portal.pai.com")
 				];
 				request.cgi["request_method"] = "OPTIONS";
+				// Preflight short-circuit requires ACAO. Inject the matching Origin
+				// so Cors emits the allow header instead of passing through to 404.
+				request.cgi["http_origin"] = "https://portal.pai.com";
 
 				var d = application.wo.$createObjectFromRoot(
 					path = "wheels", fileName = "Dispatch", method = "$init"

--- a/vendor/wheels/tests/specs/middleware/MiddlewareOrderResolverSpec.cfc
+++ b/vendor/wheels/tests/specs/middleware/MiddlewareOrderResolverSpec.cfc
@@ -123,17 +123,21 @@ component extends="wheels.WheelsTest" {
 					expect(result[2].pluginName).toBe("pluginLogger");
 				});
 
-				it("falls back to priority sort on circular dependency", function() {
+				it("throws on circular dependency", function() {
 					var entries = [
 						$entry("A", "pluginA", {priority: 1, before: "B"}),
 						$entry("B", "pluginB", {priority: 2, before: "A"})
 					];
-					// Circular: A before B AND B before A — should warn and fallback.
-					var result = resolver.resolve(entries);
-					// Fallback is priority-only: A (1) before B (2).
-					expect(ArrayLen(result)).toBe(2);
-					expect(result[1].pluginName).toBe("pluginA");
-					expect(result[2].pluginName).toBe("pluginB");
+					// Circular: A before B AND B before A — fail closed.
+					var state = {threw = false, type = ""};
+					try {
+						resolver.resolve(entries);
+					} catch (any e) {
+						state.threw = true;
+						state.type = e.type;
+					}
+					expect(state.threw).toBeTrue();
+					expect(state.type).toBe("Wheels.Middleware.CircularDependency");
 				});
 
 				it("preserves ordering constraints when duplicate names are present", function() {

--- a/vendor/wheels/tests/specs/middleware/RateLimiterSpec.cfc
+++ b/vendor/wheels/tests/specs/middleware/RateLimiterSpec.cfc
@@ -319,13 +319,12 @@ component extends="wheels.WheelsTest" {
 
 			it("defaults maxStoreSize to 100000", function() {
 				var limiter = new wheels.middleware.RateLimiter();
-				// Should construct without error.
-				expect(limiter).toBeInstanceOf("wheels.middleware.RateLimiter");
+				expect(limiter.$maxStoreSize()).toBe(100000);
 			});
 
 			it("accepts custom maxStoreSize", function() {
 				var limiter = new wheels.middleware.RateLimiter(maxStoreSize = 500);
-				expect(limiter).toBeInstanceOf("wheels.middleware.RateLimiter");
+				expect(limiter.$maxStoreSize()).toBe(500);
 			});
 
 			it("evicts entries when store exceeds maxStoreSize", function() {
@@ -342,12 +341,13 @@ component extends="wheels.WheelsTest" {
 				for (var i = 1; i <= 10; i++) {
 					var req = {remoteAddr: "client-evict-#i#"};
 					limiter.handle(request = req, next = nextFn);
+					expect(limiter.$storeSize()).toBeLTE(5);
 				}
 
-				// The limiter should still function correctly (not error out).
 				var finalReq = {remoteAddr: "client-evict-final"};
 				var result = limiter.handle(request = finalReq, next = nextFn);
 				expect(result).toBe("ok");
+				expect(limiter.$storeSize()).toBeLTE(5);
 			});
 
 			// NOTE: Testing that rate limiting still works after eviction is inherently
@@ -364,7 +364,7 @@ component extends="wheels.WheelsTest" {
 					maxRequests = 10,
 					strategy = "slidingWindow"
 				);
-				expect(limiter).toBeInstanceOf("wheels.middleware.RateLimiter");
+				expect(limiter.$maxTimestampsPerKey()).toBe(30);
 			});
 
 			it("accepts custom maxTimestampsPerKey", function() {
@@ -373,7 +373,7 @@ component extends="wheels.WheelsTest" {
 					strategy = "slidingWindow",
 					maxTimestampsPerKey = 50
 				);
-				expect(limiter).toBeInstanceOf("wheels.middleware.RateLimiter");
+				expect(limiter.$maxTimestampsPerKey()).toBe(50);
 			});
 
 			it("caps sliding window timestamps per key", function() {
@@ -393,7 +393,10 @@ component extends="wheels.WheelsTest" {
 					limiter.handle(request = req, next = nextFn);
 				}
 
-				// The limiter should still function correctly after capping.
+				// Truncate-then-append can leave at most cap+1 timestamps.
+				expect(limiter.$slidingWindowSize("flood-client")).toBeLTE(6);
+				expect(limiter.$slidingWindowSize("flood-client")).toBeGT(0);
+
 				var finalReq = {remoteAddr: "flood-client"};
 				var result = limiter.handle(request = finalReq, next = nextFn);
 				expect(result).toBe("ok");
@@ -450,13 +453,21 @@ component extends="wheels.WheelsTest" {
 		describe("RateLimiter maxKeyLength", function() {
 
 			it("defaults maxKeyLength to 128", function() {
-				var limiter = new wheels.middleware.RateLimiter();
-				expect(limiter).toBeInstanceOf("wheels.middleware.RateLimiter");
+				var limiter = new wheels.middleware.RateLimiter(maxRequests = 1, windowSeconds = 60);
+				expect(limiter.$maxKeyLength()).toBe(128);
+
+				var nextFn = function(req) { return "ok"; };
+				var longKey = RepeatString("K", 129);
+				var hashed = Hash(longKey, "SHA-256");
+				expect(limiter.handle(request = {remoteAddr: longKey}, next = nextFn)).toBe("ok");
+				expect(limiter.handle(request = {remoteAddr: hashed}, next = nextFn)).toInclude(
+					"Rate limit exceeded"
+				);
 			});
 
 			it("accepts custom maxKeyLength", function() {
 				var limiter = new wheels.middleware.RateLimiter(maxKeyLength = 64);
-				expect(limiter).toBeInstanceOf("wheels.middleware.RateLimiter");
+				expect(limiter.$maxKeyLength()).toBe(64);
 			});
 
 			it("hashes keys longer than maxKeyLength", function() {
@@ -562,18 +573,20 @@ component extends="wheels.WheelsTest" {
 		describe("RateLimiter failOpen parameter", function() {
 
 			it("defaults failOpen to false (fail-closed)", function() {
-				var limiter = new wheels.middleware.RateLimiter(maxRequests = 5, windowSeconds = 60);
-				expect(limiter).toBeInstanceOf("wheels.middleware.RateLimiter");
+				var limiter = new wheels.middleware.RateLimiter();
+				var outcome = limiter.$handleError("spec-default", "failopen-lock");
+				expect(outcome.allowed).toBeFalse();
+				expect(outcome.remaining).toBe(0);
 			});
 
 			it("accepts failOpen=true", function() {
 				var limiter = new wheels.middleware.RateLimiter(maxRequests = 5, windowSeconds = 60, failOpen = true);
-				expect(limiter).toBeInstanceOf("wheels.middleware.RateLimiter");
+				expect(limiter.$handleError("spec-open", "failopen-true").allowed).toBeTrue();
 			});
 
 			it("accepts failOpen=false", function() {
 				var limiter = new wheels.middleware.RateLimiter(maxRequests = 5, windowSeconds = 60, failOpen = false);
-				expect(limiter).toBeInstanceOf("wheels.middleware.RateLimiter");
+				expect(limiter.$handleError("spec-closed", "failopen-false").allowed).toBeFalse();
 			});
 
 			it("blocks requests by default when fail-closed with fixed window", function() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Middleware pipeline hardenings on tip `b0aa3435ffbf4ca9a1afb70135b7da9f8a7188b3`. SHOULDs S1/S3/S4/S6/S7 plus BLOCKER B1. S2/S5 stay opt-in so public contracts do not flip.

## Summary

**S1.** TenantResolver usage sample now uses `model("Tenant").where("subdomain", subdomain).findOne()` instead of interpolating the subdomain into `where=`.

**S3.** `Pipeline.getMiddleware()` returns a shallow copy. Mutating the returned array cannot change the live stack.

**S4.** `$getClientIp()` honors `trustProxy` / `X-Forwarded-For` before `request.remoteAddr`. A spoofed `remoteAddr` no longer splits buckets when proxy trust is on.

**S6.** `MiddlewareOrderResolver` throws `Wheels.Middleware.CircularDependency` on a cycle. It no longer falls back to priority-only order.

**S7.** Cors OPTIONS short-circuits and emits `Access-Control-Max-Age` only when ACAO is present. Default `allowOrigins=""` still denies. Denied origins pass through instead of returning empty 200 + Max-Age.

**B1.** RateLimiterSpec default-lock `it`s no longer stop at `toBeInstanceOf`. `$handleError` on a default constructor returns `allowed=false`. Store-size, key-length (129-char key hashes and shares the SHA-256 bucket), and timestamp-per-key caps are observed when the cap is hit. PluginMiddlewarePipelineSpec instance-ofs were left alone.

**S2 (escalated, opt-in).** Default 401 JSON still emits `authResult.error`. Pass `genericErrors=true` for a generic `Unauthorized` body.

**S5 (escalated, opt-in).** Unmatched tenants still proceed on the default datasource. Pass `failClosed=true` for a 403.

## Defaults lock

Unchanged: Cors `allowOrigins=""` / `allowCredentials=false`, RateLimiter `failOpen=false` / `trustProxy=false`, AuthMiddleware `allowAnonymous=false`, SecurityHeaders `SAMEORIGIN` + `nosniff`.

## PROVEN / UNPROVEN

| ID | Status | Evidence | Filter |
|---|---|---|---|
| S1 | PROVEN | Source-scan: no interpolated `subdomain='#…#'`; 2-arg `where("subdomain"` present | `wheels test --core --ci --filter=hardener` → **247 passed** |
| S2 | PROVEN opt-in / not flipped | Default body still `Invalid credentials`; `genericErrors=true` is generic | same |
| S3 | PROVEN | Append/delete on returned array does not change live stack | same |
| S4 | PROVEN | `trustProxy=true` + spoofed `remoteAddr` + same XFF share one bucket | same |
| S5 | PROVEN opt-in / not flipped | Default unmatched still proceeds; `failClosed=true` returns `Forbidden` | same |
| S6 | PROVEN | Cycle throws `Wheels.Middleware.CircularDependency` | same + `--filter=middleware` |
| S7 | PROVEN | OPTIONS without ACAO passes through; Max-Age only with ACAO | same + `--filter=middleware` |
| B1 | PROVEN | Default ctor `$handleError.allowed=false`; store / key / timestamp caps observed at hit | `hardener` 247 + `middleware` **208 passed** |

S2/S5 are escalated: opt-in only. Defaults were not weakened.

HEAD: `3d9186a1b6250275ceb10351cb8424036bd838df`

Driver: `wheels test --core --ci --filter=hardener` and `--filter=middleware`. No CommandBox. No merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18355d9b-4716-4f37-889f-469dc048a427?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18355d9b-4716-4f37-889f-469dc048a427&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

