### PR TITLE
fix(public): isolate helpers include from $init promote scan

### DIFF
--- a/changelog.d/3379-public-init-emptystack.fixed.md
+++ b/changelog.d/3379-public-init-emptystack.fixed.md
@@ -1,0 +1,1 @@
+- `Public.$init` no longer nests the `/wheels/public/helpers.cfm` include in the same method as `$scanAndPromoteIncludedGlobals()`. That nest threw `EmptyStackException` from Adobe `popSuperScope` on the first request after a CommandBox cold start on Adobe CF 2023; the 4.0.6 helper-promote onto `this` is unchanged (#3379)

--- a/vendor/wheels/Public.cfc
+++ b/vendor/wheels/Public.cfc
@@ -4,26 +4,50 @@ component output="false" displayName="Internal GUI" extends="wheels.Global" {
 	 * Internal function.
 	 */
 	public struct function $init() {
-		include "/wheels/public/helpers.cfm";
-
-		// The include above declares its UDFs into `variables` only — they never
-		// reach `this` on Lucee 6, Adobe 2023 or Adobe 2025 (Lucee 7 and BoxLang
-		// do promote them, which is why the split stayed invisible). Every helper
-		// in helpers.cfm is declared `public`, and the framework's own views reach
-		// them through `variables`, so the divergence only bites an external
-		// caller — `CreateObject("component", "wheels.Public").$init().$$findMatchingRoutes(…)`
-		// threw "has no function with name" on three of five engines (##3302).
-		//
-		// Same problem, same fix as the `/app/global/functions.cfm` include in
-		// `Global.cfc`'s pseudo-constructor. Call the raw scan rather than
-		// `$promoteIncludedGlobalsToThis()`: that wrapper memoizes its promote
-		// list per class in application scope, and the entry for `wheels.Public`
-		// is written by the pseudo-constructor *before* this include runs — so the
-		// memoized path would replay a stale, pre-include key list and promote
-		// nothing. This is the dev-only GUI component, not a request hot path.
+		// The helpers include MUST live in its own method. 4.0.6 added
+		// `$scanAndPromoteIncludedGlobals()` immediately after a raw `include`
+		// in this same `$init` body (##3302 / 6bff054). That nests Adobe's
+		// include page-context with a parent-class method call (Global's
+		// promote scan). On the first request after a CommandBox cold start,
+		// Adobe CF 2023's `UDFMethod.invoke` cleanup then calls
+		// `NeoPageContext.popSuperScope` against an empty stack —
+		// EmptyStackException at onapplicationstart.cfc:409
+		// (`$createObjectFromRoot` → Public.$init). A later request succeeds
+		// because helpers.cfm is already compiled. 4.0.5 `$init` only
+		// included and returned, which is why discarding 4.0.6 files cleared
+		// it. Isolate the include so its page-context pops before the promote
+		// scan runs; keep the raw scan (not the memoized wrapper) so the
+		// ##3302 `this`-visibility contract stays.
+		$includePublicHelpers();
 		$scanAndPromoteIncludedGlobals();
 
 		return this;
+	}
+
+	/**
+	 * Includes `/wheels/public/helpers.cfm` in its own UDF frame so Adobe's
+	 * include page-context is popped before `$init` calls the parent-class
+	 * promote scan. Do not inline this `include` back into `$init` — that
+	 * nest is the 4.0.6 first-boot EmptyStackException on Adobe CF 2023.
+	 *
+	 * The include declares its UDFs into `variables` only — they never
+	 * reach `this` on Lucee 6, Adobe 2023 or Adobe 2025 (Lucee 7 and BoxLang
+	 * do promote them, which is why the split stayed invisible). Every helper
+	 * in helpers.cfm is declared `public`, and the framework's own views reach
+	 * them through `variables`, so the divergence only bites an external
+	 * caller — `CreateObject("component", "wheels.Public").$init().$$findMatchingRoutes(…)`
+	 * threw "has no function with name" on three of five engines (##3302).
+	 *
+	 * Same problem, same fix as the `/app/global/functions.cfm` include in
+	 * `Global.cfc`'s pseudo-constructor. `$init` calls the raw scan rather than
+	 * `$promoteIncludedGlobalsToThis()`: that wrapper memoizes its promote
+	 * list per class in application scope, and the entry for `wheels.Public`
+	 * is written by the pseudo-constructor *before* this include runs — so the
+	 * memoized path would replay a stale, pre-include key list and promote
+	 * nothing. This is the dev-only GUI component, not a request hot path.
+	 */
+	public void function $includePublicHelpers() {
+		include "/wheels/public/helpers.cfm";
 	}
 
 	/**

--- a/vendor/wheels/tests/_assets/global/PublicInitTraceFixture.cfc
+++ b/vendor/wheels/tests/_assets/global/PublicInitTraceFixture.cfc
@@ -1,0 +1,44 @@
+/**
+ * Order-trace fixture for Public.$init's include-then-promote contract.
+ *
+ * Extends wheels.Public and records when `$includePublicHelpers` starts,
+ * when it returns, and when `$scanAndPromoteIncludedGlobals` runs. Specs
+ * reset the trace after construction (Global's pseudo-constructor also
+ * calls the promote scan) and then invoke `$init`.
+ *
+ * On the 4.0.6 nest (`include` + promote in the same `$init` body) the
+ * include helper is never called, so the trace is only `promote`. After
+ * the include is extracted, the trace is include-start, include-return,
+ * promote — prove the scan runs after the include method returns.
+ */
+component extends="wheels.Public" {
+
+	public void function $resetInitTrace() {
+		variables.$initTrace = [];
+	}
+
+	public array function $getInitTrace() {
+		if (!StructKeyExists(variables, "$initTrace") || !IsArray(variables.$initTrace)) {
+			return [];
+		}
+		return variables.$initTrace;
+	}
+
+	public void function $includePublicHelpers() {
+		if (!StructKeyExists(variables, "$initTrace") || !IsArray(variables.$initTrace)) {
+			variables.$initTrace = [];
+		}
+		ArrayAppend(variables.$initTrace, "include-start");
+		super.$includePublicHelpers();
+		ArrayAppend(variables.$initTrace, "include-return");
+	}
+
+	public array function $scanAndPromoteIncludedGlobals() {
+		if (!StructKeyExists(variables, "$initTrace") || !IsArray(variables.$initTrace)) {
+			variables.$initTrace = [];
+		}
+		ArrayAppend(variables.$initTrace, "promote");
+		return super.$scanAndPromoteIncludedGlobals();
+	}
+
+}

--- a/vendor/wheels/tests/specs/global/PublicInitPromoteSpec.cfc
+++ b/vendor/wheels/tests/specs/global/PublicInitPromoteSpec.cfc
@@ -1,0 +1,123 @@
+/**
+ * Regression gate for the 4.0.6 first-boot EmptyStackException on
+ * Adobe CF 2023 + CommandBox (issue ##3379, separate from the torn-down
+ * application.wo / onError String[] stacks on that same issue).
+ *
+ * Field stack: onapplicationstart.cfc:409 `$createObjectFromRoot` →
+ * Public.$init → Adobe `NeoPageContext.popSuperScope` EmptyStack. 4.0.5
+ * Public.$init is include helpers + return only. 4.0.6 and develop call
+ * `$scanAndPromoteIncludedGlobals()` (a parent-class method on Global)
+ * immediately after the raw `include` in the same `$init` body. Adobe's
+ * first compile of helpers.cfm after a cold start unbalances the
+ * super-scope stack; a later request succeeds.
+ *
+ * This VM cannot run Adobe CF 2023 + CommandBox, so the field EmptyStack
+ * cannot be reproduced here. What CI can prove:
+ *   1. `$init` does not throw on the LuCLI engine.
+ *   2. The ##3302 promote still lands helpers.cfm UDFs on `this`.
+ *   3. The promote scan runs after `$includePublicHelpers` returns — not
+ *      nested inside the same method as the raw include.
+ *   4. `$init`'s own body contains no raw `include` statement, so the
+ *      nest cannot silently return.
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		var ctx = {fixturePath: "wheels.tests._assets.global.PublicInitTraceFixture"};
+
+		describe("Public.$init include/promote un-nest (issue ##3379 first-boot EmptyStack)", () => {
+
+			it("Public.$init does not throw", () => {
+				var state = {threw = false, message = ""};
+				try {
+					var publicCfc = CreateObject("component", "wheels.Public");
+					publicCfc.$init();
+				} catch (any e) {
+					state.threw = true;
+					state.message = e.message;
+				}
+				expect(state.threw).toBeFalse(
+					"Public.$init threw: " & state.message
+				);
+			});
+
+			it("still promotes helpers.cfm functions onto this (##3302 contract)", () => {
+				var publicCfc = CreateObject("component", "wheels.Public");
+				publicCfc.$init();
+				expect(StructKeyExists(publicCfc, "$$findMatchingRoutes")).toBeTrue(
+					"expected $$findMatchingRoutes from helpers.cfm on this after $init"
+				);
+				expect(IsCustomFunction(publicCfc["$$findMatchingRoutes"])).toBeTrue();
+				expect(StructKeyExists(publicCfc, "pageHeader")).toBeTrue(
+					"expected pageHeader from helpers.cfm on this after $init"
+				);
+				expect(IsCustomFunction(publicCfc.pageHeader)).toBeTrue();
+			});
+
+			it("the $createObjectFromRoot boot path still returns a promoted Public instance", () => {
+				var publicCfc = application.wo.$createObjectFromRoot(
+					path = "wheels",
+					fileName = "Public",
+					method = "$init"
+				);
+				expect(IsObject(publicCfc)).toBeTrue();
+				expect(StructKeyExists(publicCfc, "$$findMatchingRoutes")).toBeTrue();
+				expect(IsCustomFunction(publicCfc["$$findMatchingRoutes"])).toBeTrue();
+			});
+
+			it("promote runs after $includePublicHelpers returns, not mid-include", () => {
+				var fixture = CreateObject("component", ctx.fixturePath);
+				fixture.$resetInitTrace();
+				fixture.$init();
+				var trace = fixture.$getInitTrace();
+				expect(ArrayLen(trace)).toBe(
+					3,
+					"expected [include-start, include-return, promote], got [" & ArrayToList(trace) & "]"
+				);
+				expect(trace[1]).toBe("include-start");
+				expect(trace[2]).toBe("include-return");
+				expect(trace[3]).toBe("promote");
+			});
+
+			it("$init body contains no raw include (structural nest guard)", () => {
+				var filePath = ExpandPath("/wheels/Public.cfc");
+				var content = FileRead(filePath);
+				var fileLines = ListToArray(content, Chr(10), true);
+				var inInit = false;
+				var offenders = [];
+				var lineNumber = 0;
+				for (var rawLine in fileLines) {
+					lineNumber++;
+					var trimmed = Trim(Replace(rawLine, Chr(13), "", "all"));
+					if (ReFindNoCase("function\s+\$init\s*\(", trimmed)) {
+						inInit = true;
+						continue;
+					}
+					if (inInit && ReFindNoCase("function\s+\$includePublicHelpers\s*\(", trimmed)) {
+						break;
+					}
+					if (inInit && ReFindNoCase("(public|private|package|remote)?\s*(any|void|struct|array|string|boolean|numeric|query|date)?\s*function\s+", trimmed)) {
+						break;
+					}
+					if (!inInit) {
+						continue;
+					}
+					if (Left(trimmed, 2) == "//" || Left(trimmed, 1) == "*" || Left(trimmed, 2) == "/*") {
+						continue;
+					}
+					if (ReFindNoCase("^\s*include\s+", trimmed)) {
+						ArrayAppend(offenders, "raw include at line " & lineNumber);
+					}
+				}
+				expect(inInit).toBeTrue("expected to find Public.$init in Public.cfc");
+				expect(ArrayLen(offenders)).toBe(
+					0,
+					"Public.$init must not contain a raw include (nest with promote scan): " & ArrayToList(offenders)
+				);
+			});
+
+		});
+	}
+
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adobe CF 2023 + CommandBox first cold start throws `EmptyStackException` from `NeoPageContext.popSuperScope` while `onapplicationstart.cfc` instantiates the Public GUI (`$createObjectFromRoot` → `Public.$init`). This is a 4.0.6 regression: discarding the 4.0.6 files and returning to 4.0.5 clears it; a later page load can succeed.

This PR is the first-boot EmptyStack path only. It is **not** the torn-down `application.wo` / `onError` `String[]` report on issue 3379. No `onError`, `EventHandlerInterface`, `Application.cfc` template, or `onSessionEnd` edits.

Refs #3379. HEAD: `d96d6024ad0b6c839d5d20f2aae8620c5e7b1f6b`.

## Root cause (verified)

The desk hypothesis holds. Investigation, not just the write-up:

1. Field stack from the 4.0.6 CommandBox report lands on `vendor/wheels/events/onapplicationstart.cfc:409` — `$createObjectFromRoot(path="wheels", fileName="Public", method="$init")`. Adobe then pops a super-scope inside `UDFMethod.invoke` (`NeoPageContext.popSuperScope`) and the stack is empty.
2. That call site already existed in 4.0.5 (line 419). It is not new work.
3. The 4.0.6 delta is inside `Public.$init` (commit `6bff05441f` / PR 3302): after `include "/wheels/public/helpers.cfm"` it now calls `$scanAndPromoteIncludedGlobals()`. That helper is a **parent-class** method on `wheels.Global`. 4.0.5 `$init` is include + return only.
4. Same-method `include` + parent-method promote nests Adobe's include page-context with a super-scope push. On the **first compile** of `helpers.cfm` after a CommandBox cold start, `popSuperScope` runs against an empty stack. A later request succeeds because the include is already compiled — matching the report.
5. The promote itself is still required (Lucee 6 / Adobe 2023 / Adobe 2025 do not lift include UDFs onto `this`). The memoized `$promoteIncludedGlobalsToThis()` wrapper cannot be used here: Global's pseudo-constructor already cached a pre-include key list for `wheels.Public`.

## 4.0.5 vs 4.0.6 vs develop

| Tree | SHA | `Public.$init` |
|---|---|---|
| 4.0.5 tag | `51eb6e47` | `include "/wheels/public/helpers.cfm"` then `return this` |
| 4.0.6 tag | `5928131d` | same include, then `$scanAndPromoteIncludedGlobals()`, then return |
| develop (this base) | `c64f6a9b` | identical to 4.0.6 |

`$createObjectFromRoot(..., Public, $init)`: 4.0.5 line 419, 4.0.6 and develop line 409. Same call.

## What changed

- Extracted the helpers include into `$includePublicHelpers()` so its UDF / page-context frame returns **before** `$init` calls the parent-class promote scan.
- `$init` still calls the raw `$scanAndPromoteIncludedGlobals()` (not the memoized wrapper) so the 4.0.6 `this`-visibility contract stays.
- Smallest production edit: `Public.$init` / the new include helper only.

## PROVEN

| Claim | Evidence |
|---|---|
| Hypothesis confirmed | 4.0.5 `$init` has no promote call; 4.0.6 / develop add `$scanAndPromoteIncludedGlobals()` in the same method as the include; field stack is `$createObjectFromRoot` → `$init` → `popSuperScope` |
| Include and promote no longer share a `$init` frame | `PublicInitPromoteSpec`: trace is `include-start`, `include-return`, `promote` |
| 4.0.6 promote behavior kept | Same spec: `$$findMatchingRoutes` and `pageHeader` are custom functions on `this` after `$init`; `$createObjectFromRoot` path still returns a promoted instance |
| Nest cannot silently return | Structural scan: `$init` body has no raw `include` statement |
| `$init` does not throw on LuCLI | Same spec (Lucee). Adobe 2023 first-boot EmptyStack cannot be fully simulated in this VM |
| Not the torn-down-scope `onError` report | Diff is `Public.cfc` + WheelsTest + changelog fragment only |
| Full core suite green | `wheels test --core --ci` → **5332 passed** (LuCLI / Lucee 7 + SQLite) |
| GitHub CI | All 12 checks on `d96d6024` completed without failures |

## Tests

- New: `vendor/wheels/tests/specs/global/PublicInitPromoteSpec.cfc` (extends `wheels.WheelsTest`) — 5/5 passed
- Fixture: `vendor/wheels/tests/_assets/global/PublicInitTraceFixture.cfc`
- Driver used: `wheels test --core --ci --timeout=1800` (full framework suite)
- `--filter=global` (`directory=wheels.tests.specs.global`) also hits this spec; confirmed 219 pass / 0 fail including all 5 new examples

Adobe CF 2023 + CommandBox first-boot is the field reproduction and cannot be fully simulated here. CI (LuCLI) is the real green for this VM. GitHub CI on this HEAD is also green (12/12).

## Out of scope / leftover

Left on issue 3379, not this PR:

- Torn-down `application.wo` during `onError` (`Element wo is undefined in a Java object of type class [Ljava.lang.String;`)
- `EventHandlerInterface` missing-template during `$invoke` from `onError`
- Copying the v4.0.6 `Application.cfc` (that drop would remove the develop `onSessionEnd` guard)

## Type of Change

- [x] Bug fix
- [x] DCO sign-off
- [x] Tests
- [x] Changelog fragment (`changelog.d/3379-public-init-emptystack.fixed.md`)
- [ ] Framework docs / AI reference / CLAUDE.md (no public API change beyond the internal include helper)

## Test Plan

1. `wheels test --core --ci` — done here, 5332 passed
2. GitHub CI on this HEAD — 12/12 green
3. Field check (Adobe CF 2023 + CommandBox): stop the server, start cold, first GET must not EmptyStack; second GET still serves the Public GUI helpers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83bb7bd0-08e6-402e-a57f-d03838bb62b1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83bb7bd0-08e6-402e-a57f-d03838bb62b1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

