### PR TITLE
test(seeder): prove seeder hardener S1–S10

### DIFF
--- a/vendor/wheels/tests/_assets/seeder/includethrow/seeds.cfm
+++ b/vendor/wheels/tests/_assets/seeder/includethrow/seeds.cfm
@@ -1,0 +1,9 @@
+<!--- S7: first entry would persist if the include-throw catch did not roll back. --->
+<cfscript>
+seedOnce(
+	modelName = "author",
+	uniqueProperties = "firstName",
+	properties = {firstName: "SeederThrowOK99", lastName: "ThrowOK"}
+);
+throw(type = "SeederIncludeBoom", message = "intentional include throw");
+</cfscript>

--- a/vendor/wheels/tests/_assets/seeder/seeds.cfm
+++ b/vendor/wheels/tests/_assets/seeder/seeds.cfm
@@ -1,5 +1,8 @@
-<!--- Test seed file for seederSpec --->
+<!--- S1: main seeds.cfm must actually create a record so runSeeds() is not a no-op. --->
 <cfscript>
-// This seed file is used by the test suite.
-// It intentionally does nothing — tests that need seeded records use seedOnce() directly.
+seedOnce(
+	modelName = "author",
+	uniqueProperties = "firstName",
+	properties = {firstName: "SeederMainOK99", lastName: "MainSeed"}
+);
 </cfscript>

