### PR TITLE
test(events): assert interface bootstrap and pin event lifecycle contracts

### DIFF
--- a/vendor/wheels/tests/_assets/events/OnErrorEventDouble.cfc
+++ b/vendor/wheels/tests/_assets/events/OnErrorEventDouble.cfc
@@ -1,0 +1,63 @@
+/**
+ * Test double for events hardener S2 / S3 / S4.
+ *
+ * Extends the real EventMethods so `$runOnError` executes the genuine
+ * status map, `$mail` swallow, and JSON/XML serialization, while:
+ * - `$header` records status/content-type instead of writing the live
+ *   test-runner response (a leaked 500 would look like a suite failure)
+ * - `$mail` records the call and can be told to throw
+ * - `$fireOnErrorCallbacks` / `$restoreTestRunnerApplicationScope` /
+ *   `$includeAndReturnOutput` are no-op'd so the spec only exercises
+ *   the error-response contract
+ */
+component extends="wheels.events.EventMethods" {
+
+	public any function init() {
+		this.headerCalls = [];
+		this.mailCalls = 0;
+		this.mailShouldThrow = false;
+		this.formatOverride = "json";
+		return this;
+	}
+
+	public void function $header() {
+		var recorded = {};
+		for (var key in arguments) {
+			recorded[key] = arguments[key];
+		}
+		ArrayAppend(this.headerCalls, recorded);
+	}
+
+	public void function $mail() {
+		this.mailCalls = this.mailCalls + 1;
+		if (this.mailShouldThrow) {
+			throw(type = "UnitTest.MailFailure", message = "forced mail failure");
+		}
+	}
+
+	public void function $fireOnErrorCallbacks(required any exception) {
+	}
+
+	public void function $restoreTestRunnerApplicationScope() {
+	}
+
+	public string function $getRequestFormat() {
+		return this.formatOverride;
+	}
+
+	public string function $includeAndReturnOutput() {
+		return "on-error-double-body";
+	}
+
+	public numeric function $lastStatusCode() {
+		var i = ArrayLen(this.headerCalls);
+		while (i >= 1) {
+			if (StructKeyExists(this.headerCalls[i], "statusCode")) {
+				return Val(this.headerCalls[i].statusCode);
+			}
+			i--;
+		}
+		return 0;
+	}
+
+}

--- a/vendor/wheels/tests/_assets/events/RequestStartAbortGuardDouble.cfc
+++ b/vendor/wheels/tests/_assets/events/RequestStartAbortGuardDouble.cfc
@@ -1,0 +1,53 @@
+/**
+ * S5 abort containment for EventsHardenerSpec.
+ *
+ * CorsArbitrationEventDouble runs the live `$runOnRequestStart` but does
+ * not trap `abort`. If `$corsMiddlewareActive()` is false while
+ * request.CGI.request_method is OPTIONS and allowCorsRequests is true,
+ * the production `abort;` kills the TestBox HTTP request (LuCLI core
+ * suite HTTP 500). This double refuses to enter that branch: it throws a
+ * contained UnitTest exception instead of invoking the aborting path.
+ *
+ * Cors-active skip still executes the live `$runOnRequestStart`. The
+ * production `abort;` stays pinned in EventMethods source — do not flip it.
+ */
+component extends="wheels.tests._assets.events.CorsArbitrationEventDouble" {
+
+	public any function init() {
+		super.init();
+		this.abortContained = false;
+		return this;
+	}
+
+	/**
+	 * cflocation / $location also abort the request. No-op so a leftover
+	 * redirectAfterReloadUrl cannot kill the suite either.
+	 */
+	public void function $location() {
+	}
+
+	/**
+	 * Invoke live `$runOnRequestStart` only when the OPTIONS abort branch
+	 * cannot fire. Mirrors EventMethods.cfc ~329-337 without executing abort.
+	 */
+	public void function $runOnRequestStartContained(required string targetPage) {
+		this.abortContained = false;
+		if ($wouldHitOptionsAbort()) {
+			this.abortContained = true;
+			throw(
+				type = "UnitTest.OptionsAbortContained",
+				message = "contained $runOnRequestStart OPTIONS abort — Cors-active skip was not live"
+			);
+		}
+		$runOnRequestStart(targetPage = arguments.targetPage);
+	}
+
+	public boolean function $wouldHitOptionsAbort() {
+		return application.wheels.allowCorsRequests
+			&& !$corsMiddlewareActive()
+			&& StructKeyExists(request, "CGI")
+			&& StructKeyExists(request.CGI, "request_method")
+			&& request.CGI.request_method eq "OPTIONS";
+	}
+
+}

