### PR TITLE
fix(di): flip injector hardener S2 S3 S7

### DIFF
--- a/changelog.d/injector-hardener-s2-s3-s7.changed.md
+++ b/changelog.d/injector-hardener-s2-s3-s7.changed.md
@@ -1,0 +1,3 @@
+- Injector rebind of an existing name resets singleton and request-scoped flags and drops `request.$wheelsDICache`
+- `asSingleton()` / `asRequestScoped()` throw `Wheels.Injector` when no mapping is in progress. `map(b).asSingleton().to(...)` flags `b`, not the previous key
+- `getMappings()` returns a `Duplicate` copy. Mutating the return value does not change later `getMappings()` or the live mappings table

--- a/vendor/wheels/Injector.cfc
+++ b/vendor/wheels/Injector.cfc
@@ -72,6 +72,16 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 	 * @name The alias name for this mapping (e.g. "global", "Plugins")
 	 */
 	public Injector function map(required string name) {
+		// S2: remapping an existing name starts a new lifecycle. Reset
+		// singleton / request flags here (not in to()) so
+		// map(b).asSingleton().to(...) can flag b after the reset.
+		// First bind of a new name is not a rebind — leave request cache
+		// and any unrelated flags alone.
+		if (structKeyExists(variables.mappings, arguments.name)) {
+			structDelete(variables.singletonFlags, arguments.name);
+			structDelete(variables.requestScopedFlags, arguments.name);
+			structDelete(request, "$wheelsDICache");
+		}
 		variables.currentMapping = arguments.name;
 		return this;
 	}
@@ -113,24 +123,22 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 	}
 
 	/**
-	 * Mark the most recently completed mapping as a singleton.
-	 * When getInstance() is called for a singleton, the instance is cached.
+	 * Mark the in-progress mapping (map then asSingleton then to) or the
+	 * most recently completed mapping as a singleton. Throws Wheels.Injector
+	 * when neither currentMapping nor lastMappedName is set.
 	 */
 	public Injector function asSingleton() {
-		if (len(variables.lastMappedName)) {
-			variables.singletonFlags[variables.lastMappedName] = true;
-		}
+		variables.singletonFlags[$scopeTarget("asSingleton")] = true;
 		return this;
 	}
 
 	/**
-	 * Mark the most recently completed mapping as request-scoped.
-	 * When getInstance() is called, the instance is cached per-request in request.$wheelsDICache.
+	 * Mark the in-progress mapping (map then asRequestScoped then to) or
+	 * the most recently completed mapping as request-scoped. Throws
+	 * Wheels.Injector when neither currentMapping nor lastMappedName is set.
 	 */
 	public Injector function asRequestScoped() {
-		if (len(variables.lastMappedName)) {
-			variables.requestScopedFlags[variables.lastMappedName] = true;
-		}
+		variables.requestScopedFlags[$scopeTarget("asRequestScoped")] = true;
 		return this;
 	}
 
