### PR TITLE
fix: repair Adobe compat-matrix failures (database hardener spec + channel DDL)

### DIFF
--- a/vendor/wheels/channel/DatabaseAdapter.cfc
+++ b/vendor/wheels/channel/DatabaseAdapter.cfc
@@ -296,7 +296,7 @@ component {
 
 			queryExecute("
 				CREATE TABLE wheels_events (
-					id #local.varcharType#(36) NOT NULL PRIMARY KEY,
+					id #local.varcharType#(255) NOT NULL PRIMARY KEY,
 					channel #local.varcharType#(255) NOT NULL,
 					event #local.varcharType#(255) NOT NULL,
 					data #local.textType#,

--- a/vendor/wheels/tests/specs/database/DatabaseAdapterHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/database/DatabaseAdapterHardenerSpec.cfc
@@ -134,21 +134,24 @@ component extends="wheels.WheelsTest" {
 
 			it("MySQL emits DEFAULT for text and float", () => {
 				var mysql = CreateObject("component", "wheels.databaseAdapters.MySQL.MySQLMigrator");
-				expect(mysql.optionsIncludeDefault(type = "text", default = "long body")).toBeTrue();
-				expect(mysql.optionsIncludeDefault(type = "float", default = "1.25")).toBeTrue();
-				expect(mysql.optionsIncludeDefault(type = "string", default = "hello")).toBeTrue();
+				// Positional args: Adobe's parser rejects `default` as a named
+				// argument (reserved word — MissingNameException at compile time).
+				expect(mysql.optionsIncludeDefault("text", "long body")).toBeTrue();
+				expect(mysql.optionsIncludeDefault("float", "1.25")).toBeTrue();
+				expect(mysql.optionsIncludeDefault("string", "hello")).toBeTrue();
 				var sql = mysql.addColumnOptions(
 					sql = "",
-					options = {type: "text", default: "long body", allowNull: true}
+					options = {type: "text", "default": "long body", allowNull: true}
 				);
 				expect(sql).toInclude("DEFAULT");
 			});
 
 			it("Abstract optionsIncludeDefault stays always true", () => {
-				var abstract = CreateObject("component", "wheels.databaseAdapters.Abstract");
-				expect(abstract.optionsIncludeDefault(type = "text", default = "long body")).toBeTrue();
-				expect(abstract.optionsIncludeDefault(type = "float", default = "1.25")).toBeTrue();
-				expect(abstract.optionsIncludeDefault()).toBeTrue();
+				// "abstract" is a reserved word on Adobe CF — use a safe variable name.
+				var abstractMigrator = CreateObject("component", "wheels.databaseAdapters.Abstract");
+				expect(abstractMigrator.optionsIncludeDefault("text", "long body")).toBeTrue();
+				expect(abstractMigrator.optionsIncludeDefault("float", "1.25")).toBeTrue();
+				expect(abstractMigrator.optionsIncludeDefault()).toBeTrue();
 			});
 
 		});
@@ -252,7 +255,7 @@ component extends="wheels.WheelsTest" {
 				try {
 					state.adapter.addColumnOptions(
 						sql = "",
-						options = {type: "string", default: "", allowNull: true}
+						options = {type: "string", "default": "", allowNull: true}
 					);
 				} catch (any e) {
 					state.type = e.type;
@@ -268,7 +271,7 @@ component extends="wheels.WheelsTest" {
 				try {
 					state.adapter.addColumnOptions(
 						sql = "",
-						options = {type: "string", default: "", allowNull: true}
+						options = {type: "string", "default": "", allowNull: true}
 					);
 				} catch (any e) {
 					state.type = e.type;


### PR DESCRIPTION
## Summary

Two pre-existing issues discovered while verifying the complexity burn-down (#3435) against the local compat matrix — both reproduced on `develop` and fixed here.

## 1. Adobe compile failure in `DatabaseAdapterHardenerSpec.cfc`

The S6 `optionsIncludeDefault` describe crashed the **entire Adobe leg at compile time** (`MissingNameException: Invalid construct: Either argument or name is missing`) because of three Adobe-only parser traps:

- a variable named `abstract` (reserved word on Adobe CF)
- `default` passed as a **named argument** (`optionsIncludeDefault(type = "text", default = "...")`)
- unquoted `default:` struct-literal keys

Fixed with positional args, quoted keys, and a renamed variable.

**Verified:** Adobe 2023 + MySQL, `specs.database` directory → **101 passed / 0 failed / 0 errors** (previously: whole leg HTTP 500 at compile).

## 2. Channel events table id too short for MySQL

`wheels_events.id` was `varchar(36)` (UUID-sized) while channel event ids can be arbitrarily long (42+ chars in the specs), so MySQL legs failed with `Data too long for column 'id'`. Widened to `varchar(255)` to match the `channel`/`event` columns.

**Verified:** Adobe 2023 + MySQL, `specs.channel` directory → **43 passed / 0 failed / 0 errors**.

Both fixes are test/DDL-only; no framework behavior change. The weekly compat-matrix should go green on the Adobe+MySQL legs once this lands.