### PR TITLE
fix(public): defer helper promote until after Public.$init

### DIFF
--- a/changelog.d/3379-first-boot-emptystack.fixed.md
+++ b/changelog.d/3379-first-boot-emptystack.fixed.md
@@ -1,0 +1,1 @@
+- Adobe CF 2023 + CommandBox no longer throws `EmptyStackException` on the first request after a cold start. `Public.$init()` is include-and-return again (the 4.0.5 shape); `$scanAndPromoteIncludedGlobals()` runs after `$createObjectFromRoot` returns so the #3302 helper-on-`this` promote still happens once the include nest has unwound (#3379)

--- a/cli/lucli/templates/app/public/Application.cfc
+++ b/cli/lucli/templates/app/public/Application.cfc
@@ -280,6 +280,7 @@ component output="false" {
 
 				// Enable the main GUI Component
 				application.wheels.public = application.wo.$createObjectFromRoot(path = "wheels", fileName = "Public", method = "$init");
+				application.wheels.public.$scanAndPromoteIncludedGlobals();
 			} else {
 				application.wheels.enablePublicComponent = application.wheels.debugIPAccess.originalEnablePublicComponent;
 				application.wheels.showDebugInformation = application.wheels.debugIPAccess.originalShowDebugInformation;

--- a/examples/starter-app/public/Application.cfc
+++ b/examples/starter-app/public/Application.cfc
@@ -249,6 +249,7 @@ component output="false" {
 
 				// Enable the main GUI Component
 				application.wheels.public = application.wo.$createObjectFromRoot(path = "wheels", fileName = "Public", method = "$init");
+				application.wheels.public.$scanAndPromoteIncludedGlobals();
 			} else {
 				application.wheels.enablePublicComponent = application.wheels.debugIPAccess.originalEnablePublicComponent;
 				application.wheels.showDebugInformation = application.wheels.debugIPAccess.originalShowDebugInformation;

--- a/examples/tweet/public/Application.cfc
+++ b/examples/tweet/public/Application.cfc
@@ -249,6 +249,7 @@ component output="false" {
 
 				// Enable the main GUI Component
 				application.wheels.public = application.wo.$createObjectFromRoot(path = "wheels", fileName = "Public", method = "$init");
+				application.wheels.public.$scanAndPromoteIncludedGlobals();
 			} else {
 				application.wheels.enablePublicComponent = application.wheels.debugIPAccess.originalEnablePublicComponent;
 				application.wheels.showDebugInformation = application.wheels.debugIPAccess.originalShowDebugInformation;

--- a/public/Application.cfc
+++ b/public/Application.cfc
@@ -281,6 +281,7 @@ component output="false" {
 
 				// Enable the main GUI Component
 				application.wheels.public = application.wo.$createObjectFromRoot(path = "wheels", fileName = "Public", method = "$init");
+				application.wheels.public.$scanAndPromoteIncludedGlobals();
 			} else {
 				application.wheels.enablePublicComponent = application.wheels.debugIPAccess.originalEnablePublicComponent;
 				application.wheels.showDebugInformation = application.wheels.debugIPAccess.originalShowDebugInformation;

--- a/vendor/wheels/Public.cfc
+++ b/vendor/wheels/Public.cfc
@@ -5,24 +5,15 @@ component output="false" displayName="Internal GUI" extends="wheels.Global" {
 	 */
 	public struct function $init() {
 		include "/wheels/public/helpers.cfm";
-
-		// The include above declares its UDFs into `variables` only — they never
-		// reach `this` on Lucee 6, Adobe 2023 or Adobe 2025 (Lucee 7 and BoxLang
-		// do promote them, which is why the split stayed invisible). Every helper
-		// in helpers.cfm is declared `public`, and the framework's own views reach
-		// them through `variables`, so the divergence only bites an external
-		// caller — `CreateObject("component", "wheels.Public").$init().$$findMatchingRoutes(…)`
-		// threw "has no function with name" on three of five engines (##3302).
-		//
-		// Same problem, same fix as the `/app/global/functions.cfm` include in
-		// `Global.cfc`'s pseudo-constructor. Call the raw scan rather than
-		// `$promoteIncludedGlobalsToThis()`: that wrapper memoizes its promote
-		// list per class in application scope, and the entry for `wheels.Public`
-		// is written by the pseudo-constructor *before* this include runs — so the
-		// memoized path would replay a stale, pre-include key list and promote
-		// nothing. This is the dev-only GUI component, not a request hot path.
-		$scanAndPromoteIncludedGlobals();
-
+		// Include only. Do not call $scanAndPromoteIncludedGlobals() here.
+		// 4.0.6 ran the scan in this method after the include (##3302). On
+		// Adobe CF 2023 + CommandBox that extra inherited call after a
+		// first-compile include empties NeoPageContext's super-scope stack,
+		// and $init's return throws EmptyStackException at
+		// onapplicationstart.cfc's $createObjectFromRoot line. 4.0.5 was
+		// include-and-return and did not throw. A later request compiles a
+		// second time and succeeds. Callers promote after $init returns:
+		// instance.$scanAndPromoteIncludedGlobals().
 		return this;
 	}
 

--- a/vendor/wheels/events/onapplicationstart.cfc
+++ b/vendor/wheels/events/onapplicationstart.cfc
@@ -407,6 +407,11 @@ component {
 		// Enable the main GUI Component
 		if (application.$wheels.enablePublicComponent) {
 			application.$wheels.public = application.wo.$createObjectFromRoot(path = "wheels", fileName = "Public", method = "$init");
+			// ##3302 promote after $init returns. Running the scan inside
+			// Public.$init after the helpers.cfm include empties Adobe CF's
+			// super-scope stack on the first compile after a CommandBox cold
+			// start (EmptyStackException at the $createObjectFromRoot line).
+			application.$wheels.public.$scanAndPromoteIncludedGlobals();
 		}
 
 		// Reload the plugins each time we reload the application.

--- a/vendor/wheels/tests/specs/dispatch/DispatchPublicHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/dispatch/DispatchPublicHardenerSpec.cfc
@@ -172,6 +172,7 @@ component extends="wheels.WheelsTest" {
 					}
 				]
 				publicCfc = CreateObject("component", "wheels.Public").$init()
+				publicCfc.$scanAndPromoteIncludedGlobals()
 			})
 
 			afterEach(() => {

--- a/vendor/wheels/tests/specs/events/PublicInitColdStartSpec.cfc
+++ b/vendor/wheels/tests/specs/events/PublicInitColdStartSpec.cfc
@@ -1,0 +1,203 @@
+/**
+ * Structural + executable guard for the 4.0.6 first-boot EmptyStack.
+ *
+ * Adobe CF 2023 + CommandBox threw java.util.EmptyStackException at
+ * NeoPageContext.popSuperScope during onapplicationstart.cfc's
+ * $createObjectFromRoot → Public.$init on the first request after a cold
+ * start. Reverting Public.$init to the 4.0.5 include-and-return shape
+ * cleared it; a later reload that compiled a second time also succeeded.
+ *
+ * The 4.0.5 → 4.0.6 delta inside $init is the $scanAndPromoteIncludedGlobals()
+ * call added by 6bff0544 (##3302). That inherited Global method after a
+ * first-compile include empties Adobe's super-scope stack, so $init's
+ * return pops an empty stack. The suite cannot boot Adobe CF 2023 +
+ * CommandBox, so this spec pins the contract that prevents the nest:
+ * Public.$init does not call the scan, and onapplicationstart promotes
+ * after $createObjectFromRoot returns so the ##3302 helpers-on-this
+ * feature still runs once the include nest has unwound.
+ *
+ * Line-anchored comment-prefix skipping, same as
+ * OnAppStartBareHelperGuardSpec / BareCfabortGuardSpec. Not a global
+ * comment-strip regex — that shape hangs Lucee 7 on large sources.
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("Public.$init first-boot promote deferral (issue ##3379)", () => {
+
+			it("Public.$init does not call $scanAndPromoteIncludedGlobals", () => {
+				var body = $publicInitBody();
+				var offenders = [];
+				var lineNumber = 0;
+
+				for (var rawLine in body.lines) {
+					lineNumber++;
+					var trimmed = Trim(Replace(rawLine, Chr(13), "", "all"));
+					if (Left(trimmed, 2) == "//" || Left(trimmed, 1) == "*" || Left(trimmed, 2) == "/*") {
+						continue;
+					}
+					if (FindNoCase("$scanAndPromoteIncludedGlobals", trimmed)) {
+						ArrayAppend(offenders, "line #body.startLine + lineNumber - 1#");
+					}
+				}
+
+				expect(ArrayLen(offenders)).toBe(
+					0,
+					"Public.$init calls $scanAndPromoteIncludedGlobals at: #ArrayToList(offenders, ', ')#. "
+					& "That inherited scan after the helpers.cfm include empties Adobe CF's "
+					& "super-scope stack on the first compile after a CommandBox cold start "
+					& "(EmptyStackException at onapplicationstart.cfc $createObjectFromRoot). "
+					& "Keep $init as include-and-return and promote after $init returns."
+				);
+			});
+
+			it("onapplicationstart promotes Public helpers after $createObjectFromRoot returns", () => {
+				var content = FileRead(ExpandPath("/wheels/events/onapplicationstart.cfc"));
+				var fileLines = ListToArray(content, Chr(10), true);
+				var createLine = 0;
+				var promoteLine = 0;
+				var lineNumber = 0;
+
+				for (var rawLine in fileLines) {
+					lineNumber++;
+					var trimmed = Trim(Replace(rawLine, Chr(13), "", "all"));
+					if (Left(trimmed, 2) == "//" || Left(trimmed, 1) == "*" || Left(trimmed, 2) == "/*") {
+						continue;
+					}
+					if (
+						createLine == 0
+						&& FindNoCase("$createObjectFromRoot", trimmed)
+						&& FindNoCase("Public", trimmed)
+						&& FindNoCase("$init", trimmed)
+					) {
+						createLine = lineNumber;
+					}
+					if (
+						createLine > 0
+						&& promoteLine == 0
+						&& FindNoCase("$scanAndPromoteIncludedGlobals", trimmed)
+					) {
+						promoteLine = lineNumber;
+					}
+				}
+
+				expect(createLine).toBeGT(
+					0,
+					"events/onapplicationstart.cfc no longer creates wheels.Public via "
+					& "$createObjectFromRoot(..., method=""$init"")."
+				);
+				expect(promoteLine).toBeGT(
+					createLine,
+					"events/onapplicationstart.cfc no longer calls $scanAndPromoteIncludedGlobals() "
+					& "after $createObjectFromRoot returns the Public instance. The ##3302 "
+					& "helpers-on-this promote would never run on first boot."
+				);
+			});
+
+			it("debug-IP Public creates also promote after $init returns", () => {
+				// These paths replace application.wheels.public after $init.
+				// Without a follow-up scan they would drop the ##3302
+				// helpers-on-this surface on Lucee 6 / Adobe.
+				var repoRoot = ExpandPath("/wheels/../..");
+				var targets = [
+					"cli/lucli/templates/app/public/Application.cfc",
+					"public/Application.cfc",
+					"examples/starter-app/public/Application.cfc",
+					"examples/tweet/public/Application.cfc"
+				];
+				for (var relPath in targets) {
+					var content = FileRead(repoRoot & "/" & relPath);
+					var fileLines = ListToArray(content, Chr(10), true);
+					var createLine = 0;
+					var promoteLine = 0;
+					var lineNumber = 0;
+					for (var rawLine in fileLines) {
+						lineNumber++;
+						var trimmed = Trim(Replace(rawLine, Chr(13), "", "all"));
+						if (Left(trimmed, 2) == "//" || Left(trimmed, 1) == "*" || Left(trimmed, 2) == "/*") {
+							continue;
+						}
+						if (
+							createLine == 0
+							&& FindNoCase("$createObjectFromRoot", trimmed)
+							&& FindNoCase("Public", trimmed)
+							&& FindNoCase("$init", trimmed)
+						) {
+							createLine = lineNumber;
+						}
+						if (
+							createLine > 0
+							&& promoteLine == 0
+							&& FindNoCase("$scanAndPromoteIncludedGlobals", trimmed)
+						) {
+							promoteLine = lineNumber;
+						}
+					}
+					expect(createLine).toBeGT(
+						0,
+						relPath & " no longer creates wheels.Public via $createObjectFromRoot."
+					);
+					expect(promoteLine).toBeGT(
+						createLine,
+						relPath & " creates Public via $init but does not call "
+						& "$scanAndPromoteIncludedGlobals() afterwards."
+					);
+				}
+			});
+
+			it("promotes helpers.cfm functions onto this after $init returns", () => {
+				var publicCfc = CreateObject("component", "wheels.Public").$init();
+				var promotedKeys = publicCfc.$scanAndPromoteIncludedGlobals();
+
+				expect(IsArray(promotedKeys)).toBeTrue();
+				expect(StructKeyExists(publicCfc, "$$findMatchingRoutes")).toBeTrue(
+					"expected $$findMatchingRoutes from helpers.cfm on this after the "
+					& "deferred $scanAndPromoteIncludedGlobals() call (##3302)"
+				);
+				expect(IsCustomFunction(publicCfc["$$findMatchingRoutes"])).toBeTrue();
+			});
+
+		});
+
+	}
+
+	/**
+	 * Extracts the $init function body lines from Public.cfc (from its
+	 * declaration up to the next function declaration). Returns
+	 * {lines, startLine} where startLine is the 1-based file line of the
+	 * declaration, so failure messages can report real file line numbers.
+	 */
+	public struct function $publicInitBody() {
+		var content = FileRead(ExpandPath("/wheels/Public.cfc"));
+		var fileLines = ListToArray(content, Chr(10), true);
+		var declarationPattern = "(public|private)\s+\w+\s+function\s+";
+		var result = {lines = [], startLine = 0};
+		var inBody = false;
+		var lineNumber = 0;
+
+		for (var rawLine in fileLines) {
+			lineNumber++;
+			if (!inBody) {
+				if (REFindNoCase(declarationPattern & "\$init\b", rawLine)) {
+					inBody = true;
+					result.startLine = lineNumber;
+					ArrayAppend(result.lines, rawLine);
+				}
+				continue;
+			}
+			if (REFindNoCase(declarationPattern & "[\w$]+\s*\(", rawLine)) {
+				break;
+			}
+			ArrayAppend(result.lines, rawLine);
+		}
+
+		expect(result.startLine).toBeGT(
+			0,
+			"Could not locate the $init declaration in Public.cfc — "
+			& "update PublicInitColdStartSpec.cfc if the function was renamed."
+		);
+		return result;
+	}
+
+}

--- a/vendor/wheels/tests/specs/security/RouteTesterHardeningSpec.cfc
+++ b/vendor/wheels/tests/specs/security/RouteTesterHardeningSpec.cfc
@@ -15,6 +15,7 @@ component extends="wheels.WheelsTest" {
 
 	function beforeAll() {
 		variables.publicCfc = CreateObject("component", "wheels.Public").$init();
+		variables.publicCfc.$scanAndPromoteIncludedGlobals();
 		variables.helperSource = FileRead(ExpandPath("/wheels/public/helpers.cfm"));
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adobe CF 2023 + CommandBox throws `EmptyStackException` from `NeoPageContext.popSuperScope` on the first request after a cold start. The stack lands on `vendor/wheels/events/onapplicationstart.cfc:409` (`$createObjectFromRoot` → `Public.$init`). Discarding the 4.0.6 files and going back to 4.0.5 clears it. A later page load that compiles a second time also succeeds.

This PR is that first-boot EmptyStack path only. It is not the torn-down `application.wo` / `onError` `String[]` report on issue 3379. No `onError`, `EventHandlerInterface`, or `onSessionEnd` edits.

Related to #3379.

## Root cause (confirmed)

The desk hypothesis holds. I compared the three trees rather than taking the write-up as given.

1. Field stack from the 4.0.6 CommandBox report is `onapplicationstart.cfc:409` → `$createObjectFromRoot(path="wheels", fileName="Public", method="$init")`. Adobe then pops a super-scope inside `UDFMethod.invoke` (`NeoPageContext.popSuperScope`) and the stack is empty.
2. That call site already existed in 4.0.5 (line 419). It is not new work.
3. The 4.0.6 delta is inside `Public.$init` (commit `6bff05441f` / #3302): after `include "/wheels/public/helpers.cfm"` it now calls `$scanAndPromoteIncludedGlobals()`. That helper is a parent-class method on `wheels.Global`. 4.0.5 `$init` is include + return only.
4. Same-method `include` + parent-method promote nests Adobe's include page-context with a super-scope push. On the first compile of `helpers.cfm` after a CommandBox cold start, `popSuperScope` runs against an empty stack. A later request succeeds because the include is already compiled, matching the report.
5. The promote itself is still required. Lucee 6 / Adobe 2023 / Adobe 2025 do not lift include UDFs onto `this`. The memoized `$promoteIncludedGlobalsToThis()` wrapper cannot be used here: Global's pseudo-constructor already cached a pre-include key list for `wheels.Public`.

Hoisting the include into a helper and still calling the scan from `$init` is the other obvious shape. I discarded it. 4.0.5 `$init` is include-and-return and does not throw. If the inherited scan extra-pops, `$init`'s own return still EmptyStacks. The safe contract is the one that already worked: `$init` does not call the scan. Promote after `$createObjectFromRoot` returns, once that Invoke has fully unwound.

## 4.0.5 vs 4.0.6 vs develop

| Tree | SHA | `Public.$init` |
|---|---|---|
| 4.0.5 tag | `51eb6e47` | `include "/wheels/public/helpers.cfm"` then `return this` |
| 4.0.6 tag | `5928131d` | same include, then `$scanAndPromoteIncludedGlobals()`, then return |
| develop (this base) | `c64f6a9b` | identical to 4.0.6 |

`$createObjectFromRoot(..., Public, $init)`: 4.0.5 line 419, 4.0.6 and develop line 409. Same call.

## What changed

- `Public.$init` is include-and-return again (the 4.0.5 shape). It does not call `$scanAndPromoteIncludedGlobals()`.
- `onapplicationstart.cfc` calls `$scanAndPromoteIncludedGlobals()` on the Public instance after `$createObjectFromRoot` returns, so the #3302 helpers-on-`this` surface still applies once the include nest has unwound.
- The debug-IP Public create in the shipped `Application.cfc` copies does the same two-step. Those paths replace `application.wheels.public` after `$init`; without the follow-up scan they would drop helpers on Lucee 6 / Adobe. `onSessionEnd` is untouched.

## Tests

- New: `vendor/wheels/tests/specs/events/PublicInitColdStartSpec.cfc` (extends `wheels.WheelsTest`)
  - `$init` body has no `$scanAndPromoteIncludedGlobals` call (the 4.0.6 nest)
  - `onapplicationstart` and the four shipped `Application.cfc` copies promote after `$createObjectFromRoot` returns
  - `$init` then `$scanAndPromoteIncludedGlobals()` puts `$$findMatchingRoutes` on `this` (#3302)
- `RouteTesterHardeningSpec` and `DispatchPublicHardenerSpec` call the scan after `$init` before they use `$$findMatchingRoutes`

Adobe CF 2023 + CommandBox first-boot cannot be fully simulated here. The spec pins the contract that prevents the nest.

## Out of scope

Left on issue 3379, not this PR:

- Torn-down `application.wo` during `onError` (`Element wo is undefined in a Java object of type class [Ljava.lang.String;`)
- `EventHandlerInterface` missing-template during `$invoke` from `onError`
- Copying the v4.0.6 `Application.cfc` (that drop would remove the develop `onSessionEnd` guard)

## Type of Change

- [x] Bug fix
- [x] DCO sign-off
- [x] Tests
- [x] Changelog fragment (`changelog.d/3379-first-boot-emptystack.fixed.md`)

## Test Plan

1. `wheels test --core --ci --filter=events` (new spec)
2. `wheels test --core --ci` (full framework suite)
3. Field check (Adobe CF 2023 + CommandBox): stop the server, start cold, first GET must not EmptyStack; Public GUI helpers still resolve after init.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f14e79db-3756-41f9-b853-a248071f0a8a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f14e79db-3756-41f9-b853-a248071f0a8a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

