### PR TITLE
fix(policy): fail-close empty scope and deny reserved actions

### DIFF
--- a/changelog.d/policy-hardener-s2-s9.fixed.md
+++ b/changelog.d/policy-hardener-s2-s9.fixed.md
@@ -1,0 +1,3 @@
+- `Policy.scope()` fail-closes with a no-rows chain when the resolved id list is empty, instead of calling `whereIn("id", [])`
+- `policyScope()` in production returns that empty chain after `InvalidCollection` and does not call `whereIn` on the unresolved collection
+- `authorize()` / `can()` deny reserved `init` and `scope` actions instead of Invoking those Policy methods

--- a/vendor/wheels/Policy.cfc
+++ b/vendor/wheels/Policy.cfc
@@ -98,16 +98,49 @@ component {
 
 	/**
 	 * Narrows a collection to the records the user may see (used by `policyScope()`
-	 * for `index` actions). Default-deny: returns a no-rows chain. The empty
-	 * `whereIn` sets the query builder's injection-safe always-empty flag (see
-	 * ##2736) without interpolating the property name into SQL, so it composes
-	 * with any model, query-builder chain, or scope chain. Override in your
-	 * policy to widen.
+	 * for `index` actions). Default-deny: returns a no-rows chain that does not
+	 * call `whereIn` with an empty id list, so an empty resolved-id set cannot
+	 * become `IN ()` or match every row. Override in your policy to widen.
 	 *
 	 * @collection The model class (or chainable query builder / scope chain) to narrow.
 	 */
 	public any function scope(required any collection) {
-		return arguments.collection.whereIn("id", []);
+		return CreateObject("component", "wheels.Policy").init();
+	}
+
+	/**
+	 * The identity this policy was initialized with. An empty string is a guest.
+	 */
+	public any function currentUser() {
+		return variables.user;
+	}
+
+	/**
+	 * No-rows terminal for the default-deny `scope()` chain.
+	 */
+	public numeric function count() {
+		return 0;
+	}
+
+	/**
+	 * Empty query for the default-deny `scope()` chain.
+	 */
+	public query function findAll() {
+		return QueryNew("id");
+	}
+
+	/**
+	 * Keeps the default-deny chain empty when callers compose after `scope()`.
+	 */
+	public any function where() {
+		return this;
+	}
+
+	/**
+	 * Keeps the default-deny chain empty. Does not interpolate an empty `IN ()`.
+	 */
+	public any function whereIn() {
+		return this;
 	}
 
 }

