### PR TITLE
test(dispatch): prove dispatch and public hardener S1-S10

### DIFF
--- a/vendor/wheels/tests/specs/dispatch/DispatchPublicHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/dispatch/DispatchPublicHardenerSpec.cfc
@@ -1,0 +1,248 @@
+/**
+ * Dispatch / Public hardener proofs for desk IDs S2, S3, S6, S7, S8.
+ * HOLD pins stay unflipped. Spec-only.
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("S2 $parseJsonBody current branches", () => {
+
+			beforeEach(() => {
+				dispatch = CreateObject("component", "wheels.Dispatch")
+				_hadHttpData = StructKeyExists(request, "wheels") && StructKeyExists(request.wheels, "httpRequestData")
+				_priorHttpData = _hadHttpData ? request.wheels.httpRequestData : {}
+			})
+
+			afterEach(() => {
+				if (_hadHttpData) {
+					request.wheels.httpRequestData = _priorHttpData
+				} else if (StructKeyExists(request, "wheels")) {
+					StructDelete(request.wheels, "httpRequestData")
+				}
+			})
+
+			it("S2: existing form keys win over JSON (StructAppend overwrite false)", () => {
+				request.wheels.httpRequestData = {
+					headers = {"Content-Type" = "application/json"},
+					content = '{"title":"from-json","body":"json-only"}'
+				}
+				var result = dispatch.$parseJsonBody(params = {title = "from-form", extra = "keep"})
+
+				expect(result.title).toBe("from-form")
+				expect(result.body).toBe("json-only")
+				expect(result.extra).toBe("keep")
+			})
+
+			it("S2: application/*+json content type is treated as JSON", () => {
+				request.wheels.httpRequestData = {
+					headers = {"Content-Type" = "application/vnd.api+json; charset=utf-8"},
+					content = '{"tag":"plus-json"}'
+				}
+				var result = dispatch.$parseJsonBody(params = {})
+
+				expect(result.tag).toBe("plus-json")
+			})
+
+			it("S2: array root is accepted on the _json key", () => {
+				request.wheels.httpRequestData = {
+					headers = {"Content-Type" = "application/json"},
+					content = '["alpha","beta"]'
+				}
+				var result = dispatch.$parseJsonBody(params = {keep = "me"})
+
+				expect(result.keep).toBe("me")
+				expect(result).toHaveKey("_json")
+				expect(result._json).toBeArray()
+				expect(ArrayLen(result._json)).toBe(2)
+				expect(result._json[1]).toBe("alpha")
+				expect(result._json[2]).toBe("beta")
+			})
+
+			it("S2: invalid JSON is ignored and does not throw", () => {
+				request.wheels.httpRequestData = {
+					headers = {"Content-Type" = "application/json"},
+					content = "{not-valid-json"
+				}
+				var threw = {flag = false}
+				var result = {}
+				try {
+					result = dispatch.$parseJsonBody(params = {keep = "me"})
+				} catch (any e) {
+					threw.flag = true
+				}
+
+				expect(threw.flag).toBeFalse()
+				expect(result.keep).toBe("me")
+				expect(result).notToHaveKey("_json")
+			})
+		})
+
+		describe("S3 $getPathFromRequest collapse to empty string", () => {
+
+			beforeEach(() => {
+				dispatch = CreateObject("component", "wheels.Dispatch")
+			})
+
+			it("S3: pathInfo equal to scriptName collapses to empty string", () => {
+				expect(dispatch.$getPathFromRequest(pathInfo = "/index.cfm", scriptName = "/index.cfm")).toBe("")
+			})
+
+			it("S3: a lone slash collapses to empty string", () => {
+				expect(dispatch.$getPathFromRequest(pathInfo = "/", scriptName = "/index.cfm")).toBe("")
+			})
+
+			it("S3: empty pathInfo collapses to empty string", () => {
+				expect(dispatch.$getPathFromRequest(pathInfo = "", scriptName = "/index.cfm")).toBe("")
+			})
+
+			it("S3: a real path still drops only the leading slash", () => {
+				expect(dispatch.$getPathFromRequest(pathInfo = "/users", scriptName = "/index.cfm")).toBe("users")
+			})
+		})
+
+		describe("S6 $deobfuscateParams catch swallow", () => {
+
+			beforeEach(() => {
+				dispatch = CreateObject("component", "wheels.Dispatch")
+				_priorObfuscate = application.wheels.obfuscateUrls
+				application.wheels.obfuscateUrls = true
+			})
+
+			afterEach(() => {
+				application.wheels.obfuscateUrls = _priorObfuscate
+			})
+
+			it("S6: a bad obfuscated value does not throw and the param survives", () => {
+				var params = {controller = "users", action = "show", key = "not-valid-obf"}
+				var threw = {flag = false}
+				var result = {}
+				try {
+					result = dispatch.$deobfuscateParams(params = params)
+				} catch (any e) {
+					threw.flag = true
+				}
+
+				expect(threw.flag).toBeFalse()
+				expect(result.key).toBe("not-valid-obf")
+				expect(result.controller).toBe("users")
+				expect(result.action).toBe("show")
+			})
+
+			it("S6: a non-string param does not throw and the value survives", () => {
+				var nested = {inner = "keep-me"}
+				var params = {controller = "users", action = "show", key = nested}
+				var threw = {flag = false}
+				var result = {}
+				try {
+					result = dispatch.$deobfuscateParams(params = params)
+				} catch (any e) {
+					threw.flag = true
+				}
+
+				expect(threw.flag).toBeFalse()
+				expect(result.key.inner).toBe("keep-me")
+			})
+
+			it("S6: a valid obfuscated value still deobfuscates when the setting is on", () => {
+				var result = dispatch.$deobfuscateParams(params = {controller = "users", action = "show", key = "9b1c6"})
+
+				expect(result.key).toBe("1")
+			})
+		})
+
+		describe("S7 $$findMatchingRoutes HEAD to GET and live regex write", () => {
+
+			beforeEach(() => {
+				_originalRoutes = Duplicate(application.wheels.routes)
+				application.wheels.routes = [
+					{
+						pattern = "s7headget",
+						methods = "GET",
+						controller = "s7",
+						action = "index",
+						name = "s7headget"
+					},
+					{
+						pattern = "s7postonly",
+						methods = "POST",
+						controller = "s7",
+						action = "create",
+						name = "s7postonly"
+					}
+				]
+				publicCfc = CreateObject("component", "wheels.Public").$init()
+			})
+
+			afterEach(() => {
+				application.wheels.routes = _originalRoutes
+			})
+
+			it("S7: HEAD requests match GET routes", () => {
+				var result = publicCfc.$$findMatchingRoutes(path = "s7headget", requestMethod = "HEAD")
+
+				expect(ArrayLen(result.errors)).toBe(0)
+				expect(ArrayLen(result.matches)).toBe(1)
+				expect(result.matches[1].name).toBe("s7headget")
+				expect(result.matches[1].methods).toBe("GET")
+			})
+
+			it("S7: HEAD does not match a POST-only route", () => {
+				var result = publicCfc.$$findMatchingRoutes(path = "s7postonly", requestMethod = "HEAD")
+
+				expect(ArrayLen(result.matches)).toBe(0)
+				expect(ArrayLen(result.errors)).toBeGT(0)
+			})
+
+			it("S7: pins the live .regex write on application.wheels.routes", () => {
+				expect(application.wheels.routes[1]).notToHaveKey("regex")
+				publicCfc.$$findMatchingRoutes(path = "s7headget", requestMethod = "GET")
+				expect(application.wheels.routes[1]).toHaveKey("regex")
+				expect(Len(application.wheels.routes[1].regex)).toBeGT(0)
+			})
+		})
+
+		describe("S8 HOLD $safeApplicationMetadata whitelist and $resolveDocFormat fallback", () => {
+
+			beforeEach(() => {
+				publicCfc = CreateObject("component", "wheels.Public").$init()
+			})
+
+			it("S8 HOLD: whitelist is the six current keys and is not widened", () => {
+				var fakeMeta = {
+					applicationTimeout = 1,
+					mappings = {wheels = "/wheels"},
+					name = "s8-app",
+					sessionManagement = true,
+					sessionTimeout = 2,
+					setClientCookies = false,
+					datasources = {main = {password = "s8-secret"}},
+					ormsettings = {dbcreate = "update"},
+					extraKey = "must-drop"
+				}
+				var safe = publicCfc.$safeApplicationMetadata(fakeMeta)
+
+				expect(StructCount(safe)).toBe(6)
+				expect(safe).toHaveKey("applicationTimeout")
+				expect(safe).toHaveKey("mappings")
+				expect(safe).toHaveKey("name")
+				expect(safe).toHaveKey("sessionManagement")
+				expect(safe).toHaveKey("sessionTimeout")
+				expect(safe).toHaveKey("setClientCookies")
+				expect(safe.name).toBe("s8-app")
+				expect(safe).notToHaveKey("datasources")
+				expect(safe).notToHaveKey("ormsettings")
+				expect(safe).notToHaveKey("extraKey")
+			})
+
+			it("S8 HOLD: $resolveDocFormat falls back to html and does not change that default", () => {
+				expect(publicCfc.$resolveDocFormat("html")).toBe("html")
+				expect(publicCfc.$resolveDocFormat("json")).toBe("json")
+				expect(publicCfc.$resolveDocFormat("")).toBe("html")
+				expect(publicCfc.$resolveDocFormat("../views/info")).toBe("html")
+				expect(publicCfc.$resolveDocFormat("html.cfm")).toBe("html")
+			})
+		})
+	}
+
+}

--- a/vendor/wheels/tests/specs/dispatch/InvokeMethodSpec.cfc
+++ b/vendor/wheels/tests/specs/dispatch/InvokeMethodSpec.cfc
@@ -40,55 +40,71 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("invokes a Public.cfc instance without throwing on $blockInProduction", function() {
-				// End-to-end shape of the dispatch flow at Dispatch.cfc:287.
+				// End-to-end shape of the dispatch flow at Dispatch.cfc:419.
 				// We don't actually serve a request — we just verify the
-				// adapter can invoke a Public.cfc handler. In the development
-				// environment $blockInProduction() short-circuits to a no-op
-				// (since #2903 the gate is a development-only allowlist), so
-				// the only thing we're testing is "did the receiver survive
-				// the dispatch?" If it didn't, the call throws before the
-				// include statement runs. (This spec invokes index(), which now
-				// calls $blockInProduction() too (a development-only no-op per
-				// the allowlist), so the production-only early-return below is
-				// belt-and-suspenders.)
-				if (
-					StructKeyExists(application, "wheels")
-					&& StructKeyExists(application.wheels, "environment")
-					&& application.wheels.environment == "production"
-				) {
-					return;
-				}
-
+				// adapter can invoke a Public.cfc handler. index() calls
+				// $blockInProduction() first (Public.cfc ~376). In development
+				// that gate is a no-op (allowlist since #2903); outside
+				// development it 404s and aborts. Force development for the
+				// invoke so a testing-env suite does not abort the runner.
+				var priorEnv = application.wheels.environment;
 				var publicCfc = createObject("component", "wheels.Public").$init();
 				var adapter = application.wheels.engineAdapter;
 				var receiverLossMessage = "";
+				var indexReturn = "not-invoked";
 
 				try {
+					application.wheels.environment = "development";
 					// index() renders the congratulations welcome page via
 					// cfinclude. Capture that output so it doesn't leak into the
 					// test-runner response buffer: on Adobe CF the leaked HTML
 					// commits the servlet response (HTTP 404 + ~1MB prefix),
-					// corrupting the JSON result for the ENTIRE suite. We only
-					// care that the dispatch invocation survives without a
-					// receiver-loss error, not what index() prints.
+					// corrupting the JSON result for the ENTIRE suite.
 					cfsavecontent(variable = "local.discardedIndexOutput") {
+						indexReturn = publicCfc.index();
+					}
+					cfsavecontent(variable = "local.discardedInvokeOutput") {
 						adapter.invokeMethod(publicCfc, "index");
 					}
 				} catch (any e) {
-					// index() doesn't call $blockInProduction so this should
-					// never throw a "Function [$...] not found" error. Any
-					// other error (e.g. missing view path or template) is
-					// unrelated — match only the receiver-loss signature so
-					// the captured message surfaces directly in the failure.
+					// index() calls $blockInProduction as a development-only
+					// no-op here. A "Function [$...] not found" error is the
+					// receiver-loss signature from #2646. Any other error
+					// (missing view path or template) is unrelated.
 					if (REFindNoCase("Function \[\$[a-zA-Z]", e.message)) {
 						receiverLossMessage = e.message;
 					}
+				} finally {
+					application.wheels.environment = priorEnv;
 				}
 
 				expect(receiverLossMessage).toBe(
 					"",
 					"Receiver-loss error thrown from Public.cfc::index: " & receiverLossMessage
 				);
+				expect(indexReturn).toBe("");
+			});
+
+			it("S4: $shouldBlockInProduction is true in production", function() {
+				var priorEnv = application.wheels.environment;
+				var publicCfc = createObject("component", "wheels.Public").$init();
+				try {
+					application.wheels.environment = "production";
+					expect(publicCfc.$shouldBlockInProduction()).toBeTrue();
+				} finally {
+					application.wheels.environment = priorEnv;
+				}
+			});
+
+			it("S9: Public.cfc index() calls $blockInProduction", function() {
+				var source = FileRead(ExpandPath("/wheels/Public.cfc"));
+				var indexPos = ReFindNoCase("function\s+index\s*\(", source);
+				expect(indexPos).toBeGT(0);
+				var afterIndex = Mid(source, indexPos, 400);
+				var blockPos = Find("$blockInProduction()", afterIndex);
+				var includePos = Find("congratulations.cfm", afterIndex);
+				expect(blockPos).toBeGT(0);
+				expect(includePos).toBeGT(blockPos);
 			});
 
 		});

--- a/vendor/wheels/tests/specs/dispatch/createParamsSpec.cfc
+++ b/vendor/wheels/tests/specs/dispatch/createParamsSpec.cfc
@@ -44,11 +44,16 @@ component extends="wheels.WheelsTest" {
 				expect(datecompare(r, e)).toBe(0)
 			})
 
-			it("defaults year to 1899", () => {
-				args.formScope["obj[published]($year)"] = 1899
+			it("S1 HOLD: omits year when $year is absent and defaults to 1899", () => {
+				// HOLD: do not flip the default year. The existing "defaults year
+				// to 1899" case was a tautology ($year=1899, expect 1899). This
+				// one omits $year and still expects 1899, matching
+				// $translateDatePartSubmissions.
+				args.formScope["obj[published]($month)"] = 3
+				args.formScope["obj[published]($day)"] = 15
 				_params = dispatch.$createParams(argumentCollection = args)
 				e = _params.obj.published
-				r = CreateDateTime(1899, 1, 1, 0, 0, 0)
+				r = CreateDateTime(1899, 3, 15, 0, 0, 0)
 
 				expect(datecompare(r, e)).toBe(0)
 			})
@@ -102,17 +107,17 @@ component extends="wheels.WheelsTest" {
 			it("does not overwrite FORM scope", () => {
 				args.formScope["obj[published]($month)"] = 2
 				_params = dispatch.$createParams(argumentCollection = args)
-				exists = StructKeyExists(args.formScope, "obj[published]($month)")
 
-				expect(exists).toBeTrue()
+				expect(args.formScope).toHaveKey("obj[published]($month)")
+				expect(args.formScope["obj[published]($month)"]).toBe(2)
 			})
 
 			it("does not overwrite URL scope", () => {
 				StructInsert(args.urlScope, "user[email]", "tpetruzzi@gmail.com", true)
 				_params = dispatch.$createParams(argumentCollection = args)
-				exists = StructKeyExists(args.urlScope, "user[email]")
 
-				expect(exists).toBeTrue()
+				expect(args.urlScope).toHaveKey("user[email]")
+				expect(args.urlScope["user[email]"]).toBe("tpetruzzi@gmail.com")
 			})
 
 			it("creates multiple objects with checkbox", () => {

--- a/vendor/wheels/tests/specs/dispatch/findMatchingRouteMegaSpec.cfc
+++ b/vendor/wheels/tests/specs/dispatch/findMatchingRouteMegaSpec.cfc
@@ -120,6 +120,89 @@ component extends="wheels.WheelsTest" {
 				expect(route.name).toBe("adminUsers")
 				expect(route.methods).toBe("GET")
 			})
+
+			it("S10: matches top-level users, not the admin namespaced collection", () => {
+				request.cgi["request_method"] = "GET"
+				route = d.$findMatchingRoute(path = "users")
+
+				expect(route.name).toBe("users")
+				expect(route.controller).toBe("users")
+				expect(route.action).toBe("index")
+				expect(route.methods).toBe("GET")
+			})
+
+			it("S10: matches a top-level member show on the fixture", () => {
+				request.cgi["request_method"] = "GET"
+				route = d.$findMatchingRoute(path = "users/1")
+
+				expect(route.name).toBe("user")
+				expect(route.action).toBe("show")
+			})
+
+			it("S10: matches POST collection create, not the GET index on the same path", () => {
+				request.cgi["request_method"] = "POST"
+				route = d.$findMatchingRoute(path = "users")
+
+				expect(route.name).toBe("users")
+				expect(route.action).toBe("create")
+				expect(route.methods).toBe("POST")
+			})
+
+			it("S10: matches a nested admin member, not the top-level user show", () => {
+				request.cgi["request_method"] = "GET"
+				route = d.$findMatchingRoute(path = "admin/users/1")
+
+				expect(route.name).toBe("adminUser")
+				expect(route.action).toBe("show")
+			})
+
+			it("S10: matches nested comments under users on the fixture", () => {
+				request.cgi["request_method"] = "GET"
+				route = d.$findMatchingRoute(path = "users/1/comments")
+
+				expect(route.controller).toBe("comments")
+				expect(route.action).toBe("index")
+			})
+
+			it("S10: matches a shallow comment member off the fixture", () => {
+				request.cgi["request_method"] = "GET"
+				route = d.$findMatchingRoute(path = "comments/1")
+
+				expect(route.controller).toBe("comments")
+				expect(route.action).toBe("show")
+			})
+
+			it("S10: matches the singular profile resource on the fixture", () => {
+				request.cgi["request_method"] = "GET"
+				route = d.$findMatchingRoute(path = "profile")
+
+				expect(route.controller).toBe("profiles")
+				expect(route.action).toBe("show")
+			})
+
+			it("S10: matches the fixture root, not a later resource collection", () => {
+				request.cgi["request_method"] = "GET"
+				route = d.$findMatchingRoute(path = "")
+
+				expect(route.controller).toBe("dashboard")
+				expect(route.action).toBe("index")
+			})
+
+			it("S10: matches another noun from the 50-resource fixture", () => {
+				request.cgi["request_method"] = "GET"
+				route = d.$findMatchingRoute(path = "miners")
+
+				expect(route.name).toBe("miners")
+				expect(route.action).toBe("index")
+			})
+
+			it("S10: HEAD aliases GET on a nested admin collection from the fixture", () => {
+				request.cgi["request_method"] = "HEAD"
+				route = d.$findMatchingRoute(path = "admin/dogs")
+
+				expect(route.name).toBe("adminDogs")
+				expect(ListFindNoCase(route.methods, "GET")).toBeGT(0)
+			})
 		})
 	}
 

--- a/vendor/wheels/tests/specs/dispatch/requestSpec.cfc
+++ b/vendor/wheels/tests/specs/dispatch/requestSpec.cfc
@@ -68,5 +68,103 @@ component extends="wheels.WheelsTest" {
 				expect(_params).notToHaveKey('format')
 			})
 		})
+
+		describe("S5 $request abort content, OPTIONS swallow, wheels hijack", () => {
+
+			beforeEach(() => {
+				_originalRoutes = Duplicate(application.wheels.routes)
+				_originalStaticRoutes = StructKeyExists(application.wheels, "staticRoutes") ? StructCopy(application.wheels.staticRoutes) : {}
+				_originalNamedRoutePositions = StructKeyExists(application.wheels, "namedRoutePositions") ? StructCopy(application.wheels.namedRoutePositions) : {}
+				_savedMiddleware = (StructKeyExists(application.wheels, "middleware") && ArrayLen(application.wheels.middleware))
+					? ArraySlice(application.wheels.middleware, 1) : []
+				_savedCgiMethod = request.cgi.request_method
+				_hadCgiOrigin = StructKeyExists(request.cgi, "http_origin")
+				_savedCgiOrigin = _hadCgiOrigin ? request.cgi.http_origin : ""
+				_savedEnablePublic = application.wheels.enablePublicComponent
+				_savedPublic = application.wheels.public
+				_savedCurrentRoute = StructKeyExists(request.wheels, "currentRoute") ? request.wheels.currentRoute : ""
+				application.wheels.routes = []
+				application.wheels.staticRoutes = {}
+			})
+
+			afterEach(() => {
+				application.wheels.routes = _originalRoutes
+				application.wheels.staticRoutes = _originalStaticRoutes
+				application.wheels.namedRoutePositions = _originalNamedRoutePositions
+				application.wheels.middleware = _savedMiddleware
+				application.wheels.enablePublicComponent = _savedEnablePublic
+				application.wheels.public = _savedPublic
+				request.cgi["request_method"] = _savedCgiMethod
+				if (IsStruct(_savedCurrentRoute)) {
+					request.wheels.currentRoute = _savedCurrentRoute
+				} else if (StructKeyExists(request.wheels, "currentRoute")) {
+					StructDelete(request.wheels, "currentRoute")
+				}
+				if (_hadCgiOrigin) {
+					request.cgi["http_origin"] = _savedCgiOrigin
+				} else {
+					StructDelete(request.cgi, "http_origin")
+				}
+				if (StructKeyExists(request, "$wheelsAbortContent")) {
+					StructDelete(request, "$wheelsAbortContent")
+				}
+			})
+
+			it("S5: honors $wheelsAbortContent and skips routing", () => {
+				request.$wheelsAbortContent = "s5-abort-body"
+				var d = application.wo.$createObjectFromRoot(path = "wheels", fileName = "Dispatch", method = "$init")
+				var result = d.$request(
+					pathInfo = "/no-such-route-s5",
+					scriptName = "",
+					formScope = {},
+					urlScope = {}
+				)
+
+				expect(result).toBe("s5-abort-body")
+			})
+
+			it("S5: swallows OPTIONS preflight when CORS middleware is registered", () => {
+				application.wheels.middleware = [
+					new wheels.middleware.Cors(allowOrigins = "https://s5.example.test")
+				]
+				request.cgi["request_method"] = "OPTIONS"
+				request.cgi["http_origin"] = "https://s5.example.test"
+				var d = application.wo.$createObjectFromRoot(path = "wheels", fileName = "Dispatch", method = "$init")
+				var threw = {flag = false}
+				var result = "s5-preflight-not-reached"
+				try {
+					result = d.$request(
+						pathInfo = "/s5/preflight",
+						scriptName = "",
+						formScope = {},
+						urlScope = {}
+					)
+				} catch (any e) {
+					threw.flag = true
+				}
+
+				expect(threw.flag).toBeFalse()
+				expect(result).toBe("")
+			})
+
+			it("S5: hijacks a wheels controller path and returns empty string", () => {
+				application.wheels.enablePublicComponent = true
+				application.wheels.public = new wheels.tests._assets.dispatch.InvokeMethodFixture()
+				application.wo.mapper()
+					.$match(pattern = "s5hijack", controller = "wheels", action = "publicHandler")
+					.end()
+				request.cgi["request_method"] = "GET"
+				var d = application.wo.$createObjectFromRoot(path = "wheels", fileName = "Dispatch", method = "$init")
+				var result = d.$request(
+					pathInfo = "/s5hijack",
+					scriptName = "",
+					formScope = {},
+					urlScope = {}
+				)
+
+				expect(result).toBe("")
+				expect(application.wheels.public.getState().handlerCompleted).toBeTrue()
+			})
+		})
 	}
 }

--- a/vendor/wheels/tests/specs/dispatch/requestSpec.cfc
+++ b/vendor/wheels/tests/specs/dispatch/requestSpec.cfc
@@ -124,11 +124,13 @@ component extends="wheels.WheelsTest" {
 			})
 
 			it("S5: swallows OPTIONS preflight when CORS middleware is registered", () => {
-				application.wheels.middleware = [
-					new wheels.middleware.Cors(allowOrigins = "https://s5.example.test")
-				]
+				// Deny-all Cors still makes $hasPreflightCapableMiddleware true,
+				// so Dispatch short-circuits OPTIONS before $findMatchingRoute.
+				// Do not reflect an Origin header: cfheader leaks into later
+				// $setCORSHeaders specs in this same request (getHeader returns
+				// the first value written, not the last).
+				application.wheels.middleware = [new wheels.middleware.Cors()]
 				request.cgi["request_method"] = "OPTIONS"
-				request.cgi["http_origin"] = "https://s5.example.test"
 				var d = application.wo.$createObjectFromRoot(path = "wheels", fileName = "Dispatch", method = "$init")
 				var threw = {flag = false}
 				var result = "s5-preflight-not-reached"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Dispatch / Public desk IDs S1–S10 were locked. HOLD pins stay unflipped. This PR only proves current behavior so a tautology, a silent leftover, or a branch drop would fail.

No production change. Spec-only. No changelog fragment.

## Scope

- `vendor/wheels/tests/specs/dispatch/DispatchPublicHardenerSpec.cfc` (new: S2, S3, S6, S7, S8)
- `createParamsSpec.cfc` (S1 HOLD omit-year, S10 overwrite values)
- `InvokeMethodSpec.cfc` (S4 production return, S9 `$blockInProduction` comment/spec)
- `requestSpec.cfc` (S5 `$request` abort content / OPTIONS swallow / wheels hijack)
- `findMatchingRouteMegaSpec.cfc` (S10 fixture kill-cases)

Out, leftover-closed: public/docs, public/views, public/layout, public/mcp, public/migrator, public/browser-fixtures, CliBridge, global/publicSpec obfuscate/humanize, hardener DispatchHardenerSpec B1–B3, security Public/CLI/consoleeval/MCP/route-tester gates, CORS specs, 404-vs-abort, XSS on `$$findMatchingRoutes`.

## PROVEN

| ID | Status | Note |
| --- | --- | --- |
| S1 | HOLD pinned | omit-year + default 1899 (not flipped). `$year` absent, month/day present, date is 1899-03-15. |
| S2 | PROVEN | `$parseJsonBody` form-over-JSON / `application/*+json` / `_json` array / invalid ignored |
| S3 | PROVEN | `$getPathFromRequest` pathInfo==scriptName / `/` / empty → `""` |
| S4 | PROVEN | InvokeMethod production return asserted (`index()` returns `""`; `$shouldBlockInProduction` is true in production) |
| S5 | PROVEN | `$request` abort content / OPTIONS swallow / wheels hijack. OPTIONS uses deny-all Cors so the short-circuit is proven without writing `Access-Control-Allow-Origin` onto the shared test response. |
| S6 | PROVEN | `$deobfuscateParams` catch swallow (bad value does not throw; params survive) |
| S7 | PROVEN | HEAD→GET; live `.regex` write PINNED (not flipped) |
| S8 | HOLD pinned | whitelist (six keys, not widened) + html fallback (not flipped) |
| S9 | tightened | comment/spec matches Public.cfc `$blockInProduction` on `index()` |
| S10 | tightened | mega-spec kill-cases + createParams overwrite values (not mere key presence) |

## Verification

Driver (LOCKED):

```
wheels test --core --ci --filter=dispatch
```

Maps to `wheels.tests.specs.dispatch`. First LuCLI run: 5325 passed, 2 failed. Both were `$setCORSHeaders` specs reading a leaked `https://s5.example.test` header from the S5 OPTIONS case. Second commit uses deny-all Cors so Dispatch still swallows OPTIONS and no Origin header is written.

HEAD `d3de6775b7677e7e9d563bd7e19ff4af4ce50bc9`

Base `9527d770b2d81f8b5283e2c105b0e193f2c3a1e6` (develop after seeder 3423).

Draft. Do not merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-448ccf35-5f28-46cc-b527-7fe90ba6f3e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-448ccf35-5f28-46cc-b527-7fe90ba6f3e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

