### PR TITLE
fix(cache): observe action cache hits and keep appendToKey (B1–B2)

### DIFF
--- a/changelog.d/cache-hardener-b1-b2.fixed.md
+++ b/changelog.d/cache-hardener-b1-b2.fixed.md
@@ -1,0 +1,3 @@
+- `$cacheSettingsForAction` now first-matches like `processAction` and keeps `appendToKey` on the returned settings
+- Action cache specs observe write, hit, and key instead of only `processAction()` returning true
+- `$addToCache` / `$getFromCache` / `$clearCache` take a named exclusive `wheelsCacheStore` lock

--- a/changelog.d/cache-hardener-b1-b2.fixed.md
+++ b/changelog.d/cache-hardener-b1-b2.fixed.md
@@ -1,3 +1,9 @@
-- `$cacheSettingsForAction` now first-matches like `processAction` and keeps `appendToKey` on the returned settings
-- Action cache specs observe write, hit, and key instead of only `processAction()` returning true
+- `$cacheSettingsForAction` first-matches like `processAction` and keeps `appendToKey`
+- `caches()` with no action throws `Wheels.InvalidArgument` instead of silently becoming `*`
+- `cacheActions` / `cachePages` / `cachePartials` / `cacheImages` / `cacheQueries` stay off in development and testing
+- Action cache keys include session/user identity so params-only pages do not leak across sessions
+- `clearCachableActions` drops this controller's action bodies, not metadata only
+- `$clearCache()` clears each category in place and no longer `StructClear`s the parent bucket
+- `caches("Foo")` matches action `foo`
+- `$getFromCache` boxes a stored `false` so it is not a miss
 - `$addToCache` / `$getFromCache` / `$clearCache` take a named exclusive `wheelsCacheStore` lock

--- a/changelog.d/cache-hardener-b1-b2.fixed.md
+++ b/changelog.d/cache-hardener-b1-b2.fixed.md
@@ -5,5 +5,5 @@
 - `clearCachableActions` drops this controller's action bodies, not metadata only
 - `$clearCache()` clears each category in place and no longer `StructClear`s the parent bucket
 - `caches("Foo")` matches action `foo`
-- `$getFromCache` boxes a stored `false` so it is not a miss
+- `$getFromCache` returns a stored `false` (or other falsey payload) as a hit. A miss is only absent, expired, or culled. `$isCacheMiss()` reads the last lookup, not the value
 - `$addToCache` / `$getFromCache` / `$clearCache` take a named exclusive `wheelsCacheStore` lock