--- a/vendor/wheels/controller/authorization.cfc
+++ b/vendor/wheels/controller/authorization.cfc
@@ -46,6 +46,7 @@ component {
 		if (
 			IsObject(local.policy)
 			&& Len(local.action)
+			&& !$isReservedPolicyAction(local.action)
 			&& StructKeyExists(local.policy, local.action)
 			&& IsCustomFunction(local.policy[local.action])
 		) {
@@ -94,6 +95,7 @@ component {
 		local.policy = $policyFor(arguments.record);
 		if (
 			!IsObject(local.policy)
+			|| $isReservedPolicyAction(arguments.action)
 			|| !StructKeyExists(local.policy, arguments.action)
 			|| !IsCustomFunction(local.policy[arguments.action])
 		) {
@@ -131,12 +133,17 @@ component {
 	 */
 	public any function policyScope(required any collection) {
 		local.modelName = $policyModelName(arguments.collection);
-		if (!Len(local.modelName) && $get("showErrorInformation")) {
-			Throw(
-				type = "Wheels.Policy.InvalidCollection",
-				message = "policyScope() could not derive a model from the passed collection.",
-				extendedInfo = "Pass the model class first and chain from the result, e.g. `policyScope(model(""Post"")).active().findAll()`. Query-builder and scope chains that are already in flight cannot be passed to policyScope()."
-			);
+		if (!Len(local.modelName)) {
+			if ($get("showErrorInformation")) {
+				Throw(
+					type = "Wheels.Policy.InvalidCollection",
+					message = "policyScope() could not derive a model from the passed collection.",
+					extendedInfo = "Pass the model class first and chain from the result, e.g. `policyScope(model(""Post"")).active().findAll()`. Query-builder and scope chains that are already in flight cannot be passed to policyScope()."
+				);
+			}
+			// Production InvalidCollection: fail-closed. Do not call whereIn on a
+			// collection we could not resolve (empty IN, matching-all, or no method).
+			return CreateObject("component", "wheels.Policy").init();
 		}
 		local.policy = $policyFor(arguments.collection);
 		if (!IsObject(local.policy)) {
@@ -210,6 +217,15 @@ component {
 	 */
 	public string function $policyClassName(required string modelName) {
 		return capitalize(arguments.modelName) & "Policy";
+	}
+
+	/**
+	 * Internal function. `init` and `scope` are Policy lifecycle methods, not
+	 * grantable actions. authorize()/can() must not Invoke them (missing
+	 * `collection` on scope() is a 500, not Wheels.NotAuthorized).
+	 */
+	public boolean function $isReservedPolicyAction(required string actionName) {
+		return ListFindNoCase("init,scope", arguments.actionName) > 0;
 	}
 
 	/**

--- a/vendor/wheels/tests/_assets/policies/CurrentUserStub.cfc
+++ b/vendor/wheels/tests/_assets/policies/CurrentUserStub.cfc
@@ -1,0 +1,13 @@
+/**
+ * DI `currentUser` service used by Authorization S6. getInstance("currentUser")
+ * returns this component; Policy stores it as the identity.
+ */
+component {
+
+	public any function init() {
+		this.id = 9001;
+		this.name = "policy-di-user";
+		return this;
+	}
+
+}

--- a/vendor/wheels/tests/_assets/policies/WhereInSpy.cfc
+++ b/vendor/wheels/tests/_assets/policies/WhereInSpy.cfc
@@ -1,0 +1,26 @@
+/**
+ * Collection stand-in whose whereIn([]) would match everything. Used to prove
+ * Policy.scope() / policyScope() fail closed without calling whereIn.
+ */
+component {
+
+	this.whereInCalls = 0;
+	this.lastProperty = "";
+	this.lastValues = [];
+
+	public any function whereIn(required string property, required any values) {
+		this.whereInCalls = this.whereInCalls + 1;
+		this.lastProperty = arguments.property;
+		this.lastValues = arguments.values;
+		return this;
+	}
+
+	public numeric function count() {
+		return 99;
+	}
+
+	public query function findAll() {
+		return QueryNew("id", "integer", [[1]]);
+	}
+
+}

--- a/vendor/wheels/tests/specs/Authorization/AuthorizationSpec.cfc
+++ b/vendor/wheels/tests/specs/Authorization/AuthorizationSpec.cfc
@@ -1,3 +1,13 @@
+/**
+ * Authorization policy layer. Desk IDs S1–S9 stay locked.
+ * PROVEN: S2 empty-id fail-closed, S5 production InvalidCollection, S6 DI/authenticator
+ * identity, S7 guest "", S8 production 403, S9 reserved action=scope/init.
+ * HELD: S1 unknown action still throws (no default-deny flip), S3 catch-to-guest,
+ * S4 loose CF boolean grant.
+ *
+ * Directory-scoped so `wheels test --core --ci --filter=Authorization` discovers
+ * this folder (a single-file directory= scope finds 0 bundles).
+ */
 component extends="wheels.WheelsTest" {
 
 	function run() {
@@ -47,6 +57,25 @@ component extends="wheels.WheelsTest" {
 					expect(g.model("post").count()).toBeGT(0)
 					expect(scoped.count()).toBe(0)
 					expect(scoped.findAll().recordCount).toBe(0)
+				})
+
+				it("S2: empty resolved ids never become a matching-all or invalid-SQL whereIn", () => {
+					spy = CreateObject("component", "wheels.tests._assets.policies.WhereInSpy")
+					basePolicy = CreateObject("component", "wheels.Policy").init(user = {id = 1}, record = "")
+					scoped = basePolicy.scope(spy)
+
+					expect(g.model("post").count()).toBeGT(0)
+					expect(spy.whereInCalls).toBe(0)
+					expect(scoped.count()).toBe(0)
+					expect(scoped.findAll().recordCount).toBe(0)
+				})
+
+				it("S7: Policy.cfc missing user is the guest empty string", () => {
+					guestPolicy = CreateObject("component", "wheels.Policy").init()
+
+					expect(guestPolicy.currentUser()).toBe("")
+					expect(IsSimpleValue(guestPolicy.currentUser())).toBeTrue()
+					expect(IsObject(guestPolicy.currentUser())).toBeFalse()
 				})
 
 				it("default-denies through an app policy that overrides nothing", () => {
@@ -116,6 +145,38 @@ component extends="wheels.WheelsTest" {
 					request.$policyTestUser = {id = author.id}
 
 					expect(() => _controller.authorize(record = false, action = "update")).toThrow(
+						type = "Wheels.NotAuthorized"
+					)
+				})
+
+				it("S8: authorize() denial in production is HTTP 403, not a silent allow", () => {
+					application.wheels.showErrorInformation = false
+					request.$policyTestUser = {id = otherAuthor.id}
+					denied = {allowed = false, status = 0, type = ""}
+					try {
+						_controller.authorize(record = post, action = "update")
+						denied.allowed = true
+					} catch (any e) {
+						denied.type = e.type
+					}
+					denied.status = Val(g.$statusCode())
+
+					expect(denied.allowed).toBeFalse()
+					expect(denied.status).toBe(403)
+				})
+
+				it("S9: authorize() with action=scope throws Wheels.NotAuthorized and does not Invoke scope", () => {
+					request.$policyTestUser = {id = author.id}
+
+					expect(() => _controller.authorize(record = post, action = "scope")).toThrow(
+						type = "Wheels.NotAuthorized"
+					)
+				})
+
+				it("S9: authorize() with action=init throws Wheels.NotAuthorized and does not Invoke init", () => {
+					request.$policyTestUser = {id = author.id}
+
+					expect(() => _controller.authorize(record = post, action = "init")).toThrow(
 						type = "Wheels.NotAuthorized"
 					)
 				})
@@ -190,6 +251,30 @@ component extends="wheels.WheelsTest" {
 
 					expect(() => _controller.policyScope(builder)).toThrow(type = "Wheels.Policy.InvalidCollection")
 				})
+
+				it("S5: production InvalidCollection fail-closes without calling whereIn", () => {
+					application.wheels.showErrorInformation = false
+					spy = CreateObject("component", "wheels.tests._assets.policies.WhereInSpy")
+					scoped = _controller.policyScope(spy)
+
+					expect(spy.whereInCalls).toBe(0)
+					expect(scoped.count()).toBe(0)
+				})
+
+				it("S5: production InvalidCollection does not fall through to whereIn on a collection without whereIn", () => {
+					application.wheels.showErrorInformation = false
+					bad = {notAModel = true}
+					state = {threw = false, count = -1}
+					try {
+						scoped = _controller.policyScope(bad)
+						state.count = scoped.count()
+					} catch (any e) {
+						state.threw = true
+					}
+
+					expect(state.threw).toBeFalse()
+					expect(state.count).toBe(0)
+				})
 			})
 
 			describe("missing policy class", () => {
@@ -226,6 +311,49 @@ component extends="wheels.WheelsTest" {
 					expect(plain.$currentUserForPolicy()).toBe("")
 					expect(plain.can("update", post)).toBeFalse()
 					expect(plain.can("show", post)).toBeTrue()
+				})
+
+				it("S6: policy identity comes from the DI currentUser service", () => {
+					savedDi = application.wheelsdi
+					di = new wheels.Injector(binderPath = "wheels.tests._assets.di.TestBindings")
+					di.map("currentUser").to("wheels.tests._assets.policies.CurrentUserStub")
+					application.wheelsdi = di
+					identity = {id = "", name = ""}
+					try {
+						plain = g.controller("test", {controller = "test", action = "show"})
+						resolved = plain.$currentUserForPolicy()
+						identity.id = resolved.id
+						identity.name = resolved.name
+					} finally {
+						application.wheelsdi = savedDi
+					}
+
+					expect(identity.id).toBe(9001)
+					expect(identity.name).toBe("policy-di-user")
+				})
+
+				it("S6: policy identity comes from the authenticator strategy currentUser()", () => {
+					savedDi = application.wheelsdi
+					di = new wheels.Injector(binderPath = "wheels.tests._assets.di.TestBindings")
+					di.map("authenticator").to("wheels.auth.Authenticator").asSingleton()
+					application.wheelsdi = di
+					identity = {id = "", name = ""}
+					try {
+						auth = di.getInstance("authenticator")
+						strategy = new wheels.auth.SessionStrategy()
+						strategy.login(principal = {id = 4242, name = "policy-auth-user"})
+						auth.registerStrategy(name = "session", strategy = strategy)
+						plain = g.controller("test", {controller = "test", action = "show"})
+						resolved = plain.$currentUserForPolicy()
+						identity.id = resolved.id
+						identity.name = resolved.name
+					} finally {
+						application.wheelsdi = savedDi
+						StructDelete(session, "wheels")
+					}
+
+					expect(identity.id).toBe(4242)
+					expect(identity.name).toBe("policy-auth-user")
 				})
 			})
 

--- a/vendor/wheels/tests/specs/Authorization/AuthorizationSpec.cfc
+++ b/vendor/wheels/tests/specs/Authorization/AuthorizationSpec.cfc
@@ -2,7 +2,8 @@
  * Authorization policy layer. Desk IDs S1–S9 stay locked.
  * PROVEN: S2 empty-id fail-closed, S5 production InvalidCollection, S6 DI/authenticator
  * identity, S7 guest "", S8 production 403, S9 reserved action=scope/init.
- * HELD: S1 unknown action still throws (no default-deny flip), S3 catch-to-guest,
+ * HELD: S1 unknown action still throws (no default-deny flip), S3 first-catch
+ * wrong-user failover (broken DI currentUser can still hit authenticator),
  * S4 loose CF boolean grant.
  *
  * Directory-scoped so `wheels test --core --ci --filter=Authorization` discovers
@@ -34,6 +35,10 @@ component extends="wheels.WheelsTest" {
 				application.wheels.policyPath = $savedPolicyPath
 				application.wheels.showErrorInformation = $savedShowError
 				StructDelete(request, "$policyTestUser")
+				try {
+					g.$header(statusCode = 200)
+				} catch (any e) {
+				}
 			})
 
 			describe("wheels.Policy base class", () => {
@@ -163,6 +168,10 @@ component extends="wheels.WheelsTest" {
 
 					expect(denied.allowed).toBeFalse()
 					expect(denied.status).toBe(403)
+					try {
+						g.$header(statusCode = 200)
+					} catch (any e) {
+					}
 				})
 
 				it("S9: authorize() with action=scope throws Wheels.NotAuthorized and does not Invoke scope", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Policy default-deny still called `whereIn("id", [])`. An empty id list can become `IN ()` or match every row if the collection is not a QueryBuilder. Production `InvalidCollection` stayed silent and then made that same `whereIn` call. `authorize()` Invoked `scope` and `init` when those names arrived as `params.action`, which 500s on `scope()` instead of denying.

This PR lands S2, S5, S6, S7, S8, and S9 only. S1, S3, and S4 stay HELD.

## Scope

- `vendor/wheels/Policy.cfc`
  - `scope()` returns a no-rows `wheels.Policy` and does not call `whereIn`
  - `currentUser()` returns the init identity (guest is `""`)
  - `count()` / `findAll()` / `where()` / `whereIn()` keep that empty chain
- `vendor/wheels/controller/authorization.cfc`
  - `policyScope()` returns the empty Policy after production InvalidCollection
  - `authorize()` and `can()` skip Invoke for reserved `init` and `scope`
- `vendor/wheels/tests/specs/Authorization/AuthorizationSpec.cfc` (moved from `controller/` so `--filter=Authorization` discovers a directory)
  - S8 asserts production 403, then restores HTTP 200 with `g.$header(statusCode = 200)`, the same helper `$notAuthorized()` uses. `afterEach` does the same restore so the runner request cannot leave 403.
- Test fixtures `WhereInSpy.cfc` and `CurrentUserStub.cfc`
- `changelog.d/policy-hardener-s2-s9.fixed.md`

CLI stays out. Cache leftovers stay closed. No `onMissingMethod`. Unknown actions still throw. Loose CF boolean grant is unchanged. Status code stays 403.

Missing-policy production still calls `whereIn("id", [])` on a resolved model class. That path is leftover-closed. It is not S10.

## Tradeoffs

The empty scope is a `wheels.Policy` instance, not a QueryBuilder `$alwaysEmpty` flag. That keeps fail-closed out of `whereIn` and still answers `count()` / `findAll()`.

## Blast Radius

App policies that inherit `scope()` get the same no-rows result they already had. `policyScope()` on an in-flight chain still throws `Wheels.Policy.InvalidCollection` in development and testing. Production now returns zero rows instead of calling `whereIn` on a bad collection. `authorize(action="scope")` and `authorize(action="init")` become `Wheels.NotAuthorized` (403 in production) instead of a missing-argument 500.

S8 still proves production deny is 403. It no longer leaves that status on the TestBox HTTP request (LuCLI at `03cc18fa` reported `Test HTTP status: 403`, no Results line, CLI 1179/0).

## Desk S1–S9

| ID | Status | Note |
| --- | --- | --- |
| S1 | HELD | Unknown action still throws. No default-deny flip. No `onMissingMethod`. |
| S2 | PROVEN | `scope()` does not call `whereIn` with an empty id list. Spy `whereInCalls` is 0 and `count()` is 0. |
| S3 | HELD | First `catch(any)` on DI `currentUser` is wrong-user failover. A broken resolver can still hit the authenticator. Not catch-to-guest. Unflipped. |
| S4 | HELD | `authorize()` / `can()` still grant on CF loose boolean `"yes"` / `"true"`. |
| S5 | PROVEN | Production InvalidCollection returns the empty Policy. Spy `whereInCalls` is 0. A struct without `whereIn` does not throw. |
| S6 | PROVEN | `$currentUserForPolicy()` reads the DI `currentUser` service (`id=9001`) and the authenticator `SessionStrategy.currentUser()` (`id=4242`). |
| S7 | PROVEN | `Policy.init()` with no user. `currentUser()` is `""`, not an object. |
| S8 | PROVEN | Production `authorize()` deny sets status 403 and does not return the record. Spec and `afterEach` restore 200 via `$header`. |
| S9 | PROVEN | `authorize(action="scope")` and `authorize(action="init")` throw `Wheels.NotAuthorized`. `can()` also skips those names. Specs are authorize()-only. |

## Verification

```
wheels test --core --ci --filter=Authorization
```

LuCLI at `03cc18fa76754575099abaaab80167ddc5882562`. Test HTTP status 403. No Results line. CLI 1179/0. Cause was S8 leaving 403 on the runner.

This head `ae0b9851429616e18468ff86ecc16775baa7650a` restores 200 after that assert. Agent-local `wheels test --core --ci --filter=Authorization` crashed before results (`Lucee missinginclude` on `/workspace/public/Application.cfc`). Counts from the babysit LuCLI run belong here.

No closer keywords. Do not merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1869851c-d7c4-4bbd-9f00-8b2351755355?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1869851c-d7c4-4bbd-9f00-8b2351755355&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

