### PR TITLE
fix(jobs): honor timeout, allowlist jobClass, return real DML counts

### DIFF
--- a/changelog.d/jobs-hardener-b1-b4.fixed.md
+++ b/changelog.d/jobs-hardener-b1-b4.fixed.md
@@ -5,5 +5,7 @@
 - Unknown-database pending SELECTs are bounded with `LIMIT 25` (`candidateLimit`) instead of scanning the whole backlog
 - Enqueue no longer writes `tenant.config` into `wheels_jobs.data`; `$restoreTenantContext` applies `dataSource` only when it is a known app datasource
 - `CreateObject(jobClass)` is allowlisted to `app/jobs` (plus configured `jobClassPrefixes`); a `perform()` method on an off-path class is not enough
+- JobWorker claim persist errors throw `Wheels.JobClaimFailed` and are contained as a failed drain result — they are no longer swallowed as `return false` / idle `skipped`
+- The job-class allowlist treats `app.jobs` (and configured `jobClassPrefixes`) as first-class; `wheels.tests._assets.jobs` is an extra testing prefix only
 - `maxRetries` (default still 3) is retries after the first failure, so a job gets 4 tries before the dead letter
 - `retryFailed` / `purgeCompleted` / `JobWorker.purge` return the real DML count, including `0` when nothing matched

--- a/changelog.d/jobs-hardener-b1-b4.fixed.md
+++ b/changelog.d/jobs-hardener-b1-b4.fixed.md
@@ -1,0 +1,3 @@
+- Job complete/retry/fail UPDATEs now require `status = 'processing'`, so a stolen job's original worker cannot overwrite `completed` or `failed`
+- Persist-fail `enqueue()` returns `persisted=false` and `error` instead of lying with `status=pending`
+- `JobWorker.getMonitorData(queue=)` filters `recentJobs` and `oldestPending` as well as throughput

--- a/changelog.d/jobs-hardener-b1-b4.fixed.md
+++ b/changelog.d/jobs-hardener-b1-b4.fixed.md
@@ -1,3 +1,9 @@
 - Job complete/retry/fail UPDATEs now require `status = 'processing'`, so a stolen job's original worker cannot overwrite `completed` or `failed`
 - Persist-fail `enqueue()` returns `persisted=false` and `error` instead of lying with `status=pending`
 - `JobWorker.getMonitorData(queue=)` filters `recentJobs` and `oldestPending` as well as throughput
+- Job `timeout` (default 300) is persisted on enqueue and honored by `processNext` / `$processJob`; a hung `perform()` is cut off instead of running until it returns
+- Unknown-database pending SELECTs are bounded with `LIMIT 25` (`candidateLimit`) instead of scanning the whole backlog
+- Enqueue no longer writes `tenant.config` into `wheels_jobs.data`; `$restoreTenantContext` applies `dataSource` only when it is a known app datasource
+- `CreateObject(jobClass)` is allowlisted to `app/jobs` (plus configured `jobClassPrefixes`); a `perform()` method on an off-path class is not enough
+- `maxRetries` (default still 3) is retries after the first failure, so a job gets 4 tries before the dead letter
+- `retryFailed` / `purgeCompleted` / `JobWorker.purge` return the real DML count, including `0` when nothing matched

--- a/vendor/wheels/Job.cfc
+++ b/vendor/wheels/Job.cfc
@@ -172,11 +172,11 @@ component {
 					);
 				} catch (any e2) {
 					writeLog(text = "Job enqueue failed after table creation: #e2.message#", type = "error", file = "wheels_jobs");
-					return {id = local.id, jobClass = arguments.jobClass, status = "pending", persisted = false};
+					return {id = local.id, jobClass = arguments.jobClass, persisted = false, error = e2.message};
 				}
 			} else {
 				writeLog(text = "Job '#arguments.jobClass#' could not be persisted: #e.message#", type = "warning", file = "wheels_jobs");
-				return {id = local.id, jobClass = arguments.jobClass, status = "pending", persisted = false};
+				return {id = local.id, jobClass = arguments.jobClass, persisted = false, error = e.message};
 			}
 		}
 
@@ -245,9 +245,13 @@ component {
 		try {
 			local.jobs = queryExecute(local.sql, local.params, {datasource = variables.$datasource, maxrows = arguments.limit});
 		} catch (any e) {
-			// Auto-create table and return empty result (no jobs to process yet)
 			$ensureJobTable();
-			return local.result;
+			try {
+				local.jobs = queryExecute(local.sql, local.params, {datasource = variables.$datasource, maxrows = arguments.limit});
+			} catch (any e2) {
+				ArrayAppend(local.result.errors, e2.message);
+				return local.result;
+			}
 		}
 
 		for (local.row in local.jobs) {
@@ -307,6 +311,9 @@ component {
 				extendedInfo = "`wheels_jobs.jobClass` must name a component extending `wheels.Job`. Only the framework writes this column; a value that names something else means the row was written by something other than `enqueue()`."
 			);
 		}
+		if (StructKeyExists(local.rv, "init")) {
+			local.rv.init();
+		}
 		return local.rv;
 	}
 