--- a/vendor/wheels/tests/_assets/seeder/stray/seeds/orphaned.cfm
+++ b/vendor/wheels/tests/_assets/seeder/stray/seeds/orphaned.cfm
@@ -1,0 +1,8 @@
+<!--- S3: stray seeds/*.cfm that hasSeedFiles() sees but runSeeds() never includes. --->
+<cfscript>
+seedOnce(
+	modelName = "author",
+	uniqueProperties = "firstName",
+	properties = {firstName: "SeederStrayOrphan99", lastName: "StrayOrphan"}
+);
+</cfscript>

--- a/vendor/wheels/tests/_assets/seeder/withenv/seeds.cfm
+++ b/vendor/wheels/tests/_assets/seeder/withenv/seeds.cfm
@@ -1,4 +1,8 @@
-<!--- Test seed file for seederSpec (withenv) --->
+<!--- S2: main seeds run before the environment-specific include. --->
 <cfscript>
-// Main seeds - runs before environment-specific seeds
+seedOnce(
+	modelName = "author",
+	uniqueProperties = "firstName",
+	properties = {firstName: "SeederEnvMain99", lastName: "EnvMain"}
+);
 </cfscript>

--- a/vendor/wheels/tests/_assets/seeder/withenv/seeds/testing.cfm
+++ b/vendor/wheels/tests/_assets/seeder/withenv/seeds/testing.cfm
@@ -1,4 +1,8 @@
-<!--- Test seed file for testing environment --->
+<!--- S2: environment-specific include — only when environment=testing. --->
 <cfscript>
-// Testing environment seeds - runs after main seeds.cfm
+seedOnce(
+	modelName = "author",
+	uniqueProperties = "firstName",
+	properties = {firstName: "SeederEnvTest99", lastName: "EnvTest"}
+);
 </cfscript>

--- a/vendor/wheels/tests/specs/seederSpec.cfc
+++ b/vendor/wheels/tests/specs/seederSpec.cfc
@@ -1,3 +1,12 @@
+/**
+ * Seeder suite plus hardener proofs for desk IDs S1–S10. Desk IDs stay locked.
+ *
+ * HOLD (pin unflipped, current behavior only):
+ *   S4 — seedOnce interpolates unique values into WHERE (quote-escape only).
+ *   S5 — generateSeeds is not transactional (a mixed list can leave rows).
+ *
+ * This is the only seeder spec file. Do not invent wheels.tests.specs.seeder.
+ */
 component extends="wheels.WheelsTest" {
 
 	function beforeAll() {
@@ -12,8 +21,10 @@ component extends="wheels.WheelsTest" {
 
 			describe("init()", () => {
 
-				it("initializes with default seed path", () => {
+				it("S9: default seedPath is ExpandPath of /app/db/", () => {
 					local.s = CreateObject("component", "wheels.Seeder").init();
+					expect(local.s.seedMappingPath).toBe("/app/db/");
+					expect(local.s.seedPath).toBe(ExpandPath("/app/db/"));
 					expect(local.s.seedPath).toInclude("app");
 				});
 
@@ -39,6 +50,21 @@ component extends="wheels.WheelsTest" {
 					expect(local.s.hasSeedFiles()).toBeFalse();
 				});
 
+				it("S3: hasSeedFiles is true for a stray seeds/*.cfm that runSeeds will not include", () => {
+					// hasSeedFiles() returns true if ANY seeds/*.cfm exists.
+					// runSeeds() only includes seeds.cfm + seeds/<environment>.cfm.
+					local.s = CreateObject("component", "wheels.Seeder").init(
+						seedPath = "/wheels/tests/_assets/seeder/stray/"
+					);
+					expect(local.s.hasSeedFiles()).toBeTrue();
+
+					$deleteAuthorByFirstName("SeederStrayOrphan99");
+					local.result = local.s.runSeeds(environment = "testing");
+					expect(local.result.success).toBeFalse();
+					expect(local.result.message).toInclude("No seed files found");
+					expect(IsObject(model("author").findOne(where = "firstName = 'SeederStrayOrphan99'"))).toBeFalse();
+				});
+
 			});
 
 			describe("runSeeds()", () => {
@@ -52,21 +78,60 @@ component extends="wheels.WheelsTest" {
 					expect(local.result.message).toInclude("No seed files found");
 				});
 
-				it("runs main seeds.cfm file", () => {
+				it("S1: runs main seeds.cfm and creates the fixture record", () => {
+					$deleteAuthorByFirstName("SeederMainOK99");
+
 					local.s = CreateObject("component", "wheels.Seeder").init(
 						seedPath = "/wheels/tests/_assets/seeder/"
 					);
 					local.result = local.s.runSeeds(environment = "testing");
+
 					expect(local.result.success).toBeTrue();
-					expect(local.result.totalCreated).toBeGTE(0);
+					expect(local.result.totalCreated).toBe(1);
+					expect(local.result.totalSkipped).toBe(0);
+					local.created = model("author").findOne(where = "firstName = 'SeederMainOK99'");
+					expect(IsObject(local.created)).toBeTrue();
+					expect(local.created.lastName).toBe("MainSeed");
+					local.created.delete();
 				});
 
-				it("includes environment-specific seeds when available", () => {
+				it("S2: includes environment-specific seeds when available", () => {
+					$deleteAuthorByFirstName("SeederEnvMain99");
+					$deleteAuthorByFirstName("SeederEnvTest99");
+
 					local.s = CreateObject("component", "wheels.Seeder").init(
 						seedPath = "/wheels/tests/_assets/seeder/withenv/"
 					);
 					local.result = local.s.runSeeds(environment = "testing");
+
 					expect(local.result.success).toBeTrue();
+					expect(local.result.totalCreated).toBe(2);
+					expect(local.result.environment).toBe("testing");
+					local.mainRow = model("author").findOne(where = "firstName = 'SeederEnvMain99'");
+					local.envRow = model("author").findOne(where = "firstName = 'SeederEnvTest99'");
+					expect(IsObject(local.mainRow)).toBeTrue();
+					expect(IsObject(local.envRow)).toBeTrue();
+					expect(local.mainRow.lastName).toBe("EnvMain");
+					expect(local.envRow.lastName).toBe("EnvTest");
+					local.mainRow.delete();
+					local.envRow.delete();
+				});
+
+				it("S2: an environment without a matching file does not include seeds/testing.cfm", () => {
+					$deleteAuthorByFirstName("SeederEnvMain99");
+					$deleteAuthorByFirstName("SeederEnvTest99");
+
+					local.s = CreateObject("component", "wheels.Seeder").init(
+						seedPath = "/wheels/tests/_assets/seeder/withenv/"
+					);
+					local.result = local.s.runSeeds(environment = "development");
+
+					expect(local.result.success).toBeTrue();
+					expect(local.result.totalCreated).toBe(1);
+					expect(local.result.environment).toBe("development");
+					expect(IsObject(model("author").findOne(where = "firstName = 'SeederEnvMain99'"))).toBeTrue();
+					expect(IsObject(model("author").findOne(where = "firstName = 'SeederEnvTest99'"))).toBeFalse();
+					$deleteAuthorByFirstName("SeederEnvMain99");
 				});
 
 				it("returns failure and rolls back when a seedOnce entry fails validation", () => {
@@ -91,6 +156,75 @@ component extends="wheels.WheelsTest" {
 					// not look like fully-applied ones).
 					local.leaked = model("user").findOne(where = "username = 'SeederPartialOK99'");
 					expect(IsObject(local.leaked)).toBeFalse();
+				});
+
+				it("S7: include-throw is caught, reported, and rolled back", () => {
+					$deleteAuthorByFirstName("SeederThrowOK99");
+
+					local.s = CreateObject("component", "wheels.Seeder").init(
+						seedPath = "/wheels/tests/_assets/seeder/includethrow/"
+					);
+					local.result = local.s.runSeeds(environment = "testing");
+
+					expect(local.result.success).toBeFalse();
+					expect(local.result.message).toInclude("Seed failed:");
+					expect(local.result.message).toInclude("intentional include throw");
+					expect(StructKeyExists(local.result, "detail")).toBeTrue();
+					expect(IsObject(model("author").findOne(where = "firstName = 'SeederThrowOK99'"))).toBeFalse();
+				});
+
+				it("S8: request.$wheelsSeeder is left set after a successful run", () => {
+					$deleteAuthorByFirstName("SeederMainOK99");
+					StructDelete(request, "$wheelsSeeder");
+
+					local.s = CreateObject("component", "wheels.Seeder").init(
+						seedPath = "/wheels/tests/_assets/seeder/"
+					);
+					local.result = local.s.runSeeds(environment = "testing");
+
+					expect(local.result.success).toBeTrue();
+					expect(StructKeyExists(request, "$wheelsSeeder")).toBeTrue();
+					expect(request.$wheelsSeeder.seedMappingPath).toBe("/wheels/tests/_assets/seeder/");
+					$deleteAuthorByFirstName("SeederMainOK99");
+				});
+
+				it("S8: a later run still sees request.$wheelsSeeder", () => {
+					$deleteAuthorByFirstName("SeederMainOK99");
+					$deleteAuthorByFirstName("SeederEnvMain99");
+					$deleteAuthorByFirstName("SeederEnvTest99");
+					StructDelete(request, "$wheelsSeeder");
+
+					local.first = CreateObject("component", "wheels.Seeder").init(
+						seedPath = "/wheels/tests/_assets/seeder/"
+					);
+					local.first.runSeeds(environment = "testing");
+					expect(StructKeyExists(request, "$wheelsSeeder")).toBeTrue();
+
+					local.second = CreateObject("component", "wheels.Seeder").init(
+						seedPath = "/wheels/tests/_assets/seeder/withenv/"
+					);
+					local.second.runSeeds(environment = "testing");
+
+					// Never cleared — a later run overwrites the leftover, it does not delete it.
+					expect(StructKeyExists(request, "$wheelsSeeder")).toBeTrue();
+					expect(request.$wheelsSeeder.seedMappingPath).toBe("/wheels/tests/_assets/seeder/withenv/");
+					$deleteAuthorByFirstName("SeederMainOK99");
+					$deleteAuthorByFirstName("SeederEnvMain99");
+					$deleteAuthorByFirstName("SeederEnvTest99");
+				});
+
+				it("S8: the include-throw catch path also leaves request.$wheelsSeeder set", () => {
+					$deleteAuthorByFirstName("SeederThrowOK99");
+					StructDelete(request, "$wheelsSeeder");
+
+					local.s = CreateObject("component", "wheels.Seeder").init(
+						seedPath = "/wheels/tests/_assets/seeder/includethrow/"
+					);
+					local.result = local.s.runSeeds(environment = "testing");
+
+					expect(local.result.success).toBeFalse();
+					expect(StructKeyExists(request, "$wheelsSeeder")).toBeTrue();
+					expect(request.$wheelsSeeder.seedMappingPath).toBe("/wheels/tests/_assets/seeder/includethrow/");
 				});
 
 				it("throws when the environment name contains path traversal characters", () => {
@@ -171,6 +305,32 @@ component extends="wheels.WheelsTest" {
 
 					// Clean up
 					local.author.delete();
+				});
+
+				it("S4 HOLD: unique values are interpolated into WHERE with quote-escape only", () => {
+					// HOLD pin: seedOnce builds `prop = 'escaped'` via Replace(val, "'", "''").
+					// Do not flip to parameterized WHERE. Apostrophes must still round-trip
+					// through that interpolation so findOne can skip a matching row.
+					local.uniqueFirst = "O'Brien_#Replace(CreateUUID(), '-', '', 'all')#";
+					local.escapedFirst = Replace(local.uniqueFirst, "'", "''", "all");
+
+					local.first = seeder.seedOnce(
+						modelName = "author",
+						uniqueProperties = "firstName",
+						properties = {firstName: local.uniqueFirst, lastName: "QuoteEscape"}
+					);
+					expect(local.first.action).toBe("created");
+
+					local.second = seeder.seedOnce(
+						modelName = "author",
+						uniqueProperties = "firstName",
+						properties = {firstName: local.uniqueFirst, lastName: "QuoteEscape"}
+					);
+					expect(local.second.action).toBe("skipped");
+
+					local.record = model("author").findOne(where = "firstName = '#local.escapedFirst#'");
+					expect(IsObject(local.record)).toBeTrue();
+					local.record.delete();
 				});
 
 				it("counts failed entries and reports them in the result", () => {
@@ -283,6 +443,78 @@ component extends="wheels.WheelsTest" {
 					expect(StructKeyExists(local.result.seeded[1], "error")).toBeTrue();
 				});
 
+				it("S5 HOLD: generateSeeds is not transactional — a mixed list can leave rows", () => {
+					// HOLD pin: generateSeeds has no transaction. Author rows persist
+					// even though the missing model forces overall success=false.
+					// Do not wrap generateSeeds in a transaction.
+					local.beforeQuery = model("Author").findAll(select = "id");
+					local.beforeIds = ValueList(local.beforeQuery.id);
+
+					local.gen = CreateObject("component", "wheels.Seeder").init();
+					local.result = local.gen.generateSeeds(
+						models = "Author,NoSuchModel_SeederS5",
+						count = 1
+					);
+
+					expect(local.result.success).toBeFalse();
+					expect(local.result.totalCreated).toBe(1);
+					expect(local.result.totalFailed).toBe(1);
+					expect(ArrayLen(local.result.seeded)).toBe(2);
+					expect(local.result.seeded[1].model).toBe("Author");
+					expect(local.result.seeded[1].success).toBeTrue();
+					expect(local.result.seeded[2].success).toBeFalse();
+
+					local.afterQuery = model("Author").findAll(select = "id");
+					local.afterIds = ValueList(local.afterQuery.id);
+					expect(ListLen(local.afterIds) - ListLen(local.beforeIds)).toBe(1);
+
+					if (Len(local.beforeIds)) {
+						model("Author").deleteAll(where = "id NOT IN (#local.beforeIds#)", instantiate = false);
+					} else {
+						model("Author").deleteAll(instantiate = false);
+					}
+				});
+
+				it("S6: count=0 reports overall failure even when the per-model entry succeeds", () => {
+					// success requires totalCreated>0. The per-model loop does not
+					// run (1 <= 0), so seededCount==count and the entry is success=true.
+					local.beforeQuery = model("Author").findAll(select = "id");
+					local.beforeIds = ValueList(local.beforeQuery.id);
+
+					local.gen = CreateObject("component", "wheels.Seeder").init();
+					local.result = local.gen.generateSeeds(models = "Author", count = 0);
+
+					expect(local.result.success).toBeFalse();
+					expect(local.result.totalCreated).toBe(0);
+					expect(local.result.totalFailed).toBe(0);
+					expect(ArrayLen(local.result.seeded)).toBe(1);
+					expect(local.result.seeded[1].count).toBe(0);
+					expect(local.result.seeded[1].success).toBeTrue();
+
+					local.afterQuery = model("Author").findAll(select = "id");
+					expect(ValueList(local.afterQuery.id)).toBe(local.beforeIds);
+				});
+
+				it("S6: a negative count creates no rows and marks the model failed", () => {
+					// The for-loop does not run. seededCount (0) != count (-1), so
+					// the entry is success=false and totalFailed increments.
+					local.beforeQuery = model("Author").findAll(select = "id");
+					local.beforeIds = ValueList(local.beforeQuery.id);
+
+					local.gen = CreateObject("component", "wheels.Seeder").init();
+					local.result = local.gen.generateSeeds(models = "Author", count = -1);
+
+					expect(local.result.success).toBeFalse();
+					expect(local.result.totalCreated).toBe(0);
+					expect(local.result.totalFailed).toBe(1);
+					expect(ArrayLen(local.result.seeded)).toBe(1);
+					expect(local.result.seeded[1].count).toBe(0);
+					expect(local.result.seeded[1].success).toBeFalse();
+
+					local.afterQuery = model("Author").findAll(select = "id");
+					expect(ValueList(local.afterQuery.id)).toBe(local.beforeIds);
+				});
+
 				it("reports failure (not silent success) when an explicit list resolves to no models", () => {
 					local.gen = CreateObject("component", "wheels.Seeder").init();
 					// A delimiter-only list is a non-blank value (so it does NOT fall
@@ -318,8 +550,114 @@ component extends="wheels.WheelsTest" {
 
 			});
 
+			describe("$generateTestData()", () => {
+
+				it("S10: email names return an example.com address", () => {
+					expect(seeder.$generateTestData(propertyName = "email", propertyType = "string", index = 1)).toBe("test1@example.com");
+					expect(seeder.$generateTestData(propertyName = "userEmail", propertyType = "integer", index = 4)).toBe("test4@example.com");
+				});
+
+				it("S10: firstname / fname cycle the first-name list", () => {
+					expect(seeder.$generateTestData(propertyName = "firstName", propertyType = "string", index = 1)).toBe("John");
+					expect(seeder.$generateTestData(propertyName = "fname", propertyType = "string", index = 2)).toBe("Jane");
+					expect(seeder.$generateTestData(propertyName = "firstName", propertyType = "string", index = 11)).toBe("John");
+				});
+
+				it("S10: lastname / lname cycle the last-name list", () => {
+					expect(seeder.$generateTestData(propertyName = "lastName", propertyType = "string", index = 1)).toBe("Smith");
+					expect(seeder.$generateTestData(propertyName = "lname", propertyType = "string", index = 2)).toBe("Johnson");
+				});
+
+				it("S10: exact name and username return TestUserN", () => {
+					expect(seeder.$generateTestData(propertyName = "name", propertyType = "string", index = 3)).toBe("TestUser3");
+					expect(seeder.$generateTestData(propertyName = "userName", propertyType = "string", index = 3)).toBe("TestUser3");
+					expect(seeder.$generateTestData(propertyName = "displayName", propertyType = "string", index = 3)).toBe("displayName Test 3");
+				});
+
+				it("S10: phone / mobile, address / street, and geo names", () => {
+					expect(seeder.$generateTestData(propertyName = "phone", propertyType = "string", index = 1)).toBe("555-1001");
+					expect(seeder.$generateTestData(propertyName = "mobile", propertyType = "string", index = 2)).toBe("555-1002");
+					expect(seeder.$generateTestData(propertyName = "address", propertyType = "string", index = 4)).toBe("4 Test Street");
+					expect(seeder.$generateTestData(propertyName = "street", propertyType = "string", index = 4)).toBe("4 Test Street");
+					expect(seeder.$generateTestData(propertyName = "city", propertyType = "string", index = 1)).toBe("New York");
+					expect(seeder.$generateTestData(propertyName = "city", propertyType = "string", index = 2)).toBe("Los Angeles");
+					expect(seeder.$generateTestData(propertyName = "state", propertyType = "string", index = 1)).toBe("CA");
+					expect(seeder.$generateTestData(propertyName = "province", propertyType = "string", index = 2)).toBe("TX");
+					expect(seeder.$generateTestData(propertyName = "zip", propertyType = "string", index = 1)).toBe("10001");
+					expect(seeder.$generateTestData(propertyName = "postal", propertyType = "string", index = 2)).toBe("10002");
+				});
+
+				it("S10: url / website and password names", () => {
+					expect(seeder.$generateTestData(propertyName = "url", propertyType = "string", index = 5)).toBe("https://example5.com");
+					expect(seeder.$generateTestData(propertyName = "website", propertyType = "string", index = 5)).toBe("https://example5.com");
+					expect(seeder.$generateTestData(propertyName = "password", propertyType = "string", index = 5)).toBe("TestPass5!");
+				});
+
+				it("S10: boolean type and active / enabled / published names", () => {
+					expect(seeder.$generateTestData(propertyName = "flag", propertyType = "boolean", index = 1)).toBeTrue();
+					expect(seeder.$generateTestData(propertyName = "flag", propertyType = "boolean", index = 2)).toBeFalse();
+					expect(seeder.$generateTestData(propertyName = "isActive", propertyType = "string", index = 1)).toBeTrue();
+					expect(seeder.$generateTestData(propertyName = "enabled", propertyType = "string", index = 2)).toBeFalse();
+					// publishedAt matches "published" before the later date-name branch.
+					expect(seeder.$generateTestData(propertyName = "publishedAt", propertyType = "string", index = 1)).toBeTrue();
+				});
+
+				it("S10: integer / numeric type — age, price, quantity, and default", () => {
+					expect(seeder.$generateTestData(propertyName = "age", propertyType = "integer", index = 1)).toBe(21);
+					expect(seeder.$generateTestData(propertyName = "price", propertyType = "numeric", index = 1)).toBe(10.99);
+					expect(seeder.$generateTestData(propertyName = "cost", propertyType = "integer", index = 2)).toBe(20.99);
+					expect(seeder.$generateTestData(propertyName = "amount", propertyType = "integer", index = 3)).toBe(30.99);
+					expect(seeder.$generateTestData(propertyName = "quantity", propertyType = "integer", index = 2)).toBe(10);
+					expect(seeder.$generateTestData(propertyName = "count", propertyType = "integer", index = 3)).toBe(15);
+					expect(seeder.$generateTestData(propertyName = "views", propertyType = "integer", index = 7)).toBe(7);
+				});
+
+				it("S10: date type and date / birthday / dob names", () => {
+					local.typed = seeder.$generateTestData(propertyName = "foo", propertyType = "date", index = 3);
+					expect(IsDate(local.typed)).toBeTrue();
+					expect(DateDiff("d", local.typed, Now())).toBe(3);
+
+					local.named = seeder.$generateTestData(propertyName = "startDate", propertyType = "string", index = 2);
+					expect(IsDate(local.named)).toBeTrue();
+					expect(DateDiff("d", local.named, Now())).toBe(2);
+
+					local.birthday = seeder.$generateTestData(propertyName = "birthday", propertyType = "string", index = 1);
+					expect(IsDate(local.birthday)).toBeTrue();
+					local.dob = seeder.$generateTestData(propertyName = "dob", propertyType = "datetime", index = 4);
+					expect(IsDate(local.dob)).toBeTrue();
+					expect(DateDiff("d", local.dob, Now())).toBe(4);
+				});
+
+				it("S10: text type and description / content / body / title / status", () => {
+					local.lorem = "This is test content 1. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+					expect(seeder.$generateTestData(propertyName = "foo", propertyType = "text", index = 1)).toBe(local.lorem);
+					expect(seeder.$generateTestData(propertyName = "description", propertyType = "string", index = 1)).toBe(local.lorem);
+					expect(seeder.$generateTestData(propertyName = "content", propertyType = "string", index = 1)).toBe(local.lorem);
+					expect(seeder.$generateTestData(propertyName = "body", propertyType = "string", index = 1)).toBe(local.lorem);
+					expect(seeder.$generateTestData(propertyName = "title", propertyType = "string", index = 8)).toBe("Test Title 8");
+					expect(seeder.$generateTestData(propertyName = "subject", propertyType = "string", index = 8)).toBe("Test Title 8");
+					expect(seeder.$generateTestData(propertyName = "status", propertyType = "string", index = 1)).toBe("pending");
+					expect(seeder.$generateTestData(propertyName = "status", propertyType = "string", index = 2)).toBe("active");
+					expect(seeder.$generateTestData(propertyName = "status", propertyType = "string", index = 5)).toBe("pending");
+				});
+
+				it("S10: unmatched names fall through to the default string", () => {
+					expect(seeder.$generateTestData(propertyName = "zzz", propertyType = "string", index = 9)).toBe("zzz Test 9");
+					expect(seeder.$generateTestData(propertyName = "notes", index = 1)).toBe("notes Test 1");
+				});
+
+			});
+
 		});
 
+	}
+
+	public void function $deleteAuthorByFirstName(required string firstName) {
+		local.escaped = Replace(arguments.firstName, "'", "''", "all");
+		local.record = model("author").findOne(where = "firstName = '#local.escaped#'");
+		if (IsObject(local.record)) {
+			local.record.delete();
+		}
 	}
 
 }

--- a/vendor/wheels/tests/specs/seederSpec.cfc
+++ b/vendor/wheels/tests/specs/seederSpec.cfc
@@ -308,11 +308,13 @@ component extends="wheels.WheelsTest" {
 				});
 
 				it("S4 HOLD: unique values are interpolated into WHERE with quote-escape only", () => {
-					// HOLD pin: seedOnce builds `prop = 'escaped'` via Replace(val, "'", "''").
-					// Do not flip to parameterized WHERE. Apostrophes must still round-trip
-					// through that interpolation so findOne can skip a matching row.
+					// HOLD pin: seedOnce builds `prop = 'escaped'` via
+					// Replace(val, "'", "''") and hands that string to findOne(where=).
+					// It does not bind parameters. After the query layer processes
+					// the interpolated clause, an apostrophe in the unique value
+					// does not match the stored row — the second call creates again.
+					// Do not flip to parameterized WHERE.
 					local.uniqueFirst = "O'Brien_#Replace(CreateUUID(), '-', '', 'all')#";
-					local.escapedFirst = Replace(local.uniqueFirst, "'", "''", "all");
 
 					local.first = seeder.seedOnce(
 						modelName = "author",
@@ -320,17 +322,25 @@ component extends="wheels.WheelsTest" {
 						properties = {firstName: local.uniqueFirst, lastName: "QuoteEscape"}
 					);
 					expect(local.first.action).toBe("created");
+					expect(StructKeyExists(local.first, "key")).toBeTrue();
 
 					local.second = seeder.seedOnce(
 						modelName = "author",
 						uniqueProperties = "firstName",
 						properties = {firstName: local.uniqueFirst, lastName: "QuoteEscape"}
 					);
-					expect(local.second.action).toBe("skipped");
+					expect(local.second.action).toBe("created");
+					expect(StructKeyExists(local.second, "key")).toBeTrue();
+					expect(local.second.key).notToBe(local.first.key);
 
-					local.record = model("author").findOne(where = "firstName = '#local.escapedFirst#'");
-					expect(IsObject(local.record)).toBeTrue();
-					local.record.delete();
+					local.firstRow = model("author").findByKey(local.first.key);
+					if (IsObject(local.firstRow)) {
+						local.firstRow.delete();
+					}
+					local.secondRow = model("author").findByKey(local.second.key);
+					if (IsObject(local.secondRow)) {
+						local.secondRow.delete();
+					}
 				});
 
 				it("counts failed entries and reports them in the result", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Seeder desk IDs S1–S10 were locked. HOLD pins stay unflipped. This PR only proves current behavior so a vacuous include, a silent leftover, or a `$generateTestData` branch drop would fail.

S4 stays WHERE interpolation with quote-escape only (`Replace(val, "'", "''")`). An apostrophe in the unique value does not skip — the second `seedOnce` creates another row. S5 stays non-transactional: a mixed `generateSeeds` list can leave rows.

## Scope

- `vendor/wheels/tests/specs/seederSpec.cfc` — the only seeder spec file. Do not invent `wheels.tests.specs.seeder`.
- Fixture files under `vendor/wheels/tests/_assets/seeder/` (`seeds.cfm`, `withenv/`, `stray/`, `includethrow/`)

No production change in `Seeder.cfc`. Spec-only. No changelog fragment.

Out: CLI `db/seed` + `generate/seed`, docs/blog, migrator `001_seed_tag_via_model_create`, blank environment throw (`InvalidEnvironment` its only cover `../` and `/`), mixed-model generate honesty (`totalFailed==0 && totalCreated>0`).

Already-proven, not refiled: InvalidEnvironment (`../` `/`), MissingProperty, InvalidUniqueValue, EmptyUniqueProperties, no-files failure, partial-failure rollback, single-model generate honesty / Model.cfc skip.

## Desk S1–S10

| ID | Status | Note |
| --- | --- | --- |
| S1 | PROVEN | Main `seeds.cfm` creates `SeederMainOK99`. `totalCreated` is 1, not `toBeGTE(0)` on an empty fixture. |
| S2 | PROVEN | `withenv` main + `seeds/testing.cfm` both create rows. `environment=development` runs main only — the testing include did not run. |
| S3 | PROVEN | A stray `seeds/orphaned.cfm` makes `hasSeedFiles()` true, but `runSeeds(environment=testing)` returns "No seed files found" and does not create the orphan row. |
| S4 | HOLD | Unique values are interpolated into WHERE with quote-escape only. An apostrophe in `firstName` creates, then creates again (does not skip). No parameterized flip. |
| S5 | HOLD | `generateSeeds(models="Author,NoSuchModel_SeederS5")` leaves the Author row. Not transactional. No wrap-in-transaction flip. |
| S6 | PROVEN | `count=0`: overall `success=false`, per-model entry `success=true`, no rows. `count=-1`: overall failure, per-model `success=false`, `totalFailed=1`, no rows. |
| S7 | PROVEN | Include-throw is caught: `success=false`, message includes `Seed failed:` and `intentional include throw`, first row rolled back. |
| S8 | PROVEN | `request.$wheelsSeeder` is left set after success, after a later run (overwritten, not deleted), and after the include-throw catch. |
| S9 | PROVEN | Default `seedMappingPath` is `/app/db/` and `seedPath` is `ExpandPath("/app/db/")`, not only `toInclude("app")`. |
| S10 | PROVEN | `$generateTestData` name and type branches: email, first/last, name/username vs displayName, phone/geo, url/password, boolean (including `publishedAt` before date), integer age/price/quantity/default, date, text/title/status, default string. |

## Verification

Command actually run (LOCKED driver — not `--filter=seeder` / `--filter=seederSpec`):

```
wheels test --core --ci
```

```
Running core tests (sqlite)...
5291 passed, 0 failed, 5 error(s) (16.51s)
```

The 5 errors are all `cli.lucli.services.RewriteConfigInstaller` not found (rewrite.config installer specs). Out of this seeder slice. Seeder itself is 0 fail / 0 error.

Wheels CLI 4.0.6. Lucee 7.0.0.395. sqlite.

Did not run `--filter=seeder` (that directory does not exist; 0-bundle fail-close). Did not invent `wheels.tests.specs.seeder`.

HEAD `c136de20ef190d3ef6575e51bae5fef9afb66d66`

Base `24cd4421ffb31634636c40d045a748222257fa34` (develop after #3421).

No closer keywords. Do not merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9bf11e97-7b65-4a26-a1ee-c3230d535e16?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9bf11e97-7b65-4a26-a1ee-c3230d535e16&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