@@ -287,7 +295,9 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 	 * Return all registered mappings (name → componentPath).
 	 */
 	public struct function getMappings() {
-		return variables.mappings;
+		// S7: callers get a Duplicate copy. Mutating the return value
+		// must not change later getMappings() or the live mappings table.
+		return Duplicate(variables.mappings);
 	}
 
 	/**
@@ -353,6 +363,25 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 			return variables.mappings[arguments.name];
 		}
 		return arguments.name;
+	}
+
+	/**
+	 * Name that asSingleton() / asRequestScoped() should flag.
+	 * Prefers the in-progress map() name so map(b).asSingleton().to(...)
+	 * binds b, not the previous lastMappedName. Empty both sides is
+	 * Wheels.Injector — same type as to() without map().
+	 */
+	private string function $scopeTarget(required string methodName) {
+		if (len(variables.currentMapping)) {
+			return variables.currentMapping;
+		}
+		if (len(variables.lastMappedName)) {
+			return variables.lastMappedName;
+		}
+		throw(
+			type = "Wheels.Injector",
+			message = "#arguments.methodName#() called without a preceding map() or to() call."
+		);
 	}
 
 	/**

--- a/vendor/wheels/tests/specs/injector/InjectorHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/injector/InjectorHardenerSpec.cfc
@@ -1,8 +1,8 @@
 /**
  * Hardener proofs for Injector desk IDs S1–S10. Desk IDs stay locked.
  *
- * HOLD (pin current behavior, no production flip): S2, S3, S7.
- * PROVE: S1, S4, S5, S6, S8, S9, S10. S4 stays dotted-path fallback.
+ * Flipped: S2 rebind reset, S3 fail-loud / flag the new key, S7 Duplicate copy.
+ * Unchanged on develop: S1, S4, S5, S6, S8, S9, S10. S4 stays dotted-path fallback.
  *
  * Directory-scoped so `wheels test --core --ci --filter=injector` discovers
  * this folder (a single-file directory= scope finds 0 bundles).
@@ -38,81 +38,172 @@ component extends="wheels.WheelsTest" {
 
 			});
 
-			describe("S2 HOLD rebind keeps flags and request cache", () => {
+			describe("S2 rebind resets flags and drops request cache", () => {
 
-				it("S2 HOLD: rebind overwrites the path but keeps the singleton flag", () => {
+				it("S2: rebind overwrites the path and resets the singleton flag", () => {
 					di.map("rebind").to("wheels.tests._assets.di.SimpleService").asSingleton();
 					expect(di.isSingleton("rebind")).toBeTrue();
 					di.map("rebind").to("wheels.tests._assets.di.OptionalDependentService");
 					expect(di.getMappings()["rebind"]).toBe("wheels.tests._assets.di.OptionalDependentService");
-					expect(di.isSingleton("rebind")).toBeTrue();
+					expect(di.isSingleton("rebind")).toBeFalse();
+					expect(di.isRequestScoped("rebind")).toBeFalse();
+					var after = di.getInstance("rebind");
+					expect(after.hasDependency()).toBeFalse();
 				});
 
-				it("S2 HOLD: rebind keeps the request-scoped flag and does not drop request.$wheelsDICache", () => {
+				it("S2: rebind resets the request-scoped flag and drops request.$wheelsDICache", () => {
 					di.map("rebindReq").to("wheels.tests._assets.di.SimpleService").asRequestScoped();
 					structDelete(request, "$wheelsDICache");
 					var first = di.getInstance("rebindReq");
 					first.setMarker("cached");
 					expect(structKeyExists(request, "$wheelsDICache")).toBeTrue();
-					di.map("rebindReq").to("wheels.tests._assets.di.OptionalDependentService");
-					expect(di.isRequestScoped("rebindReq")).toBeTrue();
-					expect(di.getMappings()["rebindReq"]).toBe("wheels.tests._assets.di.OptionalDependentService");
-					expect(structKeyExists(request, "$wheelsDICache")).toBeTrue();
 					expect(structKeyExists(request["$wheelsDICache"], "rebindReq")).toBeTrue();
-					expect(request["$wheelsDICache"]["rebindReq"].getMarker()).toBe("cached");
+					di.map("rebindReq").to("wheels.tests._assets.di.OptionalDependentService");
+					expect(di.isRequestScoped("rebindReq")).toBeFalse();
+					expect(di.isSingleton("rebindReq")).toBeFalse();
+					expect(di.getMappings()["rebindReq"]).toBe("wheels.tests._assets.di.OptionalDependentService");
+					expect(structKeyExists(request, "$wheelsDICache")).toBeFalse();
 				});
 
-				it("S2 HOLD: singleton rebind never structDeletes request.$wheelsDICache", () => {
+				it("S2: singleton rebind structDeletes request.$wheelsDICache including unrelated keys", () => {
 					request["$wheelsDICache"] = {sentinel = true};
 					di.map("rebindSolo").to("wheels.tests._assets.di.SimpleService").asSingleton();
-					di.getInstance("rebindSolo");
-					di.map("rebindSolo").to("wheels.tests._assets.di.OptionalDependentService");
 					expect(structKeyExists(request, "$wheelsDICache")).toBeTrue();
 					expect(request["$wheelsDICache"].sentinel).toBeTrue();
+					di.getInstance("rebindSolo");
+					di.map("rebindSolo").to("wheels.tests._assets.di.OptionalDependentService");
+					expect(structKeyExists(request, "$wheelsDICache")).toBeFalse();
+					expect(di.isSingleton("rebindSolo")).toBeFalse();
+				});
+
+				it("S2: first bind of a new name does not drop request.$wheelsDICache", () => {
+					request["$wheelsDICache"] = {sentinel = true};
+					di.map("firstBind").to("wheels.tests._assets.di.SimpleService");
+					expect(structKeyExists(request, "$wheelsDICache")).toBeTrue();
+					expect(request["$wheelsDICache"].sentinel).toBeTrue();
+					expect(di.isSingleton("firstBind")).toBeFalse();
+				});
+
+				it("S2: rebind of one name does not reset an unrelated mapping's flags", () => {
+					di.map("keepSolo").to("wheels.tests._assets.di.SimpleService").asSingleton();
+					di.map("keepReq").to("wheels.tests._assets.di.SimpleService").asRequestScoped();
+					di.map("rebindOther").to("wheels.tests._assets.di.SimpleService").asSingleton();
+					expect(di.isSingleton("keepSolo")).toBeTrue();
+					expect(di.isRequestScoped("keepReq")).toBeTrue();
+					di.map("rebindOther").to("wheels.tests._assets.di.OptionalDependentService");
+					expect(di.isSingleton("rebindOther")).toBeFalse();
+					expect(di.isSingleton("keepSolo")).toBeTrue();
+					expect(di.isRequestScoped("keepReq")).toBeTrue();
+					expect(di.isSingleton("keepReq")).toBeFalse();
+				});
+
+				it("S2: same-path rebind still resets flags until asSingleton is called again", () => {
+					di.map("samePath").to("wheels.tests._assets.di.SimpleService").asSingleton();
+					var before = di.getInstance("samePath");
+					before.setMarker("stable");
+					di.map("samePath").to("wheels.tests._assets.di.SimpleService");
+					expect(di.isSingleton("samePath")).toBeFalse();
+					var mid = di.getInstance("samePath");
+					expect(mid.getMarker()).toBe("");
+					di.map("samePath").to("wheels.tests._assets.di.SimpleService").asSingleton();
+					expect(di.isSingleton("samePath")).toBeTrue();
 				});
 
 			});
 
-			describe("S3 HOLD lastMappedName empty no-op and previous-key flag", () => {
+			describe("S3 asSingleton / asRequestScoped fail loud and flag the new key", () => {
 
-				it("S3 HOLD: asSingleton is a silent no-op when lastMappedName is empty", () => {
-					di.asSingleton();
+				it("S3: asSingleton throws Wheels.Injector when lastMappedName is empty", () => {
+					var state = {type = ""};
+					try {
+						di.asSingleton();
+					} catch (any e) {
+						state.type = e.type;
+					}
+					expect(state.type).toBe("Wheels.Injector");
 					expect(di.isSingleton("anything")).toBeFalse();
 					expect(structCount(di.getMappings())).toBe(0);
 				});
 
-				it("S3 HOLD: asRequestScoped is a silent no-op when lastMappedName is empty", () => {
-					di.asRequestScoped();
+				it("S3: asRequestScoped throws Wheels.Injector when lastMappedName is empty", () => {
+					var state = {type = ""};
+					try {
+						di.asRequestScoped();
+					} catch (any e) {
+						state.type = e.type;
+					}
+					expect(state.type).toBe("Wheels.Injector");
 					expect(di.isRequestScoped("anything")).toBeFalse();
+					expect(structCount(di.getMappings())).toBe(0);
 				});
 
-				it("S3 HOLD: asSingleton after map() but before to() does not flag the in-progress name", () => {
+				it("S3: empty lastMappedName throw type matches to() without map()", () => {
+					var stateBare = {type = ""};
+					try {
+						di.to("wheels.tests._assets.di.SimpleService");
+					} catch (any e) {
+						stateBare.type = e.type;
+					}
+					var stateSolo = {type = ""};
+					try {
+						di.asSingleton();
+					} catch (any e) {
+						stateSolo.type = e.type;
+					}
+					var stateReq = {type = ""};
+					try {
+						di.asRequestScoped();
+					} catch (any e) {
+						stateReq.type = e.type;
+					}
+					expect(stateBare.type).toBe("Wheels.Injector");
+					expect(stateSolo.type).toBe("Wheels.Injector");
+					expect(stateReq.type).toBe("Wheels.Injector");
+					expect(stateSolo.type).toBe(stateBare.type);
+					expect(stateReq.type).toBe(stateBare.type);
+				});
+
+				it("S3: asSingleton after map() but before to() flags the in-progress name", () => {
 					di.map("incomplete");
 					di.asSingleton();
-					expect(di.isSingleton("incomplete")).toBeFalse();
+					expect(di.isSingleton("incomplete")).toBeTrue();
 					di.to("wheels.tests._assets.di.SimpleService");
 					expect(di.containsInstance("incomplete")).toBeTrue();
-					expect(di.isSingleton("incomplete")).toBeFalse();
+					expect(di.isSingleton("incomplete")).toBeTrue();
+					var first = di.getInstance("incomplete");
+					first.setMarker("incomplete");
+					expect(di.getInstance("incomplete").getMarker()).toBe("incomplete");
 				});
 
-				it("S3 HOLD: map(b).asSingleton().to(...) flags the previous key, not b", () => {
+				it("S3: map(b).asSingleton().to(...) flags b, not the previous key", () => {
 					di.map("previous").to("wheels.tests._assets.di.SimpleService");
 					di.map("b").asSingleton().to("wheels.tests._assets.di.SimpleService");
-					expect(di.isSingleton("previous")).toBeTrue();
-					expect(di.isSingleton("b")).toBeFalse();
+					expect(di.isSingleton("previous")).toBeFalse();
+					expect(di.isSingleton("b")).toBeTrue();
 					var prev = di.getInstance("previous");
 					prev.setMarker("prev");
-					expect(di.getInstance("previous").getMarker()).toBe("prev");
+					expect(di.getInstance("previous").getMarker()).toBe("");
 					var bee = di.getInstance("b");
 					bee.setMarker("bee");
-					expect(di.getInstance("b").getMarker()).toBe("");
+					expect(di.getInstance("b").getMarker()).toBe("bee");
 				});
 
-				it("S3 HOLD: map(b).asRequestScoped().to(...) flags the previous key, not b", () => {
+				it("S3: map(b).asRequestScoped().to(...) flags b, not the previous key", () => {
 					di.map("previousReq").to("wheels.tests._assets.di.SimpleService");
 					di.map("bReq").asRequestScoped().to("wheels.tests._assets.di.SimpleService");
-					expect(di.isRequestScoped("previousReq")).toBeTrue();
-					expect(di.isRequestScoped("bReq")).toBeFalse();
+					expect(di.isRequestScoped("previousReq")).toBeFalse();
+					expect(di.isRequestScoped("bReq")).toBeTrue();
+					expect(di.isSingleton("previousReq")).toBeFalse();
+					expect(di.isSingleton("bReq")).toBeFalse();
+				});
+
+				it("S3: map(b).asSingleton().to(...) on a fresh injector flags b when lastMappedName is empty", () => {
+					di.map("bFresh").asSingleton().to("wheels.tests._assets.di.SimpleService");
+					expect(di.isSingleton("bFresh")).toBeTrue();
+					expect(di.isRequestScoped("bFresh")).toBeFalse();
+					var first = di.getInstance("bFresh");
+					first.setMarker("fresh");
+					expect(di.getInstance("bFresh").getMarker()).toBe("fresh");
 				});
 
 			});
@@ -209,21 +300,35 @@ component extends="wheels.WheelsTest" {
 
 			});
 
-			describe("S7 HOLD getMappings returns the live struct", () => {
+			describe("S7 getMappings returns a Duplicate copy", () => {
 
-				it("S7 HOLD: mutating the struct returned by getMappings() mutates the container", () => {
+				it("S7: mutating the struct returned by getMappings() does not mutate the container", () => {
 					di.map("live").to("wheels.tests._assets.di.SimpleService");
 					var mappings = di.getMappings();
-					mappings["injectedByTest"] = "should-mutate-live";
-					expect(di.containsInstance("injectedByTest")).toBeTrue();
-					expect(di.getMappings()["injectedByTest"]).toBe("should-mutate-live");
+					mappings["injectedByTest"] = "should-not-mutate-live";
+					expect(di.containsInstance("injectedByTest")).toBeFalse();
+					expect(structKeyExists(di.getMappings(), "injectedByTest")).toBeFalse();
+					expect(di.getMappings()["live"]).toBe("wheels.tests._assets.di.SimpleService");
 				});
 
-				it("S7 HOLD: a later map().to() is visible on a previously returned getMappings() struct", () => {
+				it("S7: a later map().to() is not visible on a previously returned getMappings() struct", () => {
 					var mappings = di.getMappings();
+					expect(structCount(mappings)).toBe(0);
 					di.map("later").to("wheels.tests._assets.di.SimpleService");
-					expect(structKeyExists(mappings, "later")).toBeTrue();
-					expect(mappings["later"]).toBe("wheels.tests._assets.di.SimpleService");
+					expect(structKeyExists(mappings, "later")).toBeFalse();
+					expect(structCount(mappings)).toBe(0);
+					expect(di.containsInstance("later")).toBeTrue();
+					expect(di.getMappings()["later"]).toBe("wheels.tests._assets.di.SimpleService");
+				});
+
+				it("S7: deleting or overwriting a key on the copy leaves the live mapping", () => {
+					di.map("keep").to("wheels.tests._assets.di.SimpleService");
+					var mappings = di.getMappings();
+					mappings["keep"] = "overwritten-on-copy";
+					structDelete(mappings, "keep");
+					expect(di.containsInstance("keep")).toBeTrue();
+					expect(di.getMappings()["keep"]).toBe("wheels.tests._assets.di.SimpleService");
+					expect(structKeyExists(mappings, "keep")).toBeFalse();
 				});
 
 			});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Peter flipped injector HOLDs S2, S3, and S7. Rebind kept stale singleton/request flags and `request.$wheelsDICache`. `asSingleton` / `asRequestScoped` were silent no-ops when `lastMappedName` was empty, and `map(b).asSingleton().to(...)` flagged the previous key. `getMappings()` returned the live internal struct.

This PR flips those three contracts in `Injector.cfc` and updates the HOLD-pin specs so they assert the new behavior.

Desk IDs stay S1–S10. S1/S4/S5/S6/S8/S9/S10 stay as already proven on develop. S4 stays dotted-path fallback.

## Scope

- `vendor/wheels/Injector.cfc` — production flips
- `vendor/wheels/tests/specs/injector/InjectorHardenerSpec.cfc` — HOLD pins become the new contract
- `changelog.d/injector-hardener-s2-s3-s7.changed.md`

Out: CLI Application.cfc injector, SQL-injection specs, docs/blog, `inject()` in controller/services.cfc, `$snapshotBindings`/`$restoreBindings`, `application.wheelsdi` self-register.

## Exception types

Reuse `Wheels.Injector` (same type as `to()` without `map()`, and as S9 empty `map("")` then `to()`).

- `asSingleton()` with no in-progress `map()` and no completed `to()` throws `Wheels.Injector`
- `asRequestScoped()` under the same empty state throws `Wheels.Injector`

No new type.

## Tradeoffs

Rebind reset lives in `map()`, not `to()`. That lets `map(b).asSingleton().to(...)` flag `b` after the reset. Resetting in `to()` would wipe the flag that `asSingleton` just set.

`getMappings()` now returns `Duplicate(variables.mappings)`. Callers that mutated the old live struct to register aliases will no longer change the container.

Dropping `request.$wheelsDICache` on rebind is the whole request cache, not one key. That is what the old HOLD pin asserted we never did.

## Desk S1–S10

| ID | Status | Note |
| --- | --- | --- |
| S1 | PROVEN | Already on develop. Two transient `getInstance` calls of the same mapping get distinct instances. Unchanged. |
| S2 | PROVEN flipped | Rebind resets singleton and request-scoped flags and drops `request.$wheelsDICache`. First bind of a new name does not drop the cache. Unrelated flags stay. |
| S3 | PROVEN flipped | `asSingleton` / `asRequestScoped` throw `Wheels.Injector` when `lastMappedName` and `currentMapping` are empty. `map(b).asSingleton().to(...)` flags `b`, not the previous key. |
| S4 | PROVEN | Already on develop. Unmapped `getInstance` is dotted-path fallback. Unchanged. |
| S5 | PROVEN | Already on develop. Circular-recovery catch asserts `Wheels.DI.CircularDependency`. Unchanged. |
| S6 | PROVEN | Already on develop. Resolve-all skips missing keys. Unchanged. |
| S7 | PROVEN flipped | `getMappings()` returns a `Duplicate` copy. Mutating it, or mapping later, does not change later `getMappings()` or `containsInstance`. |
| S8 | PROVEN | Already on develop. `onDIcomplete` once per constructed instance. Unchanged. |
| S9 | PROVEN | Already on develop. Empty `map("")` then `to()` throws `Wheels.Injector`. Unchanged. |
| S10 | PROVEN | Already on develop. Both flags set, singleton wins. Unchanged. |

## Verification

Command actually run:

```
wheels test --core --ci --filter=injector
```

```
Running core tests (sqlite)...
Scope: wheels.tests.specs.injector
30 passed (0.15s)
```

JSON from the same filter (`directory=wheels.tests.specs.injector`):

```
totalPass=30
totalFail=0
totalError=0
totalSkipped=0
totalSpecs=30
bundlesDiscovered=1
directoryRejected=false
directoryResolved=wheels.tests.specs.injector
```

Also ran, not the driver:

```
wheels test --core --ci --filter=di
39 passed (0.13s)
```

```
totalPass=39
totalFail=0
totalError=0
totalSkipped=0
totalSpecs=39
bundlesDiscovered=2
directoryRejected=false
directoryResolved=wheels.tests.specs.di
```

Wheels CLI 4.0.6. Lucee 7.0.0.395. sqlite.

Adobe and BoxLang were not run here.

HEAD `a28a2814e982a3997eba0bf0b9343a69fcfb14e0`

Base `32aa26747e29b884a9970f77c100cd06b0055905` (develop after injector hardener prove).

Do not merge. Hive off merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f3294c4-0338-4c6f-a797-ad8a60b12a0f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f3294c4-0338-4c6f-a797-ad8a60b12a0f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