@@ -354,6 +361,7 @@ component {
 		// mirroring JobWorker.$scheduleRetry so both paths share one retry schedule.
 		local.backoffBaseDelay = this.baseDelay;
 		local.backoffMaxDelay = this.maxDelay;
+		local.backoffRetryBackoff = this.retryBackoff;
 
 		try {
 			// Instantiate and execute the job
@@ -363,6 +371,9 @@ component {
 			}
 			if (StructKeyExists(local.jobInstance, "maxDelay")) {
 				local.backoffMaxDelay = local.jobInstance.maxDelay;
+			}
+			if (StructKeyExists(local.jobInstance, "retryBackoff")) {
+				local.backoffRetryBackoff = local.jobInstance.retryBackoff;
 			}
 			local.jobData = DeserializeJSON(arguments.jobRow.data);
 
@@ -376,7 +387,7 @@ component {
 			queryExecute(
 				"UPDATE wheels_jobs
 				SET status = 'completed', completedAt = :completedAt, updatedAt = :updatedAt
-				WHERE id = :id",
+				WHERE id = :id AND status = 'processing'",
 				{
 					completedAt = {value = $now(), cfsqltype = "cf_sql_timestamp"},
 					updatedAt = {value = $now(), cfsqltype = "cf_sql_timestamp"},
@@ -402,7 +413,12 @@ component {
 				// Schedule retry with configurable exponential backoff, capped at maxDelay.
 				// Settings were captured from the failing job's class above so subclass
 				// overrides apply (the base instance defaults are only the fallback).
-				local.backoffSeconds = Min(local.backoffBaseDelay * (2 ^ local.currentAttempts), local.backoffMaxDelay);
+				local.backoffSeconds = $backoffDelay(
+					attempts = local.currentAttempts,
+					baseDelay = local.backoffBaseDelay,
+					maxDelay = local.backoffMaxDelay,
+					retryBackoff = local.backoffRetryBackoff
+				);
 				local.nextRunAt = DateAdd("s", local.backoffSeconds, $now());
 
 				queryExecute(
@@ -411,7 +427,7 @@ component {
 						lastError = :lastError,
 						runAt = :runAt,
 						updatedAt = :updatedAt
-					WHERE id = :id",
+					WHERE id = :id AND status = 'processing'",
 					{
 						lastError = {value = Left(e.message, 1000), cfsqltype = "cf_sql_longvarchar"},
 						runAt = {value = local.nextRunAt, cfsqltype = "cf_sql_timestamp"},
@@ -434,7 +450,7 @@ component {
 						failedAt = :failedAt,
 						lastError = :lastError,
 						updatedAt = :updatedAt
-					WHERE id = :id",
+					WHERE id = :id AND status = 'processing'",
 					{
 						failedAt = {value = $now(), cfsqltype = "cf_sql_timestamp"},
 						lastError = {value = Left(e.message, 1000), cfsqltype = "cf_sql_longvarchar"},
@@ -660,6 +676,23 @@ component {
 			writeLog(text = "Failed to auto-create wheels_jobs table: #createError.message#", type = "error", file = "wheels_jobs");
 			return false;
 		}
+	}
+
+	/**
+	 * Retry delay in seconds. `retryBackoff=exponential` is the live schedule
+	 * (`baseDelay * 2^attempts`, capped at `maxDelay`). `linear` is a reserved
+	 * no-op and keeps that same formula.
+	 */
+	public numeric function $backoffDelay(
+		required numeric attempts,
+		numeric baseDelay = this.baseDelay,
+		numeric maxDelay = this.maxDelay,
+		string retryBackoff = this.retryBackoff
+	) {
+		if (CompareNoCase(arguments.retryBackoff, "linear") == 0) {
+			// reserved no-op — exponential remains the schedule
+		}
+		return Min(arguments.baseDelay * (2 ^ arguments.attempts), arguments.maxDelay);
 	}
 
 	/**

--- a/vendor/wheels/Job.cfc
+++ b/vendor/wheels/Job.cfc
@@ -132,15 +132,17 @@ component {
 	) {
 		local.id = CreateUUID();
 
-		// Capture tenant context so jobs run against the correct tenant datasource
+		arguments.data["$wheelsJobTimeout"] = this.timeout;
+
+		// Capture tenant context so jobs run against the correct tenant datasource.
+		// Persist id + dataSource only — never dump tenant.config into the queue row.
 		if (
 			IsDefined("request.wheels.tenant.dataSource")
 			&& Len(request.wheels.tenant.dataSource)
 		) {
 			arguments.data["$wheelsTenantContext"] = {
 				id = StructKeyExists(request.wheels.tenant, "id") ? request.wheels.tenant.id : "",
-				dataSource = request.wheels.tenant.dataSource,
-				config = StructKeyExists(request.wheels.tenant, "config") ? request.wheels.tenant.config : {}
+				dataSource = request.wheels.tenant.dataSource
 			};
 		}
 
@@ -290,6 +292,13 @@ component {
 	 */
 	public any function $instantiateJobClass(required string jobClass, string jobId = "") {
 		local.rowLabel = Len(arguments.jobId) ? " named by queue row [#arguments.jobId#]" : "";
+		if (!$isAllowedJobClass(arguments.jobClass)) {
+			Throw(
+				type = "Wheels.JobClassNotAllowed",
+				message = "The job class `#arguments.jobClass#`#local.rowLabel# is not on an allowed jobs path.",
+				extendedInfo = "CreateObject is restricted to `app.jobs` (and any `jobClassPrefixes` you configure). A `perform()` method is not enough."
+			);
+		}
 		try {
 			local.rv = CreateObject("component", arguments.jobClass);
 		} catch (any e) {
@@ -380,8 +389,18 @@ component {
 			// Restore tenant context if the job was enqueued within a tenant scope and
 			// strip the internal $wheelsTenantContext key before passing data to perform()
 			local.hasTenantContext = $restoreTenantContext(local.jobData);
-
-			local.jobInstance.perform(data = local.jobData);
+			local.timeoutSeconds = $takeJobTimeout(local.jobData, local.jobInstance.timeout ?: 300);
+			local.performOutcome = $runPerformWithTimeout(
+				jobInstance = local.jobInstance,
+				jobData = local.jobData,
+				timeoutSeconds = local.timeoutSeconds
+			);
+			if (local.performOutcome.timedOut) {
+				throw(type = "Wheels.JobTimeout", message = local.performOutcome.error);
+			}
+			if (!local.performOutcome.success) {
+				throw(type = "Wheels.JobFailed", message = local.performOutcome.error);
+			}
 
 			// Mark as completed
 			queryExecute(
@@ -409,7 +428,7 @@ component {
 			local.currentAttempts = Val(arguments.jobRow.attempts) + 1;
 			local.maxRetries = Val(arguments.jobRow.maxRetries);
 
-			if (local.currentAttempts < local.maxRetries) {
+			if (local.currentAttempts <= local.maxRetries) {
 				// Schedule retry with configurable exponential backoff, capped at maxDelay.
 				// Settings were captured from the failing job's class above so subclass
 				// overrides apply (the base instance defaults are only the fallback).
@@ -489,18 +508,17 @@ component {
 		local.restored = false;
 		if (StructKeyExists(arguments.jobData, "$wheelsTenantContext") && IsStruct(arguments.jobData["$wheelsTenantContext"])) {
 			local.tenantCtx = arguments.jobData["$wheelsTenantContext"];
-			if (StructKeyExists(local.tenantCtx, "dataSource") && Len(local.tenantCtx.dataSource)) {
+			local.ds = StructKeyExists(local.tenantCtx, "dataSource") ? ToString(local.tenantCtx.dataSource) : "";
+			if (Len(local.ds) && $isAllowedJobDataSource(local.ds)) {
 				if (!StructKeyExists(request, "wheels")) {
 					request.wheels = {};
 				}
 				request.wheels.tenant = {
 					id = StructKeyExists(local.tenantCtx, "id") ? local.tenantCtx.id : "",
-					dataSource = local.tenantCtx.dataSource,
-					config = StructKeyExists(local.tenantCtx, "config") ? local.tenantCtx.config : {}
+					dataSource = local.ds
 				};
 				local.restored = true;
 			}
-			// Remove internal key before passing data to perform()
 			StructDelete(arguments.jobData, "$wheelsTenantContext");
 		}
 		return local.restored;
@@ -568,8 +586,15 @@ component {
 		}
 
 		try {
+			local.countSql = "SELECT COUNT(*) AS cnt FROM wheels_jobs WHERE status = 'failed'";
+			local.countParams = {};
+			if (Len(arguments.queue)) {
+				local.countSql &= " AND queue = :queue";
+				local.countParams.queue = {value = arguments.queue, cfsqltype = "cf_sql_varchar"};
+			}
+			local.countResult = queryExecute(local.countSql, local.countParams, {datasource = variables.$datasource});
 			queryExecute(local.sql, local.params, {datasource = variables.$datasource});
-			return 1; // DML executed successfully; exact count unreliable across engines
+			return local.countResult.cnt ?: 0;
 		} catch (any e) {
 			$ensureJobTable();
 			return 0;
@@ -594,8 +619,15 @@ component {
 		}
 
 		try {
+			local.countSql = "SELECT COUNT(*) AS cnt FROM wheels_jobs WHERE status = 'completed' AND completedAt < :cutoff";
+			local.countParams = {cutoff = {value = local.cutoff, cfsqltype = "cf_sql_timestamp"}};
+			if (Len(arguments.queue)) {
+				local.countSql &= " AND queue = :queue";
+				local.countParams.queue = {value = arguments.queue, cfsqltype = "cf_sql_varchar"};
+			}
+			local.countResult = queryExecute(local.countSql, local.countParams, {datasource = variables.$datasource});
 			queryExecute(local.sql, local.params, {datasource = variables.$datasource});
-			return 1; // DML executed successfully; exact count unreliable across engines
+			return local.countResult.cnt ?: 0;
 		} catch (any e) {
 			$ensureJobTable();
 			return 0;
@@ -675,6 +707,124 @@ component {
 		} catch (any createError) {
 			writeLog(text = "Failed to auto-create wheels_jobs table: #createError.message#", type = "error", file = "wheels_jobs");
 			return false;
+		}
+	}
+
+	public boolean function $isAllowedJobClass(required string jobClass) {
+		local.name = Replace(Replace(Trim(arguments.jobClass), "/", ".", "all"), "\", ".", "all");
+		local.prefixes = ListToArray($jobClassPrefixes());
+		for (local.prefix in local.prefixes) {
+			local.prefix = Trim(local.prefix);
+			if (!Len(local.prefix)) {
+				continue;
+			}
+			if (CompareNoCase(local.name, local.prefix) == 0) {
+				return true;
+			}
+			if (Len(local.name) > Len(local.prefix) && CompareNoCase(Left(local.name, Len(local.prefix) + 1), local.prefix & ".") == 0) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public string function $jobClassPrefixes() {
+		local.prefixes = "app.jobs,wheels.tests._assets.jobs";
+		if (StructKeyExists(application, "wheels") && StructKeyExists(application.wheels, "jobClassPrefixes") && Len(application.wheels.jobClassPrefixes)) {
+			local.prefixes = ListAppend(local.prefixes, application.wheels.jobClassPrefixes);
+		}
+		return local.prefixes;
+	}
+
+	public boolean function $isAllowedJobDataSource(required string dataSource) {
+		return ListFindNoCase($allowedJobDataSources(), arguments.dataSource) > 0;
+	}
+
+	public string function $allowedJobDataSources() {
+		local.names = "";
+		if (StructKeyExists(application, "wheels")) {
+			if (StructKeyExists(application.wheels, "dataSourceName") && Len(application.wheels.dataSourceName)) {
+				local.names = ListAppend(local.names, application.wheels.dataSourceName);
+			}
+			if (StructKeyExists(application.wheels, "coreTestDataSourceName") && Len(application.wheels.coreTestDataSourceName)) {
+				local.names = ListAppend(local.names, application.wheels.coreTestDataSourceName);
+			}
+			if (StructKeyExists(application.wheels, "tenantDataSources")) {
+				if (IsArray(application.wheels.tenantDataSources)) {
+					local.names = ListAppend(local.names, ArrayToList(application.wheels.tenantDataSources));
+				} else if (Len(application.wheels.tenantDataSources)) {
+					local.names = ListAppend(local.names, application.wheels.tenantDataSources);
+				}
+			}
+		}
+		try {
+			local.meta = GetApplicationMetaData();
+			if (IsStruct(local.meta) && StructKeyExists(local.meta, "datasources") && IsStruct(local.meta.datasources)) {
+				for (local.dsName in local.meta.datasources) {
+					local.names = ListAppend(local.names, local.dsName);
+				}
+			}
+		} catch (any e) {
+		}
+		return local.names;
+	}
+
+	public numeric function $takeJobTimeout(required struct jobData, numeric fallback = 300) {
+		local.timeout = arguments.fallback;
+		if (StructKeyExists(arguments.jobData, "$wheelsJobTimeout") && IsNumeric(arguments.jobData["$wheelsJobTimeout"])) {
+			local.timeout = Val(arguments.jobData["$wheelsJobTimeout"]);
+		}
+		StructDelete(arguments.jobData, "$wheelsJobTimeout");
+		if (!IsNumeric(local.timeout) || local.timeout <= 0) {
+			return 300;
+		}
+		return local.timeout;
+	}
+
+	public struct function $runPerformWithTimeout(
+		required any jobInstance,
+		required struct jobData,
+		required numeric timeoutSeconds
+	) {
+		local.rv = {success = false, error = "", timedOut = false};
+		local.timeoutMs = Max(1, Int(arguments.timeoutSeconds)) * 1000;
+		local.threadName = "wheelsJob" & Replace(CreateUUID(), "-", "", "all");
+		local.box = {instance = arguments.jobInstance, data = arguments.jobData, ok = false, err = ""};
+
+		try {
+			thread name="#local.threadName#" action="run" box="#local.box#" {
+				try {
+					attributes.box.instance.perform(data = attributes.box.data);
+					thread.ok = true;
+					thread.err = "";
+				} catch (any e) {
+					thread.ok = false;
+					thread.err = e.message;
+				}
+			}
+			thread action="join" name="#local.threadName#" timeout="#local.timeoutMs#";
+			local.meta = cfthread[local.threadName];
+			local.status = StructKeyExists(local.meta, "status") ? ToString(local.meta.status) : "";
+			if (CompareNoCase(local.status, "COMPLETED") != 0 && CompareNoCase(local.status, "TERMINATED") != 0) {
+				try {
+					thread action="terminate" name="#local.threadName#";
+				} catch (any termErr) {
+				}
+				local.rv.timedOut = true;
+				local.rv.error = "Job timed out after #arguments.timeoutSeconds# seconds";
+				return local.rv;
+			}
+			if (StructKeyExists(local.meta, "ok") && local.meta.ok) {
+				local.rv.success = true;
+				return local.rv;
+			}
+			local.rv.error = (StructKeyExists(local.meta, "err") && Len(local.meta.err)) ? local.meta.err : "Job failed";
+			return local.rv;
+		} catch (any threadErr) {
+			// Fail closed. Inline perform() would hang until the job finished.
+			local.rv.timedOut = true;
+			local.rv.error = "Job timed out after #arguments.timeoutSeconds# seconds";
+			return local.rv;
 		}
 	}
 

--- a/vendor/wheels/Job.cfc
+++ b/vendor/wheels/Job.cfc
@@ -729,9 +729,16 @@ component {
 	}
 
 	public string function $jobClassPrefixes() {
-		local.prefixes = "app.jobs,wheels.tests._assets.jobs";
+		local.prefixes = "app.jobs";
 		if (StructKeyExists(application, "wheels") && StructKeyExists(application.wheels, "jobClassPrefixes") && Len(application.wheels.jobClassPrefixes)) {
 			local.prefixes = ListAppend(local.prefixes, application.wheels.jobClassPrefixes);
+		}
+		if (
+			!StructKeyExists(application, "wheels")
+			|| !StructKeyExists(application.wheels, "environment")
+			|| CompareNoCase(application.wheels.environment, "production") != 0
+		) {
+			local.prefixes = ListAppend(local.prefixes, "wheels.tests._assets.jobs");
 		}
 		return local.prefixes;
 	}

--- a/vendor/wheels/JobWorker.cfc
+++ b/vendor/wheels/JobWorker.cfc
@@ -67,14 +67,7 @@ component {
 		// and maxrows only truncates client-side after the driver fetched everything.
 		local.candidateLimit = 25;
 		local.dbType = $dbType();
-		if (ListFindNoCase("mysql,postgresql,sqlite,h2", local.dbType)) {
-			local.sql &= " LIMIT #local.candidateLimit#";
-		} else if (local.dbType == "sqlserver") {
-			local.sql &= " OFFSET 0 ROWS FETCH NEXT #local.candidateLimit# ROWS ONLY";
-		} else if (local.dbType == "oracle") {
-			local.sql &= " FETCH FIRST #local.candidateLimit# ROWS ONLY";
-		}
-		// Unknown database type: leave unbounded rather than risk a syntax error.
+		local.sql &= $candidateLimitClause(dbType = local.dbType, candidateLimit = local.candidateLimit);
 
 		try {
 			local.candidates = queryExecute(local.sql, local.params, {datasource = variables.$datasource});
@@ -107,7 +100,7 @@ component {
 					attempts = local.row.attempts,
 					maxRetries = local.row.maxRetries
 				};
-				local.processResult = $executeJob(local.jobRow);
+				local.processResult = $executeJob(jobRow = local.jobRow, timeout = arguments.timeout);
 				local.result.jobId = local.row.id;
 				local.result.jobClass = local.row.jobClass;
 
@@ -122,7 +115,7 @@ component {
 					local.currentAttempts = Val(local.row.attempts) + 1;
 					local.maxRetries = Val(local.row.maxRetries);
 
-					if (local.currentAttempts < local.maxRetries) {
+					if (local.currentAttempts <= local.maxRetries) {
 						$scheduleRetry(local.row.id, local.currentAttempts, local.row.jobClass, local.maxRetries, local.processResult.error);
 					} else {
 						$markFailed(local.row.id, local.row.jobClass, local.maxRetries, local.processResult.error);
@@ -163,7 +156,7 @@ component {
 			local.currentAttempts = Val(local.row.attempts);
 			local.maxRetries = Val(local.row.maxRetries);
 
-			if (local.currentAttempts < local.maxRetries) {
+			if (local.currentAttempts <= local.maxRetries) {
 				// Reschedule for retry
 				$scheduleRetry(local.row.id, local.currentAttempts, local.row.jobClass, local.maxRetries, "Job timed out after #arguments.timeout# seconds");
 				local.recovered++;
@@ -419,8 +412,22 @@ component {
 		}
 
 		try {
+			local.countSql = "SELECT COUNT(*) AS cnt FROM wheels_jobs WHERE status = :status AND #local.dateColumn# < :cutoff";
+			local.countParams = {
+				status = {value = arguments.status, cfsqltype = "cf_sql_varchar"},
+				cutoff = {value = local.cutoff, cfsqltype = "cf_sql_timestamp"}
+			};
+			if (Len(arguments.queue)) {
+				local.countSql &= " AND queue = :queue";
+				local.countParams.queue = {value = arguments.queue, cfsqltype = "cf_sql_varchar"};
+			}
+			local.countResult = queryExecute(local.countSql, local.countParams, {datasource = variables.$datasource});
+			local.cnt = local.countResult.cnt ?: 0;
+			if (local.cnt <= 0) {
+				return 0;
+			}
 			queryExecute(local.sql, local.params, {datasource = variables.$datasource});
-			return 1; // DML executed successfully; exact count unreliable across engines
+			return local.cnt;
 		} catch (any e) {
 			$ensureJobTable();
 			return 0;
@@ -458,7 +465,7 @@ component {
 	/**
 	 * Execute a job's perform() method.
 	 */
-	private struct function $executeJob(required struct jobRow) {
+	private struct function $executeJob(required struct jobRow, numeric timeout = 300) {
 		local.result = {success = false, error = ""};
 
 		// Initialized before the try so the cleanup below never reads an undefined
@@ -479,8 +486,23 @@ component {
 			// perform() — shared with Job.$processJob so both processing paths run
 			// tenant jobs against the correct tenant datasource.
 			local.hasTenantContext = $jobBridge().$restoreTenantContext(local.jobData);
-
-			local.jobInstance.perform(data = local.jobData);
+			local.fromRow = $jobBridge().$takeJobTimeout(jobData = local.jobData, fallback = 300);
+			local.workerCap = Val(arguments.timeout);
+			if (local.workerCap <= 0) {
+				local.workerCap = 300;
+			}
+			local.timeoutSeconds = Min(local.fromRow, local.workerCap);
+			local.performOutcome = $jobBridge().$runPerformWithTimeout(
+				jobInstance = local.jobInstance,
+				jobData = local.jobData,
+				timeoutSeconds = local.timeoutSeconds
+			);
+			if (local.performOutcome.timedOut) {
+				throw(type = "Wheels.JobTimeout", message = local.performOutcome.error);
+			}
+			if (!local.performOutcome.success) {
+				throw(type = "Wheels.JobFailed", message = local.performOutcome.error);
+			}
 
 			// Mark completed
 			queryExecute(
@@ -664,6 +686,26 @@ component {
 			variables.$jobBridgeInstance = new wheels.Job();
 		}
 		return variables.$jobBridgeInstance;
+	}
+
+	/**
+	 * SQL fragment that bounds a pending-job candidate SELECT.
+	 * Unknown database types get LIMIT too — an unbounded backlog scan is worse
+	 * than a syntax error that the existing catch already contains.
+	 */
+	public string function $candidateLimitClause(required string dbType, numeric candidateLimit = 25) {
+		local.n = Int(Val(arguments.candidateLimit));
+		if (local.n <= 0) {
+			local.n = 25;
+		}
+		local.normalized = LCase(Trim(arguments.dbType));
+		if (local.normalized == "sqlserver") {
+			return " OFFSET 0 ROWS FETCH NEXT #local.n# ROWS ONLY";
+		}
+		if (local.normalized == "oracle") {
+			return " FETCH FIRST #local.n# ROWS ONLY";
+		}
+		return " LIMIT #local.n#";
 	}
 
 }

--- a/vendor/wheels/JobWorker.cfc
+++ b/vendor/wheels/JobWorker.cfc
@@ -80,8 +80,13 @@ component {
 			local.candidates = queryExecute(local.sql, local.params, {datasource = variables.$datasource});
 		} catch (any e) {
 			$ensureJobTable();
-			local.result.skipped = true;
-			return local.result;
+			try {
+				local.candidates = queryExecute(local.sql, local.params, {datasource = variables.$datasource});
+			} catch (any e2) {
+				local.result.skipped = true;
+				local.result.error = e2.message;
+				return local.result;
+			}
 		}
 
 		if (!local.candidates.recordCount) {
@@ -260,8 +265,14 @@ component {
 		// Recent jobs
 		try {
 			local.recentSql = "SELECT id, jobClass, queue, status, attempts, lastError, updatedAt
-				FROM wheels_jobs ORDER BY updatedAt DESC";
-			local.recentRows = queryExecute(local.recentSql, {}, {datasource = variables.$datasource, maxrows = 10});
+				FROM wheels_jobs";
+			local.recentParams = {};
+			if (Len(arguments.queue)) {
+				local.recentSql &= " WHERE queue = :queue";
+				local.recentParams.queue = {value = arguments.queue, cfsqltype = "cf_sql_varchar"};
+			}
+			local.recentSql &= " ORDER BY updatedAt DESC";
+			local.recentRows = queryExecute(local.recentSql, local.recentParams, {datasource = variables.$datasource, maxrows = 10});
 
 			for (local.row in local.recentRows) {
 				ArrayAppend(local.result.recentJobs, {
@@ -280,8 +291,14 @@ component {
 
 		// Oldest pending job
 		try {
-			local.oldestSql = "SELECT createdAt FROM wheels_jobs WHERE status = 'pending' ORDER BY createdAt ASC";
-			local.oldestRow = queryExecute(local.oldestSql, {}, {datasource = variables.$datasource, maxrows = 1});
+			local.oldestSql = "SELECT createdAt FROM wheels_jobs WHERE status = 'pending'";
+			local.oldestParams = {};
+			if (Len(arguments.queue)) {
+				local.oldestSql &= " AND queue = :queue";
+				local.oldestParams.queue = {value = arguments.queue, cfsqltype = "cf_sql_varchar"};
+			}
+			local.oldestSql &= " ORDER BY createdAt ASC";
+			local.oldestRow = queryExecute(local.oldestSql, local.oldestParams, {datasource = variables.$datasource, maxrows = 1});
 			if (local.oldestRow.recordCount) {
 				local.result.oldestPending = local.oldestRow.createdAt;
 			}
@@ -469,7 +486,7 @@ component {
 			queryExecute(
 				"UPDATE wheels_jobs
 				SET status = 'completed', completedAt = :completedAt, updatedAt = :updatedAt
-				WHERE id = :id",
+				WHERE id = :id AND status = 'processing'",
 				{
 					completedAt = {value = $now(), cfsqltype = "cf_sql_timestamp"},
 					updatedAt = {value = $now(), cfsqltype = "cf_sql_timestamp"},
@@ -506,21 +523,25 @@ component {
 		required numeric maxRetries,
 		required string errorMessage
 	) {
-		// Use configurable backoff: baseDelay * 2^attempt, capped at maxDelay
-		// Default values match Job.cfc: baseDelay=2, maxDelay=3600
 		local.baseDelay = 2;
 		local.maxDelay = 3600;
+		local.retryBackoff = "exponential";
 
-		// Try to get the job instance's backoff settings
 		try {
-			local.jobInstance = CreateObject("component", arguments.jobClass);
+			local.jobInstance = $jobBridge().$instantiateJobClass(jobClass = arguments.jobClass);
 			if (StructKeyExists(local.jobInstance, "baseDelay")) local.baseDelay = local.jobInstance.baseDelay;
 			if (StructKeyExists(local.jobInstance, "maxDelay")) local.maxDelay = local.jobInstance.maxDelay;
+			if (StructKeyExists(local.jobInstance, "retryBackoff")) local.retryBackoff = local.jobInstance.retryBackoff;
 		} catch (any e) {
 			// Use defaults
 		}
 
-		local.backoffSeconds = Min(local.baseDelay * (2 ^ arguments.currentAttempts), local.maxDelay);
+		local.backoffSeconds = $jobBridge().$backoffDelay(
+			attempts = arguments.currentAttempts,
+			baseDelay = local.baseDelay,
+			maxDelay = local.maxDelay,
+			retryBackoff = local.retryBackoff
+		);
 		local.nextRunAt = DateAdd("s", local.backoffSeconds, $now());
 
 		queryExecute(
@@ -529,7 +550,7 @@ component {
 				lastError = :lastError,
 				runAt = :runAt,
 				updatedAt = :updatedAt
-			WHERE id = :id",
+			WHERE id = :id AND status = 'processing'",
 			{
 				lastError = {value = Left(arguments.errorMessage, 1000), cfsqltype = "cf_sql_longvarchar"},
 				runAt = {value = local.nextRunAt, cfsqltype = "cf_sql_timestamp"},
@@ -561,7 +582,7 @@ component {
 				failedAt = :failedAt,
 				lastError = :lastError,
 				updatedAt = :updatedAt
-			WHERE id = :id",
+			WHERE id = :id AND status = 'processing'",
 			{
 				failedAt = {value = $now(), cfsqltype = "cf_sql_timestamp"},
 				lastError = {value = Left(arguments.errorMessage, 1000), cfsqltype = "cf_sql_longvarchar"},

--- a/vendor/wheels/JobWorker.cfc
+++ b/vendor/wheels/JobWorker.cfc
@@ -89,7 +89,18 @@ component {
 
 		// Try to claim each candidate with optimistic locking
 		for (local.row in local.candidates) {
-			local.claimed = $claimJob(local.row.id);
+			try {
+				local.claimFn = this["$claimJob"];
+				local.claimed = local.claimFn(local.row.id);
+			} catch (any e) {
+				// Persist/claim errors are contained — they must not look like an idle skip.
+				local.result.skipped = false;
+				local.result.success = false;
+				local.result.jobId = local.row.id;
+				local.result.jobClass = local.row.jobClass;
+				local.result.error = Left(e.message, 1000);
+				return local.result;
+			}
 			if (local.claimed) {
 				// We claimed it — fetch the payload for just this job, then process
 				local.jobRow = {
@@ -439,8 +450,11 @@ component {
 	/**
 	 * Claim a job using optimistic locking.
 	 * Returns true if this worker successfully claimed the job.
+	 * A lost race (0 rows) returns false. A persist/query error is not a lost
+	 * race — it throws Wheels.JobClaimFailed so processNext can contain it
+	 * without disguising the failure as an idle skip.
 	 */
-	private boolean function $claimJob(required string jobId) {
+	public boolean function $claimJob(required string jobId) {
 		try {
 			// Use the result option to get affected-row count from the same connection
 			// that executed the UPDATE. A separate verification SELECT can fail on
@@ -458,7 +472,10 @@ component {
 			);
 			return (local.updateResult.recordCount ?: 0) > 0;
 		} catch (any e) {
-			return false;
+			throw(
+				type = "Wheels.JobClaimFailed",
+				message = "Failed to claim job #arguments.jobId#: #e.message#"
+			);
 		}
 	}
 

--- a/vendor/wheels/tests/_assets/jobs/ConfigBackoffJob.cfc
+++ b/vendor/wheels/tests/_assets/jobs/ConfigBackoffJob.cfc
@@ -1,0 +1,17 @@
+/**
+ * Backoff settings live only in config(). Proves S3: processing paths must
+ * call init() so config() is not stuck unused after CreateObject().
+ */
+component extends="wheels.Job" {
+
+	public void function config() {
+		super.config();
+		this.baseDelay = 600;
+		this.maxDelay = 7200;
+	}
+
+	public void function perform(struct data = {}) {
+		throw(type = "Wheels.Tests.JobFailure", message = "ConfigBackoffJob always fails");
+	}
+
+}

--- a/vendor/wheels/tests/_assets/jobs/ExplodingClaimWorker.cfc
+++ b/vendor/wheels/tests/_assets/jobs/ExplodingClaimWorker.cfc
@@ -1,0 +1,11 @@
+/**
+ * Test worker whose claim always persist-fails. S6: processNext must
+ * contain that as a failed result, not an idle skip.
+ */
+component extends="wheels.JobWorker" {
+
+	public boolean function $claimJob(required string jobId) {
+		throw(type = "Wheels.JobClaimFailed", message = "claim persist failed");
+	}
+
+}

--- a/vendor/wheels/tests/_assets/jobs/LinearBackoffJob.cfc
+++ b/vendor/wheels/tests/_assets/jobs/LinearBackoffJob.cfc
@@ -1,0 +1,18 @@
+/**
+ * Sets retryBackoff=linear in config(). Linear is a reserved no-op: the
+ * schedule must stay exponential (S2) once config() actually runs (S3).
+ */
+component extends="wheels.Job" {
+
+	public void function config() {
+		super.config();
+		this.baseDelay = 600;
+		this.maxDelay = 7200;
+		this.retryBackoff = "linear";
+	}
+
+	public void function perform(struct data = {}) {
+		throw(type = "Wheels.Tests.JobFailure", message = "LinearBackoffJob always fails");
+	}
+
+}

--- a/vendor/wheels/tests/_assets/jobs/NoPerformStub.cfc
+++ b/vendor/wheels/tests/_assets/jobs/NoPerformStub.cfc
@@ -1,0 +1,6 @@
+/**
+ * Allowlisted jobs path, but not a job. Pins InvalidJobClass after S8
+ * rejects off-path names before CreateObject.
+ */
+component {
+}

--- a/vendor/wheels/tests/_assets/jobs/PersistFailJob.cfc
+++ b/vendor/wheels/tests/_assets/jobs/PersistFailJob.cfc
@@ -1,0 +1,14 @@
+/**
+ * Forces $enqueueJob down the persist-fail path by pointing at a datasource
+ * that cannot exist. Used to pin B2: a failed persist must not lie with
+ * status=pending.
+ */
+component extends="wheels.Job" {
+
+	public function init() {
+		super.init();
+		variables.$datasource = "wheels_jobs_no_such_ds_zzz";
+		return this;
+	}
+
+}

--- a/vendor/wheels/tests/_assets/jobs/SlowTimeoutJob.cfc
+++ b/vendor/wheels/tests/_assets/jobs/SlowTimeoutJob.cfc
@@ -1,0 +1,17 @@
+/**
+ * Sleeps longer than this.timeout so S1 can prove perform is cut off
+ * instead of hanging until the method returns.
+ */
+component extends="wheels.Job" {
+
+	public void function config() {
+		super.config();
+		this.timeout = 1;
+	}
+
+	public void function perform(struct data = {}) {
+		sleep(3000);
+		request.$wheelsSlowJobFinished = true;
+	}
+
+}

--- a/vendor/wheels/tests/_assets/jobs/StealDuringPerformJob.cfc
+++ b/vendor/wheels/tests/_assets/jobs/StealDuringPerformJob.cfc
@@ -1,0 +1,24 @@
+/**
+ * Marks its own row completed, then throws. Reproduces the B1 race:
+ * checkTimeouts / a second worker finished the job while this worker
+ * still holds the in-memory claim and is about to write fail/retry.
+ */
+component extends="wheels.Job" {
+
+	public void function perform(struct data = {}) {
+		local.now = Now();
+		queryExecute(
+			"UPDATE wheels_jobs
+			SET status = 'completed', completedAt = :completedAt, updatedAt = :updatedAt
+			WHERE id = :id",
+			{
+				id = {value = arguments.data.jobId, cfsqltype = "cf_sql_varchar"},
+				completedAt = {value = local.now, cfsqltype = "cf_sql_timestamp"},
+				updatedAt = {value = local.now, cfsqltype = "cf_sql_timestamp"}
+			},
+			{datasource = application.wheels.dataSourceName}
+		);
+		throw(type = "Wheels.Tests.JobFailure", message = "original worker failed after steal");
+	}
+
+}

--- a/vendor/wheels/tests/_assets/jobs/StealToFailedJob.cfc
+++ b/vendor/wheels/tests/_assets/jobs/StealToFailedJob.cfc
@@ -1,0 +1,23 @@
+/**
+ * Marks its own row failed, then returns. Reproduces the B1 complete-path
+ * race: another worker already failed the job before this worker's success
+ * UPDATE runs.
+ */
+component extends="wheels.Job" {
+
+	public void function perform(struct data = {}) {
+		local.now = Now();
+		queryExecute(
+			"UPDATE wheels_jobs
+			SET status = 'failed', failedAt = :failedAt, updatedAt = :updatedAt
+			WHERE id = :id",
+			{
+				id = {value = arguments.data.jobId, cfsqltype = "cf_sql_varchar"},
+				failedAt = {value = local.now, cfsqltype = "cf_sql_timestamp"},
+				updatedAt = {value = local.now, cfsqltype = "cf_sql_timestamp"}
+			},
+			{datasource = application.wheels.dataSourceName}
+		);
+	}
+
+}

--- a/vendor/wheels/tests/_assets/offpath/OffPathPerformJob.cfc
+++ b/vendor/wheels/tests/_assets/offpath/OffPathPerformJob.cfc
@@ -1,0 +1,16 @@
+/**
+ * Off-path component with perform(). S8: CreateObject must not run this
+ * just because perform() exists. The component body sets a request flag so
+ * specs can see whether instantiation happened at all.
+ */
+component {
+
+	if (!StructKeyExists(request, "$wheelsOffPathConstructed")) {
+		request.$wheelsOffPathConstructed = true;
+	}
+
+	public void function perform(struct data = {}) {
+		request.$wheelsOffPathRan = true;
+	}
+
+}

--- a/vendor/wheels/tests/specs/jobs/JobClassRoundTripSpec.cfc
+++ b/vendor/wheels/tests/specs/jobs/JobClassRoundTripSpec.cfc
@@ -106,22 +106,27 @@ component extends="wheels.WheelsTest" {
 				expect(thrown.message).toInclude("abc-123")
 			})
 
-			it("throws Wheels.InvalidJobClass when the path resolves to something that is not a job", () => {
-				// NOT `local.`-scoped, deliberately. Cross-engine invariant 11: a catch body
-				// runs under a nested `local` on BoxLang, so `thrown.type = e.type`
-				// inside the catch writes to a struct that is discarded on exit and the
-				// assertion below reads the untouched outer value. The blessed form is a
-				// `var`-declared struct accessed WITHOUT the `local.` prefix. Scoping this
-				// one for consistency cost two BoxLang failures on every database
-				// (`Expected [Wheels.JobClassNotFound] but received []`) — caught by the
-				// compat matrix, invisible on Lucee.
+			it("throws Wheels.JobClassNotAllowed for an off-path component even if it exists", () => {
 				var thrown = {type: ""}
 
 				local.bridge = new wheels.Job()
 
 				try {
-					// a real component with no perform()
 					local.bridge.$instantiateJobClass(jobClass = "wheels.tests._assets.models.Post")
+				} catch (any e) {
+					thrown.type = e.type
+				}
+
+				expect(thrown.type).toBe("Wheels.JobClassNotAllowed")
+			})
+
+			it("throws Wheels.InvalidJobClass when an allowlisted path is not a job", () => {
+				var thrown = {type: ""}
+
+				local.bridge = new wheels.Job()
+
+				try {
+					local.bridge.$instantiateJobClass(jobClass = "wheels.tests._assets.jobs.NoPerformStub")
 				} catch (any e) {
 					thrown.type = e.type
 				}

--- a/vendor/wheels/tests/specs/jobs/JobHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/jobs/JobHardenerSpec.cfc
@@ -1,5 +1,5 @@
 /**
- * Hardener proofs for Jobs BLOCKERs B1–B4 and the safe SHOULDs (S2/S3/S5/S6).
+ * Hardener proofs for Jobs BLOCKERs B1–B4 and SHOULDs S1–S10.
  * Desk IDs are stable. Do not renumber.
  */
 component extends="wheels.WheelsTest" {
@@ -18,6 +18,12 @@ component extends="wheels.WheelsTest" {
 			});
 
 			afterEach(function() {
+				if (StructKeyExists(request, "wheels")) {
+					StructDelete(request.wheels, "tenant");
+				}
+				StructDelete(request, "$wheelsSlowJobFinished");
+				StructDelete(request, "$wheelsOffPathConstructed");
+				StructDelete(request, "$wheelsOffPathRan");
 				try {
 					queryExecute("DELETE FROM wheels_jobs WHERE queue LIKE 'test_hard_%'", {}, {datasource = application.wheels.dataSourceName});
 				} catch (any e) {
@@ -270,6 +276,170 @@ component extends="wheels.WheelsTest" {
 				local.batch = local.job.processQueue(queue = "test_hard_idle_#CreateUUID()#");
 				expect(local.batch.processed).toBe(0);
 				expect(local.batch.failed).toBe(0);
+			});
+
+			it("S1: enqueue persists timeout=300 and perform honors it", function() {
+				local.job = new app.jobs.ProcessOrdersJob();
+				local.enqueued = local.job.enqueue(data = {batchSize: 1}, queue = "test_hard_s1_persist");
+				expect(local.enqueued.persisted).toBeTrue();
+				local.row = queryExecute(
+					"SELECT data FROM wheels_jobs WHERE id = :id",
+					{id = {value = local.enqueued.id, cfsqltype = "cf_sql_varchar"}},
+					{datasource = application.wheels.dataSourceName}
+				);
+				local.stored = DeserializeJSON(local.row.data);
+				expect(local.stored).toHaveKey("$wheelsJobTimeout");
+				expect(Val(local.stored["$wheelsJobTimeout"])).toBe(300);
+
+				local.slowId = CreateUUID();
+				$insertTestJob(
+					id = local.slowId,
+					jobClass = "wheels.tests._assets.jobs.SlowTimeoutJob",
+					queue = "test_hard_s1_honor",
+					data = SerializeJSON({"$wheelsJobTimeout": 1})
+				);
+				local.processor = new wheels.Job();
+				prepareMock(local.processor);
+				makePublic(local.processor, "$processJob");
+				local.jobResult = local.processor.$processJob(
+					jobRow = {
+						id = local.slowId,
+						jobClass = "wheels.tests._assets.jobs.SlowTimeoutJob",
+						queue = "test_hard_s1_honor",
+						data = SerializeJSON({"$wheelsJobTimeout": 1}),
+						attempts = 0,
+						maxRetries = 3
+					}
+				);
+				expect(local.jobResult.success).toBeFalse();
+				expect(StructKeyExists(request, "$wheelsSlowJobFinished")).toBeFalse();
+			});
+
+			it("S4: unknown db pending SELECT is bounded by candidateLimit", function() {
+				local.worker = new wheels.JobWorker();
+				prepareMock(local.worker);
+				makePublic(local.worker, "$candidateLimitClause");
+				local.clause = local.worker.$candidateLimitClause(dbType = "unknown");
+				expect(local.clause).toInclude("LIMIT");
+				expect(local.clause).toInclude("25");
+			});
+
+			it("S7: enqueue does not persist tenant.config and restore allowlists dataSource", function() {
+				if (!StructKeyExists(request, "wheels")) {
+					request.wheels = {};
+				}
+				request.wheels.tenant = {
+					id = "t-s7",
+					dataSource = application.wheels.dataSourceName,
+					config = {secret = "s7-must-not-persist", nested = {token = "abc"}}
+				};
+				local.job = new app.jobs.ProcessOrdersJob();
+				local.enqueued = local.job.enqueue(data = {orderId = 1}, queue = "test_hard_s7");
+				expect(local.enqueued.persisted).toBeTrue();
+				local.row = queryExecute(
+					"SELECT data FROM wheels_jobs WHERE id = :id",
+					{id = {value = local.enqueued.id, cfsqltype = "cf_sql_varchar"}},
+					{datasource = application.wheels.dataSourceName}
+				);
+				local.stored = DeserializeJSON(local.row.data);
+				expect(SerializeJSON(local.stored)).notToInclude("s7-must-not-persist");
+				expect(local.stored).toHaveKey("$wheelsTenantContext");
+				expect(local.stored["$wheelsTenantContext"]).notToHaveKey("config");
+				StructDelete(request.wheels, "tenant");
+
+				local.evil = {orderId = 9};
+				local.evil["$wheelsTenantContext"] = {
+					id = "evil",
+					dataSource = "wheels_jobs_arbitrary_ds_zzz",
+					config = {secret = "s7-must-not-restore"}
+				};
+				local.bridge = new wheels.Job();
+				expect(local.bridge.$restoreTenantContext(local.evil)).toBeFalse();
+				expect(IsDefined("request.wheels.tenant")).toBeFalse();
+
+				local.ok = {};
+				local.ok["$wheelsTenantContext"] = {
+					id = "tenant-ok",
+					dataSource = application.wheels.dataSourceName,
+					config = {secret = "s7-must-not-restore"}
+				};
+				expect(local.bridge.$restoreTenantContext(local.ok)).toBeTrue();
+				expect(request.wheels.tenant.dataSource).toBe(application.wheels.dataSourceName);
+				expect(request.wheels.tenant).notToHaveKey("config");
+				local.bridge.$clearTenantContext();
+			});
+
+			it("S8: off-path class with perform() is not instantiated", function() {
+				var thrown = {type: ""};
+				StructDelete(request, "$wheelsOffPathConstructed");
+				StructDelete(request, "$wheelsOffPathRan");
+				local.bridge = new wheels.Job();
+				try {
+					local.bridge.$instantiateJobClass(jobClass = "wheels.tests._assets.offpath.OffPathPerformJob");
+				} catch (any e) {
+					thrown.type = e.type;
+				}
+				expect(thrown.type).toBe("Wheels.JobClassNotAllowed");
+				expect(StructKeyExists(request, "$wheelsOffPathConstructed")).toBeFalse();
+				expect(StructKeyExists(request, "$wheelsOffPathRan")).toBeFalse();
+			});
+
+			it("S9: maxRetries=3 allows 4 tries (retries after first fail)", function() {
+				local.id = CreateUUID();
+				$insertTestJob(
+					id = local.id,
+					jobClass = "wheels.tests._assets.jobs.FailingBackoffJob",
+					queue = "test_hard_s9",
+					attempts = 2,
+					maxRetries = 3
+				);
+				local.processor = new wheels.Job();
+				prepareMock(local.processor);
+				makePublic(local.processor, "$processJob");
+				local.processor.$processJob(
+					jobRow = {
+						id = local.id,
+						jobClass = "wheels.tests._assets.jobs.FailingBackoffJob",
+						queue = "test_hard_s9",
+						data = "{}",
+						attempts = 2,
+						maxRetries = 3
+					}
+				);
+				local.row = queryExecute(
+					"SELECT status FROM wheels_jobs WHERE id = :id",
+					{id = {value = local.id, cfsqltype = "cf_sql_varchar"}},
+					{datasource = application.wheels.dataSourceName}
+				);
+				expect(local.row.status).toBe("pending");
+			});
+
+			it("S10: retryFailed and purgeCompleted return the real DML count", function() {
+				local.emptyQ = "test_hard_s10_empty_#CreateUUID()#";
+				local.job = new wheels.Job();
+				expect(local.job.retryFailed(queue = local.emptyQ)).toBe(0);
+
+				local.failA = CreateUUID();
+				local.failB = CreateUUID();
+				$insertTestJob(id = local.failA, jobClass = "app.jobs.ProcessOrdersJob", queue = "test_hard_s10_retry", status = "failed", attempts = 3);
+				$insertTestJob(id = local.failB, jobClass = "app.jobs.ProcessOrdersJob", queue = "test_hard_s10_retry", status = "failed", attempts = 3);
+				expect(local.job.retryFailed(queue = "test_hard_s10_retry")).toBe(2);
+
+				local.oldTime = DateAdd("d", -30, Now());
+				local.doneA = CreateUUID();
+				local.doneB = CreateUUID();
+				$insertTestJob(id = local.doneA, jobClass = "app.jobs.ProcessOrdersJob", queue = "test_hard_s10_purge", status = "completed", createdAt = local.oldTime, updatedAt = local.oldTime);
+				$insertTestJob(id = local.doneB, jobClass = "app.jobs.ProcessOrdersJob", queue = "test_hard_s10_purge", status = "completed", createdAt = local.oldTime, updatedAt = local.oldTime);
+				queryExecute(
+					"UPDATE wheels_jobs SET completedAt = :oldTime WHERE id IN (:a, :b)",
+					{
+						oldTime = {value = local.oldTime, cfsqltype = "cf_sql_timestamp"},
+						a = {value = local.doneA, cfsqltype = "cf_sql_varchar"},
+						b = {value = local.doneB, cfsqltype = "cf_sql_varchar"}
+					},
+					{datasource = application.wheels.dataSourceName}
+				);
+				expect(local.job.purgeCompleted(days = 7, queue = "test_hard_s10_purge")).toBe(2);
 			});
 
 		});

--- a/vendor/wheels/tests/specs/jobs/JobHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/jobs/JobHardenerSpec.cfc
@@ -18,6 +18,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			afterEach(function() {
+				if (StructKeyExists(request, "wheelsHardenerPrevEnv")) {
+					application.wheels.environment = request.wheelsHardenerPrevEnv;
+					StructDelete(request, "wheelsHardenerPrevEnv");
+				}
 				if (StructKeyExists(request, "wheels")) {
 					StructDelete(request.wheels, "tenant");
 				}
@@ -265,7 +269,7 @@ component extends="wheels.WheelsTest" {
 				expect(local.linearCheck.cnt).toBe(1);
 			});
 
-			it("S5/S6: idle queue stays skipped and does not throw", function() {
+			it("S5: idle queue stays skipped and does not throw", function() {
 				local.worker = new wheels.JobWorker();
 				local.result = local.worker.processNext(queues = "test_hard_idle_#CreateUUID()#");
 				expect(local.result.skipped).toBeTrue();
@@ -276,6 +280,65 @@ component extends="wheels.WheelsTest" {
 				local.batch = local.job.processQueue(queue = "test_hard_idle_#CreateUUID()#");
 				expect(local.batch.processed).toBe(0);
 				expect(local.batch.failed).toBe(0);
+			});
+
+			it("S6: claim persist error is not treated as idle skip", function() {
+				// BoxLang catch writes are discarded on a local.-scoped struct (invariant 11).
+				var claim = {threw = false, type = "", returnedFalse = false};
+				local.claimer = new wheels.JobWorker();
+				queryExecute("DROP TABLE wheels_jobs", {}, {datasource = application.wheels.dataSourceName});
+				try {
+					if (local.claimer.$claimJob(jobId = CreateUUID()) == false) {
+						claim.returnedFalse = true;
+					}
+				} catch (any e) {
+					claim.threw = true;
+					claim.type = e.type;
+				} finally {
+					local.restore = new wheels.Job();
+					local.restore.$ensureJobTable();
+				}
+				expect(claim.returnedFalse).toBeFalse();
+				expect(claim.threw).toBeTrue();
+				expect(claim.type).toBe("Wheels.JobClaimFailed");
+
+				local.id = CreateUUID();
+				local.past = DateAdd("s", -30, Now());
+				$insertTestJob(
+					id = local.id,
+					jobClass = "app.jobs.ProcessOrdersJob",
+					queue = "test_hard_s6_claim",
+					createdAt = local.past,
+					updatedAt = local.past
+				);
+				local.s6Worker = new wheels.tests._assets.jobs.ExplodingClaimWorker();
+				var escaped = {type = "", message = ""};
+				local.drainResult = {skipped = true, error = "", success = false};
+				try {
+					local.drainResult = local.s6Worker.processNext(queues = "test_hard_s6_claim");
+				} catch (any e) {
+					escaped.type = e.type;
+					escaped.message = e.message;
+				}
+				expect(escaped.type).toBe("");
+				expect(local.drainResult.skipped).toBeFalse();
+				expect(local.drainResult.success).toBeFalse();
+				expect(Len(local.drainResult.error)).toBeGT(0);
+			});
+
+			it("S8 leftover: app.jobs is first-class; test prefix is extra", function() {
+				local.bridge = new wheels.Job();
+				request.wheelsHardenerPrevEnv = application.wheels.environment;
+				application.wheels.environment = "production";
+				local.prodPrefixes = local.bridge.$jobClassPrefixes();
+				application.wheels.environment = request.wheelsHardenerPrevEnv;
+				StructDelete(request, "wheelsHardenerPrevEnv");
+				expect(ListFirst(local.prodPrefixes)).toBe("app.jobs");
+				expect(ListFindNoCase(local.prodPrefixes, "wheels.tests._assets.jobs")).toBe(0);
+
+				local.testPrefixes = local.bridge.$jobClassPrefixes();
+				expect(ListFirst(local.testPrefixes)).toBe("app.jobs");
+				expect(ListFindNoCase(local.testPrefixes, "wheels.tests._assets.jobs")).toBeGT(0);
 			});
 
 			it("S1: enqueue persists timeout=300 and perform honors it", function() {

--- a/vendor/wheels/tests/specs/jobs/JobHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/jobs/JobHardenerSpec.cfc
@@ -1,0 +1,311 @@
+/**
+ * Hardener proofs for Jobs BLOCKERs B1–B4 and the safe SHOULDs (S2/S3/S5/S6).
+ * Desk IDs are stable. Do not renumber.
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("Jobs hardener B1–B4", function() {
+
+			beforeEach(function() {
+				local.bootstrapJob = new wheels.Job();
+				local.bootstrapJob.$ensureJobTable();
+				try {
+					queryExecute("DELETE FROM wheels_jobs WHERE queue LIKE 'test_hard_%'", {}, {datasource = application.wheels.dataSourceName});
+				} catch (any e) {
+				}
+			});
+
+			afterEach(function() {
+				try {
+					queryExecute("DELETE FROM wheels_jobs WHERE queue LIKE 'test_hard_%'", {}, {datasource = application.wheels.dataSourceName});
+				} catch (any e) {
+				}
+			});
+
+			it("B1: fail/retry UPDATE does not overwrite a stolen job already completed", function() {
+				local.id = CreateUUID();
+				local.payload = SerializeJSON({jobId: local.id});
+				$insertTestJob(
+					id = local.id,
+					jobClass = "wheels.tests._assets.jobs.StealDuringPerformJob",
+					queue = "test_hard_b1_fail",
+					data = local.payload
+				);
+
+				local.processor = new wheels.Job();
+				prepareMock(local.processor);
+				makePublic(local.processor, "$processJob");
+				local.jobResult = local.processor.$processJob(
+					jobRow = {
+						id = local.id,
+						jobClass = "wheels.tests._assets.jobs.StealDuringPerformJob",
+						queue = "test_hard_b1_fail",
+						data = local.payload,
+						attempts = 0,
+						maxRetries = 3
+					}
+				);
+
+				expect(local.jobResult.success).toBeFalse();
+				expect(local.jobResult.skipped).toBeFalse();
+
+				local.row = queryExecute(
+					"SELECT status FROM wheels_jobs WHERE id = :id",
+					{id = {value = local.id, cfsqltype = "cf_sql_varchar"}},
+					{datasource = application.wheels.dataSourceName}
+				);
+				expect(local.row.status).toBe("completed");
+			});
+
+			it("B1: complete UPDATE does not overwrite a stolen job already failed", function() {
+				local.id = CreateUUID();
+				local.payload = SerializeJSON({jobId: local.id});
+				$insertTestJob(
+					id = local.id,
+					jobClass = "wheels.tests._assets.jobs.StealToFailedJob",
+					queue = "test_hard_b1_complete",
+					data = local.payload
+				);
+
+				local.worker = new wheels.JobWorker();
+				prepareMock(local.worker);
+				makePublic(local.worker, "$executeJob");
+				local.execResult = local.worker.$executeJob(
+					jobRow = {
+						id = local.id,
+						jobClass = "wheels.tests._assets.jobs.StealToFailedJob",
+						queue = "test_hard_b1_complete",
+						data = local.payload,
+						attempts = 0,
+						maxRetries = 3
+					}
+				);
+
+				expect(local.execResult.success).toBeTrue();
+
+				local.row = queryExecute(
+					"SELECT status FROM wheels_jobs WHERE id = :id",
+					{id = {value = local.id, cfsqltype = "cf_sql_varchar"}},
+					{datasource = application.wheels.dataSourceName}
+				);
+				expect(local.row.status).toBe("failed");
+			});
+
+			it("B1: checkTimeouts retry/fail UPDATE does not overwrite completed", function() {
+				local.id = CreateUUID();
+				local.oldTime = DateAdd("s", -600, Now());
+				$insertTestJob(
+					id = local.id,
+					jobClass = "app.jobs.ProcessOrdersJob",
+					queue = "test_hard_b1_timeout",
+					status = "processing",
+					attempts = 1,
+					createdAt = local.oldTime,
+					updatedAt = local.oldTime
+				);
+				local.now = Now();
+				queryExecute(
+					"UPDATE wheels_jobs SET status = 'completed', completedAt = :now WHERE id = :id",
+					{
+						id = {value = local.id, cfsqltype = "cf_sql_varchar"},
+						now = {value = local.now, cfsqltype = "cf_sql_timestamp"}
+					},
+					{datasource = application.wheels.dataSourceName}
+				);
+
+				local.worker = new wheels.JobWorker();
+				prepareMock(local.worker);
+				makePublic(local.worker, "$scheduleRetry");
+				local.worker.$scheduleRetry(
+					jobId = local.id,
+					currentAttempts = 1,
+					jobClass = "app.jobs.ProcessOrdersJob",
+					maxRetries = 3,
+					errorMessage = "Job timed out after 300 seconds"
+				);
+
+				local.row = queryExecute(
+					"SELECT status FROM wheels_jobs WHERE id = :id",
+					{id = {value = local.id, cfsqltype = "cf_sql_varchar"}},
+					{datasource = application.wheels.dataSourceName}
+				);
+				expect(local.row.status).toBe("completed");
+			});
+
+			it("B2: persist fail does not return status=pending", function() {
+				local.job = new wheels.tests._assets.jobs.PersistFailJob();
+				local.result = local.job.enqueue(data = {test: true});
+
+				expect(local.result).toHaveKey("persisted");
+				expect(local.result.persisted).toBeFalse();
+				expect(local.result).toHaveKey("error");
+				expect(Len(local.result.error)).toBeGT(0);
+				if (StructKeyExists(local.result, "status")) {
+					expect(local.result.status).notToBe("pending");
+				}
+			});
+
+			it("B2: successful enqueue still returns status=pending and persisted=true", function() {
+				local.job = new app.jobs.ProcessOrdersJob();
+				local.result = local.job.enqueue(data = {batchSize: 1}, queue = "test_hard_b2_ok");
+
+				expect(local.result.persisted).toBeTrue();
+				expect(local.result.status).toBe("pending");
+				expect(local.result).toHaveKey("id");
+				expect(Len(local.result.id)).toBeGT(0);
+			});
+
+			it("B3: getMonitorData queue filter applies to recentJobs and oldestPending", function() {
+				local.otherCreated = DateAdd("h", -2, Now());
+				local.targetCreated = DateAdd("h", -1, Now());
+				local.otherPending = CreateUUID();
+				local.targetPending = CreateUUID();
+				local.otherDone = CreateUUID();
+				local.targetDone = CreateUUID();
+
+				$insertTestJob(
+					id = local.otherPending,
+					jobClass = "app.jobs.ProcessOrdersJob",
+					queue = "test_hard_b3_other",
+					status = "pending",
+					createdAt = local.otherCreated,
+					updatedAt = local.otherCreated
+				);
+				$insertTestJob(
+					id = local.targetPending,
+					jobClass = "app.jobs.ProcessOrdersJob",
+					queue = "test_hard_b3_target",
+					status = "pending",
+					createdAt = local.targetCreated,
+					updatedAt = local.targetCreated
+				);
+				$insertTestJob(
+					id = local.otherDone,
+					jobClass = "app.jobs.ProcessOrdersJob",
+					queue = "test_hard_b3_other",
+					status = "completed"
+				);
+				$insertTestJob(
+					id = local.targetDone,
+					jobClass = "app.jobs.ProcessOrdersJob",
+					queue = "test_hard_b3_target",
+					status = "completed"
+				);
+
+				local.worker = new wheels.JobWorker();
+				local.data = local.worker.getMonitorData(queue = "test_hard_b3_target", minutes = 180);
+
+				expect(local.data).toHaveKey("recentJobs");
+				expect(ArrayLen(local.data.recentJobs)).toBeGT(0);
+				for (local.recent in local.data.recentJobs) {
+					expect(local.recent.queue).toBe("test_hard_b3_target");
+				}
+
+				expect(IsDate(local.data.oldestPending)).toBeTrue();
+				expect(Abs(DateDiff("s", local.targetCreated, local.data.oldestPending))).toBeLTE(2);
+			});
+
+			it("S2/S3: config() backoff is applied and linear stays exponential", function() {
+				local.configId = CreateUUID();
+				local.linearId = CreateUUID();
+				$insertTestJob(id = local.configId, jobClass = "wheels.tests._assets.jobs.ConfigBackoffJob", queue = "test_hard_s3");
+				$insertTestJob(id = local.linearId, jobClass = "wheels.tests._assets.jobs.LinearBackoffJob", queue = "test_hard_s2");
+
+				local.processor = new wheels.Job();
+				prepareMock(local.processor);
+				makePublic(local.processor, "$processJob");
+
+				local.processor.$processJob(
+					jobRow = {
+						id = local.configId,
+						jobClass = "wheels.tests._assets.jobs.ConfigBackoffJob",
+						queue = "test_hard_s3",
+						data = "{}",
+						attempts = 0,
+						maxRetries = 3
+					}
+				);
+				local.processor.$processJob(
+					jobRow = {
+						id = local.linearId,
+						jobClass = "wheels.tests._assets.jobs.LinearBackoffJob",
+						queue = "test_hard_s2",
+						data = "{}",
+						attempts = 0,
+						maxRetries = 3
+					}
+				);
+
+				local.threshold = DateAdd("s", 600, Now());
+				local.configCheck = queryExecute(
+					"SELECT COUNT(*) AS cnt FROM wheels_jobs WHERE id = :id AND status = 'pending' AND runAt > :threshold",
+					{
+						id = {value = local.configId, cfsqltype = "cf_sql_varchar"},
+						threshold = {value = local.threshold, cfsqltype = "cf_sql_timestamp"}
+					},
+					{datasource = application.wheels.dataSourceName}
+				);
+				local.linearCheck = queryExecute(
+					"SELECT COUNT(*) AS cnt FROM wheels_jobs WHERE id = :id AND status = 'pending' AND runAt > :threshold",
+					{
+						id = {value = local.linearId, cfsqltype = "cf_sql_varchar"},
+						threshold = {value = local.threshold, cfsqltype = "cf_sql_timestamp"}
+					},
+					{datasource = application.wheels.dataSourceName}
+				);
+				expect(local.configCheck.cnt).toBe(1);
+				expect(local.linearCheck.cnt).toBe(1);
+			});
+
+			it("S5/S6: idle queue stays skipped and does not throw", function() {
+				local.worker = new wheels.JobWorker();
+				local.result = local.worker.processNext(queues = "test_hard_idle_#CreateUUID()#");
+				expect(local.result.skipped).toBeTrue();
+				expect(local.result.success).toBeFalse();
+				expect(local.result.error).toBe("");
+
+				local.job = new wheels.Job();
+				local.batch = local.job.processQueue(queue = "test_hard_idle_#CreateUUID()#");
+				expect(local.batch.processed).toBe(0);
+				expect(local.batch.failed).toBe(0);
+			});
+
+		});
+	}
+
+	private void function $insertTestJob(
+		required string id,
+		required string jobClass,
+		required string queue,
+		string status = "pending",
+		string data = "{}",
+		numeric attempts = 0,
+		numeric maxRetries = 3,
+		createdAt = "",
+		updatedAt = ""
+	) {
+		local.stamp = Now();
+		local.createdAt = IsDate(arguments.createdAt) ? arguments.createdAt : local.stamp;
+		local.updatedAt = IsDate(arguments.updatedAt) ? arguments.updatedAt : local.stamp;
+		queryExecute(
+			"INSERT INTO wheels_jobs (id, jobClass, queue, data, priority, status, attempts, maxRetries, runAt, createdAt, updatedAt)
+			VALUES (:id, :jobClass, :queue, :data, 0, :status, :attempts, :maxRetries, :runAt, :createdAt, :updatedAt)",
+			{
+				id = {value = arguments.id, cfsqltype = "cf_sql_varchar"},
+				jobClass = {value = arguments.jobClass, cfsqltype = "cf_sql_varchar"},
+				queue = {value = arguments.queue, cfsqltype = "cf_sql_varchar"},
+				data = {value = arguments.data, cfsqltype = "cf_sql_longvarchar"},
+				status = {value = arguments.status, cfsqltype = "cf_sql_varchar"},
+				attempts = {value = arguments.attempts, cfsqltype = "cf_sql_integer"},
+				maxRetries = {value = arguments.maxRetries, cfsqltype = "cf_sql_integer"},
+				runAt = {value = local.createdAt, cfsqltype = "cf_sql_timestamp"},
+				createdAt = {value = local.createdAt, cfsqltype = "cf_sql_timestamp"},
+				updatedAt = {value = local.updatedAt, cfsqltype = "cf_sql_timestamp"}
+			},
+			{datasource = application.wheels.dataSourceName}
+		);
+	}
+
+}

--- a/vendor/wheels/tests/specs/jobs/JobQueueSpec.cfc
+++ b/vendor/wheels/tests/specs/jobs/JobQueueSpec.cfc
@@ -18,6 +18,7 @@ component extends="wheels.WheelsTest" {
 				expect(local.job.queue).toBe("default");
 				expect(local.job.priority).toBe(0);
 				expect(local.job.maxRetries).toBe(3);
+				expect(local.job.retryBackoff).toBe("exponential");
 				expect(local.job.timeout).toBe(300);
 				expect(local.job.baseDelay).toBe(2);
 				expect(local.job.maxDelay).toBe(3600);
@@ -268,9 +269,16 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("perform executes without error", function() {
+				var performed = {ok = true, error = ""};
 				local.job = new app.jobs.ProcessOrdersJob();
-				// Should not throw
-				local.job.perform(data = {batchSize: 5});
+				try {
+					local.job.perform(data = {batchSize: 5});
+				} catch (any e) {
+					performed.ok = false;
+					performed.error = e.message;
+				}
+				expect(performed.ok).toBeTrue();
+				expect(performed.error).toBe("");
 			});
 
 			it("can be enqueued", function() {

--- a/vendor/wheels/tests/specs/jobs/JobRobustnessSpec.cfc
+++ b/vendor/wheels/tests/specs/jobs/JobRobustnessSpec.cfc
@@ -97,7 +97,7 @@ component extends="wheels.WheelsTest" {
 
 			it("worker path restores tenant context and strips the internal key", function() {
 				local.payload = {orderId = 42};
-				local.payload["$wheelsTenantContext"] = {id = "tenant-1", dataSource = "wheels_test_tenant_ds", config = {}};
+				local.payload["$wheelsTenantContext"] = {id = "tenant-1", dataSource = application.wheels.dataSourceName, config = {}};
 
 				local.worker = new wheels.JobWorker();
 				prepareMock(local.worker);
@@ -116,7 +116,7 @@ component extends="wheels.WheelsTest" {
 				expect(request).toHaveKey("$wheelsJobProbe");
 				expect(request.$wheelsJobProbe.sawInternalKey).toBeFalse();
 				expect(request.$wheelsJobProbe.tenantRestored).toBeTrue();
-				expect(request.$wheelsJobProbe.tenantDataSource).toBe("wheels_test_tenant_ds");
+				expect(request.$wheelsJobProbe.tenantDataSource).toBe(application.wheels.dataSourceName);
 				expect(request.$wheelsJobProbe.tenantId).toBe("tenant-1");
 
 				// And the context must be cleaned up after execution
@@ -126,7 +126,7 @@ component extends="wheels.WheelsTest" {
 			it("in-app path still restores tenant context via the shared helper", function() {
 				local.id = CreateUUID();
 				local.payload = {orderId = 7};
-				local.payload["$wheelsTenantContext"] = {id = "tenant-2", dataSource = "wheels_test_tenant_ds", config = {}};
+				local.payload["$wheelsTenantContext"] = {id = "tenant-2", dataSource = application.wheels.dataSourceName, config = {}};
 				$insertTestJob(
 					id = local.id,
 					jobClass = "wheels.tests._assets.jobs.ProbeJob",
@@ -150,7 +150,7 @@ component extends="wheels.WheelsTest" {
 				expect(local.jobResult.success).toBeTrue();
 				expect(request.$wheelsJobProbe.sawInternalKey).toBeFalse();
 				expect(request.$wheelsJobProbe.tenantRestored).toBeTrue();
-				expect(request.$wheelsJobProbe.tenantDataSource).toBe("wheels_test_tenant_ds");
+				expect(request.$wheelsJobProbe.tenantDataSource).toBe(application.wheels.dataSourceName);
 				expect(IsDefined("request.wheels.tenant")).toBeFalse();
 			});
 

--- a/vendor/wheels/tests/specs/jobs/JobWorkerSpec.cfc
+++ b/vendor/wheels/tests/specs/jobs/JobWorkerSpec.cfc
@@ -105,17 +105,17 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("increments jobsProcessed counter on success", function() {
-				// Enqueue a job that will succeed (ProcessOrdersJob has a no-op perform)
 				local.testJob = new app.jobs.ProcessOrdersJob();
 				local.enqueued = local.testJob.enqueue(data = {batchSize: 1}, queue = "test_counter");
+				expect(local.enqueued.persisted).toBeTrue();
 
 				local.worker = new wheels.JobWorker();
 				expect(local.worker.jobsProcessed).toBe(0);
 				local.result = local.worker.processNext(queues = "test_counter");
 
-				if (local.result.success) {
-					expect(local.worker.jobsProcessed).toBe(1);
-				}
+				expect(local.result.success).toBeTrue();
+				expect(local.result.skipped).toBeFalse();
+				expect(local.worker.jobsProcessed).toBe(1);
 			});
 		});
 
@@ -128,37 +128,33 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("recovers stuck processing jobs", function() {
-				// Insert a job stuck in 'processing' with old updatedAt
+				local.bootstrap = new wheels.Job();
+				local.bootstrap.$ensureJobTable();
+
 				local.id = CreateUUID();
 				local.oldTime = DateAdd("s", -600, Now());
-				try {
-					queryExecute(
-						"INSERT INTO wheels_jobs (id, jobClass, queue, data, priority, status, attempts, maxRetries, runAt, createdAt, updatedAt)
-						VALUES (:id, 'wheels.Job', 'test_timeout', '{}', 0, 'processing', 1, 3, :runAt, :createdAt, :updatedAt)",
-						{
-							id = {value = local.id, cfsqltype = "cf_sql_varchar"},
-							runAt = {value = local.oldTime, cfsqltype = "cf_sql_timestamp"},
-							createdAt = {value = local.oldTime, cfsqltype = "cf_sql_timestamp"},
-							updatedAt = {value = local.oldTime, cfsqltype = "cf_sql_timestamp"}
-						},
-						{datasource = application.wheels.dataSourceName}
-					);
+				queryExecute(
+					"INSERT INTO wheels_jobs (id, jobClass, queue, data, priority, status, attempts, maxRetries, runAt, createdAt, updatedAt)
+					VALUES (:id, 'wheels.Job', 'test_timeout', '{}', 0, 'processing', 1, 3, :runAt, :createdAt, :updatedAt)",
+					{
+						id = {value = local.id, cfsqltype = "cf_sql_varchar"},
+						runAt = {value = local.oldTime, cfsqltype = "cf_sql_timestamp"},
+						createdAt = {value = local.oldTime, cfsqltype = "cf_sql_timestamp"},
+						updatedAt = {value = local.oldTime, cfsqltype = "cf_sql_timestamp"}
+					},
+					{datasource = application.wheels.dataSourceName}
+				);
 
-					local.worker = new wheels.JobWorker();
-					local.recovered = local.worker.checkTimeouts(timeout = 300);
-					expect(local.recovered).toBeGTE(1);
+				local.worker = new wheels.JobWorker();
+				local.recovered = local.worker.checkTimeouts(timeout = 300);
+				expect(local.recovered).toBeGTE(1);
 
-					// Verify job was reset
-					local.job = queryExecute(
-						"SELECT status FROM wheels_jobs WHERE id = :id",
-						{id = {value = local.id, cfsqltype = "cf_sql_varchar"}},
-						{datasource = application.wheels.dataSourceName}
-					);
-					// Should be either pending (retried) or failed (exhausted)
-					expect(ListFindNoCase("pending,failed", local.job.status)).toBeGT(0);
-				} catch (any e) {
-					// Table may not exist in clean test environments
-				}
+				local.job = queryExecute(
+					"SELECT status FROM wheels_jobs WHERE id = :id",
+					{id = {value = local.id, cfsqltype = "cf_sql_varchar"}},
+					{datasource = application.wheels.dataSourceName}
+				);
+				expect(ListFindNoCase("pending,failed", local.job.status)).toBeGT(0);
 			});
 		});
 
@@ -223,7 +219,11 @@ component extends="wheels.WheelsTest" {
 			it("accepts queue filter", function() {
 				local.worker = new wheels.JobWorker();
 				local.data = local.worker.getMonitorData(queue = "default");
-				expect(local.data).toBeStruct();
+				expect(local.data).toHaveKey("recentJobs");
+				expect(local.data).toHaveKey("oldestPending");
+				for (local.recent in local.data.recentJobs) {
+					expect(local.recent.queue).toBe("default");
+				}
 			});
 		});
 
@@ -248,35 +248,32 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("resets failed jobs to pending", function() {
-				// Insert a failed job
+				local.bootstrap = new wheels.Job();
+				local.bootstrap.$ensureJobTable();
+
 				local.id = CreateUUID();
 				local.now = Now();
-				try {
-					queryExecute(
-						"INSERT INTO wheels_jobs (id, jobClass, queue, data, priority, status, attempts, maxRetries, lastError, runAt, failedAt, createdAt, updatedAt)
-						VALUES (:id, 'wheels.Job', 'test_retry', '{}', 0, 'failed', 3, 3, 'Test error', :now, :now, :now, :now)",
-						{
-							id = {value = local.id, cfsqltype = "cf_sql_varchar"},
-							now = {value = local.now, cfsqltype = "cf_sql_timestamp"}
-						},
-						{datasource = application.wheels.dataSourceName}
-					);
+				queryExecute(
+					"INSERT INTO wheels_jobs (id, jobClass, queue, data, priority, status, attempts, maxRetries, lastError, runAt, failedAt, createdAt, updatedAt)
+					VALUES (:id, 'wheels.Job', 'test_retry', '{}', 0, 'failed', 3, 3, 'Test error', :now, :now, :now, :now)",
+					{
+						id = {value = local.id, cfsqltype = "cf_sql_varchar"},
+						now = {value = local.now, cfsqltype = "cf_sql_timestamp"}
+					},
+					{datasource = application.wheels.dataSourceName}
+				);
 
-					local.worker = new wheels.JobWorker();
-					local.count = local.worker.retryFailed(queue = "test_retry");
-					expect(local.count).toBeGTE(1);
+				local.worker = new wheels.JobWorker();
+				local.count = local.worker.retryFailed(queue = "test_retry");
+				expect(local.count).toBeGTE(1);
 
-					// Verify job was reset
-					local.job = queryExecute(
-						"SELECT status, attempts FROM wheels_jobs WHERE id = :id",
-						{id = {value = local.id, cfsqltype = "cf_sql_varchar"}},
-						{datasource = application.wheels.dataSourceName}
-					);
-					expect(local.job.status).toBe("pending");
-					expect(local.job.attempts).toBe(0);
-				} catch (any e) {
-					// Table may not exist
-				}
+				local.job = queryExecute(
+					"SELECT status, attempts FROM wheels_jobs WHERE id = :id",
+					{id = {value = local.id, cfsqltype = "cf_sql_varchar"}},
+					{datasource = application.wheels.dataSourceName}
+				);
+				expect(local.job.status).toBe("pending");
+				expect(local.job.attempts).toBe(0);
 			});
 		});
 
@@ -308,34 +305,31 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("deletes old completed jobs", function() {
-				// Insert an old completed job
+				local.bootstrap = new wheels.Job();
+				local.bootstrap.$ensureJobTable();
+
 				local.id = CreateUUID();
 				local.oldTime = DateAdd("d", -30, Now());
-				try {
-					queryExecute(
-						"INSERT INTO wheels_jobs (id, jobClass, queue, data, priority, status, attempts, maxRetries, runAt, completedAt, createdAt, updatedAt)
-						VALUES (:id, 'wheels.Job', 'test_purge', '{}', 0, 'completed', 1, 3, :oldTime, :oldTime, :oldTime, :oldTime)",
-						{
-							id = {value = local.id, cfsqltype = "cf_sql_varchar"},
-							oldTime = {value = local.oldTime, cfsqltype = "cf_sql_timestamp"}
-						},
-						{datasource = application.wheels.dataSourceName}
-					);
+				queryExecute(
+					"INSERT INTO wheels_jobs (id, jobClass, queue, data, priority, status, attempts, maxRetries, runAt, completedAt, createdAt, updatedAt)
+					VALUES (:id, 'wheels.Job', 'test_purge', '{}', 0, 'completed', 1, 3, :oldTime, :oldTime, :oldTime, :oldTime)",
+					{
+						id = {value = local.id, cfsqltype = "cf_sql_varchar"},
+						oldTime = {value = local.oldTime, cfsqltype = "cf_sql_timestamp"}
+					},
+					{datasource = application.wheels.dataSourceName}
+				);
 
-					local.worker = new wheels.JobWorker();
-					local.count = local.worker.purge(status = "completed", days = 7, queue = "test_purge");
-					expect(local.count).toBeGTE(1);
+				local.worker = new wheels.JobWorker();
+				local.count = local.worker.purge(status = "completed", days = 7, queue = "test_purge");
+				expect(local.count).toBeGTE(1);
 
-					// Verify job was deleted
-					local.remaining = queryExecute(
-						"SELECT COUNT(*) as cnt FROM wheels_jobs WHERE id = :id",
-						{id = {value = local.id, cfsqltype = "cf_sql_varchar"}},
-						{datasource = application.wheels.dataSourceName}
-					);
-					expect(local.remaining.cnt).toBe(0);
-				} catch (any e) {
-					// Table may not exist
-				}
+				local.remaining = queryExecute(
+					"SELECT COUNT(*) as cnt FROM wheels_jobs WHERE id = :id",
+					{id = {value = local.id, cfsqltype = "cf_sql_varchar"}},
+					{datasource = application.wheels.dataSourceName}
+				);
+				expect(local.remaining.cnt).toBe(0);
 			});
 		});
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Jobs hardener for BLOCKERs B1–B4 and SHOULDs S1–S10. Same draft; Peter flipped the remaining SHOULDs, then requested S6 because `$claimJob` still swallowed persist errors as idle skip. Base is develop after #3411 (`71f65da594f47d33761efd45e9304146afc005ca`). Defaults that stay locked: `queue=default`, `maxRetries=3` (value), `retryBackoff=exponential`, `timeout=300` (persisted and honored), `baseDelay=2`, `maxDelay=3600`, `processQueue limit=10`, `purge days=7`, `candidateLimit=25`, `retryFailed limit=0`, claim `WHERE pending`.

S6: `$claimJob` throws `Wheels.JobClaimFailed` on persist/query error instead of `return false`. `processNext` contains that as `skipped=false` + `error`, not an idle skip. Empty queues still `skipped` / `processed=0`.

Leftover landed: `$jobClassPrefixes` treats `app.jobs` (plus configured `jobClassPrefixes`) as first-class. `wheels.tests._assets.jobs` is an extra prefix outside production only.

## PROVEN / HELD

| ID | Status | One line |
|---|---|---|
| B1 | **PROVEN** | complete/retry/fail UPDATE requires `status='processing'`; checkTimeouts cannot overwrite completed |
| B2 | **PROVEN** | persist fail returns `persisted=false` + `error`, never `status=pending`; success still `pending`/`persisted=true` |
| B3 | **PROVEN** | `getMonitorData(queue=)` filters `recentJobs` and `oldestPending` (not only throughput) |
| B4 | **PROVEN** | perform / jobsProcessed / checkTimeouts / retryFailed / purge use real expects, no swallow |
| S1 | **PROVEN (flipped)** | persist `$wheelsJobTimeout` (default 300) and honor it; SlowTimeoutJob is cut off, not hang-until-done |
| S2 | **PROVEN** | `retryBackoff=exponential` is read; default string stays `exponential` |
| S3 | **PROVEN** | `$instantiateJobClass` calls `init()` so `config()` backoff applies |
| S4 | **PROVEN (flipped)** | `$candidateLimitClause` emits `LIMIT 25` for unknown db types |
| S5 | **PROVEN** | idle empty queue still `skipped` / `processed=0` and does not throw |
| S6 | **PROVEN** | killing spec: `$claimJob` persist error throws `Wheels.JobClaimFailed` (not `return false`); `processNext` contains it as failed, not idle skip |
| S7 | **PROVEN (flipped)** | enqueue writes tenant id + dataSource only; restore allowlists known app datasources |
| S8 | **PROVEN (flipped)** | `CreateObject(jobClass)` allowlisted (`app.jobs` first-class + configured prefixes); test prefix is extra, not a production default |
| S9 | **PROVEN (flipped)** | `maxRetries` is retries after first fail (default 3 = 4 tries); compare is `<=`; default value stays 3 |
| S10 | **PROVEN (flipped)** | `retryFailed` / `purgeCompleted` / `JobWorker.purge` return the real DML count, including 0 |

## Type of Change

- [x] Bug fix

## Feature Completeness Checklist

- [x] **DCO sign-off**
- [x] **Tests**
- [ ] **Framework Docs** — no public default *value* change
- [ ] **AI Reference Docs**
- [ ] **CLAUDE.md**
- [x] **Changelog fragment** — `changelog.d/jobs-hardener-b1-b4.fixed.md`
- [x] **Test runner passes** — `wheels test --core --ci --filter=jobs`

## Test Plan

Command actually run:

```
wheels test --core --ci --filter=jobs
```

Scope: `wheels.tests.specs.jobs` (directory accepted, not rejected).

RED (S6 killing spec + leftover prefix spec against unfixed `$claimJob` / hardcoded test prefix):

```
84 passed, 2 failed, 0 error(s)
S6: Expected [true] to be false ($claimJob returned false on persist error)
S8 leftover: Expected [0] but received [2] (wheels.tests._assets.jobs still a production default)
```

GREEN (this HEAD):

```
wheels test --core --ci --filter=jobs
Scope: wheels.tests.specs.jobs
bundlesDiscovered=5 totalSpecs=86
86 passed, 0 failed, 0 error, 0 skipped
Lucee 7.0.0.395 / sqlite
```

Bundles: JobClassRoundTripSpec 6, JobHardenerSpec 16, JobQueueSpec 24, JobRobustnessSpec 7, JobWorkerSpec 33.

## HEAD

`4553fb0abe2c776513a0e6e04527ef6e3f94ade9`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-602bbaf3-4cdc-4bf1-ac59-4afb005b83e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-602bbaf3-4cdc-4bf1-ac59-4afb005b83e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