--- a/vendor/wheels/tests/specs/events/EventsHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/events/EventsHardenerSpec.cfc
@@ -271,7 +271,7 @@ component extends="wheels.WheelsTest" {
 
 			it("keeps the empty cfcatch around the docs-link rewrite", () => {
 				var src = FileRead(ExpandPath("/wheels/events/onerror/wheelserror.cfm"));
-				// Concatenate so the CFML parser does not treat "<cf..." / "</cf..." as tags.
+				// Concatenate so the CFML parser does not treat cf-tag text as tags.
 				var emptyCatch = "<" & "cfcatch><" & "/cfcatch>";
 				var rethrowTag = "<" & "cfrethrow";
 				expect(FindNoCase("<" & "cfcatch>", src)).toBeGT(

--- a/vendor/wheels/tests/specs/events/EventsHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/events/EventsHardenerSpec.cfc
@@ -277,13 +277,30 @@ component extends="wheels.WheelsTest" {
 
 			it("keeps the empty catch-any around the reloadPassword writeLog", () => {
 				var src = FileRead(ExpandPath("/wheels/events/onapplicationstart.cfc"));
-				var writeLogPos = FindNoCase('writeLog(file="wheels_security"', src);
-				expect(writeLogPos).toBeGT(
+				// Unique to the locked empty-reloadPassword swallow (~371-372).
+				// FindNoCase('writeLog(file="wheels_security"') first-hits the
+				// password-rejected writeLog (~216) and would stay green if
+				// the locked catch (any e) {} was deleted.
+				var marker = "Wheels: reloadPassword is empty";
+				var markerPos = Find(marker, src);
+				expect(markerPos).toBeGT(
 					0,
-					"onapplicationstart.cfc no longer writeLogs an empty reloadPassword warning"
+					"onapplicationstart.cfc no longer writeLogs the empty-reloadPassword warning"
 				);
-				var window = Mid(src, writeLogPos, 500);
-				expect(Find("catch (any e)", window)).toBeGT(0);
+				expect(Find(marker, src, markerPos + 1)).toBe(
+					0,
+					"empty-reloadPassword writeLog marker must be unique"
+				);
+				var lookbackStart = Max(1, markerPos - 80);
+				expect(FindNoCase("writeLog", Mid(src, lookbackStart, 80))).toBeGT(
+					0,
+					"empty-reloadPassword marker must sit on a writeLog call"
+				);
+				var window = Mid(src, markerPos, 300);
+				expect(Find("catch (any e) {}", window)).toBeGT(
+					0,
+					"locked empty-reloadPassword swallow must stay `catch (any e) {}`"
+				);
 				expect(FindNoCase("rethrow", window)).toBe(0);
 				expect(FindNoCase("throw(", window)).toBe(0);
 			});

--- a/vendor/wheels/tests/specs/events/EventsHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/events/EventsHardenerSpec.cfc
@@ -271,8 +271,8 @@ component extends="wheels.WheelsTest" {
 
 			it("keeps the empty cfcatch around the docs-link rewrite", () => {
 				var src = FileRead(ExpandPath("/wheels/events/onerror/wheelserror.cfm"));
-				// Concatenate so the CFML parser does not treat "<cf..." as a tag.
-				var emptyCatch = "<" & "cfcatch></cfcatch>";
+				// Concatenate so the CFML parser does not treat "<cf..." / "</cf..." as tags.
+				var emptyCatch = "<" & "cfcatch><" & "/cfcatch>";
 				var rethrowTag = "<" & "cfrethrow";
 				expect(FindNoCase("<" & "cfcatch>", src)).toBeGT(
 					0,

--- a/vendor/wheels/tests/specs/events/EventsHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/events/EventsHardenerSpec.cfc
@@ -269,17 +269,20 @@ component extends="wheels.WheelsTest" {
 
 		describe("S7 wheelserror.cfm empty cfcatch keep-going", () => {
 
-			it("keeps the empty <cfcatch> around the docs-link rewrite", () => {
+			it("keeps the empty cfcatch around the docs-link rewrite", () => {
 				var src = FileRead(ExpandPath("/wheels/events/onerror/wheelserror.cfm"));
-				expect(FindNoCase("<cfcatch>", src)).toBeGT(
+				// Concatenate so the CFML parser does not treat "<cf..." as a tag.
+				var emptyCatch = "<" & "cfcatch></cfcatch>";
+				var rethrowTag = "<" & "cfrethrow";
+				expect(FindNoCase("<" & "cfcatch>", src)).toBeGT(
 					0,
 					"wheelserror.cfm no longer has a cfcatch around the docs-link rewrite"
 				);
-				expect(FindNoCase("<cfcatch></cfcatch>", src)).toBeGT(
+				expect(FindNoCase(emptyCatch, src)).toBeGT(
 					0,
 					"wheelserror.cfm cfcatch must stay empty (keep-going, no rethrow)"
 				);
-				expect(FindNoCase("<cfrethrow", src)).toBe(0);
+				expect(FindNoCase(rethrowTag, src)).toBe(0);
 			});
 
 			it("still renders extendedInfo when the docs-link rewrite throws", () => {

--- a/vendor/wheels/tests/specs/events/EventsHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/events/EventsHardenerSpec.cfc
@@ -8,7 +8,9 @@
  * PROVE: S2 live $runOnError status map, S3 $mail swallow, S6 writeLog
  * swallow, S7 wheelserror.cfm keep-going cfcatch.
  * HOLD / PIN: S4 non-Wheels JSON/XML serializes the full exception;
- * S5 OPTIONS abort stays, skipped when Cors middleware is active.
+ * S5 OPTIONS abort stays in EventMethods source; live prove is the
+ * Cors-active skip only. RequestStartAbortGuardDouble contains abort
+ * so a false $corsMiddlewareActive() cannot kill the suite.
  * S9 leftover: do not split $runOnError / $runOnRequestStart.
  * S10 leftover: SecurityDefaultsSpec / reloadPasswordSpec already proven.
  */
@@ -200,27 +202,48 @@ component extends="wheels.WheelsTest" {
 				}
 			});
 
-			it("OPTIONS does not abort when a wheels.middleware.Cors instance is registered", () => {
-				application.wheels.middleware = [
-					new wheels.middleware.Cors(allowOrigins = "https://app.example")
-				];
+			it("OPTIONS skip is live when Cors middleware is active (abort contained)", () => {
+				// String path — $corsMiddlewareActive() matches this exactly.
+				// IsInstanceOf(new Cors()) is the flakier gate that left the
+				// abort branch reachable and killed LuCLI with HTTP 500.
+				application.wheels.middleware = ["wheels.middleware.Cors"];
 				application.wheels.allowCorsRequests = true;
 				application.wheels.cacheModelConfig = true;
 				application.wheels.cacheControllerConfig = true;
 				application.wheels.cacheDatabaseSchema = true;
 				application.wheels.mixins = {};
+
+				var em = CreateObject("component", "wheels.tests._assets.events.RequestStartAbortGuardDouble").init();
+				expect(em.$corsMiddlewareActive()).toBeTrue(
+					"Cors-active skip cannot be proven unless $corsMiddlewareActive() is true BEFORE OPTIONS is set"
+				);
+				expect(em.$wouldHitOptionsAbort()).toBeFalse();
+
 				if (!StructKeyExists(request, "cgi")) {
 					request.cgi = {};
 				}
 				request.cgi.request_method = "OPTIONS";
 
-				var em = CreateObject("component", "wheels.tests._assets.events.CorsArbitrationEventDouble").init();
-				var state = {completed = false};
-				em.$runOnRequestStart(targetPage = "/index.cfm");
-				state.completed = true;
+				// Re-check after OPTIONS is set: skip must still be the live
+				// path. If not, $runOnRequestStartContained throws a contained
+				// UnitTest error instead of executing the production abort.
+				expect(em.$corsMiddlewareActive()).toBeTrue();
+				expect(em.$wouldHitOptionsAbort()).toBeFalse(
+					"refusing to invoke $runOnRequestStart — OPTIONS abort branch would fire"
+				);
 
+				var state = {completed = false, type = ""};
+				try {
+					em.$runOnRequestStartContained(targetPage = "/index.cfm");
+					state.completed = true;
+				} catch (any e) {
+					state.type = e.type;
+				}
+
+				expect(em.abortContained).toBeFalse("guard must not fire when Cors is active");
+				expect(state.type).toBe("");
 				expect(state.completed).toBeTrue(
-					"$runOnRequestStart OPTIONS must skip abort when Cors middleware is active"
+					"$runOnRequestStart OPTIONS must skip abort when Cors middleware is active (got #state.type#)"
 				);
 				expect(em.corsHeaderCalls).toBe(
 					0,

--- a/vendor/wheels/tests/specs/events/EventsHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/events/EventsHardenerSpec.cfc
@@ -1,0 +1,387 @@
+/**
+ * Events hardener desks S2–S7 (S1 lives in interfaceBootstrapSpec;
+ * S8 lives in TestContextIsolationSpec). Desk IDs are locked.
+ *
+ * Directory-scoped so `wheels test --core --ci --filter=events` discovers it.
+ *
+ * FIX: S1 assert on $verifyInterfaceContracts (interfaceBootstrapSpec).
+ * PROVE: S2 live $runOnError status map, S3 $mail swallow, S6 writeLog
+ * swallow, S7 wheelserror.cfm keep-going cfcatch.
+ * HOLD / PIN: S4 non-Wheels JSON/XML serializes the full exception;
+ * S5 OPTIONS abort stays, skipped when Cors middleware is active.
+ * S9 leftover: do not split $runOnError / $runOnRequestStart.
+ * S10 leftover: SecurityDefaultsSpec / reloadPasswordSpec already proven.
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("S2 live $runOnError status map (not a mirrored regex)", () => {
+
+			beforeEach(() => {
+				_savedShowError = application.wheels.showErrorInformation;
+				application.wheels.showErrorInformation = true;
+			});
+
+			afterEach(() => {
+				application.wheels.showErrorInformation = _savedShowError;
+			});
+
+			it("EventMethods.$runOnError source holds the frozen 404/403/500 map", () => {
+				var body = $functionBody("EventMethods.cfc", "$runOnError");
+				expect(Find('ReFindNoCase("^Wheels\.([A-Za-z]*NotFound|ActionNotAllowed)$"', body)).toBeGT(
+					0,
+					"live $runOnError no longer maps Wheels.*NotFound / ActionNotAllowed via the frozen regex"
+				);
+				expect(Find('ReFindNoCase("^Wheels\.NotAuthorized$"', body)).toBeGT(
+					0,
+					"live $runOnError no longer maps Wheels.NotAuthorized via the frozen regex"
+				);
+				expect(Find("$header(statusCode = 404)", body)).toBeGT(0);
+				expect(Find("$header(statusCode = 403)", body)).toBeGT(0);
+				expect(Find("$header(statusCode = 500)", body)).toBeGT(0);
+				var pos404 = Find("$header(statusCode = 404)", body);
+				var pos403 = Find("$header(statusCode = 403)", body);
+				expect(pos403).toBeGT(pos404, "403 mapping must follow the 404 *NotFound / ActionNotAllowed branch");
+			});
+
+			it("maps Wheels.RouteNotFound to 404 through live $runOnError", () => {
+				var em = $onErrorDouble();
+				em.$runOnError(exception = $wheelsTypedException("Wheels.RouteNotFound"), eventName = "onRequest");
+				expect(em.$lastStatusCode()).toBe(404);
+			});
+
+			it("maps Wheels.ActionNotAllowed to 404 through live $runOnError", () => {
+				var em = $onErrorDouble();
+				em.$runOnError(exception = $wheelsTypedException("Wheels.ActionNotAllowed"), eventName = "onRequest");
+				expect(em.$lastStatusCode()).toBe(404);
+			});
+
+			it("maps Wheels.NotAuthorized to 403 through live $runOnError", () => {
+				var em = $onErrorDouble();
+				em.$runOnError(exception = $wheelsTypedException("Wheels.NotAuthorized"), eventName = "onRequest");
+				expect(em.$lastStatusCode()).toBe(403);
+			});
+
+			it("maps a generic Wheels type to 500 through live $runOnError", () => {
+				var em = $onErrorDouble();
+				em.$runOnError(exception = $wheelsTypedException("Wheels.UnknownThingHappened"), eventName = "onRequest");
+				expect(em.$lastStatusCode()).toBe(500);
+			});
+
+		});
+
+		describe("S3 $mail catch-any swallow stays (does not rethrow)", () => {
+
+			beforeEach(() => {
+				_savedSendEmail = application.wheels.sendEmailOnError;
+				_savedFrom = application.wheels.errorEmailFromAddress;
+				_savedTo = application.wheels.errorEmailToAddress;
+				_savedAddr = application.wheels.errorEmailAddress;
+				_savedShowError = application.wheels.showErrorInformation;
+				application.wheels.sendEmailOnError = true;
+				application.wheels.errorEmailFromAddress = "from@example.com";
+				application.wheels.errorEmailToAddress = "to@example.com";
+				application.wheels.errorEmailAddress = "webmaster@example.com";
+				application.wheels.showErrorInformation = true;
+			});
+
+			afterEach(() => {
+				application.wheels.sendEmailOnError = _savedSendEmail;
+				application.wheels.errorEmailFromAddress = _savedFrom;
+				application.wheels.errorEmailToAddress = _savedTo;
+				application.wheels.errorEmailAddress = _savedAddr;
+				application.wheels.showErrorInformation = _savedShowError;
+			});
+
+			it("does not rethrow when $mail fails inside $runOnError", () => {
+				var em = $onErrorDouble();
+				em.mailShouldThrow = true;
+				var state = {threw = false, type = "", result = ""};
+				try {
+					state.result = em.$runOnError(
+						exception = $plainException(),
+						eventName = "onRequest"
+					);
+				} catch (any e) {
+					state.threw = true;
+					state.type = e.type;
+				}
+				expect(em.mailCalls).toBe(1, "$runOnError must reach $mail when sendEmailOnError is on");
+				expect(state.threw).toBeFalse(
+					"$mail catch-any must swallow (got #state.type#)"
+				);
+				expect(state.result).toInclude("full-exception-secret-detail");
+			});
+
+			it("keeps the empty catch-any around $mail in EventMethods source", () => {
+				var body = $functionBody("EventMethods.cfc", "$runOnError");
+				var mailPos = Find("$mail(argumentCollection", body);
+				expect(mailPos).toBeGT(0, "$runOnError no longer calls $mail");
+				var window = Mid(body, mailPos, 180);
+				expect(Find("catch (any e)", window)).toBeGT(0);
+				expect(FindNoCase("rethrow", window)).toBe(0);
+				expect(FindNoCase("throw(", window)).toBe(0);
+			});
+
+		});
+
+		describe("S4 HOLD pin: non-Wheels JSON/XML serializes the full exception", () => {
+
+			beforeEach(() => {
+				_savedShowError = application.wheels.showErrorInformation;
+				application.wheels.showErrorInformation = true;
+			});
+
+			afterEach(() => {
+				application.wheels.showErrorInformation = _savedShowError;
+			});
+
+			it("JSON error body is SerializeJSON of the raw exception, not a redacted struct", () => {
+				var em = $onErrorDouble();
+				em.formatOverride = "json";
+				var exception = $plainException();
+				var result = em.$runOnError(exception = exception, eventName = "onRequest");
+				expect(em.$lastStatusCode()).toBe(500);
+				expect(result).toInclude("full-exception-secret-detail");
+				expect(result).toInclude("password=hunter2");
+				expect(result).toInclude("java.sql.SQLException");
+			});
+
+			it("XML error body is $toXml of the raw exception, not a redacted struct", () => {
+				var em = $onErrorDouble();
+				em.formatOverride = "xml";
+				var result = em.$runOnError(exception = $plainException(), eventName = "onRequest");
+				expect(em.$lastStatusCode()).toBe(500);
+				var xmlText = IsSimpleValue(result) ? result : ToString(result);
+				expect(xmlText).toInclude("full-exception-secret-detail");
+				expect(xmlText).toInclude("password=hunter2");
+			});
+
+			it("live $runOnError source serializes arguments.exception (HOLD: no redact flip)", () => {
+				var body = $functionBody("EventMethods.cfc", "$runOnError");
+				expect(Find("SerializeJSON(arguments.exception)", body)).toBeGT(
+					0,
+					"non-Wheels JSON path must keep SerializeJSON(arguments.exception)"
+				);
+				expect(Find("$toXml(arguments.exception)", body)).toBeGT(
+					0,
+					"non-Wheels XML path must keep $toXml(arguments.exception)"
+				);
+			});
+
+		});
+
+		describe("S5 HOLD pin: OPTIONS abort skipped when Cors middleware is active", () => {
+
+			beforeEach(() => {
+				_savedMiddleware = StructKeyExists(application.wheels, "middleware")
+					? Duplicate(application.wheels.middleware) : [];
+				_savedAllowCors = application.wheels.allowCorsRequests;
+				_savedCacheModelConfig = application.wheels.cacheModelConfig;
+				_savedCacheControllerConfig = application.wheels.cacheControllerConfig;
+				_savedCacheDatabaseSchema = application.wheels.cacheDatabaseSchema;
+				_savedMixins = application.wheels.mixins;
+				_hadCgi = StructKeyExists(request, "cgi");
+				_priorCgi = _hadCgi ? Duplicate(request.cgi) : {};
+			});
+
+			afterEach(() => {
+				application.wheels.middleware = _savedMiddleware;
+				application.wheels.allowCorsRequests = _savedAllowCors;
+				application.wheels.cacheModelConfig = _savedCacheModelConfig;
+				application.wheels.cacheControllerConfig = _savedCacheControllerConfig;
+				application.wheels.cacheDatabaseSchema = _savedCacheDatabaseSchema;
+				application.wheels.mixins = _savedMixins;
+				if (_hadCgi) {
+					request.cgi = _priorCgi;
+				} else {
+					StructDelete(request, "cgi");
+				}
+			});
+
+			it("OPTIONS does not abort when a wheels.middleware.Cors instance is registered", () => {
+				application.wheels.middleware = [
+					new wheels.middleware.Cors(allowOrigins = "https://app.example")
+				];
+				application.wheels.allowCorsRequests = true;
+				application.wheels.cacheModelConfig = true;
+				application.wheels.cacheControllerConfig = true;
+				application.wheels.cacheDatabaseSchema = true;
+				application.wheels.mixins = {};
+				if (!StructKeyExists(request, "cgi")) {
+					request.cgi = {};
+				}
+				request.cgi.request_method = "OPTIONS";
+
+				var em = CreateObject("component", "wheels.tests._assets.events.CorsArbitrationEventDouble").init();
+				var state = {completed = false};
+				em.$runOnRequestStart(targetPage = "/index.cfm");
+				state.completed = true;
+
+				expect(state.completed).toBeTrue(
+					"$runOnRequestStart OPTIONS must skip abort when Cors middleware is active"
+				);
+				expect(em.corsHeaderCalls).toBe(
+					0,
+					"Cors-active skip must also defer $setCORSHeaders"
+				);
+			});
+
+			it("live $runOnRequestStart still aborts OPTIONS when Cors middleware is not active", () => {
+				var body = $functionBody("EventMethods.cfc", "$runOnRequestStart");
+				expect(Find("!$corsMiddlewareActive()", body)).toBeGT(
+					0,
+					"$runOnRequestStart OPTIONS abort must stay gated on !$corsMiddlewareActive()"
+				);
+				expect(FindNoCase("request_method", body)).toBeGT(0);
+				expect(FindNoCase("OPTIONS", body)).toBeGT(0);
+				var abortPos = REFindNoCase("(^|[^.\w])abort\s*;", body);
+				expect(abortPos).toBeGT(
+					0,
+					"HOLD: OPTIONS abort must remain (LuCLI poison leftover if flipped)"
+				);
+				var skipPos = Find("!$corsMiddlewareActive()", body);
+				expect(abortPos).toBeGT(
+					skipPos,
+					"OPTIONS abort must sit after the Cors-active skip"
+				);
+			});
+
+		});
+
+		describe("S6 onapplicationstart writeLog catch-any swallow", () => {
+
+			it("keeps the empty catch-any around the reloadPassword writeLog", () => {
+				var src = FileRead(ExpandPath("/wheels/events/onapplicationstart.cfc"));
+				var writeLogPos = FindNoCase('writeLog(file="wheels_security"', src);
+				expect(writeLogPos).toBeGT(
+					0,
+					"onapplicationstart.cfc no longer writeLogs an empty reloadPassword warning"
+				);
+				var window = Mid(src, writeLogPos, 500);
+				expect(Find("catch (any e)", window)).toBeGT(0);
+				expect(FindNoCase("rethrow", window)).toBe(0);
+				expect(FindNoCase("throw(", window)).toBe(0);
+			});
+
+		});
+
+		describe("S7 wheelserror.cfm empty cfcatch keep-going", () => {
+
+			it("keeps the empty <cfcatch> around the docs-link rewrite", () => {
+				var src = FileRead(ExpandPath("/wheels/events/onerror/wheelserror.cfm"));
+				expect(FindNoCase("<cfcatch>", src)).toBeGT(
+					0,
+					"wheelserror.cfm no longer has a cfcatch around the docs-link rewrite"
+				);
+				expect(FindNoCase("<cfcatch></cfcatch>", src)).toBeGT(
+					0,
+					"wheelserror.cfm cfcatch must stay empty (keep-going, no rethrow)"
+				);
+				expect(FindNoCase("<cfrethrow", src)).toBe(0);
+			});
+
+			it("still renders extendedInfo when the docs-link rewrite throws", () => {
+				var wheelsError = {
+					type = "Wheels.TestError",
+					message = "s7-keep-going-message",
+					extendedInfo = "s7-keep-going-marker-xyz",
+					tagContext = [
+						{template = "/tmp/a.cfm", line = 1},
+						{template = "/tmp/b.cfm", line = 2}
+					]
+				};
+				var hadCgi = StructKeyExists(request, "cgi");
+				var priorCgi = hadCgi ? Duplicate(request.cgi) : {};
+				var actual = "";
+				var state = {threw = false, type = ""};
+				try {
+					// Force the docs-link ReReplace to throw (request.cgi.script_name).
+					request.cgi = {};
+					actual = application.wo.$includeAndReturnOutput(
+						$template = "/wheels/events/onerror/wheelserror.cfm",
+						wheelsError = wheelsError
+					);
+				} catch (any e) {
+					state.threw = true;
+					state.type = e.type;
+				} finally {
+					if (hadCgi) {
+						request.cgi = priorCgi;
+					} else {
+						StructDelete(request, "cgi");
+					}
+				}
+				expect(state.threw).toBeFalse(
+					"wheelserror.cfm empty cfcatch must keep going (got #state.type#)"
+				);
+				expect(actual).toInclude("s7-keep-going-marker-xyz");
+				expect(actual).toInclude("Wheels.TestError");
+			});
+
+		});
+
+	}
+
+	private any function $onErrorDouble() {
+		var em = CreateObject("component", "wheels.tests._assets.events.OnErrorEventDouble").init();
+		em.formatOverride = "json";
+		return em;
+	}
+
+	private struct function $wheelsTypedException(required string wheelsType) {
+		// Both engines: BoxLang reads exception.type, Lucee/Adobe read rootCause.type.
+		return {
+			type = arguments.wheelsType,
+			message = arguments.wheelsType,
+			rootCause = {
+				type = arguments.wheelsType,
+				message = arguments.wheelsType
+			}
+		};
+	}
+
+	private struct function $plainException() {
+		return {
+			type = "java.sql.SQLException",
+			message = "full-exception-secret-detail",
+			detail = "password=hunter2"
+		};
+	}
+
+	/**
+	 * Extracts one function body from an events/ CFC. Same line-scan shape as
+	 * RequestStartPluginsConstructionSpec (no global comment-strip — that
+	 * hangs Lucee 7 on large sources).
+	 */
+	private string function $functionBody(required string fileName, required string functionName) {
+		var content = FileRead(ExpandPath("/wheels/events/#arguments.fileName#"));
+		var fileLines = ListToArray(content, Chr(10), true);
+		var declarationPattern = "(public|private)\s+\w+\s+function\s+";
+		var lines = [];
+		var inBody = false;
+		var escapedName = Replace(Replace(arguments.functionName, "$", "\$", "all"), ".", "\.", "all");
+
+		for (var rawLine in fileLines) {
+			if (!inBody) {
+				if (REFindNoCase(declarationPattern & escapedName & "\b", rawLine)) {
+					inBody = true;
+					ArrayAppend(lines, rawLine);
+				}
+				continue;
+			}
+			if (REFindNoCase(declarationPattern & "[\w$]+\s*\(", rawLine)) {
+				break;
+			}
+			ArrayAppend(lines, rawLine);
+		}
+
+		expect(ArrayLen(lines)).toBeGT(
+			0,
+			"Could not locate #arguments.functionName# in events/#arguments.fileName#"
+		);
+		return ArrayToList(lines, Chr(10));
+	}
+
+}

--- a/vendor/wheels/tests/specs/events/TestContextIsolationSpec.cfc
+++ b/vendor/wheels/tests/specs/events/TestContextIsolationSpec.cfc
@@ -1,0 +1,90 @@
+/**
+ * S8: TestContext isolation (requestIsTestContext / isolated name) under
+ * `wheels test --core --ci --filter=events`.
+ *
+ * TestRunnerIsolationSpec lives in internal/ and is OUT of this desk.
+ * These specs prove the same contract from events/ so a --filter=events
+ * run fails if isolation is reverted. Do not move or re-prove the
+ * internal/ suite (S10 leftover territory for other leftover specs).
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("S8 TestContext isolation (requestIsTestContext / isolated name)", () => {
+
+			it("suffixes an application name exactly once", () => {
+				var ctx = new wheels.events.TestContext();
+				expect(ctx.applicationNameSuffix()).toBe("_wheelsTest");
+				expect(ctx.isolatedApplicationName("wheels-dev")).toBe("wheels-dev_wheelsTest");
+				expect(ctx.isolatedApplicationName("wheels-dev_wheelsTest")).toBe("wheels-dev_wheelsTest");
+				expect(ctx.isIsolatedApplicationName("wheels-dev")).toBeFalse();
+				expect(ctx.isIsolatedApplicationName("wheels-dev_wheelsTest")).toBeTrue();
+			});
+
+			it("treats /wheels/core/tests and /wheels/app/tests paths as test context", () => {
+				var ctx = new wheels.events.TestContext();
+				expect(
+					ctx.requestIsTestContext(cgiScope = {path_info = "/wheels/core/tests"})
+				).toBeTrue();
+				expect(
+					ctx.requestIsTestContext(cgiScope = {script_name = "/index.cfm", path_info = "/wheels/app/tests"})
+				).toBeTrue();
+				expect(
+					ctx.requestIsTestContext(cgiScope = {query_string = "controller=wheels&view=core/tests"})
+				).toBeFalse("a query string without the runner path is not a test context");
+				expect(
+					ctx.requestIsTestContext(cgiScope = {path_info = "/", script_name = "/index.cfm"})
+				).toBeFalse();
+			});
+
+			it("treats the isolation header or cookie as test context", () => {
+				var ctx = new wheels.events.TestContext();
+				var cgiArgs = {};
+				cgiArgs[ctx.cgiHeaderKey()] = "1";
+				expect(ctx.requestIsTestContext(cgiScope = cgiArgs)).toBeTrue();
+
+				var cookieArgs = {};
+				cookieArgs[ctx.cookieName()] = "1";
+				expect(ctx.requestIsTestContext(cookieScope = cookieArgs)).toBeTrue();
+			});
+
+			it("does not treat an empty header or cookie as test context", () => {
+				var ctx = new wheels.events.TestContext();
+				var cgiArgs = {};
+				cgiArgs[ctx.cgiHeaderKey()] = "";
+				expect(ctx.requestIsTestContext(cgiScope = cgiArgs)).toBeFalse();
+
+				var cookieArgs = {};
+				cookieArgs[ctx.cookieName()] = "";
+				expect(ctx.requestIsTestContext(cookieScope = cookieArgs)).toBeFalse();
+			});
+
+			it("testcontext.cfm and TestContext.cfc share suffix, header CGI key, and cookie name", () => {
+				var ctx = new wheels.events.TestContext();
+				var includeSource = FileRead(ExpandPath("/wheels/events/testcontext.cfm"));
+				expect(Find(ctx.applicationNameSuffix(), includeSource) > 0).toBeTrue(
+					"testcontext.cfm must use the same application-name suffix as TestContext.cfc"
+				);
+				expect(FindNoCase(ctx.cgiHeaderKey(), includeSource) > 0).toBeTrue(
+					"testcontext.cfm must read the same CGI header key as TestContext.cgiHeaderKey()"
+				);
+				expect(FindNoCase(ctx.cookieName(), includeSource) > 0).toBeTrue(
+					"testcontext.cfm must read the same cookie name as TestContext.cookieName()"
+				);
+				expect(FindNoCase("/wheels/core/tests", includeSource) > 0).toBeTrue();
+				expect(FindNoCase("/wheels/app/tests", includeSource) > 0).toBeTrue();
+			});
+
+			it("the suite itself is bound to the isolated application name", () => {
+				var ctx = new wheels.events.TestContext();
+				expect(ctx.isIsolatedApplicationName(application.applicationName)).toBeTrue(
+					"the web runner request must bind `<this.name>_wheelsTest` so application.wheels here is NOT the live app"
+				);
+			});
+
+		});
+
+	}
+
+}

--- a/vendor/wheels/tests/specs/events/interfaceBootstrapSpec.cfc
+++ b/vendor/wheels/tests/specs/events/interfaceBootstrapSpec.cfc
@@ -7,7 +7,19 @@ component extends="wheels.WheelsTest" {
 		describe("Dev-Mode Interface Contract Verification", () => {
 
 			it("$verifyInterfaceContracts does not throw in a healthy app", () => {
-				g.$verifyInterfaceContracts();
+				// S1: a call with no expect() is a silent no-op. completed=true
+				// only after the live function returns; a throw, or deleting the
+				// call and leaving this expect, fails the spec.
+				var state = {completed = false, type = ""};
+				try {
+					g.$verifyInterfaceContracts();
+					state.completed = true;
+				} catch (any e) {
+					state.type = e.type;
+				}
+				expect(state.completed).toBeTrue(
+					"$verifyInterfaceContracts must complete without throwing (got #state.type#)"
+				);
 			});
 
 			it("$verifyInterfaceContracts checks that model has finder methods", () => {

--- a/vendor/wheels/tests/specs/events/onerrorSpec.cfc
+++ b/vendor/wheels/tests/specs/events/onerrorSpec.cfc
@@ -21,13 +21,11 @@ component extends="wheels.WheelsTest" {
 			// Regression coverage for GH ##2319: Wheels-typed errors rendered
 			// in HTML format used to leave the status code at Lucee's default
 			// (200), misleading anything monitoring/alerting/retrying on
-			// status. The mapping (RouteNotFound/RecordNotFound → 404,
-			// everything else → 500) is mirrored from EventMethods.$runOnError;
-			// this spec freezes the contract so a rename there breaks the
-			// build immediately. Tested via a helper rather than a full
-			// onError invocation because $runOnError needs an active request
-			// scope and a real exception path that isn't easy to fake from
-			// inside a spec.
+			// status. The mapping below is the frozen contract. A helper that
+			// only reimplements the regex would stay green if the LIVE map
+			// flipped — EventsHardenerSpec S2 proves the same types against
+			// $runOnError and a source-scan of EventMethods.cfc. Do not flip
+			// the live status map.
 			it("maps Wheels.RouteNotFound to HTTP 404 (##2319)", () => {
 				expect($expectedStatusFor("Wheels.RouteNotFound")).toBe(404)
 			})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Events desk IDs S1–S10 are locked. This PR fixes the S1 silent no-op and proves current event-lifecycle behavior so a leftover, a mirrored-regex fork, or a HOLD flip would fail.

No production change. Spec-only. No changelog fragment.

## Scope

- `vendor/wheels/tests/specs/events/interfaceBootstrapSpec.cfc` — S1 FIX: `$verifyInterfaceContracts does not throw` now has an expect()
- `vendor/wheels/tests/specs/events/EventsHardenerSpec.cfc` — S2 live `$runOnError` status map; S3 `$mail` swallow; S4 HOLD full-exception JSON/XML; S5 HOLD Cors-gated OPTIONS abort (contained); S6 unique empty-reloadPassword writeLog swallow; S7 wheelserror.cfm keep-going
- `vendor/wheels/tests/specs/events/TestContextIsolationSpec.cfc` — S8 TestContext isolation under `--filter=events`
- `vendor/wheels/tests/_assets/events/OnErrorEventDouble.cfc` — records `$header` / `$mail` so `$runOnError` can be invoked without poisoning the runner response
- `vendor/wheels/tests/_assets/events/RequestStartAbortGuardDouble.cfc` — S5 containment (kept as extra insurance)
- `onerrorSpec.cfc` — points the GH #2319 map at the live S2 proofs

Out / leftover-closed: app/events + examples + CLI templates; events/init/caching.cfm; security leftovers; Channel CORS; CSRF cookie defaults; `$getRequestFormat` LFI html fallback; `$fireOnErrorCallbacks`; CORS deny-all; dispatch/public just-landed; Public.$init already landed. S9 does not split `$runOnError` / `$runOnRequestStart`. S10 does not re-prove SecurityDefaultsSpec / reloadPasswordSpec.

## PROVEN

| ID | Status | Spec that kills a revert |
| --- | --- | --- |
| S1 | FIX | `interfaceBootstrapSpec` — `$verifyInterfaceContracts does not throw in a healthy app` |
| S2 | PROVEN | `EventsHardenerSpec` — live `$runOnError` 404/403/500 plus source-scan of EventMethods |
| S3 | PROVEN | `EventsHardenerSpec` — `$mail` throw is swallowed; empty catch-any still in source |
| S4 | PINNED HOLD | `EventsHardenerSpec` — non-Wheels JSON/XML is `SerializeJSON` / `$toXml` of the raw exception |
| S5 | PINNED HOLD | `EventsHardenerSpec` — Cors-active skip is the live prove; `abort` remains in `$runOnRequestStart` source. `RequestStartAbortGuardDouble` kept |
| S6 | PROVEN | `EventsHardenerSpec` — unique needle `Wheels: reloadPassword is empty` plus one-line `catch (any e) {}` (not the password-rejected writeLog at ~216) |
| S7 | PROVEN | `EventsHardenerSpec` — empty cfcatch keep-going |
| S8 | PROVEN | `TestContextIsolationSpec` — `requestIsTestContext` / isolated `_wheelsTest` name |
| S9 | leftover | not split |
| S10 | leftover | SecurityDefaultsSpec / reloadPasswordSpec not re-proven |

## S6 needle (desk REQUEST CHANGES)

`FindNoCase('writeLog(file="wheels_security"')` first-hit the password-rejected writeLog at ~216. S6 now scans for the unique empty-reloadPassword warning at ~371-372 and pins that site's one-line `catch (any e) {}`.

## Verification

```
wheels test --core --ci --filter=events
```

Result: **87 passed**, 0 fail, 0 error.

HEAD `ada8dbcc773dff7860d69b379b4abc0d6802c981`

Base `51edf9dcebb7539bef0024a94485d3bfe2a30ac7` (develop tip, locked).

Draft. Do not merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fab05da-6f20-41c3-982d-8cf25f034dd2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fab05da-6f20-41c3-982d-8cf25f034dd2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

