### PR TITLE
test(storage): pin S1-S8 contracts without flipping defaults

### DIFF
--- a/changelog.d/storage-hardener-s1-s8.changed.md
+++ b/changelog.d/storage-hardener-s1-s8.changed.md
@@ -1,0 +1,2 @@
+- `S3Signer.signedHeaders()` accepts an optional `range` argument so the official AWS GET Object header-auth vector can be pinned. The no-range canonical request is unchanged
+- LocalDisk `$resolve` and S3Disk `$request` are public so tests can call and override them. `S3Disk.delete()` still returns true after any 2xx

--- a/vendor/wheels/storage/S3Signer.cfc
+++ b/vendor/wheels/storage/S3Signer.cfc
@@ -119,13 +119,15 @@ component output="false" {
 	 * @key Object key.
 	 * @payload Request body (binary or string); empty for GET/DELETE/HEAD.
 	 * @amzDate Optional deterministic timestamp override.
+	 * @range Optional Range header value (e.g. "bytes=0-9"). Empty keeps the current signed header set.
 	 * @return Struct of header name => value to attach to the request.
 	 */
 	public struct function signedHeaders(
 		required string method,
 		required string key,
 		any payload = "",
-		string amzDate = ""
+		string amzDate = "",
+		string range = ""
 	) {
 		local.amzDate = Len(arguments.amzDate) ? arguments.amzDate : $amzNow();
 		local.dateStamp = Left(local.amzDate, 8);
@@ -143,6 +145,16 @@ component output="false" {
 			& "x-amz-date:" & local.amzDate & Chr(10);
 		local.signedHeaderList = "host;x-amz-content-sha256;x-amz-date";
 
+		if (Len(arguments.range)) {
+			// Official AWS GET Object header-auth vector includes Range; insert
+			// in sort order without changing the empty-range canonical request.
+			local.canonicalHeaders = "host:" & variables.host & Chr(10)
+				& "range:" & arguments.range & Chr(10)
+				& "x-amz-content-sha256:" & local.payloadHash & Chr(10)
+				& "x-amz-date:" & local.amzDate & Chr(10);
+			local.signedHeaderList = "host;range;x-amz-content-sha256;x-amz-date";
+		}
+
 		local.canonicalRequest = UCase(arguments.method) & Chr(10)
 			& local.canonicalUri & Chr(10)
 			& "" & Chr(10)
@@ -157,6 +169,15 @@ component output="false" {
 			& "SignedHeaders=" & local.signedHeaderList & ", "
 			& "Signature=" & local.signature;
 
+		if (Len(arguments.range)) {
+			return {
+				"Authorization" = local.authorization,
+				"x-amz-content-sha256" = local.payloadHash,
+				"x-amz-date" = local.amzDate,
+				"Host" = variables.host,
+				"Range" = arguments.range
+			};
+		}
 		return {
 			"Authorization" = local.authorization,
 			"x-amz-content-sha256" = local.payloadHash,

--- a/vendor/wheels/storage/S3Signer.cfc
+++ b/vendor/wheels/storage/S3Signer.cfc
@@ -146,8 +146,6 @@ component output="false" {
 		local.signedHeaderList = "host;x-amz-content-sha256;x-amz-date";
 
 		if (Len(arguments.range)) {
-			// Official AWS GET Object header-auth vector includes Range; insert
-			// in sort order without changing the empty-range canonical request.
 			local.canonicalHeaders = "host:" & variables.host & Chr(10)
 				& "range:" & arguments.range & Chr(10)
 				& "x-amz-content-sha256:" & local.payloadHash & Chr(10)

--- a/vendor/wheels/storage/drivers/LocalDisk.cfc
+++ b/vendor/wheels/storage/drivers/LocalDisk.cfc
@@ -148,7 +148,7 @@ component implements="wheels.interfaces.StorageDiskInterface" output="false" {
 		return local.diff == 0;
 	}
 
-	private string function $resolve(required string key) {
+	public string function $resolve(required string key) {
 		// Reject traversal — a key must stay inside root.
 		local.clean = Replace(arguments.key, "\", "/", "all");
 		if (Find("..", local.clean)) {

--- a/vendor/wheels/storage/drivers/S3Disk.cfc
+++ b/vendor/wheels/storage/drivers/S3Disk.cfc
@@ -140,7 +140,7 @@ component implements="wheels.interfaces.StorageDiskInterface" output="false" {
 	 * before being attached one-by-one — never `attributeCollection=arguments`,
 	 * which Adobe CF 2023/2025 reject on built-in tags.
 	 */
-	private struct function $request(
+	public struct function $request(
 		required string method,
 		required string key,
 		required struct headers,

--- a/vendor/wheels/tests/_assets/storage/S3DiskDeleteStub.cfc
+++ b/vendor/wheels/tests/_assets/storage/S3DiskDeleteStub.cfc
@@ -1,0 +1,14 @@
+component extends="wheels.storage.drivers.S3Disk" {
+
+	public struct function $request(
+		required string method,
+		required string key,
+		required struct headers,
+		any body = "",
+		string contentType = "",
+		boolean getAsBinary = false
+	) {
+		return {statusCode = "204 No Content", fileContent = ""};
+	}
+
+}

--- a/vendor/wheels/tests/specs/storage/StorageSpec.cfc
+++ b/vendor/wheels/tests/specs/storage/StorageSpec.cfc
@@ -70,6 +70,33 @@ component extends="wheels.WheelsTest" {
 					expect(headers.Authorization).toInclude("Signature=");
 				});
 
+				it("reproduces the AWS-documented SigV4 GET Object header-auth test vector", function() {
+					// Official example from AWS "Authenticating Requests: Using the
+					// Authorization Header (AWS Signature Version 4)". Same credentials
+					// and timestamp as the presigned-GET vector; Range is part of the
+					// published canonical request.
+					var signer = new wheels.storage.S3Signer(
+						accessKeyId = "AKIAIOSFODNN7EXAMPLE",
+						secretAccessKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+						region = "us-east-1",
+						bucket = "examplebucket",
+						endpoint = "examplebucket.s3.amazonaws.com"
+					);
+					var headers = signer.signedHeaders(
+						method = "GET",
+						key = "test.txt",
+						payload = "",
+						amzDate = "20130524T000000Z",
+						range = "bytes=0-9"
+					);
+
+					expect(headers["x-amz-content-sha256"]).toBe(
+						"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+					);
+					expect(headers.Authorization).toInclude("SignedHeaders=host;range;x-amz-content-sha256;x-amz-date");
+					expect(headers.Authorization).toInclude("Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41");
+				});
+
 			});
 
 			// ---- LocalDisk --------------------------------------------------
@@ -118,6 +145,47 @@ component extends="wheels.WheelsTest" {
 					expect(function() {
 						disk.put(key = "../escape.txt", content = "x");
 					}).toThrow("Wheels.Storage.InvalidKey");
+				});
+
+				it("resolves empty and slash-only keys as root concatenations, not InvalidKey", function() {
+					var expectedRoot = REReplace(Replace(ctx.root, "\", "/", "all"), "/+$", "");
+					expect(disk.$resolve("")).toBe(expectedRoot & "/");
+					expect(disk.$resolve("/")).toBe(expectedRoot & "//");
+					expect(disk.$resolve("///")).toBe(expectedRoot & "////");
+
+					expect(function() {
+						disk.get("");
+					}).toThrow("Wheels.Storage.NotFound");
+					expect(function() {
+						disk.get("/");
+					}).toThrow("Wheels.Storage.NotFound");
+					expect(function() {
+						disk.get("///");
+					}).toThrow("Wheels.Storage.NotFound");
+				});
+
+				it("follows a symlink under root to a file outside (Find('..') does not see the hop)", function() {
+					// DirectoryDelete follows symlinks, so the link must be removed
+					// before afterEach wipes the root. Find("..") does not see this hop.
+					var outside = GetTempDirectory() & "wheels-storage-outside-" & CreateUUID();
+					var linkPath = ctx.root & "/link";
+					DirectoryCreate(outside);
+					if (!DirectoryExists(ctx.root)) {
+						DirectoryCreate(ctx.root);
+					}
+					FileWrite(outside & "/secret.txt", CharsetDecode("outside-secret", "utf-8"));
+					$createSymlink(outside, linkPath);
+					try {
+						expect(function() {
+							disk.exists("link/secret.txt");
+						}).notToThrow(type = "Wheels.Storage.InvalidKey");
+						expect(ToString(disk.get("link/secret.txt"))).toBe("outside-secret");
+					} finally {
+						$deleteSymlink(linkPath);
+						if (DirectoryExists(outside)) {
+							DirectoryDelete(outside, true);
+						}
+					}
 				});
 
 				it("builds a public url from the urlPrefix", function() {
@@ -172,6 +240,11 @@ component extends="wheels.WheelsTest" {
 					expect(function() {
 						unsigned.signedUrl(key = "a.png");
 					}).toThrow("Wheels.Storage.MissingSigningKey");
+				});
+
+				it("verifySignature returns false when no signingKey is configured", function() {
+					var unsigned = new wheels.storage.drivers.LocalDisk(config = {root = ctx.root, urlPrefix = "/u"});
+					expect(unsigned.verifySignature(key = "a.png", expires = 4102444800, signature = "deadbeef")).toBeFalse();
 				});
 
 				it("requires a non-empty root", function() {
@@ -271,6 +344,21 @@ component extends="wheels.WheelsTest" {
 
 			});
 
+			describe("S3Disk delete()", function() {
+
+				it("returns true after a 2xx, including a second delete of the same missing key", function() {
+					var stubDisk = new wheels.tests._assets.storage.S3DiskDeleteStub(config = {
+						bucket = "myapp",
+						region = "us-east-1",
+						accessKeyId = "AKIAIOSFODNN7EXAMPLE",
+						secretAccessKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+					});
+					expect(stubDisk.delete("gone.txt")).toBeTrue();
+					expect(stubDisk.delete("gone.txt")).toBeTrue();
+				});
+
+			});
+
 			// ---- StorageManager ---------------------------------------------
 
 			describe("StorageManager", function() {
@@ -330,6 +418,29 @@ component extends="wheels.WheelsTest" {
 
 		});
 
+	}
+
+	function $toPath(required string filePath) {
+		return CreateObject("java", "java.io.File").init(arguments.filePath).toPath();
+	}
+
+	function $createSymlink(required string target, required string link) {
+		$deleteSymlink(arguments.link);
+		var pb = CreateObject("java", "java.lang.ProcessBuilder")
+			.init(["ln", "-s", arguments.target, arguments.link]);
+		var proc = pb.start();
+		proc.waitFor();
+		if (proc.exitValue() != 0) {
+			throw(type = "Wheels.Test.SymlinkError", message = "Failed to create symlink: #arguments.link# -> #arguments.target#");
+		}
+	}
+
+	function $deleteSymlink(required string link) {
+		var jFiles = CreateObject("java", "java.nio.file.Files");
+		var linkPath = $toPath(arguments.link);
+		if (jFiles.isSymbolicLink(linkPath)) {
+			jFiles.delete(linkPath);
+		}
 	}
 
 }

--- a/vendor/wheels/tests/specs/storage/StorageSpec.cfc
+++ b/vendor/wheels/tests/specs/storage/StorageSpec.cfc
@@ -71,10 +71,6 @@ component extends="wheels.WheelsTest" {
 				});
 
 				it("reproduces the AWS-documented SigV4 GET Object header-auth test vector", function() {
-					// Official example from AWS "Authenticating Requests: Using the
-					// Authorization Header (AWS Signature Version 4)". Same credentials
-					// and timestamp as the presigned-GET vector; Range is part of the
-					// published canonical request.
 					var signer = new wheels.storage.S3Signer(
 						accessKeyId = "AKIAIOSFODNN7EXAMPLE",
 						secretAccessKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -165,8 +161,6 @@ component extends="wheels.WheelsTest" {
 				});
 
 				it("follows a symlink under root to a file outside (Find('..') does not see the hop)", function() {
-					// DirectoryDelete follows symlinks, so the link must be removed
-					// before afterEach wipes the root. Find("..") does not see this hop.
 					var outside = GetTempDirectory() & "wheels-storage-outside-" & CreateUUID();
 					var linkPath = ctx.root & "/link";
 					DirectoryCreate(outside);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

LocalDisk `$resolve`, LocalDisk `verifySignature`, S3Disk `delete()`, and S3Signer `signedHeaders()` already had these contracts. The spec did not pin them. A later canonicalize, HEAD-then-false delete, or unsigned header-auth rewrite would merge without a failing test.

This PR proves S1 (current root behavior), S2, S4 (idempotent-true), S7, and S8. Holds stay unflipped. No public default changes.

## Scope

In:

- `vendor/wheels/storage/S3Signer.cfc` — optional `range` on `signedHeaders()`. Empty range keeps today's canonical request.
- `vendor/wheels/storage/drivers/LocalDisk.cfc` — `$resolve` is public. `Find("..")` and concat are unchanged.
- `vendor/wheels/storage/drivers/S3Disk.cfc` — `$request` is public. `delete()` still returns true after `$assertSuccess`.
- `vendor/wheels/tests/specs/storage/StorageSpec.cfc` — S1, S2, S4, S7, S8 `it()` blocks.
- `vendor/wheels/tests/_assets/storage/S3DiskDeleteStub.cfc` — 204 stub for the S4 contract.
- `changelog.d/storage-hardener-s1-s8.changed.md`

Out: empty or slash-key throw, `url()` / `signedUrl()` key encoding, HEAD-then-false delete, S3 ACL headers, `expiresIn` clamp or throw. Policy leftovers stay closed.

## Tradeoffs

The official AWS GET Object header-auth vector signs `Range: bytes=0-9`. `signedHeaders()` takes an optional `range` so the published signature can be pinned. Callers that omit it keep the current three-header set.

S2 is a fixture, not a canonicalize. The spec shows that `Find("..")` does not reject a symlink hop under root. The resolver is unchanged. Not an ESCALATE.

## Blast Radius

Existing `signedHeaders(method, key, payload)` callers are unchanged. LocalDisk still rejects `".."` by substring and concatenates onto root. S3 `delete()` still returns true after any 2xx, including a missing key. Apps that already call `$resolve` or `$request` see the same logic with public visibility.

## Desk S1–S8

| ID | Status | One line |
| --- | --- | --- |
| S1 | PROVEN (current root only) | `$resolve("", "/", "///")` is `root/`, `root//`, `root////`. `get()` throws `NotFound`, not `InvalidKey`. |
| S1 throw | HELD | Empty or slash-only keys still do not throw. |
| S2 | PROVEN | Symlink-under-root fixture. `exists("link/secret.txt")` is not `InvalidKey`. `get()` reads the outside canary. Resolver unchanged. |
| S3 encode | HELD | `url()` / `signedUrl()` key encoding unflipped. |
| S4 | PROVEN | Stubbed 204. `delete("gone.txt")` is true twice. No HEAD-then-false. |
| S4 HEAD-then-false | HELD | Missing objects still return true after 2xx. |
| S5 | HELD | S3 ACL unflipped. |
| S6 | HELD | `expiresIn` clamp or throw unflipped. |
| S7 | PROVEN | `verifySignature` with no `signingKey` returns false. `signedUrl` throw is the existing spec. |
| S8 | PROVEN | Official AWS GET Object header-auth vector. `Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41`. |

## Verification

Command actually run:

```
wheels test --core --ci --filter=storage
```

Scope: `wheels.tests.specs.storage`

```
bundlesDiscovered=1
32 passed, 0 failed, 0 error, 0 skipped
Lucee 7.0.0.395 / sqlite
directoryRejected=false
```

The same filter after moving the delete stub out of `specs/storage/` stayed at 32 passed and dropped the empty extra bundle. The comment-only follow-up stayed at 32 passed.

Adobe and BoxLang were not run here.

## HEAD

`8191659e500e093c49336cb9a16e351235317334`

Base tip: `3bb4bcd3be7592e8fc04fc5c90964c7d72e2091f`

No closer keywords. Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c677b55-5a56-4a75-bb78-5134b9f0bf67?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c677b55-5a56-4a75-bb78-5134b9f0bf67&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