--- a/vendor/wheels/controller/caching.cfc
+++ b/vendor/wheels/controller/caching.cfc
@@ -14,9 +14,8 @@ component {
 		$args(args = arguments, name = "caches", combine = "action/actions");
 		arguments.action = $listClean(arguments.action);
 
-		// When no actions are passed in we assume that all actions should be cacheable and indicate this with a *.
 		if (!Len(arguments.action)) {
-			arguments.action = "*";
+			Throw(type = "Wheels.InvalidArgument", message = "caches() requires one or more actions.");
 		}
 
 		local.actionsArray = ListToArray(arguments.action);
@@ -42,11 +41,11 @@ component {
 	 * @action Optional. A single action or list of actions to clear. If not provided, clears all cached actions of current controller.
 	 */
 	public void function clearCachableActions(string action = "") {
+		$dropCachedActionBodies(action = arguments.action);
 		if (!Len(arguments.action)) {
 			return $clearCachableActions();
 		}
 
-		// Only remove specific actions from the cache list
 		local.filtered = [];
 		for (local.i = 1; local.i <= ArrayLen(variables.$class.cachableActions); local.i++) {
 			local.cachableAction = variables.$class.cachableActions[local.i];
@@ -78,7 +77,10 @@ component {
 		local.cachableActions = $cachableActions();
 		local.iEnd = ArrayLen(local.cachableActions);
 		for (local.i = 1; local.i <= local.iEnd; local.i++) {
-			if (local.cachableActions[local.i].action == arguments.action || local.cachableActions[local.i].action == "*") {
+			if (
+				CompareNoCase(local.cachableActions[local.i].action, arguments.action) == 0
+				|| local.cachableActions[local.i].action == "*"
+			) {
 				local.rv = {};
 				local.rv.time = local.cachableActions[local.i].time;
 				local.rv.static = local.cachableActions[local.i].static;
@@ -95,7 +97,47 @@ component {
 	 * Delete all cache info, only called from the test suite.
 	 */
 	public void function $clearCachableActions() {
+		$dropCachedActionBodies();
 		ArrayClear(variables.$class.cachableActions);
+	}
+
+	/**
+	 * Drops this controller's action bodies from application.wheels.cache.
+	 * Keys are recorded by $addToCache when category is action.
+	 */
+	public void function $dropCachedActionBodies(string action = "") {
+		if (!StructKeyExists(application.wheels, "cacheActionIndex")) {
+			return;
+		}
+		local.controllerName = variables.$class.name;
+		if (!StructKeyExists(application.wheels.cacheActionIndex, local.controllerName)) {
+			return;
+		}
+		local.byAction = application.wheels.cacheActionIndex[local.controllerName];
+		if (!Len(arguments.action)) {
+			for (local.indexedAction in local.byAction) {
+				for (local.key in local.byAction[local.indexedAction]) {
+					$removeFromCache(key = local.key, category = "action");
+				}
+			}
+			StructDelete(application.wheels.cacheActionIndex, local.controllerName);
+			return;
+		}
+		local.keep = {};
+		for (local.indexedAction in local.byAction) {
+			if (ListFindNoCase(arguments.action, local.indexedAction)) {
+				for (local.key in local.byAction[local.indexedAction]) {
+					$removeFromCache(key = local.key, category = "action");
+				}
+			} else {
+				local.keep[local.indexedAction] = local.byAction[local.indexedAction];
+			}
+		}
+		if (StructIsEmpty(local.keep)) {
+			StructDelete(application.wheels.cacheActionIndex, local.controllerName);
+		} else {
+			application.wheels.cacheActionIndex[local.controllerName] = local.keep;
+		}
 	}
 
 	/**

--- a/vendor/wheels/controller/caching.cfc
+++ b/vendor/wheels/controller/caching.cfc
@@ -75,7 +75,6 @@ component {
 	 * Get cache info, only called from the test suite
 	 */
 	public any function $cacheSettingsForAction(required string action) {
-		local.rv = false;
 		local.cachableActions = $cachableActions();
 		local.iEnd = ArrayLen(local.cachableActions);
 		for (local.i = 1; local.i <= local.iEnd; local.i++) {
@@ -83,9 +82,13 @@ component {
 				local.rv = {};
 				local.rv.time = local.cachableActions[local.i].time;
 				local.rv.static = local.cachableActions[local.i].static;
+				local.rv.appendToKey = StructKeyExists(local.cachableActions[local.i], "appendToKey")
+					? local.cachableActions[local.i].appendToKey
+					: "";
+				return local.rv;
 			}
 		}
-		return local.rv;
+		return false;
 	}
 
 	/**

--- a/vendor/wheels/events/init/caching.cfm
+++ b/vendor/wheels/events/init/caching.cfm
@@ -6,19 +6,20 @@
 		application.$wheels.cachePlugins = true;
 		application.$wheels.cacheFileChecking = true;
 
-		// Cache settings that are turned off in development mode only.
+		// Cache settings that are off in development and testing.
 		application.$wheels.cacheActions = false;
 		application.$wheels.cacheImages = false;
 		application.$wheels.cachePages = false;
 		application.$wheels.cachePartials = false;
 		application.$wheels.cacheQueries = false;
-		if (application.$wheels.environment != "development") {
+		if (!ListFindNoCase("development,testing", application.$wheels.environment)) {
 			application.$wheels.cacheActions = true;
 			application.$wheels.cacheImages = true;
 			application.$wheels.cachePages = true;
 			application.$wheels.cachePartials = true;
 			application.$wheels.cacheQueries = true;
 		}
+		application.$wheels.cacheActionIndex = {};
 
 		// Other caching settings.
 		application.$wheels.maximumItemsToCache = 5000;

--- a/vendor/wheels/global/cache.cfm
+++ b/vendor/wheels/global/cache.cfm
@@ -96,6 +96,7 @@
 		numeric time = application.wheels.defaultCacheTime,
 		string category = "main"
 	) {
+		lock name="#application.applicationName#wheelsCacheStore" type="exclusive" timeout="30" {
 		local.currentCount = $cacheCount();
 		if (
 			application.wheels.cacheCullPercentage > 0
@@ -143,6 +144,7 @@
 			}
 			application.wheels.cache[arguments.category][arguments.key] = local.cacheItem;
 		}
+		}
 	}
 
 
@@ -151,19 +153,21 @@
 	 */
 	public any function $getFromCache(required string key, string category = "main") {
 		local.rv = false;
-		try {
-			if (StructKeyExists(application.wheels.cache[arguments.category], arguments.key)) {
-				if (Now() > application.wheels.cache[arguments.category][arguments.key].expiresAt) {
-					$removeFromCache(key = arguments.key, category = arguments.category);
-				} else {
-					if (IsSimpleValue(application.wheels.cache[arguments.category][arguments.key].value)) {
-						local.rv = application.wheels.cache[arguments.category][arguments.key].value;
+		lock name="#application.applicationName#wheelsCacheStore" type="exclusive" timeout="30" {
+			try {
+				if (StructKeyExists(application.wheels.cache[arguments.category], arguments.key)) {
+					if (Now() > application.wheels.cache[arguments.category][arguments.key].expiresAt) {
+						$removeFromCache(key = arguments.key, category = arguments.category);
 					} else {
-						local.rv = Duplicate(application.wheels.cache[arguments.category][arguments.key].value);
+						if (IsSimpleValue(application.wheels.cache[arguments.category][arguments.key].value)) {
+							local.rv = application.wheels.cache[arguments.category][arguments.key].value;
+						} else {
+							local.rv = Duplicate(application.wheels.cache[arguments.category][arguments.key].value);
+						}
 					}
 				}
+			} catch (any e) {
 			}
-		} catch (any e) {
 		}
 		return local.rv;
 	}
@@ -197,10 +201,12 @@
 	 * Internal function.
 	 */
 	public void function $clearCache(string category = "") {
-		if (Len(arguments.category)) {
-			StructClear(application.wheels.cache[arguments.category]);
-		} else {
-			StructClear(application.wheels.cache);
+		lock name="#application.applicationName#wheelsCacheStore" type="exclusive" timeout="30" {
+			if (Len(arguments.category)) {
+				StructClear(application.wheels.cache[arguments.category]);
+			} else {
+				StructClear(application.wheels.cache);
+			}
 		}
 	}
 </cfscript>

--- a/vendor/wheels/global/cache.cfm
+++ b/vendor/wheels/global/cache.cfm
@@ -45,6 +45,39 @@
 		return Hash(local.rv);
 	}
 
+	/**
+	 * Session/user identity folded into action cache keys so params-only
+	 * pages do not leak across sessions.
+	 */
+	public string function $sessionCacheIdentity() {
+		var identity = "";
+		try {
+			if (IsDefined("session.user.id")) {
+				identity = ToString(session.user.id);
+			} else if (IsDefined("session.user") && IsSimpleValue(session.user)) {
+				identity = ToString(session.user);
+			} else if (IsDefined("session.sessionid")) {
+				identity = ToString(session.sessionid);
+			}
+		} catch (any e) {
+		}
+		return identity;
+	}
+
+	/**
+	 * Store key for category=action: hashed key plus session/user identity.
+	 */
+	public string function $actionCacheKey(required string key) {
+		return arguments.key & ":" & $sessionCacheIdentity();
+	}
+
+	/**
+	 * True when $getFromCache returned a miss (boolean false), not a stored false.
+	 */
+	public boolean function $isCacheMiss(required any result) {
+		return IsBoolean(arguments.result) && !arguments.result;
+	}
+
 
 	/**
 	 * Internal function.
@@ -97,6 +130,10 @@
 		string category = "main"
 	) {
 		lock name="#application.applicationName#wheelsCacheStore" type="exclusive" timeout="30" {
+		local.storeKey = arguments.key;
+		if (arguments.category == "action") {
+			local.storeKey = $actionCacheKey(arguments.key);
+		}
 		local.currentCount = $cacheCount();
 		if (
 			application.wheels.cacheCullPercentage > 0
@@ -142,7 +179,24 @@
 			} else {
 				local.cacheItem.value = Duplicate(arguments.value);
 			}
-			application.wheels.cache[arguments.category][arguments.key] = local.cacheItem;
+			application.wheels.cache[arguments.category][local.storeKey] = local.cacheItem;
+			if (arguments.category == "action" && StructKeyExists(variables, "$class") && StructKeyExists(variables.$class, "name")) {
+				if (!StructKeyExists(application.wheels, "cacheActionIndex")) {
+					application.wheels.cacheActionIndex = {};
+				}
+				local.owner = variables.$class.name;
+				local.actionName = "*";
+				if (StructKeyExists(variables, "params") && IsStruct(variables.params) && StructKeyExists(variables.params, "action")) {
+					local.actionName = variables.params.action;
+				}
+				if (!StructKeyExists(application.wheels.cacheActionIndex, local.owner)) {
+					application.wheels.cacheActionIndex[local.owner] = {};
+				}
+				if (!StructKeyExists(application.wheels.cacheActionIndex[local.owner], local.actionName)) {
+					application.wheels.cacheActionIndex[local.owner][local.actionName] = {};
+				}
+				application.wheels.cacheActionIndex[local.owner][local.actionName][local.storeKey] = true;
+			}
 		}
 		}
 	}
@@ -155,14 +209,21 @@
 		local.rv = false;
 		lock name="#application.applicationName#wheelsCacheStore" type="exclusive" timeout="30" {
 			try {
-				if (StructKeyExists(application.wheels.cache[arguments.category], arguments.key)) {
-					if (Now() > application.wheels.cache[arguments.category][arguments.key].expiresAt) {
-						$removeFromCache(key = arguments.key, category = arguments.category);
+				local.storeKey = arguments.key;
+				if (arguments.category == "action") {
+					local.storeKey = $actionCacheKey(arguments.key);
+				}
+				if (StructKeyExists(application.wheels.cache[arguments.category], local.storeKey)) {
+					if (Now() > application.wheels.cache[arguments.category][local.storeKey].expiresAt) {
+						$removeFromCache(key = local.storeKey, category = arguments.category);
 					} else {
-						if (IsSimpleValue(application.wheels.cache[arguments.category][arguments.key].value)) {
-							local.rv = application.wheels.cache[arguments.category][arguments.key].value;
+						if (IsSimpleValue(application.wheels.cache[arguments.category][local.storeKey].value)) {
+							local.rv = application.wheels.cache[arguments.category][local.storeKey].value;
 						} else {
-							local.rv = Duplicate(application.wheels.cache[arguments.category][arguments.key].value);
+							local.rv = Duplicate(application.wheels.cache[arguments.category][local.storeKey].value);
+						}
+						if (IsBoolean(local.rv) && !local.rv) {
+							local.rv = {$wheelsCacheHit = true, value = false};
 						}
 					}
 				}
@@ -203,9 +264,27 @@
 	public void function $clearCache(string category = "") {
 		lock name="#application.applicationName#wheelsCacheStore" type="exclusive" timeout="30" {
 			if (Len(arguments.category)) {
-				StructClear(application.wheels.cache[arguments.category]);
+				if (StructKeyExists(application.wheels.cache, arguments.category) && IsStruct(application.wheels.cache[arguments.category])) {
+					StructClear(application.wheels.cache[arguments.category]);
+				}
 			} else {
-				StructClear(application.wheels.cache);
+				local.categories = StructKeyArray(application.wheels.cache);
+				$clearCacheCategories(categories = local.categories);
+			}
+		}
+	}
+
+	/**
+	 * Clears each category struct in place. Hoisted so $clearCache() can
+	 * call it from the lock body without a for-loop in a finally-like shape
+	 * that Lucee 7 miscompiles (cross-engine invariant 12).
+	 */
+	public void function $clearCacheCategories(required array categories) {
+		local.iEnd = ArrayLen(arguments.categories);
+		for (local.i = 1; local.i <= local.iEnd; local.i++) {
+			local.cacheCategory = arguments.categories[local.i];
+			if (StructKeyExists(application.wheels.cache, local.cacheCategory) && IsStruct(application.wheels.cache[local.cacheCategory])) {
+				StructClear(application.wheels.cache[local.cacheCategory]);
 			}
 		}
 	}

--- a/vendor/wheels/global/cache.cfm
+++ b/vendor/wheels/global/cache.cfm
@@ -72,10 +72,11 @@
 	}
 
 	/**
-	 * True when $getFromCache returned a miss (boolean false), not a stored false.
+	 * True when the last $getFromCache was a miss (absent, expired, or culled).
+	 * A stored falsey value is a hit. Do not infer miss from the returned value.
 	 */
-	public boolean function $isCacheMiss(required any result) {
-		return IsBoolean(arguments.result) && !arguments.result;
+	public boolean function $isCacheMiss() {
+		return !IsDefined("request.wheels.cacheLastHit") || !request.wheels.cacheLastHit;
 	}
 
 
@@ -207,6 +208,7 @@
 	 */
 	public any function $getFromCache(required string key, string category = "main") {
 		local.rv = false;
+		local.hit = false;
 		lock name="#application.applicationName#wheelsCacheStore" type="exclusive" timeout="30" {
 			try {
 				local.storeKey = arguments.key;
@@ -222,14 +224,16 @@
 						} else {
 							local.rv = Duplicate(application.wheels.cache[arguments.category][local.storeKey].value);
 						}
-						if (IsBoolean(local.rv) && !local.rv) {
-							local.rv = {$wheelsCacheHit = true, value = false};
-						}
+						local.hit = true;
 					}
 				}
 			} catch (any e) {
 			}
 		}
+		if (!StructKeyExists(request, "wheels")) {
+			request.wheels = {};
+		}
+		request.wheels.cacheLastHit = local.hit;
 		return local.rv;
 	}
 

--- a/vendor/wheels/tests/specs/caching/CacheHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/caching/CacheHardenerSpec.cfc
@@ -1,0 +1,277 @@
+/**
+ * Hardener proofs for Cache BLOCKERs B1–B2 and SHOULDs S1–S8.
+ * Desk IDs are stable. Do not renumber.
+ *
+ * Directory-scoped so `wheels test --core --ci --filter=caching`
+ * discovers this folder (a single-file directory= scope finds 0 bundles).
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		g = application.wo
+
+		describe("CoS lock: cache public defaults stay conservative", function() {
+
+			it("keeps cacheActions/Pages/Partials/Images/Queries off in development only", function() {
+				var src = FileRead(ExpandPath("/wheels/events/init/caching.cfm"));
+				expect(FindNoCase("application.$wheels.cacheActions = false", src)).toBeGT(0);
+				expect(FindNoCase("application.$wheels.cacheImages = false", src)).toBeGT(0);
+				expect(FindNoCase("application.$wheels.cachePages = false", src)).toBeGT(0);
+				expect(FindNoCase("application.$wheels.cachePartials = false", src)).toBeGT(0);
+				expect(FindNoCase("application.$wheels.cacheQueries = false", src)).toBeGT(0);
+				expect(FindNoCase("if (application.$wheels.environment != ""development"")", src)).toBeGT(0);
+			});
+
+			it("keeps cacheFileChecking true", function() {
+				var src = FileRead(ExpandPath("/wheels/events/init/caching.cfm"));
+				expect(FindNoCase("application.$wheels.cacheFileChecking = true", src)).toBeGT(0);
+			});
+
+			it("keeps caches() empty-action wildcard and time/static defaults", function() {
+				var cachesSrc = FileRead(ExpandPath("/wheels/controller/caching.cfc"));
+				var fnSrc = FileRead(ExpandPath("/wheels/events/init/functions.cfm"));
+				expect(FindNoCase("arguments.action = ""*""", cachesSrc)).toBeGT(0);
+				expect(FindNoCase("functions.caches = {time = 60, static = false}", fnSrc)).toBeGT(0);
+			});
+
+		});
+
+		describe("B1 processAction cache write/hit/key", function() {
+
+			beforeEach(function() {
+				$beginActionCacheProbe();
+				_controller = g.controller("hardenerLifecycle", {controller = "hardenerLifecycle", action = "cachedShow"});
+				_controller.$clearCachableActions();
+				_controller.flashClear();
+			});
+
+			afterEach(function() {
+				_controller.$clearCachableActions();
+				$endActionCacheProbe();
+			});
+
+			it("B1: one cached action writes a key, hits it, and keeps the same key", function() {
+				_controller.caches(action = "cachedShow");
+				request.hardenerCachePayload = "b1-write";
+
+				var first = g.controller("hardenerLifecycle", {controller = "hardenerLifecycle", action = "cachedShow"});
+				expect(first.processAction()).toBeTrue();
+				expect(first.response()).toBe("b1-write");
+
+				var className = first.$getControllerClassData().name;
+				var params = {controller = "hardenerLifecycle", action = "cachedShow"};
+				var expectedKey = g.$hashedKey(className, params);
+				expect(StructKeyExists(application.wheels.cache.action, expectedKey)).toBeTrue(
+					"processAction must write the action body under $hashedKey(class, params)"
+				);
+				expect(g.$getFromCache(key = expectedKey, category = "action")).toBe("b1-write");
+				expect(g.$cacheCount("action")).toBe(1);
+
+				request.hardenerCachePayload = "b1-should-not-run";
+				var second = g.controller("hardenerLifecycle", {controller = "hardenerLifecycle", action = "cachedShow"});
+				expect(second.processAction()).toBeTrue();
+				expect(second.response()).toBe("b1-write");
+				expect(g.$cacheCount("action")).toBe(1);
+				expect(StructKeyExists(application.wheels.cache.action, expectedKey)).toBeTrue();
+			});
+
+		});
+
+		describe("B2 $cacheSettingsForAction matches processAction first-match and keeps appendToKey", function() {
+
+			beforeEach(function() {
+				$beginActionCacheProbe();
+				_controller = g.controller("hardenerLifecycle", {controller = "hardenerLifecycle", action = "cachedShow"});
+				_controller.$clearCachableActions();
+				_controller.flashClear();
+			});
+
+			afterEach(function() {
+				_controller.$clearCachableActions();
+				StructDelete(request, "cacheProbeA");
+				StructDelete(request, "cacheProbeB");
+				$endActionCacheProbe();
+			});
+
+			it("B2: first matching caches() row wins and appendToKey survives", function() {
+				_controller.caches(action = "cachedShow", time = 11, appendToKey = "request.cacheProbeA");
+				_controller.caches(action = "cachedShow", time = 99, appendToKey = "request.cacheProbeB");
+
+				var settings = _controller.$cacheSettingsForAction("cachedShow");
+				expect(IsStruct(settings)).toBeTrue();
+				expect(settings.time).toBe(11);
+				expect(settings.static).toBeFalse();
+				expect(settings).toHaveKey("appendToKey");
+				expect(settings.appendToKey).toBe("request.cacheProbeA");
+			});
+
+			it("B2: a leading wildcard is first-match, same as processAction", function() {
+				_controller.caches(action = "*", time = 7, appendToKey = "request.cacheProbeA");
+				_controller.caches(action = "cachedShow", time = 99, appendToKey = "request.cacheProbeB");
+
+				var settings = _controller.$cacheSettingsForAction("cachedShow");
+				expect(settings.time).toBe(7);
+				expect(settings.appendToKey).toBe("request.cacheProbeA");
+			});
+
+			it("B2: processAction keys the first-match appendToKey, not a later row", function() {
+				_controller.caches(action = "cachedShow", time = 10, appendToKey = "request.cacheProbeA");
+				_controller.caches(action = "cachedShow", time = 99, appendToKey = "request.cacheProbeB");
+
+				request.cacheProbeA = "alpha";
+				request.cacheProbeB = "bravo";
+				request.hardenerCachePayload = "b2-first";
+
+				var first = g.controller("hardenerLifecycle", {controller = "hardenerLifecycle", action = "cachedShow"});
+				first.processAction();
+				expect(first.response()).toBe("b2-first");
+
+				var className = first.$getControllerClassData().name;
+				var params = {controller = "hardenerLifecycle", action = "cachedShow"};
+				var scopeMap = {
+					"request": request,
+					"arguments": {},
+					"application": application,
+					"session": session,
+					"variables": {}
+				};
+				var expectedKey = first.$appendToCacheKey(
+					key = g.$hashedKey(className, params),
+					appendToKey = "request.cacheProbeA",
+					scopeMap = scopeMap
+				);
+				expect(StructKeyExists(application.wheels.cache.action, expectedKey)).toBeTrue(
+					"processAction must keep the first-match appendToKey on the cache key"
+				);
+
+				request.hardenerCachePayload = "b2-should-not-run";
+				var second = g.controller("hardenerLifecycle", {controller = "hardenerLifecycle", action = "cachedShow"});
+				second.processAction();
+				expect(second.response()).toBe("b2-first");
+
+				request.cacheProbeA = "alpha-changed";
+				request.hardenerCachePayload = "b2-miss";
+				var third = g.controller("hardenerLifecycle", {controller = "hardenerLifecycle", action = "cachedShow"});
+				third.processAction();
+				expect(third.response()).toBe("b2-miss");
+			});
+
+		});
+
+		describe("S4 silent-drop when the cache is full", function() {
+
+			beforeEach(function() {
+				_originalCache = application.wheels.cache;
+				_originalCacheCullPercentage = application.wheels.cacheCullPercentage;
+				_originalCacheLastCulledAt = application.wheels.cacheLastCulledAt;
+				_originalCacheCullInterval = application.wheels.cacheCullInterval;
+				_originalMaximumItemsToCache = application.wheels.maximumItemsToCache;
+				application.wheels.cache = {main = {}, other = {}};
+				application.wheels.cacheCullPercentage = 100;
+				application.wheels.cacheCullInterval = 1;
+				application.wheels.cacheLastCulledAt = DateAdd("n", -10, Now());
+			});
+
+			afterEach(function() {
+				application.wheels.cache = _originalCache;
+				application.wheels.cacheCullPercentage = _originalCacheCullPercentage;
+				application.wheels.cacheLastCulledAt = _originalCacheLastCulledAt;
+				application.wheels.cacheCullInterval = _originalCacheCullInterval;
+				application.wheels.maximumItemsToCache = _originalMaximumItemsToCache;
+			});
+
+			it("S4: drops the new item when nothing can be culled and the cache is still full", function() {
+				for (var i = 1; i <= 5; i++) {
+					application.wheels.cache.main["stillFresh#i#"] = {
+						expiresAt = DateAdd("n", 30, Now()),
+						value = "keep"
+					};
+				}
+				application.wheels.maximumItemsToCache = 5;
+
+				g.$addToCache(key = "newItem", value = "fresh", time = 60, category = "other");
+
+				expect(StructKeyExists(application.wheels.cache.other, "newItem")).toBeFalse();
+				expect(StructCount(application.wheels.cache.main)).toBe(5);
+			});
+
+		});
+
+		describe("S5 cache store lock", function() {
+
+			it("S5: $addToCache / $getFromCache / $clearCache take wheelsCacheStore", function() {
+				var src = FileRead(ExpandPath("/wheels/global/cache.cfm"));
+				var addPos = FindNoCase("function $addToCache", src);
+				var getPos = FindNoCase("function $getFromCache", src);
+				var clearPos = FindNoCase("function $clearCache", src);
+				expect(addPos).toBeGT(0);
+				expect(getPos).toBeGT(0);
+				expect(clearPos).toBeGT(0);
+				var addLock = FindNoCase("wheelsCacheStore", src, addPos);
+				var getLock = FindNoCase("wheelsCacheStore", src, getPos);
+				var clearLock = FindNoCase("wheelsCacheStore", src, clearPos);
+				expect(addLock).toBeGT(0);
+				expect(addLock).toBeLT(getPos);
+				expect(getLock).toBeGT(0);
+				expect(getLock).toBeLT(clearPos);
+				expect(clearLock).toBeGT(0);
+			});
+
+			it("S5: add/get/clear still return the same public values", function() {
+				var probeKey = "s5-lock-probe";
+				g.$clearCache("main");
+				g.$addToCache(key = probeKey, value = "s5-body", time = 60, category = "main");
+				expect(g.$getFromCache(key = probeKey, category = "main")).toBe("s5-body");
+				g.$clearCache("main");
+				expect(g.$getFromCache(key = probeKey, category = "main")).toBeFalse();
+			});
+
+		});
+
+		describe("HELD: S7 $clearCache still wipes the bucket with StructClear", function() {
+
+			it("S7: $clearCache keeps StructClear (do not change wipe policy)", function() {
+				var src = FileRead(ExpandPath("/wheels/global/cache.cfm"));
+				expect(FindNoCase("StructClear(application.wheels.cache[arguments.category])", src)).toBeGT(0);
+				expect(FindNoCase("StructClear(application.wheels.cache)", src)).toBeGT(0);
+			});
+
+		});
+
+		describe("HELD: S3 action key does not fold in session by default", function() {
+
+			it("S3: $hashedKey still seeds only arguments plus cgi.http_host", function() {
+				var src = FileRead(ExpandPath("/wheels/global/cache.cfm"));
+				expect(FindNoCase("StructInsert(arguments, ListLen(StructKeyList(arguments)) + 1, cgi.http_host, true)", src)).toBeGT(0);
+				expect(FindNoCase("session", src)).toBe(0);
+			});
+
+		});
+
+	}
+
+	public void function $beginActionCacheProbe() {
+		_hadCacheActions = StructKeyExists(application.wheels, "cacheActions");
+		if (_hadCacheActions) {
+			_priorCacheActions = application.wheels.cacheActions;
+		}
+		application.wheels.cacheActions = true;
+		_originalForm = Duplicate(form);
+		StructClear(form);
+		g.$clearCache("action");
+	}
+
+	public void function $endActionCacheProbe() {
+		g.$clearCache("action");
+		StructClear(form);
+		StructAppend(form, _originalForm, false);
+		if (_hadCacheActions) {
+			application.wheels.cacheActions = _priorCacheActions;
+		} else {
+			StructDelete(application.wheels, "cacheActions");
+		}
+		StructDelete(request, "hardenerCachePayload");
+	}
+
+}

--- a/vendor/wheels/tests/specs/caching/CacheHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/caching/CacheHardenerSpec.cfc
@@ -292,7 +292,8 @@ component extends="wheels.WheelsTest" {
 				g.$addToCache(key = probeKey, value = "s5-body", time = 60, category = "main");
 				expect(g.$getFromCache(key = probeKey, category = "main")).toBe("s5-body");
 				g.$clearCache("main");
-				expect(g.$isCacheMiss(g.$getFromCache(key = probeKey, category = "main"))).toBeTrue();
+				g.$getFromCache(key = probeKey, category = "main");
+				expect(g.$isCacheMiss()).toBeTrue();
 			});
 
 		});
@@ -398,16 +399,29 @@ component extends="wheels.WheelsTest" {
 				g.$clearCache("main");
 			});
 
-			it("S9: a cached boolean false is distinguishable from a miss", function() {
+			it("S9: $addToCache(key, false) then $getFromCache returns false as a hit", function() {
 				g.$clearCache("main");
-				expect(g.$isCacheMiss(g.$getFromCache(key = "s9-missing", category = "main"))).toBeTrue();
+
+				var miss = g.$getFromCache(key = "s9-missing", category = "main");
+				expect(miss).toBeFalse();
+				expect(g.$isCacheMiss()).toBeTrue();
+				expect(StructKeyExists(application.wheels.cache.main, "s9-missing")).toBeFalse();
 
 				g.$addToCache(key = "s9-false", value = false, time = 60, category = "main");
 				var hit = g.$getFromCache(key = "s9-false", category = "main");
-				expect(g.$isCacheMiss(hit)).toBeFalse();
-				expect(IsStruct(hit)).toBeTrue();
-				expect(hit.$wheelsCacheHit).toBeTrue();
-				expect(hit.value).toBeFalse();
+				expect(hit).toBeFalse();
+				expect(g.$isCacheMiss()).toBeFalse();
+				expect(StructKeyExists(application.wheels.cache.main, "s9-false")).toBeTrue();
+			});
+
+			it("S9: other falsey stored payloads are hits, not misses", function() {
+				g.$clearCache("main");
+				g.$addToCache(key = "s9-zero", value = 0, time = 60, category = "main");
+				g.$addToCache(key = "s9-blank", value = "", time = 60, category = "main");
+				expect(g.$getFromCache(key = "s9-zero", category = "main")).toBe(0);
+				expect(g.$isCacheMiss()).toBeFalse();
+				expect(g.$getFromCache(key = "s9-blank", category = "main")).toBe("");
+				expect(g.$isCacheMiss()).toBeFalse();
 			});
 
 		});

--- a/vendor/wheels/tests/specs/caching/CacheHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/caching/CacheHardenerSpec.cfc
@@ -1,5 +1,5 @@
 /**
- * Hardener proofs for Cache BLOCKERs B1–B2 and SHOULDs S1–S8.
+ * Hardener proofs for Cache BLOCKERs B1–B2 and SHOULDs S1–S9.
  * Desk IDs are stable. Do not renumber.
  *
  * Directory-scoped so `wheels test --core --ci --filter=caching`
@@ -11,27 +11,15 @@ component extends="wheels.WheelsTest" {
 
 		g = application.wo
 
-		describe("CoS lock: cache public defaults stay conservative", function() {
-
-			it("keeps cacheActions/Pages/Partials/Images/Queries off in development only", function() {
-				var src = FileRead(ExpandPath("/wheels/events/init/caching.cfm"));
-				expect(FindNoCase("application.$wheels.cacheActions = false", src)).toBeGT(0);
-				expect(FindNoCase("application.$wheels.cacheImages = false", src)).toBeGT(0);
-				expect(FindNoCase("application.$wheels.cachePages = false", src)).toBeGT(0);
-				expect(FindNoCase("application.$wheels.cachePartials = false", src)).toBeGT(0);
-				expect(FindNoCase("application.$wheels.cacheQueries = false", src)).toBeGT(0);
-				expect(FindNoCase("if (application.$wheels.environment != ""development"")", src)).toBeGT(0);
-			});
+		describe("CoS lock: cacheFileChecking and named-action time/static", function() {
 
 			it("keeps cacheFileChecking true", function() {
 				var src = FileRead(ExpandPath("/wheels/events/init/caching.cfm"));
 				expect(FindNoCase("application.$wheels.cacheFileChecking = true", src)).toBeGT(0);
 			});
 
-			it("keeps caches() empty-action wildcard and time/static defaults", function() {
-				var cachesSrc = FileRead(ExpandPath("/wheels/controller/caching.cfc"));
+			it("keeps caches() time=60 and static=false defaults when an action is named", function() {
 				var fnSrc = FileRead(ExpandPath("/wheels/events/init/functions.cfm"));
-				expect(FindNoCase("arguments.action = ""*""", cachesSrc)).toBeGT(0);
 				expect(FindNoCase("functions.caches = {time = 60, static = false}", fnSrc)).toBeGT(0);
 			});
 
@@ -61,11 +49,12 @@ component extends="wheels.WheelsTest" {
 
 				var className = first.$getControllerClassData().name;
 				var params = {controller = "hardenerLifecycle", action = "cachedShow"};
-				var expectedKey = g.$hashedKey(className, params);
-				expect(StructKeyExists(application.wheels.cache.action, expectedKey)).toBeTrue(
-					"processAction must write the action body under $hashedKey(class, params)"
+				var hashedKey = g.$hashedKey(className, params);
+				var storeKey = g.$actionCacheKey(hashedKey);
+				expect(StructKeyExists(application.wheels.cache.action, storeKey)).toBeTrue(
+					"processAction must write the action body under the session-qualified store key"
 				);
-				expect(g.$getFromCache(key = expectedKey, category = "action")).toBe("b1-write");
+				expect(g.$getFromCache(key = hashedKey, category = "action")).toBe("b1-write");
 				expect(g.$cacheCount("action")).toBe(1);
 
 				request.hardenerCachePayload = "b1-should-not-run";
@@ -73,7 +62,7 @@ component extends="wheels.WheelsTest" {
 				expect(second.processAction()).toBeTrue();
 				expect(second.response()).toBe("b1-write");
 				expect(g.$cacheCount("action")).toBe(1);
-				expect(StructKeyExists(application.wheels.cache.action, expectedKey)).toBeTrue();
+				expect(StructKeyExists(application.wheels.cache.action, storeKey)).toBeTrue();
 			});
 
 		});
@@ -136,10 +125,12 @@ component extends="wheels.WheelsTest" {
 					"session": session,
 					"variables": {}
 				};
-				var expectedKey = first.$appendToCacheKey(
-					key = g.$hashedKey(className, params),
-					appendToKey = "request.cacheProbeA",
-					scopeMap = scopeMap
+				var expectedKey = g.$actionCacheKey(
+					first.$appendToCacheKey(
+						key = g.$hashedKey(className, params),
+						appendToKey = "request.cacheProbeA",
+						scopeMap = scopeMap
+					)
 				);
 				expect(StructKeyExists(application.wheels.cache.action, expectedKey)).toBeTrue(
 					"processAction must keep the first-match appendToKey on the cache key"
@@ -155,6 +146,83 @@ component extends="wheels.WheelsTest" {
 				var third = g.controller("hardenerLifecycle", {controller = "hardenerLifecycle", action = "cachedShow"});
 				third.processAction();
 				expect(third.response()).toBe("b2-miss");
+			});
+
+		});
+
+		describe("S1 caches() requires named actions", function() {
+
+			beforeEach(function() {
+				_controller = g.controller("dummy", {controller = "dummy", action = "dummy"});
+				_controller.$clearCachableActions();
+			});
+
+			it("S1: caches() with no action throws instead of silently becoming *", function() {
+				expect(function() {
+					_controller.caches();
+				}).toThrow("Wheels.InvalidArgument");
+			});
+
+			it("S1: caches(static=true) with no action throws", function() {
+				expect(function() {
+					_controller.caches(static = true);
+				}).toThrow("Wheels.InvalidArgument");
+			});
+
+			it("S1: an explicit * is still allowed when named", function() {
+				_controller.caches(action = "*");
+				expect(_controller.$cachableActions()[1].action).toBe("*");
+			});
+
+		});
+
+		describe("S2 testing stays cache-off like development", function() {
+
+			it("S2: only non-dev/non-test environments enable cacheActions/Pages/Partials/Images/Queries", function() {
+				var src = FileRead(ExpandPath("/wheels/events/init/caching.cfm"));
+				expect(FindNoCase("ListFindNoCase(""development,testing"", application.$wheels.environment)", src)).toBeGT(0);
+				expect(FindNoCase("if (application.$wheels.environment != ""development"")", src)).toBe(0);
+			});
+
+		});
+
+		describe("S3 action cache key includes session/user", function() {
+
+			beforeEach(function() {
+				$beginActionCacheProbe();
+				if (StructKeyExists(session, "user")) {
+					_priorSessionUser = Duplicate(session.user);
+				}
+				_controller = g.controller("hardenerLifecycle", {controller = "hardenerLifecycle", action = "cachedShow"});
+				_controller.$clearCachableActions();
+				_controller.flashClear();
+				_controller.caches(action = "cachedShow");
+			});
+
+			afterEach(function() {
+				_controller.$clearCachableActions();
+				if (StructKeyExists(variables, "_priorSessionUser")) {
+					session.user = _priorSessionUser;
+					StructDelete(variables, "_priorSessionUser");
+				} else {
+					StructDelete(session, "user");
+				}
+				$endActionCacheProbe();
+			});
+
+			it("S3: params-only pages do not leak one session's body to another", function() {
+				session.user = {id = "alice"};
+				request.hardenerCachePayload = "payload-alice";
+				var alice = g.controller("hardenerLifecycle", {controller = "hardenerLifecycle", action = "cachedShow"});
+				alice.processAction();
+				expect(alice.response()).toBe("payload-alice");
+
+				session.user = {id = "bob"};
+				request.hardenerCachePayload = "payload-bob";
+				var bob = g.controller("hardenerLifecycle", {controller = "hardenerLifecycle", action = "cachedShow"});
+				bob.processAction();
+				expect(bob.response()).toBe("payload-bob");
+				expect(g.$cacheCount("action")).toBe(2);
 			});
 
 		});
@@ -224,27 +292,122 @@ component extends="wheels.WheelsTest" {
 				g.$addToCache(key = probeKey, value = "s5-body", time = 60, category = "main");
 				expect(g.$getFromCache(key = probeKey, category = "main")).toBe("s5-body");
 				g.$clearCache("main");
-				expect(g.$getFromCache(key = probeKey, category = "main")).toBeFalse();
+				expect(g.$isCacheMiss(g.$getFromCache(key = probeKey, category = "main"))).toBeTrue();
 			});
 
 		});
 
-		describe("HELD: S7 $clearCache still wipes the bucket with StructClear", function() {
+		describe("S6 clearCachableActions drops this-controller action bodies", function() {
 
-			it("S7: $clearCache keeps StructClear (do not change wipe policy)", function() {
-				var src = FileRead(ExpandPath("/wheels/global/cache.cfm"));
-				expect(FindNoCase("StructClear(application.wheels.cache[arguments.category])", src)).toBeGT(0);
-				expect(FindNoCase("StructClear(application.wheels.cache)", src)).toBeGT(0);
+			beforeEach(function() {
+				$beginActionCacheProbe();
+				_controller = g.controller("hardenerLifecycle", {controller = "hardenerLifecycle", action = "cachedShow"});
+				_controller.$clearCachableActions();
+				_controller.flashClear();
+			});
+
+			afterEach(function() {
+				_controller.$clearCachableActions();
+				$endActionCacheProbe();
+			});
+
+			it("S6: clearCachableActions removes this controller's bodies and leaves others", function() {
+				_controller.caches(action = "cachedShow");
+				request.hardenerCachePayload = "s6-body";
+				var first = g.controller("hardenerLifecycle", {controller = "hardenerLifecycle", action = "cachedShow"});
+				first.processAction();
+				expect(g.$cacheCount("action")).toBeGT(0);
+
+				application.wheels.cache.action["other-controller-decoy"] = {
+					expiresAt = DateAdd("n", 30, Now()),
+					value = "keep-other"
+				};
+
+				_controller.clearCachableActions();
+				expect(StructKeyExists(application.wheels.cache.action, "other-controller-decoy")).toBeTrue();
+				expect(application.wheels.cache.action["other-controller-decoy"].value).toBe("keep-other");
+				expect(g.$cacheCount("action")).toBe(1);
 			});
 
 		});
 
-		describe("HELD: S3 action key does not fold in session by default", function() {
+		describe("S7 $clearCache is targeted", function() {
 
-			it("S3: $hashedKey still seeds only arguments plus cgi.http_host", function() {
+			beforeEach(function() {
+				_originalCache = Duplicate(application.wheels.cache);
+			});
+
+			afterEach(function() {
+				application.wheels.cache = _originalCache;
+			});
+
+			it("S7: no-arg $clearCache() clears each category and keeps the buckets", function() {
+				application.wheels.cache.main["s7-main"] = {expiresAt = DateAdd("n", 30, Now()), value = "m"};
+				application.wheels.cache.action["s7-action"] = {expiresAt = DateAdd("n", 30, Now()), value = "a"};
+				g.$clearCache();
+				expect(application.wheels.cache).toHaveKey("main");
+				expect(application.wheels.cache).toHaveKey("action");
+				expect(IsStruct(application.wheels.cache.main)).toBeTrue();
+				expect(IsStruct(application.wheels.cache.action)).toBeTrue();
+				expect(StructCount(application.wheels.cache.main)).toBe(0);
+				expect(StructCount(application.wheels.cache.action)).toBe(0);
+			});
+
+			it("S7: $clearCache no longer wipes the parent cache struct", function() {
 				var src = FileRead(ExpandPath("/wheels/global/cache.cfm"));
-				expect(FindNoCase("StructInsert(arguments, ListLen(StructKeyList(arguments)) + 1, cgi.http_host, true)", src)).toBeGT(0);
-				expect(FindNoCase("session", src)).toBe(0);
+				expect(ReFindNoCase("StructClear\s*\(\s*application\.wheels\.cache\s*\)", src)).toBe(0);
+			});
+
+		});
+
+		describe("S8 caches(Foo) matches action foo", function() {
+
+			beforeEach(function() {
+				$beginActionCacheProbe();
+				_controller = g.controller("hardenerLifecycle", {controller = "hardenerLifecycle", action = "cachedShow"});
+				_controller.$clearCachableActions();
+				_controller.flashClear();
+			});
+
+			afterEach(function() {
+				_controller.$clearCachableActions();
+				$endActionCacheProbe();
+			});
+
+			it("S8: $cacheSettingsForAction is case-insensitive", function() {
+				_controller.caches(action = "CachedShow", time = 15);
+				var settings = _controller.$cacheSettingsForAction("cachedShow");
+				expect(IsStruct(settings)).toBeTrue();
+				expect(settings.time).toBe(15);
+			});
+
+			it("S8: processAction caches CachedShow when the action is cachedShow", function() {
+				_controller.caches(action = "CachedShow");
+				request.hardenerCachePayload = "s8-body";
+				var first = g.controller("hardenerLifecycle", {controller = "hardenerLifecycle", action = "cachedShow"});
+				first.processAction();
+				expect(first.response()).toBe("s8-body");
+				expect(g.$cacheCount("action")).toBe(1);
+			});
+
+		});
+
+		describe("S9 stored false is not a miss", function() {
+
+			afterEach(function() {
+				g.$clearCache("main");
+			});
+
+			it("S9: a cached boolean false is distinguishable from a miss", function() {
+				g.$clearCache("main");
+				expect(g.$isCacheMiss(g.$getFromCache(key = "s9-missing", category = "main"))).toBeTrue();
+
+				g.$addToCache(key = "s9-false", value = false, time = 60, category = "main");
+				var hit = g.$getFromCache(key = "s9-false", category = "main");
+				expect(g.$isCacheMiss(hit)).toBeFalse();
+				expect(IsStruct(hit)).toBeTrue();
+				expect(hit.$wheelsCacheHit).toBeTrue();
+				expect(hit.value).toBeFalse();
 			});
 
 		});

--- a/vendor/wheels/tests/specs/controller/cachingSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/cachingSpec.cfc
@@ -109,10 +109,37 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("is specifying one action to cache and running it", () => {
-				_controller.caches(action = "test")
-				result = _controller.processAction("test", params)
+				var g = application.wo
+				var hadCacheActions = StructKeyExists(application.wheels, "cacheActions")
+				var priorCacheActions = hadCacheActions ? application.wheels.cacheActions : false
+				var originalForm = Duplicate(form)
+				try {
+					application.wheels.cacheActions = true
+					StructClear(form)
+					g.$clearCache("action")
+					_controller.flashClear()
+					_controller.caches(action = "test")
+					var expectedKey = g.$hashedKey(_controller.$getControllerClassData().name, params)
+					result = _controller.processAction()
 
-				expect(result).toBeTrue()
+					expect(result).toBeTrue()
+					expect(StructKeyExists(application.wheels.cache.action, expectedKey)).toBeTrue()
+					expect(Len(g.$getFromCache(key = expectedKey, category = "action"))).toBeGT(0)
+
+					application.wheels.cache.action[expectedKey].value = "b1-cache-hit-probe"
+					var second = g.controller("test", params)
+					second.processAction()
+					expect(second.response()).toBe("b1-cache-hit-probe")
+				} finally {
+					g.$clearCache("action")
+					StructClear(form)
+					StructAppend(form, originalForm, false)
+					if (hadCacheActions) {
+						application.wheels.cacheActions = priorCacheActions
+					} else {
+						StructDelete(application.wheels, "cacheActions")
+					}
+				}
 			})
 
 			it("is specifying multiple actions to cache", () => {

--- a/vendor/wheels/tests/specs/controller/cachingSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/cachingSpec.cfc
@@ -119,14 +119,15 @@ component extends="wheels.WheelsTest" {
 					g.$clearCache("action")
 					_controller.flashClear()
 					_controller.caches(action = "test")
-					var expectedKey = g.$hashedKey(_controller.$getControllerClassData().name, params)
+					var hashedKey = g.$hashedKey(_controller.$getControllerClassData().name, params)
+					var storeKey = g.$actionCacheKey(hashedKey)
 					result = _controller.processAction()
 
 					expect(result).toBeTrue()
-					expect(StructKeyExists(application.wheels.cache.action, expectedKey)).toBeTrue()
-					expect(Len(g.$getFromCache(key = expectedKey, category = "action"))).toBeGT(0)
+					expect(StructKeyExists(application.wheels.cache.action, storeKey)).toBeTrue()
+					expect(Len(g.$getFromCache(key = hashedKey, category = "action"))).toBeGT(0)
 
-					application.wheels.cache.action[expectedKey].value = "b1-cache-hit-probe"
+					application.wheels.cache.action[storeKey].value = "b1-cache-hit-probe"
 					var second = g.controller("test", params)
 					second.processAction()
 					expect(second.response()).toBe("b1-cache-hit-probe")
@@ -159,11 +160,17 @@ component extends="wheels.WheelsTest" {
 				expect(r[2].static).toBeTrue()
 			})
 
-			it("is specifying actions to cache with options", () => {
-				_controller.caches(static = true)
+			it("is specifying a named action to cache as static", () => {
+				_controller.caches(action = "dummy", static = true)
 				r = _controller.$cacheSettingsForAction("dummy")
 
 				expect(r.static).toBeTrue()
+			})
+
+			it("throws when caches() is called with no action", () => {
+				expect(() => {
+					_controller.caches(static = true)
+				}).toThrow("Wheels.InvalidArgument")
 			})
 		})
 

--- a/vendor/wheels/tests/specs/controller/cachingSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/cachingSpec.cfc
@@ -37,7 +37,18 @@ component extends="wheels.WheelsTest" {
 
 			it("is getting cache settings for action", () => {
 				_controller = application.wo.controller(name = "dummy")
+				_controller.$clearCachableActions()
 				_controller.caches(action = "dummy1", time = 100)
+				r = _controller.$cacheSettingsForAction("dummy1")
+
+				expect(r.time).toBe(100)
+			})
+
+			it("keeps first-match when two caches() rows name the same action", () => {
+				_controller = application.wo.controller(name = "dummy")
+				_controller.$clearCachableActions()
+				_controller.caches(action = "dummy1", time = 100)
+				_controller.caches(action = "dummy1", time = 5)
 				r = _controller.$cacheSettingsForAction("dummy1")
 
 				expect(r.time).toBe(100)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Cache hardener for BLOCKERs B1–B2 and SHOULDs S1–S9. Peter flipped S1/S2/S3/S6/S7/S8. S9 is in. Base is develop after #3412 (`26f71776568c1360b12b3025f96479abbb009f61`).

`cacheFileChecking` stays true. `caches()` still defaults `time=60` / `static=false` when an action is named.

## Scope

- `vendor/wheels/controller/caching.cfc` — B2 first-match + `appendToKey`; S1 named actions; S6 body drop; S8 `CompareNoCase`
- `vendor/wheels/events/init/caching.cfm` — S2 testing stays cache-off
- `vendor/wheels/global/cache.cfm` — S3 session/user action key; S5 store lock; S7 targeted `$clearCache()`; S9 stored false is a hit; S6 action key index
- `vendor/wheels/tests/specs/caching/CacheHardenerSpec.cfc` — Desk IDs B1–B2 / S1–S9
- `vendor/wheels/tests/specs/controller/cachingSpec.cfc` — B1 write/hit/key; S1 no-action throw; `$cacheSettingsForAction` clears leftover `dummy1` before `caches(time=100)` so first-match is not the earlier default `time=60` row

Out of scope: CLI, ManifestCache, model query/schema cache, Global leftover S4 (catch swallow).

## PROVEN

| ID | Status | One line |
|---|---|---|
| B1 | **PROVEN** | `cachingSpec` and CacheHardenerSpec observe write, hit, and the session-qualified store key, not only `processAction` toBeTrue |
| B2 | **PROVEN** | `$cacheSettingsForAction` first-matches like `processAction` and keeps `appendToKey`. Not an ESCALATE: public `caches()` runtime stays first-match. `cachingSpec` now clears before the time=100 lookup so leftover dummy1 does not win |
| S1 | **PROVEN** | `caches()` / `caches(static=true)` with no action throws `Wheels.InvalidArgument`. Explicit `caches(action="*")` still allowed |
| S2 | **PROVEN** | `cacheActions/Pages/Partials/Images/Queries` enable only when environment is not `development` or `testing` |
| S3 | **PROVEN** | `$actionCacheKey` folds `$sessionCacheIdentity()` (session.user.id / session.user / sessionid) so alice/bob params-only pages do not leak |
| S4 | **PROVEN** | `$addToCache` still silent-drops when full after cull. Cull/drop policy unchanged |
| S5 | **PROVEN** | `$addToCache` / `$getFromCache` / `$clearCache` take exclusive `wheelsCacheStore`. add/get/clear values unchanged |
| S6 | **PROVEN** | `clearCachableActions` drops this controller's action bodies via `cacheActionIndex`. A decoy key for another controller stays |
| S7 | **PROVEN** | no-arg `$clearCache()` clears each category in place and keeps the `main` / `action` buckets. Parent `StructClear(application.wheels.cache)` is gone |
| S8 | **PROVEN** | `caches("CachedShow")` matches action `cachedShow` in `$cacheSettingsForAction` and `processAction` |
| S9 | **PROVEN** | `$addToCache(key, false)` then `$getFromCache(key)` returns `false` as a hit. A miss is only absent / expired / culled. `$isCacheMiss()` reads the last lookup, not the value. Missing keys still return `false` |

## Tradeoffs

B2 aligns the test getter to `processAction` first-match. That is not a public last-wins flip.

S3 suffixes only `category=action` store keys. Page/partial/query `$hashedKey` consumers are unchanged.

S6 indexes keys at `$addToCache` when `variables.$class.name` is present. No full-bucket wipe of every controller.

S9 returns the stored payload, including `false`. Public miss for an absent key is still `false`. Distinguish with `$isCacheMiss()` (last lookup). `$doubleCheckedLock` still treats a boolean-false return as a miss, so a cached boolean false will re-execute on the DCL path.

## Blast Radius

Apps that called `caches()` with no action now get `Wheels.InvalidArgument`. Testing no longer enables action/page/partial/image/query caches at boot. Action cache entries are per session/user. `$clearCache()` no longer destroys category structs. Callers that stored boolean false and compared the get result with `false` must use `$isCacheMiss()` to tell a hit from a miss.

## Verification

```
wheels test --core --ci --filter=caching
Scope: wheels.tests.specs.caching
21 passed, 0 failed, 0 error, 0 skipped
```

```
wheels test --core --ci --filter=controller
Scope: wheels.tests.specs.controller
552 passed, 0 failed, 0 error, 0 skipped
```

LuCLI 32796766018 failed `cachingSpec` “is getting cache settings for action” (Expected [100] but received [60]) because leftover `dummy1` at default time=60 was first-match. That spec now calls `$clearCachableActions()` first. `$cacheSettingsForAction` stays first-match.

Lucee 7.0.0.395 / sqlite

## HEAD

`b9e209137815fd5a787ffdea6697b633ef35537c`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48b61f27-9a2f-41ab-98fa-9b9c03f919f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48b61f27-9a2f-41ab-98fa-9b9c03f919f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

