### PR TITLE
refactor: burn down wave 2 — adapter type maps, ORM dynamic methods, URLFor, form/migrator helpers

### DIFF
--- a/vendor/wheels/Migrator.cfc
+++ b/vendor/wheels/Migrator.cfc
@@ -120,19 +120,12 @@ component output="false" extends="wheels.Global"{
 					return local.rv;
 				}
 				local.rv &= "Migrating from #local.currentVersion# down to #arguments.version#.#Chr(13) & Chr(10)#";
-				for (local.i = ArrayLen(local.migrations); local.i >= 1; local.i--) {
-					local.migration = local.migrations[local.i];
-					if (local.migration.version <= arguments.version) {
-						break;
-					}
-					if (local.migration.status == "migrated" && application[local.appKey].allowMigrationDown) {
-						local.step = $runMigrationStep(migration = local.migration, direction = "down");
-						local.rv &= local.step.output;
-						if (!local.step.success) {
-							break;
-						}
-					}
-				}
+				local.rv = $migrateToDownLoop(
+					rv = local.rv,
+					migrations = local.migrations,
+					version = arguments.version,
+					allowMigrationDown = application[local.appKey].allowMigrationDown
+				);
 			} else {
 				if(arguments.missingMigFlag){
 					// Note: this path used to delete the current version's
@@ -155,20 +148,65 @@ component output="false" extends="wheels.Global"{
 				} else {
 					local.rv &= "Migrating from #local.currentVersion# up to #arguments.version#.#Chr(13) & Chr(10)#";
 				}
-				for (local.migration in local.migrations) {
-					if (local.migration.version <= arguments.version && local.migration.status != "migrated") {
-						local.step = $runMigrationStep(migration = local.migration, direction = "up");
-						local.rv &= local.step.output;
-						if (!local.step.success) {
-							break;
-						}
-					} else if (local.migration.version > arguments.version) {
-						break;
-					}
-				};
+				local.rv = $migrateToUpLoop(
+					rv = local.rv,
+					migrations = local.migrations,
+					version = arguments.version
+				);
 			}
 		}
 		return local.rv;
+	}
+
+	/**
+	 * Internal function. Applies the `down` migration loop for migrateTo, iterating migrations
+	 * from newest to oldest and running down() on migrated ones above the target version. Appends
+	 * each step's output to `rv` and returns the accumulated output string.
+	 */
+	public string function $migrateToDownLoop(
+		required string rv,
+		required array migrations,
+		required string version,
+		required boolean allowMigrationDown
+	) {
+		for (local.i = ArrayLen(arguments.migrations); local.i >= 1; local.i--) {
+			local.migration = arguments.migrations[local.i];
+			if (local.migration.version <= arguments.version) {
+				break;
+			}
+			if (local.migration.status == "migrated" && arguments.allowMigrationDown) {
+				local.step = $runMigrationStep(migration = local.migration, direction = "down");
+				arguments.rv &= local.step.output;
+				if (!local.step.success) {
+					break;
+				}
+			}
+		}
+		return arguments.rv;
+	}
+
+	/**
+	 * Internal function. Applies the `up` migration loop for migrateTo, iterating migrations in
+	 * order and running up() on pending ones at or below the target version. Appends each step's
+	 * output to `rv` and returns the accumulated output string.
+	 */
+	public string function $migrateToUpLoop(
+		required string rv,
+		required array migrations,
+		required string version
+	) {
+		for (local.migration in arguments.migrations) {
+			if (local.migration.version <= arguments.version && local.migration.status != "migrated") {
+				local.step = $runMigrationStep(migration = local.migration, direction = "up");
+				arguments.rv &= local.step.output;
+				if (!local.step.success) {
+					break;
+				}
+			} else if (local.migration.version > arguments.version) {
+				break;
+			}
+		}
+		return arguments.rv;
 	}
 
 	/**

--- a/vendor/wheels/channel/DatabaseAdapter.cfc
+++ b/vendor/wheels/channel/DatabaseAdapter.cfc
@@ -296,7 +296,7 @@ component {
 
 			queryExecute("
 				CREATE TABLE wheels_events (
-					id #local.varcharType#(36) NOT NULL PRIMARY KEY,
+					id #local.varcharType#(255) NOT NULL PRIMARY KEY,
 					channel #local.varcharType#(255) NOT NULL,
 					event #local.varcharType#(255) NOT NULL,
 					data #local.textType#,

--- a/vendor/wheels/databaseAdapters/H2/H2Model.cfc
+++ b/vendor/wheels/databaseAdapters/H2/H2Model.cfc
@@ -9,117 +9,83 @@ component extends="wheels.databaseAdapters.Base" output=false {
 		return true;
 	}
 
+	variables.h2TypeMap = {
+		"bigint": "cf_sql_bigint",
+		"int8": "cf_sql_bigint",
+		"binary": "cf_sql_binary",
+		"bytea": "cf_sql_binary",
+		"raw": "cf_sql_binary",
+		"binary varying": "cf_sql_binary",
+		"bit": "cf_sql_bit",
+		"bool": "cf_sql_bit",
+		"boolean": "cf_sql_bit",
+		"binary large object": "cf_sql_blob",
+		"blob": "cf_sql_blob",
+		"tinyblob": "cf_sql_blob",
+		"mediumblob": "cf_sql_blob",
+		"longblob": "cf_sql_blob",
+		"image": "cf_sql_blob",
+		"oid": "cf_sql_blob",
+		"char": "cf_sql_char",
+		"character": "cf_sql_char",
+		"nchar": "cf_sql_char",
+		"uuid": "cf_sql_char",
+		"date": "cf_sql_date",
+		"dec": "cf_sql_decimal",
+		"decimal": "cf_sql_decimal",
+		"number": "cf_sql_decimal",
+		"numeric": "cf_sql_decimal",
+		"double": "cf_sql_double",
+		"double precision": "cf_sql_double",
+		"float": "cf_sql_float",
+		"float4": "cf_sql_float",
+		"float8": "cf_sql_float",
+		"real": "cf_sql_float",
+		"int": "cf_sql_integer",
+		"int4": "cf_sql_integer",
+		"integer": "cf_sql_integer",
+		"mediumint": "cf_sql_integer",
+		"signed": "cf_sql_integer",
+		"identity": "cf_sql_integer",
+		"int2": "cf_sql_smallint",
+		"smallint": "cf_sql_smallint",
+		"year": "cf_sql_smallint",
+		"time": "cf_sql_time",
+		"datetime": "cf_sql_timestamp",
+		"smalldatetime": "cf_sql_timestamp",
+		"timestamp": "cf_sql_timestamp",
+		"tinyint": "cf_sql_tinyint",
+		"varbinary": "cf_sql_varbinary",
+		"longvarbinary": "cf_sql_varbinary",
+		"varchar": "cf_sql_varchar",
+		"varchar2": "cf_sql_varchar",
+		"longvarchar": "cf_sql_varchar",
+		"varchar_ignorecase": "cf_sql_varchar",
+		"nvarchar": "cf_sql_varchar",
+		"nvarchar2": "cf_sql_varchar",
+		"clob": "cf_sql_varchar",
+		"nclob": "cf_sql_varchar",
+		"text": "cf_sql_varchar",
+		"tinytext": "cf_sql_varchar",
+		"mediumtext": "cf_sql_varchar",
+		"longtext": "cf_sql_varchar",
+		"ntext": "cf_sql_varchar",
+		"enum": "cf_sql_varchar",
+		"character varying": "cf_sql_varchar",
+		"character large object": "cf_sql_varchar",
+		"nvarchar_casesensitive": "cf_sql_nvarchar",
+		"json": "cf_sql_longvarchar"
+	};
+
 	/**
 	 * Map database types to the ones used in CFML.
 	 */
 	public string function $getType(required string type, string scale, string details) {
-		switch (arguments.type) {
-			case "bigint":
-			case "int8":
-				local.rv = "cf_sql_bigint";
-				break;
-			case "binary":
-			case "bytea":
-			case "raw":
-			case "binary varying":
-				local.rv = "cf_sql_binary";
-				break;
-			case "bit":
-			case "bool":
-			case "boolean":
-				local.rv = "cf_sql_bit";
-				break;
-			case "binary large object":
-			case "blob":
-			case "tinyblob":
-			case "mediumblob":
-			case "longblob":
-			case "image":
-			case "oid":
-				local.rv = "cf_sql_blob";
-				break;
-			case "char":
-			case "character":
-			case "nchar":
-			case "UUID":
-				local.rv = "cf_sql_char";
-				break;
-			case "date":
-				local.rv = "cf_sql_date";
-				break;
-			case "dec":
-			case "decimal":
-			case "number":
-			case "numeric":
-				local.rv = "cf_sql_decimal";
-				break;
-			case "double":
-			case "double precision":
-				local.rv = "cf_sql_double";
-				break;
-			case "float":
-			case "float4":
-			case "float8":
-			case "real":
-				local.rv = "cf_sql_float";
-				break;
-			case "int":
-			case "int4":
-			case "integer":
-			case "mediumint":
-			case "signed":
-			case "identity":
-				local.rv = "cf_sql_integer";
-				break;
-			case "int2":
-			case "smallint":
-			case "year":
-				local.rv = "cf_sql_smallint";
-				break;
-			case "time":
-				local.rv = "cf_sql_time";
-				break;
-			case "datetime":
-			case "smalldatetime":
-			case "timestamp":
-				local.rv = "cf_sql_timestamp";
-				break;
-			case "tinyint":
-				local.rv = "cf_sql_tinyint";
-				break;
-			case "varbinary":
-			case "longvarbinary":
-				local.rv = "cf_sql_varbinary";
-				break;
-			case "varchar":
-			case "varchar2":
-			case "longvarchar":
-			case "varchar_ignorecase":
-			case "nvarchar":
-			case "nvarchar2":
-			case "clob":
-			case "nclob":
-			case "text":
-			case "tinytext":
-			case "mediumtext":
-			case "longtext":
-			case "ntext":
-			case "enum":
-			case "character varying":
-			case "character large object":
-				local.rv = "cf_sql_varchar";
-				break;
-			case "nvarchar_casesensitive":
-				local.rv = "cf_sql_nvarchar";
-				break;
-			case "json":
-				local.rv = "cf_sql_longvarchar";
-				break;
-			default:
-				$throwUnknownColumnType(arguments.type);
-				break;
+		local.key = LCase(arguments.type);
+		if (StructKeyExists(variables.h2TypeMap, local.key)) {
+			return variables.h2TypeMap[local.key];
 		}
-		return local.rv;
+		$throwUnknownColumnType(arguments.type);
 	}
 
 	/**

--- a/vendor/wheels/databaseAdapters/MicrosoftSQLServer/MicrosoftSQLServerModel.cfc
+++ b/vendor/wheels/databaseAdapters/MicrosoftSQLServer/MicrosoftSQLServerModel.cfc
@@ -1,86 +1,50 @@
 component extends="wheels.databaseAdapters.Base" output=false {
 
+	variables.mssqlTypeMap = {
+		"bigint": "cf_sql_bigint",
+		"binary": "cf_sql_binary",
+		"geography": "cf_sql_binary",
+		"geometry": "cf_sql_binary",
+		"timestamp": "cf_sql_binary",
+		"bit": "cf_sql_bit",
+		"char": "cf_sql_char",
+		"nchar": "cf_sql_char",
+		"uniqueidentifier": "cf_sql_char",
+		"date": "cf_sql_date",
+		"datetime": "cf_sql_timestamp",
+		"datetime2": "cf_sql_timestamp",
+		"smalldatetime": "cf_sql_timestamp",
+		"datetimeoffset": "cf_sql_timestamp",
+		"decimal": "cf_sql_decimal",
+		"money": "cf_sql_decimal",
+		"smallmoney": "cf_sql_decimal",
+		"float": "cf_sql_float",
+		"int": "cf_sql_integer",
+		"image": "cf_sql_longvarbinary",
+		"text": "cf_sql_longvarchar",
+		"ntext": "cf_sql_longvarchar",
+		"xml": "cf_sql_longvarchar",
+		"numeric": "cf_sql_numeric",
+		"real": "cf_sql_real",
+		"smallint": "cf_sql_smallint",
+		"time": "cf_sql_time",
+		"tinyint": "cf_sql_tinyint",
+		"varbinary": "cf_sql_varbinary",
+		"varchar": "cf_sql_varchar",
+		"nvarchar": "cf_sql_varchar",
+		"hierarchyid": "cf_sql_varchar",
+		"cursor": "cf_sql_refcursor"
+	};
+
 	/**
 	 * Map database types to the ones used in CFML.
 	 */
 	public string function $getType(required string type, string scale, string details) {
-		switch (arguments.type) {
-			case "bigint":
-				local.rv = "cf_sql_bigint";
-				break;
-			case "binary":
-			case "geography":
-			case "geometry":
-			case "timestamp":
-				local.rv = "cf_sql_binary";
-				break;
-			case "bit":
-				local.rv = "cf_sql_bit";
-				break;
-			case "char":
-			case "nchar":
-			case "uniqueidentifier":
-				local.rv = "cf_sql_char";
-				break;
-			case "date":
-				local.rv = "cf_sql_date";
-				break;
-			case "datetime":
-			case "datetime2":
-			case "smalldatetime":
-			case "datetimeoffset":
-				local.rv = "cf_sql_timestamp";
-				break;
-			case "decimal":
-			case "money":
-			case "smallmoney":
-				local.rv = "cf_sql_decimal";
-				break;
-			case "float":
-				local.rv = "cf_sql_float";
-				break;
-			case "int":
-				local.rv = "cf_sql_integer";
-				break;
-			case "image":
-				local.rv = "cf_sql_longvarbinary";
-				break;
-			case "text":
-			case "ntext":
-			case "xml":
-				local.rv = "cf_sql_longvarchar";
-				break;
-			case "numeric":
-				local.rv = "cf_sql_numeric";
-				break;
-			case "real":
-				local.rv = "cf_sql_real";
-				break;
-			case "smallint":
-				local.rv = "cf_sql_smallint";
-				break;
-			case "time":
-				local.rv = "cf_sql_time";
-				break;
-			case "tinyint":
-				local.rv = "cf_sql_tinyint";
-				break;
-			case "varbinary":
-				local.rv = "cf_sql_varbinary";
-				break;
-			case "varchar":
-			case "nvarchar":
-			case "hierarchyid":
-				local.rv = "cf_sql_varchar";
-				break;
-			case "cursor":
-				local.rv = "cf_sql_refcursor";
-				break;
-			default:
-				$throwUnknownColumnType(arguments.type);
-				break;
+		local.key = LCase(arguments.type);
+		if (StructKeyExists(variables.mssqlTypeMap, local.key)) {
+			return variables.mssqlTypeMap[local.key];
 		}
-		return local.rv;
+		$throwUnknownColumnType(arguments.type);
 	}
 
 	/**

--- a/vendor/wheels/databaseAdapters/MySQL/MySQLModel.cfc
+++ b/vendor/wheels/databaseAdapters/MySQL/MySQLModel.cfc
@@ -1,5 +1,46 @@
 component extends="wheels.databaseAdapters.Base" output=false {
 
+	variables.mysqlTypeMap = {
+		"bigint": "cf_sql_bigint",
+		"binary": "cf_sql_binary",
+		"geometry": "cf_sql_binary",
+		"point": "cf_sql_binary",
+		"linestring": "cf_sql_binary",
+		"polygon": "cf_sql_binary",
+		"multipoint": "cf_sql_binary",
+		"multilinestring": "cf_sql_binary",
+		"multipolygon": "cf_sql_binary",
+		"geometrycollection": "cf_sql_binary",
+		"bit": "cf_sql_bit",
+		"bool": "cf_sql_bit",
+		"blob": "cf_sql_blob",
+		"tinyblob": "cf_sql_blob",
+		"mediumblob": "cf_sql_blob",
+		"longblob": "cf_sql_blob",
+		"char": "cf_sql_char",
+		"date": "cf_sql_date",
+		"decimal": "cf_sql_decimal",
+		"double": "cf_sql_double",
+		"float": "cf_sql_float",
+		"int": "cf_sql_integer",
+		"mediumint": "cf_sql_integer",
+		"smallint": "cf_sql_smallint",
+		"year": "cf_sql_smallint",
+		"time": "cf_sql_time",
+		"datetime": "cf_sql_timestamp",
+		"timestamp": "cf_sql_timestamp",
+		"tinyint": "cf_sql_tinyint",
+		"varbinary": "cf_sql_varbinary",
+		"varchar": "cf_sql_varchar",
+		"enum": "cf_sql_varchar",
+		"set": "cf_sql_varchar",
+		"tinytext": "cf_sql_varchar",
+		"json": "cf_sql_longvarchar",
+		"text": "cf_sql_longvarchar",
+		"mediumtext": "cf_sql_longvarchar",
+		"longtext": "cf_sql_longvarchar"
+	};
+
 	/**
 	 * Map database types to the ones used in CFML.
 	 */
@@ -15,84 +56,11 @@ component extends="wheels.databaseAdapters.Base" output=false {
 			}
 		}
 
-		switch (arguments.type) {
-			case "bigint":
-				local.rv = "cf_sql_bigint";
-				break;
-			case "binary":
-			case "geometry":
-			case "point":
-			case "linestring":
-			case "polygon":
-			case "multipoint":
-			case "multilinestring":
-			case "multipolygon":
-			case "geometrycollection":
-				local.rv = "cf_sql_binary";
-				break;
-			case "bit":
-			case "bool":
-				local.rv = "cf_sql_bit";
-				break;
-			case "blob":
-			case "tinyblob":
-			case "mediumblob":
-			case "longblob":
-				local.rv = "cf_sql_blob";
-				break;
-			case "char":
-				local.rv = "cf_sql_char";
-				break;
-			case "date":
-				local.rv = "cf_sql_date";
-				break;
-			case "decimal":
-				local.rv = "cf_sql_decimal";
-				break;
-			case "double":
-				local.rv = "cf_sql_double";
-				break;
-			case "float":
-				local.rv = "cf_sql_float";
-				break;
-			case "int":
-			case "mediumint":
-				local.rv = "cf_sql_integer";
-				break;
-			case "smallint":
-			case "year":
-				local.rv = "cf_sql_smallint";
-				break;
-			case "time":
-				local.rv = "cf_sql_time";
-				break;
-			case "datetime":
-			case "timestamp":
-				local.rv = "cf_sql_timestamp";
-				break;
-			case "tinyint":
-				local.rv = "cf_sql_tinyint";
-				break;
-			case "varbinary":
-				local.rv = "cf_sql_varbinary";
-				break;
-			case "varchar":
-			case "enum":
-			case "set":
-			case "tinytext":
-				local.rv = "cf_sql_varchar";
-				break;
-			case "json":
-			case "text":
-			case "mediumtext":
-			case "longtext":
-				local.rv = "cf_sql_longvarchar";
-				break;
-			default:
-				$throwUnknownColumnType(arguments.type);
-				break;
+		local.key = LCase(arguments.type);
+		if (StructKeyExists(variables.mysqlTypeMap, local.key)) {
+			return variables.mysqlTypeMap[local.key];
 		}
-		return local.rv;
+		$throwUnknownColumnType(arguments.type);
 	}
 
 	/**

--- a/vendor/wheels/databaseAdapters/PostgreSQL/PostgreSQLModel.cfc
+++ b/vendor/wheels/databaseAdapters/PostgreSQL/PostgreSQLModel.cfc
@@ -1,110 +1,85 @@
 component extends="wheels.databaseAdapters.Base" output=false {
 
+	variables.postgresTypeMap = {
+		"bigint": "cf_sql_bigint",
+		"int8": "cf_sql_bigint",
+		"bigserial": "cf_sql_bigint",
+		"serial8": "cf_sql_bigint",
+		"bool": "cf_sql_bit",
+		"boolean": "cf_sql_bit",
+		"bit": "cf_sql_bit",
+		"varbit": "cf_sql_bit",
+		"bytea": "cf_sql_binary",
+		"char": "cf_sql_char",
+		"character": "cf_sql_char",
+		"date": "cf_sql_timestamp",
+		"datetime": "cf_sql_timestamp",
+		"timestamp": "cf_sql_timestamp",
+		"timestamptz": "cf_sql_timestamp",
+		"decimal": "cf_sql_decimal",
+		"double": "cf_sql_decimal",
+		"precision": "cf_sql_decimal",
+		"float": "cf_sql_decimal",
+		"float4": "cf_sql_decimal",
+		"float8": "cf_sql_decimal",
+		"integer": "cf_sql_integer",
+		"int": "cf_sql_integer",
+		"int4": "cf_sql_integer",
+		"serial": "cf_sql_integer",
+		"oid": "cf_sql_integer",
+		"numeric": "cf_sql_numeric",
+		"smallmoney": "cf_sql_numeric",
+		"money": "cf_sql_numeric",
+		"real": "cf_sql_real",
+		"smallint": "cf_sql_smallint",
+		"smallserial": "cf_sql_smallint",
+		"int2": "cf_sql_smallint",
+		"json": "cf_sql_longvarchar",
+		"jsonb": "cf_sql_longvarchar",
+		"text": "cf_sql_longvarchar",
+		"cidr": "cf_sql_longvarchar",
+		"inet": "cf_sql_longvarchar",
+		"xml": "cf_sql_longvarchar",
+		"time": "cf_sql_time",
+		"timetz": "cf_sql_time",
+		"varchar": "cf_sql_varchar",
+		"varying": "cf_sql_varchar",
+		"bpchar": "cf_sql_varchar",
+		"uuid": "cf_sql_varchar",
+		"macaddr": "cf_sql_varchar",
+		"macaddr8": "cf_sql_varchar",
+		"point": "cf_sql_other",
+		"line": "cf_sql_other",
+		"lseg": "cf_sql_other",
+		"box": "cf_sql_other",
+		"path": "cf_sql_other",
+		"polygon": "cf_sql_other",
+		"circle": "cf_sql_other",
+		"geography": "cf_sql_other"
+	};
+
 	/**
 	 * Map database types to the ones used in CFML.
 	 * Using oid cols should probably be avoided, included here for completeness.
 	 * PostgreSQL has deprecated the money type, included here for completeness.
 	 */
 	public string function $getType(required string type, string scale, string details) {
-		switch (arguments.type) {
-			case "bigint":
-			case "int8":
-			case "bigserial":
-			case "serial8":
-				local.rv = "cf_sql_bigint";
-				break;
-			case "bool":
-			case "boolean":
-			case "bit":
-			case "varbit":
-				local.rv = "cf_sql_bit";
-				break;
-			case "bytea":
-				local.rv = "cf_sql_binary";
-				break;
-			case "char":
-			case "character":
-				local.rv = "cf_sql_char";
-				break;
-			case "date":
-			case "datetime":
-			case "timestamp":
-			case "timestamptz":
-				local.rv = "cf_sql_timestamp";
-				break;
-			case "decimal":
-			case "double":
-			case "precision":
-			case "float":
-			case "float4":
-			case "float8":
-				local.rv = "cf_sql_decimal";
-				break;
-			case "integer":
-			case "int":
-			case "int4":
-			case "serial":
-			case "oid":
-				local.rv = "cf_sql_integer";
-				break;
-			case "numeric":
-			case "smallmoney":
-			case "money":
-				local.rv = "cf_sql_numeric";
-				break;
-			case "real":
-				local.rv = "cf_sql_real";
-				break;
-			case "smallint":
-			case "smallserial":
-			case "int2":
-				local.rv = "cf_sql_smallint";
-				break;
-			case "json":
-			case "jsonb":
-			case "text":
-			case "cidr":
-			case "inet":
-			case "xml":
-				local.rv = "cf_sql_longvarchar";
-				break;
-			case "time":
-			case "timetz":
-				local.rv = "cf_sql_time";
-				break;
-			case "varchar":
-			case "varying":
-			case "bpchar":
-			case "uuid":
-			case "macaddr":
-			case "macaddr8":
-				local.rv = "cf_sql_varchar";
-				break;
-			case "point":
-			case "line":
-			case "lseg":
-			case "box":
-			case "path":
-			case "polygon":
-			case "circle":
-			case "geography":
-				local.rv = "cf_sql_other";
-				break;
-			default:
-				// Without this branch `local.rv` is never assigned and the return throws
-				// `key [RV] doesn't exist` — an error that names nothing useful and reads
-				// like a framework bug. The classic source was catalog bleed: a table whose
-				// name collides with an `information_schema` view picked up phantom columns
-				// typed `"information_schema"."sql_identifier"` (issue #3349, fixed in
-				// `$getColumnInfo()` below). Anything reaching here now is a genuinely
-				// unmapped PostgreSQL type, so say so.
-				Throw(
-					type = "Wheels.UnknownColumnType",
-					message = "The PostgreSQL column type `#arguments.type#` is not mapped to a CFML SQL type.",
-					extendedInfo = "Add a case for `#arguments.type#` to `$getType()` in `vendor/wheels/databaseAdapters/PostgreSQL/PostgreSQLModel.cfc`. If the type name looks schema-qualified (e.g. `""information_schema"".""sql_identifier""`), the column is not yours — it came from a catalog view sharing your table's name."
-				);
+		local.key = LCase(arguments.type);
+		if (StructKeyExists(variables.postgresTypeMap, local.key)) {
+			return variables.postgresTypeMap[local.key];
 		}
-		return local.rv;
+		// Without this branch `local.rv` is never assigned and the return throws
+		// `key [RV] doesn't exist` — an error that names nothing useful and reads
+		// like a framework bug. The classic source was catalog bleed: a table whose
+		// name collides with an `information_schema` view picked up phantom columns
+		// typed `"information_schema"."sql_identifier"` (issue #3349, fixed in
+		// `$getColumnInfo()` below). Anything reaching here now is a genuinely
+		// unmapped PostgreSQL type, so say so.
+		Throw(
+			type = "Wheels.UnknownColumnType",
+			message = "The PostgreSQL column type `#arguments.type#` is not mapped to a CFML SQL type.",
+			extendedInfo = "Add a case for `#arguments.type#` to `$getType()` in `vendor/wheels/databaseAdapters/PostgreSQL/PostgreSQLModel.cfc`. If the type name looks schema-qualified (e.g. `""information_schema"".""sql_identifier""`), the column is not yours — it came from a catalog view sharing your table's name."
+		);
 	}
 
 	/**

--- a/vendor/wheels/global/plugins.cfm
+++ b/vendor/wheels/global/plugins.cfm
@@ -115,22 +115,114 @@
 	}
 
 
-	public string function $checkMinimumVersion(required string engine, required string version) {
-		local.rv = "";
+	/**
+	 * Internal function. Splits a dotted engine version into numeric major,
+	 * minor, patch, and build parts; trailing parts default to 0.
+	 */
+	public any function $parseVersionParts(required string version) {
 		local.version = Replace(arguments.version, ".", ",", "all");
-		local.major = Val(ListGetAt(local.version, 1));
-		local.minor = 0;
-		local.patch = 0;
-		local.build = 0;
+		local.parts = {
+			major = Val(ListGetAt(local.version, 1)),
+			minor = 0,
+			patch = 0,
+			build = 0
+		};
 		if (ListLen(local.version) > 1) {
-			local.minor = Val(ListGetAt(local.version, 2));
+			local.parts.minor = Val(ListGetAt(local.version, 2));
 		}
 		if (ListLen(local.version) > 2) {
-			local.patch = Val(ListGetAt(local.version, 3));
+			local.parts.patch = Val(ListGetAt(local.version, 3));
 		}
 		if (ListLen(local.version) > 3) {
-			local.build = Val(ListGetAt(local.version, 4));
+			local.parts.build = Val(ListGetAt(local.version, 4));
 		}
+		return local.parts;
+	}
+
+
+	/**
+	 * Internal function. Builds the BoxLang version warning for versions below
+	 * the minimum or above the maximum; returns an empty string when the version
+	 * is within the supported range.
+	 */
+	public string function $boxLangVersionMessage(
+		required any major,
+		required any minor,
+		required any patch,
+		required any minimumMajor,
+		required any minimumMinor,
+		required any minimumPatch,
+		required any maximumMajor,
+		required any maximumMinor,
+		required any maximumPatch,
+		required string version
+	) {
+		local.rv = "";
+		// Check minimum version
+		if (
+			arguments.major < arguments.minimumMajor
+			|| (arguments.major == arguments.minimumMajor && arguments.minor < arguments.minimumMinor)
+			|| (arguments.major == arguments.minimumMajor && arguments.minor == arguments.minimumMinor && arguments.patch < arguments.minimumPatch)
+		) {
+			local.rv = "The Wheels framework requires BoxLang version #arguments.minimumMajor#.#arguments.minimumMinor#.#arguments.minimumPatch# or higher. You are currently running version #arguments.version#.";
+		}
+		// Check maximum version (optional - for major version compatibility)
+		if (
+			arguments.major > arguments.maximumMajor
+			|| (arguments.major == arguments.maximumMajor && arguments.minor > arguments.maximumMinor)
+			|| (arguments.major == arguments.maximumMajor && arguments.minor == arguments.maximumMinor && arguments.patch > arguments.maximumPatch)
+		) {
+			local.rv = "The Wheels framework has been tested up to BoxLang version #arguments.maximumMajor#.#arguments.maximumMinor#.#arguments.maximumPatch#. You are currently running version #arguments.version#. Please check for framework updates or compatibility issues.";
+		}
+		return local.rv;
+	}
+
+
+	/**
+	 * Internal function. Applies the shared minimum-version floor and any
+	 * per-major-release floor to the given result. Reads every value from the
+	 * passed state struct so optional fields (minimumBuild, floor) keep their
+	 * existing lazy-resolution semantics.
+	 */
+	public any function $checkMinimumVersionFloor(required any rv, required struct state) {
+		local.rv = arguments.rv;
+		if (
+			arguments.state.major < arguments.state.minimumMajor
+			|| (arguments.state.major == arguments.state.minimumMajor && arguments.state.minor < arguments.state.minimumMinor)
+			|| (arguments.state.major == arguments.state.minimumMajor && arguments.state.minor == arguments.state.minimumMinor && arguments.state.patch < arguments.state.minimumPatch)
+			|| (
+				arguments.state.major == arguments.state.minimumMajor
+				&& arguments.state.minor == arguments.state.minimumMinor
+				&& arguments.state.patch == arguments.state.minimumPatch
+				&& Len(arguments.state.minimumBuild)
+				&& arguments.state.build < arguments.state.minimumBuild
+			)
+		) {
+			local.rv = arguments.state.minimumMajor & "." & arguments.state.minimumMinor & "." & arguments.state.minimumPatch;
+			if (Len(arguments.state.minimumBuild)) {
+				local.rv &= "." & arguments.state.minimumBuild;
+			}
+		}
+		if (StructKeyExists(arguments.state, "floor")) {
+			// special requirements for having a specific minor or patch version within a major release exists
+			if (
+				arguments.state.minor < arguments.state.floor.minimumMinor
+				|| (arguments.state.minor == arguments.state.floor.minimumMinor && arguments.state.patch < arguments.state.floor.minimumPatch)
+			) {
+				local.rv = arguments.state.major & "." & arguments.state.floor.minimumMinor & "." & arguments.state.floor.minimumPatch;
+			}
+		}
+		return local.rv;
+	}
+
+
+	public string function $checkMinimumVersion(required string engine, required string version) {
+		local.rv = "";
+		local.parts = $parseVersionParts(arguments.version);
+		local.major = local.parts.major;
+		local.minor = local.parts.minor;
+		local.patch = local.parts.patch;
+		local.build = local.parts.build;
 		if (arguments.engine == "BoxLang") {
 			local.minimumMajor = "1";
 			local.minimumMinor = "0";
@@ -138,24 +230,18 @@
 			local.maximumMajor = "1";
 			local.maximumMinor = "15";
 			local.maximumPatch = "999";
-
-			// Check minimum version
-			if (
-				local.major < local.minimumMajor
-				|| (local.major == local.minimumMajor && local.minor < local.minimumMinor)
-				|| (local.major == local.minimumMajor && local.minor == local.minimumMinor && local.patch < local.minimumPatch)
-			) {
-				local.rv = "The Wheels framework requires BoxLang version #local.minimumMajor#.#local.minimumMinor#.#local.minimumPatch# or higher. You are currently running version #arguments.version#.";
-			}
-
-			// Check maximum version (optional - for major version compatibility)
-			if (
-				local.major > local.maximumMajor
-				|| (local.major == local.maximumMajor && local.minor > local.maximumMinor)
-				|| (local.major == local.maximumMajor && local.minor == local.maximumMinor && local.patch > local.maximumPatch)
-			) {
-				local.rv = "The Wheels framework has been tested up to BoxLang version #local.maximumMajor#.#local.maximumMinor#.#local.maximumPatch#. You are currently running version #arguments.version#. Please check for framework updates or compatibility issues.";
-			}
+			local.rv = $boxLangVersionMessage(
+				major = local.major,
+				minor = local.minor,
+				patch = local.patch,
+				minimumMajor = local.minimumMajor,
+				minimumMinor = local.minimumMinor,
+				minimumPatch = local.minimumPatch,
+				maximumMajor = local.maximumMajor,
+				maximumMinor = local.maximumMinor,
+				maximumPatch = local.maximumPatch,
+				version = arguments.version
+			);
 		} else if (arguments.engine == "Lucee") {
 			local.minimumMajor = "5";
 			local.minimumMinor = "3";
@@ -181,32 +267,22 @@
 			local.rv = false;
 		}
 		if (StructKeyExists(local, "minimumMajor")) {
-			if (
-				local.major < local.minimumMajor
-				|| (local.major == local.minimumMajor && local.minor < local.minimumMinor)
-				|| (local.major == local.minimumMajor && local.minor == local.minimumMinor && local.patch < local.minimumPatch)
-				|| (
-					local.major == local.minimumMajor
-					&& local.minor == local.minimumMinor
-					&& local.patch == local.minimumPatch
-					&& Len(local.minimumBuild)
-					&& local.build < local.minimumBuild
-				)
-			) {
-				local.rv = local.minimumMajor & "." & local.minimumMinor & "." & local.minimumPatch;
-				if (Len(local.minimumBuild)) {
-					local.rv &= "." & local.minimumBuild;
-				}
+			local.state = {
+				major = local.major,
+				minor = local.minor,
+				patch = local.patch,
+				build = local.build,
+				minimumMajor = local.minimumMajor,
+				minimumMinor = local.minimumMinor,
+				minimumPatch = local.minimumPatch
+			};
+			if (StructKeyExists(local, "minimumBuild")) {
+				local.state.minimumBuild = local.minimumBuild;
 			}
 			if (StructKeyExists(local, local.major)) {
-				// special requirements for having a specific minor or patch version within a major release exists
-				if (
-					local.minor < local[local.major].minimumMinor
-					|| (local.minor == local[local.major].minimumMinor && local.patch < local[local.major].minimumPatch)
-				) {
-					local.rv = local.major & "." & local[local.major].minimumMinor & "." & local[local.major].minimumPatch;
-				}
+				local.state.floor = local[local.major];
 			}
+			local.rv = $checkMinimumVersionFloor(rv = local.rv, state = local.state);
 		}
 		return local.rv;
 	}

--- a/vendor/wheels/global/routing.cfm
+++ b/vendor/wheels/global/routing.cfm
@@ -313,6 +313,144 @@
 
 
 	/**
+	 * Internal function. Resolves a (controller, action) pair to a named route
+	 * via the application-scoped memo, mutating `args.route` (and `args.controller`
+	 * when empty) in place when a match is found. Extracted from URLFor; behavior
+	 * is unchanged.
+	 */
+	public void function $urlForResolveRouteFromMemo(required struct args, required struct params) {
+		if (!Len(arguments.args.route) && Len(arguments.args.action)) {
+			if (!Len(arguments.args.controller)) {
+				arguments.args.controller = arguments.params.controller;
+			}
+			// Look up actual route paths instead of providing default Wheels path generation.
+			// Loop over all routes to find matching one, break the loop on first match.
+			// The (controller, action) → route-name memo lives in application scope and
+			// negative-caches misses (empty string sentinel) so wildcard-`[controller]`
+			// apps — where `$addRoute` strips the `controller` key, guaranteeing no
+			// match — don't re-scan the route table for every link helper. The cache
+			// is invalidated by `$addRoute` and `$lockedLoadRoutes`.
+			local.appKey = $appKey();
+			if (!StructKeyExists(application[local.appKey], "urlForCache")) {
+				application[local.appKey].urlForCache = {};
+			}
+			local.cache = application[local.appKey].urlForCache;
+			local.key = arguments.args.controller & "##" & arguments.args.action;
+			if (!StructKeyExists(local.cache, local.key)) {
+				local.found = "";
+				local.iEnd = ArrayLen(application[local.appKey].routes);
+				for (local.i = 1; local.i <= local.iEnd; local.i++) {
+					local.route = application[local.appKey].routes[local.i];
+					local.controllerMatch = StructKeyExists(local.route, "controller") && local.route.controller == arguments.args.controller;
+					local.actionMatch = StructKeyExists(local.route, "action") && local.route.action == arguments.args.action;
+					if (local.controllerMatch && local.actionMatch) {
+						local.found = local.route.name;
+						break;
+					}
+				}
+				local.cache[local.key] = local.found;
+			}
+			if (Len(local.cache[local.key])) {
+				arguments.args.route = local.cache[local.key];
+			}
+		}
+	}
+
+
+	/**
+	 * Internal function. Fills in `args.action` / `args.controller` from the
+	 * matched route or request params when they were not supplied. Extracted from
+	 * URLFor; behavior is unchanged.
+	 */
+	public void function $urlForControllerActionFallback(required struct args, required struct route, required struct params) {
+		// Handle action
+		if (!Len(arguments.args.action)) {
+			if (StructKeyExists(arguments.route, "action")) {
+				arguments.args.action = arguments.route.action;
+			} else if (Len(arguments.args.controller)) {
+				arguments.args.action = "index";
+			} else if (StructKeyExists(arguments.params, "action")) {
+				arguments.args.action = arguments.params.action;
+			}
+		}
+		// Handle controller
+		if (!Len(arguments.args.controller)) {
+			if (StructKeyExists(arguments.route, "controller")) {
+				arguments.args.controller = arguments.route.controller;
+			} else if (StructKeyExists(arguments.params, "controller")) {
+				arguments.args.controller = arguments.params.controller;
+			}
+		}
+	}
+
+
+	/**
+	 * Internal function. Substitutes route/path variables into the URL, appending
+	 * unmatched variables to `args.params` and returning the updated path. Extracted
+	 * from URLFor; behavior (including the Wheels.IncorrectRoutingArguments throw)
+	 * is unchanged.
+	 */
+	public string function $urlForSubstituteVariables(
+		required string rv,
+		required struct args,
+		required string foundVariables,
+		required string coreVariables,
+		required struct route
+	) {
+		local.rv = arguments.rv;
+		for (local.i = 1; local.i <= ListLen(arguments.foundVariables); local.i++) {
+			local.property = ListGetAt(arguments.foundVariables, local.i);
+			local.reg = "\[\*?#local.property#\]";
+
+			// Read necessary variables from different sources.
+			if (StructKeyExists(arguments.args, local.property) && Len(arguments.args[local.property])) {
+				local.value = arguments.args[local.property];
+			} else if (StructKeyExists(arguments.route, local.property)) {
+				local.value = arguments.route[local.property];
+			} else if (Len(arguments.args.route) && arguments.args.$URLRewriting != "Off") {
+				Throw(
+					type = "Wheels.IncorrectRoutingArguments",
+					message = "Incorrect Arguments",
+					extendedInfo = "The route chosen by Wheels `#arguments.route.name#` requires the argument `#local.property#`. Pass the argument `#local.property#` or change your routes to reflect the proper variables needed."
+				);
+			} else {
+				continue;
+			}
+
+			// If value is a model object, get its key value.
+			if (IsObject(local.value)) {
+				local.value = local.value.key();
+			}
+
+			// Any value we find from above, URL encode it here.
+			if (arguments.args.encode && $get("encodeURLs")) {
+				local.value = EncodeForURL($canonicalize(local.value));
+				if (arguments.args.$encodeForHtmlAttribute) {
+					local.value = EncodeForHTMLAttribute(local.value);
+				}
+			}
+
+			// If property is not in pattern, store it in the params argument.
+			if (!ReFind(local.reg, local.rv)) {
+				if (!ListFindNoCase(arguments.coreVariables, local.property)) {
+					arguments.args.params = ListAppend(arguments.args.params, "#local.property#=#local.value#", "&");
+				}
+				continue;
+			}
+
+			// Transform value before setting it in pattern.
+			if (local.property == "controller" || local.property == "action") {
+				local.value = hyphenize(local.value);
+			} else if (application.wheels.obfuscateUrls) {
+				local.value = obfuscateParam(local.value);
+			}
+			local.rv = ReReplace(local.rv, local.reg, local.value);
+		}
+		return local.rv;
+	}
+
+
+	/**
 	 * Creates an internal URL based on supplied arguments.
 	 *
 	 * [section: Global Helpers]
@@ -363,40 +501,7 @@
 		}
 
 		// Look up actual route paths instead of providing default Wheels path generation.
-		// Loop over all routes to find matching one, break the loop on first match.
-		// The (controller, action) → route-name memo lives in application scope and
-		// negative-caches misses (empty string sentinel) so wildcard-`[controller]`
-		// apps — where `$addRoute` strips the `controller` key, guaranteeing no
-		// match — don't re-scan the route table for every link helper. The cache
-		// is invalidated by `$addRoute` and `$lockedLoadRoutes`.
-		if (!Len(arguments.route) && Len(arguments.action)) {
-			if (!Len(arguments.controller)) {
-				arguments.controller = local.params.controller;
-			}
-			local.appKey = $appKey();
-			if (!StructKeyExists(application[local.appKey], "urlForCache")) {
-				application[local.appKey].urlForCache = {};
-			}
-			local.cache = application[local.appKey].urlForCache;
-			local.key = arguments.controller & "##" & arguments.action;
-			if (!StructKeyExists(local.cache, local.key)) {
-				local.found = "";
-				local.iEnd = ArrayLen(application[local.appKey].routes);
-				for (local.i = 1; local.i <= local.iEnd; local.i++) {
-					local.route = application[local.appKey].routes[local.i];
-					local.controllerMatch = StructKeyExists(local.route, "controller") && local.route.controller == arguments.controller;
-					local.actionMatch = StructKeyExists(local.route, "action") && local.route.action == arguments.action;
-					if (local.controllerMatch && local.actionMatch) {
-						local.found = local.route.name;
-						break;
-					}
-				}
-				local.cache[local.key] = local.found;
-			}
-			if (Len(local.cache[local.key])) {
-				arguments.route = local.cache[local.key];
-			}
-		}
+		$urlForResolveRouteFromMemo(args = arguments, params = local.params);
 
 		// Start building the URL to return by setting the sub folder path and script name portion.
 		// Script name index.cfm will be removed later if applicable (e.g. when URL rewriting is on).
@@ -423,77 +528,16 @@
 		}
 
 		// Shared fallback logic for controller/action
-		if (StructKeyExists(local, "params")) {
-			// Handle action
-			if (!Len(arguments.action)) {
-				if (StructKeyExists(local.route, "action")) {
-					arguments.action = local.route.action;
-				} else if (Len(arguments.controller)) {
-					arguments.action = "index";
-				} else if (StructKeyExists(local.params, "action")) {
-					arguments.action = local.params.action;
-				}
-			}
-
-			// Handle controller
-			if (!Len(arguments.controller)) {
-				if (StructKeyExists(local.route, "controller")) {
-					arguments.controller = local.route.controller;
-				} else if (StructKeyExists(local.params, "controller")) {
-					arguments.controller = local.params.controller;
-				}
-			}
-		}
+		$urlForControllerActionFallback(args = arguments, route = local.route, params = local.params);
 
 		// Replace each params variable with the correct value.
-		for (local.i = 1; local.i <= ListLen(local.foundVariables); local.i++) {
-			local.property = ListGetAt(local.foundVariables, local.i);
-			local.reg = "\[\*?#local.property#\]";
-
-			// Read necessary variables from different sources.
-			if (StructKeyExists(arguments, local.property) && Len(arguments[local.property])) {
-				local.value = arguments[local.property];
-			} else if (StructKeyExists(local.route, local.property)) {
-				local.value = local.route[local.property];
-			} else if (Len(arguments.route) && arguments.$URLRewriting != "Off") {
-				Throw(
-					type = "Wheels.IncorrectRoutingArguments",
-					message = "Incorrect Arguments",
-					extendedInfo = "The route chosen by Wheels `#local.route.name#` requires the argument `#local.property#`. Pass the argument `#local.property#` or change your routes to reflect the proper variables needed."
-				);
-			} else {
-				continue;
-			}
-
-			// If value is a model object, get its key value.
-			if (IsObject(local.value)) {
-				local.value = local.value.key();
-			}
-
-			// Any value we find from above, URL encode it here.
-			if (arguments.encode && $get("encodeURLs")) {
-				local.value = EncodeForURL($canonicalize(local.value));
-				if (arguments.$encodeForHtmlAttribute) {
-					local.value = EncodeForHTMLAttribute(local.value);
-				}
-			}
-
-			// If property is not in pattern, store it in the params argument.
-			if (!ReFind(local.reg, local.rv)) {
-				if (!ListFindNoCase(local.coreVariables, local.property)) {
-					arguments.params = ListAppend(arguments.params, "#local.property#=#local.value#", "&");
-				}
-				continue;
-			}
-
-			// Transform value before setting it in pattern.
-			if (local.property == "controller" || local.property == "action") {
-				local.value = hyphenize(local.value);
-			} else if (application.wheels.obfuscateUrls) {
-				local.value = obfuscateParam(local.value);
-			}
-			local.rv = ReReplace(local.rv, local.reg, local.value);
-		}
+		local.rv = $urlForSubstituteVariables(
+			rv = local.rv,
+			args = arguments,
+			foundVariables = local.foundVariables,
+			coreVariables = local.coreVariables,
+			route = local.route
+		);
 
 		// Clean up unused keys in pattern.
 		local.rv = ReReplace(local.rv, "((&|\?)\w+=|\/|\.)\[\*?\w+\]", "", "ALL");

--- a/vendor/wheels/migrator/AutoMigrator.cfc
+++ b/vendor/wheels/migrator/AutoMigrator.cfc
@@ -533,78 +533,70 @@ component extends="wheels.migrator.Base" {
 		}
 	}
 
+	variables.dbTypeMap = {
+		"int": "integer",
+		"int4": "integer",
+		"integer": "integer",
+		"mediumint": "integer",
+		"smallint": "integer",
+		"tinyint": "integer",
+		"bigint": "biginteger",
+		"int8": "biginteger",
+		"int64": "biginteger",
+		"varchar": "string",
+		"character varying": "string",
+		"nvarchar": "string",
+		"char": "string",
+		"nchar": "string",
+		"text": "text",
+		"ntext": "text",
+		"clob": "text",
+		"character large object": "text",
+		"mediumtext": "text",
+		"longtext": "text",
+		"tinytext": "text",
+		"datetime": "datetime",
+		"timestamp": "datetime",
+		"timestamp without time zone": "datetime",
+		"timestamp with time zone": "datetime",
+		"date": "date",
+		"time": "time",
+		"time without time zone": "time",
+		"time with time zone": "time",
+		"bit": "boolean",
+		"boolean": "boolean",
+		"bool": "boolean",
+		"decimal": "decimal",
+		"numeric": "decimal",
+		"money": "decimal",
+		"smallmoney": "decimal",
+		"float": "float",
+		"float4": "float",
+		"float8": "float",
+		"double": "float",
+		"double precision": "float",
+		"real": "float",
+		"binary": "binary",
+		"varbinary": "binary",
+		"image": "binary",
+		"blob": "binary",
+		"bytea": "binary",
+		"longblob": "binary",
+		"mediumblob": "binary",
+		"tinyblob": "binary",
+		"uniqueidentifier": "string"
+	};
+
 	/**
 	 * Maps raw database type names (from cfdbinfo) to Wheels migration types.
 	 * Used to compare the actual DB schema against the model's expected types.
 	 */
 	public string function $dbTypeToMigrationType(required string dbType) {
-		switch (LCase(arguments.dbType)) {
-			case "int":
-			case "int4":
-			case "integer":
-			case "mediumint":
-			case "smallint":
-			case "tinyint":
-				return "integer";
-			case "bigint":
-			case "int8":
-			case "int64":
-				return "biginteger";
-			case "varchar":
-			case "character varying":
-			case "nvarchar":
-			case "char":
-			case "nchar":
-				return "string";
-			case "text":
-			case "ntext":
-			case "clob":
-			case "character large object":
-			case "mediumtext":
-			case "longtext":
-			case "tinytext":
-				return "text";
-			case "datetime":
-			case "timestamp":
-			case "timestamp without time zone":
-			case "timestamp with time zone":
-				return "datetime";
-			case "date":
-				return "date";
-			case "time":
-			case "time without time zone":
-			case "time with time zone":
-				return "time";
-			case "bit":
-			case "boolean":
-			case "bool":
-				return "boolean";
-			case "decimal":
-			case "numeric":
-			case "money":
-			case "smallmoney":
-				return "decimal";
-			case "float":
-			case "float4":
-			case "float8":
-			case "double":
-			case "double precision":
-			case "real":
-				return "float";
-			case "binary":
-			case "varbinary":
-			case "image":
-			case "blob":
-			case "bytea":
-			case "longblob":
-			case "mediumblob":
-			case "tinyblob":
-				return "binary";
-			case "uniqueidentifier":
-				return "string";
-			default:
-				return "unknown";
+		local.key = LCase(arguments.dbType);
+		if (StructKeyExists(variables.dbTypeMap, local.key)) {
+			return variables.dbTypeMap[local.key];
 		}
+		return "unknown";
 	}
 
 }

--- a/vendor/wheels/model/onmissingmethod.cfc
+++ b/vendor/wheels/model/onmissingmethod.cfc
@@ -9,46 +9,17 @@ component {
 		// --- Query Scopes ---
 		// Check if the called method matches a named scope defined in config().
 		// Returns a ScopeChain proxy that supports further chaining and terminal finder methods.
-		if (
-			StructKeyExists(variables.wheels.class, "scopes")
-			&& StructKeyExists(variables.wheels.class.scopes, arguments.missingMethodName)
-		) {
-			local.scopeDef = variables.wheels.class.scopes[arguments.missingMethodName];
-			if (StructKeyExists(local.scopeDef, "handler") && Len(local.scopeDef.handler)) {
-				local.sanitizedArgs = $sanitizeScopeHandlerArgs(arguments.missingMethodArguments);
-				local.spec = $invoke(method = local.scopeDef.handler, invokeArgs = local.sanitizedArgs);
-			} else {
-				local.spec = Duplicate(local.scopeDef);
-			}
-			local.rv = new wheels.model.query.ScopeChain(modelReference = this, specs = [local.spec]);
-			return local.rv;
+		local.scopeResult = $onMissingMethodResolveScope(arguments.missingMethodName, arguments.missingMethodArguments);
+		if (local.scopeResult.handled) {
+			return local.scopeResult.rv;
 		}
 
 		// --- Enum is<Value>() boolean checkers ---
 		// For a property with enum(property="status", values="draft,published,archived"),
 		// generates isDraft(), isPublished(), isArchived() that return true/false.
-		if (
-			Left(arguments.missingMethodName, 2) == "is"
-			&& Len(arguments.missingMethodName) > 2
-			&& StructKeyExists(variables.wheels.class, "enums")
-		) {
-			local.valueName = Right(arguments.missingMethodName, Len(arguments.missingMethodName) - 2);
-			// Check against each enum definition
-			for (local.enumProp in variables.wheels.class.enums) {
-				local.enumDef = variables.wheels.class.enums[local.enumProp];
-				// Match case-insensitively against enum value names
-				for (local.name in ListToArray(local.enumDef.names)) {
-					if (CompareNoCase(local.valueName, local.name) == 0) {
-						// Found a match — return true if the property equals the stored value
-						if (StructKeyExists(this, local.enumProp)) {
-							local.rv = (Compare(this[local.enumProp], local.enumDef.values[local.name]) == 0);
-						} else {
-							local.rv = false;
-						}
-						return local.rv;
-					}
-				}
-			}
+		local.enumResult = $onMissingMethodResolveEnumChecker(arguments.missingMethodName);
+		if (local.enumResult.handled) {
+			return local.enumResult.rv;
 		}
 
 		// --- Chainable Query Builder entry points ---
@@ -64,44 +35,141 @@ component {
 			return Invoke(local.builder, arguments.missingMethodName, arguments.missingMethodArguments);
 		}
 
+		// --- Dynamic property helpers (hasChanged, changedFrom, isPresent, isBlank, columnFor, toggle, has<Property>, update<Property>) ---
+		local.propertyResult = $onMissingMethodResolveDynamicProperty(arguments.missingMethodName, arguments.missingMethodArguments);
+		if (local.propertyResult.handled) {
+			local.rv = local.propertyResult.rv;
+		} else {
+			// --- Dynamic finders (findOneBy / findAllBy / findOrCreateBy) and associations ---
+			local.finderResult = $onMissingMethodResolveDynamicFinder(arguments.missingMethodName, arguments.missingMethodArguments);
+			if (local.finderResult.handled) {
+				local.rv = local.finderResult.rv;
+			} else {
+				local.rv = $associationMethod(argumentCollection = arguments);
+			}
+		}
+
+		if (!StructKeyExists(local, "rv")) {
+			Throw(
+				type = "Wheels.MethodNotFound",
+				message = "The method `#arguments.missingMethodName#` was not found in the `#variables.wheels.class.modelName#` model.",
+				extendedInfo = "Check your spelling or add the method to the model's CFC file."
+			);
+		}
+
+		return local.rv;
+	}
+
+	/**
+	 * Internal function. Resolves a dynamic method call against the named query scopes
+	 * defined in config(). Returns `{ handled, rv }` with `handled = true` when the
+	 * method matches a scope and `rv` holding the resulting ScopeChain.
+	 */
+	public any function $onMissingMethodResolveScope(required string missingMethodName, required struct missingMethodArguments) {
+		local.result = { handled = false, rv = "" };
+		if (
+			StructKeyExists(variables.wheels.class, "scopes")
+			&& StructKeyExists(variables.wheels.class.scopes, arguments.missingMethodName)
+		) {
+			local.scopeDef = variables.wheels.class.scopes[arguments.missingMethodName];
+			if (StructKeyExists(local.scopeDef, "handler") && Len(local.scopeDef.handler)) {
+				local.sanitizedArgs = $sanitizeScopeHandlerArgs(arguments.missingMethodArguments);
+				local.spec = $invoke(method = local.scopeDef.handler, invokeArgs = local.sanitizedArgs);
+			} else {
+				local.spec = Duplicate(local.scopeDef);
+			}
+			local.result.rv = new wheels.model.query.ScopeChain(modelReference = this, specs = [local.spec]);
+			local.result.handled = true;
+		}
+		return local.result;
+	}
+
+	/**
+	 * Internal function. Resolves the enum `is<Value>()` boolean checker form.
+	 * Returns `{ handled, rv }` with `handled = true` when the method name matches an
+	 * enum value name.
+	 */
+	public any function $onMissingMethodResolveEnumChecker(required string missingMethodName) {
+		local.result = { handled = false, rv = false };
+		if (
+			Left(arguments.missingMethodName, 2) == "is"
+			&& Len(arguments.missingMethodName) > 2
+			&& StructKeyExists(variables.wheels.class, "enums")
+		) {
+			local.valueName = Right(arguments.missingMethodName, Len(arguments.missingMethodName) - 2);
+			// Check against each enum definition
+			for (local.enumProp in variables.wheels.class.enums) {
+				local.enumDef = variables.wheels.class.enums[local.enumProp];
+				// Match case-insensitively against enum value names
+				for (local.name in ListToArray(local.enumDef.names)) {
+					if (CompareNoCase(local.valueName, local.name) == 0) {
+						// Found a match — return true if the property equals the stored value
+						if (StructKeyExists(this, local.enumProp)) {
+							local.result.rv = (Compare(this[local.enumProp], local.enumDef.values[local.name]) == 0);
+						} else {
+							local.result.rv = false;
+						}
+						local.result.handled = true;
+						return local.result;
+					}
+				}
+			}
+		}
+		return local.result;
+	}
+
+	/**
+	 * Internal function. Resolves the dynamic property method forms (`hasChanged`,
+	 * `changedFrom`, `isPresent`, `isBlank`, `columnFor`, `toggle`, `has<Property>`,
+	 * `update<Property>`). Returns `{ handled, rv }`.
+	 */
+	public any function $onMissingMethodResolveDynamicProperty(required string missingMethodName, required struct missingMethodArguments) {
+		local.result = { handled = false, rv = "" };
 		if (
 			Right(arguments.missingMethodName, 10) == "hasChanged"
 			&& StructKeyExists(variables.wheels.class.properties, ReplaceNoCase(arguments.missingMethodName, "hasChanged", ""))
 		) {
-			local.rv = hasChanged(property = ReplaceNoCase(arguments.missingMethodName, "hasChanged", ""));
+			local.result.rv = hasChanged(property = ReplaceNoCase(arguments.missingMethodName, "hasChanged", ""));
+			local.result.handled = true;
 		} else if (
 			Right(arguments.missingMethodName, 11) == "changedFrom"
 			&& StructKeyExists(variables.wheels.class.properties, ReplaceNoCase(arguments.missingMethodName, "changedFrom", ""))
 		) {
-			local.rv = changedFrom(property = ReplaceNoCase(arguments.missingMethodName, "changedFrom", ""));
+			local.result.rv = changedFrom(property = ReplaceNoCase(arguments.missingMethodName, "changedFrom", ""));
+			local.result.handled = true;
 		} else if (
 			Right(arguments.missingMethodName, 9) == "IsPresent"
 			&& StructKeyExists(variables.wheels.class.properties, ReplaceNoCase(arguments.missingMethodName, "IsPresent", ""))
 		) {
-			local.rv = propertyIsPresent(property = ReplaceNoCase(arguments.missingMethodName, "IsPresent", ""));
+			local.result.rv = propertyIsPresent(property = ReplaceNoCase(arguments.missingMethodName, "IsPresent", ""));
+			local.result.handled = true;
 		} else if (
 			Right(arguments.missingMethodName, 7) == "IsBlank"
 			&& StructKeyExists(variables.wheels.class.properties, ReplaceNoCase(arguments.missingMethodName, "IsBlank", ""))
 		) {
-			local.rv = propertyIsBlank(property = ReplaceNoCase(arguments.missingMethodName, "IsBlank", ""));
+			local.result.rv = propertyIsBlank(property = ReplaceNoCase(arguments.missingMethodName, "IsBlank", ""));
+			local.result.handled = true;
 		} else if (
 			Left(arguments.missingMethodName, 9) == "columnFor"
 			&& StructKeyExists(variables.wheels.class.properties, ReplaceNoCase(arguments.missingMethodName, "columnFor", ""))
 		) {
-			local.rv = columnForProperty(property = ReplaceNoCase(arguments.missingMethodName, "columnFor", ""));
+			local.result.rv = columnForProperty(property = ReplaceNoCase(arguments.missingMethodName, "columnFor", ""));
+			local.result.handled = true;
 		} else if (
 			Left(arguments.missingMethodName, 6) == "toggle"
 			&& StructKeyExists(variables.wheels.class.properties, ReplaceNoCase(arguments.missingMethodName, "toggle", ""))
 		) {
-			local.rv = toggle(
+			local.result.rv = toggle(
 				property = ReplaceNoCase(arguments.missingMethodName, "toggle", ""),
 				argumentCollection = arguments.missingMethodArguments
 			);
+			local.result.handled = true;
 		} else if (
 			Left(arguments.missingMethodName, 3) == "has"
 			&& StructKeyExists(variables.wheels.class.properties, ReplaceNoCase(arguments.missingMethodName, "has", ""))
 		) {
-			local.rv = hasProperty(property = ReplaceNoCase(arguments.missingMethodName, "has", ""));
+			local.result.rv = hasProperty(property = ReplaceNoCase(arguments.missingMethodName, "has", ""));
+			local.result.handled = true;
 		} else if (
 			Left(arguments.missingMethodName, 6) == "update"
 			&& StructKeyExists(variables.wheels.class.properties, ReplaceNoCase(arguments.missingMethodName, "update", ""))
@@ -113,11 +181,23 @@ component {
 					extendedInfo = "Pass in a value to the dynamic updateProperty in the `value` argument."
 				);
 			}
-			local.rv = updateProperty(
+			local.result.rv = updateProperty(
 				property = ReplaceNoCase(arguments.missingMethodName, "update", ""),
 				value = arguments.missingMethodArguments.value
 			);
-		} else if (
+			local.result.handled = true;
+		}
+		return local.result;
+	}
+
+	/**
+	 * Internal function. Resolves the dynamic finder forms (`findOneByX`, `findAllByX`,
+	 * `findOrCreateByX`). Mutates `missingMethodArguments` in place and returns
+	 * `{ handled, rv }`.
+	 */
+	public any function $onMissingMethodResolveDynamicFinder(required string missingMethodName, required struct missingMethodArguments) {
+		local.result = { handled = false, rv = "" };
+		if (
 			Left(arguments.missingMethodName, 9) == "findOneBy"
 			|| Left(arguments.missingMethodName, 9) == "findAllBy"
 		) {
@@ -173,7 +253,7 @@ component {
 
 			// construct where clause
 			local.addToWhere = ArrayToList(local.addToWhere, " AND ");
-			
+
 			if (StructKeyExists(arguments.missingMethodArguments, "where") && Len(arguments.missingMethodArguments.where)) {
 				arguments.missingMethodArguments.where = "(" & arguments.missingMethodArguments.where & ") AND (" & local.addToWhere & ")";
 			} else {
@@ -188,25 +268,16 @@ component {
 
 			// call finder method
 			if (Left(arguments.missingMethodName, 9) == "findOneBy") {
-				local.rv = findOne(argumentCollection = arguments.missingMethodArguments);
+				local.result.rv = findOne(argumentCollection = arguments.missingMethodArguments);
 			} else {
-				local.rv = findAll(argumentCollection = arguments.missingMethodArguments);
+				local.result.rv = findAll(argumentCollection = arguments.missingMethodArguments);
 			}
+			local.result.handled = true;
 		} else if (Left(arguments.missingMethodName, 14) == "findOrCreateBy") {
-			local.rv = $findOrCreateBy(argumentCollection = arguments);
-		} else {
-			local.rv = $associationMethod(argumentCollection = arguments);
+			local.result.rv = $findOrCreateBy(argumentCollection = arguments);
+			local.result.handled = true;
 		}
-
-		if (!StructKeyExists(local, "rv")) {
-			Throw(
-				type = "Wheels.MethodNotFound",
-				message = "The method `#arguments.missingMethodName#` was not found in the `#variables.wheels.class.modelName#` model.",
-				extendedInfo = "Check your spelling or add the method to the model's CFC file."
-			);
-		}
-
-		return local.rv;
+		return local.result;
 	}
 
 	/**
@@ -330,212 +401,25 @@ component {
 					&& local.assoc.polymorphic
 					&& local.assoc.type == "belongsTo"
 				) {
-					local.name = ReplaceNoCase(arguments.missingMethodName, local.key, "object");
-					local.foreignKeyProp = local.assoc.foreignKey;
-					local.foreignTypeProp = local.assoc.foreignType;
-
-					if (local.name == "object") {
-						// Read the type column to determine which model to query.
-						if (StructKeyExists(this, local.foreignTypeProp) && Len(this[local.foreignTypeProp])
-							&& StructKeyExists(this, local.foreignKeyProp) && Len(this[local.foreignKeyProp])) {
-							local.componentReference = model(this[local.foreignTypeProp]);
-							local.method = "findByKey";
-							arguments.missingMethodArguments.key = this[local.foreignKeyProp];
-						}
-					} else if (local.name == "hasObject") {
-						// Check if the foreign key is non-empty.
-						if (StructKeyExists(this, local.foreignKeyProp) && Len(this[local.foreignKeyProp])
-							&& StructKeyExists(this, local.foreignTypeProp) && Len(this[local.foreignTypeProp])) {
-							local.componentReference = model(this[local.foreignTypeProp]);
-							local.method = "exists";
-							arguments.missingMethodArguments.key = this[local.foreignKeyProp];
-						} else {
-							local.rv = false;
-						}
-					}
-
-					if (Len(local.method) && StructKeyExists(local, "componentReference")) {
-						local.rv = $invoke(
-							componentReference = local.componentReference,
-							method = local.method,
-							invokeArgs = arguments.missingMethodArguments
-						);
+					local.polyResult = $associationMethodResolvePolymorphicBelongsTo(
+						missingMethodName = arguments.missingMethodName,
+						key = local.key,
+						assoc = local.assoc,
+						missingMethodArguments = arguments.missingMethodArguments
+					);
+					if (local.polyResult.handled) {
+						local.rv = local.polyResult.rv;
 					}
 					continue;
 				}
 
-				local.info = $expandedAssociations(include = local.key);
-				local.info = local.info[1];
-				local.componentReference = model(local.info.modelName);
-				local.isPolymorphic = StructKeyExists(local.info, "as") && Len(local.info.as) && StructKeyExists(local.info, "foreignType");
-				if (local.info.type == "hasOne") {
-					local.where = $keyWhereString(properties = local.info.foreignKey, keys = primaryKeys());
-					if (local.isPolymorphic) {
-						local.where = "(#local.where#) AND (#local.info.foreignType# = '#variables.wheels.class.modelName#')";
-					}
-					if (StructKeyExists(arguments.missingMethodArguments, "where") && Len(arguments.missingMethodArguments.where)) {
-						local.where = "(#local.where#) AND (#arguments.missingMethodArguments.where#)";
-					}
-
-					// create a generic method name (example: "hasProfile" becomes "hasObject")
-					local.name = ReplaceNoCase(arguments.missingMethodName, local.key, "object");
-
-					if (local.name == "object") {
-						local.method = "findOne";
-						arguments.missingMethodArguments.where = local.where;
-					} else if (local.name == "hasObject") {
-						local.method = "exists";
-						arguments.missingMethodArguments.where = local.where;
-					} else if (local.name == "newObject") {
-						local.method = "new";
-						$setForeignKeyValues(missingMethodArguments = arguments.missingMethodArguments, keys = local.info.foreignKey);
-						if (local.isPolymorphic) {
-							arguments.missingMethodArguments[local.info.foreignType] = variables.wheels.class.modelName;
-						}
-					} else if (local.name == "createObject") {
-						local.method = "create";
-						$setForeignKeyValues(missingMethodArguments = arguments.missingMethodArguments, keys = local.info.foreignKey);
-						if (local.isPolymorphic) {
-							arguments.missingMethodArguments[local.info.foreignType] = variables.wheels.class.modelName;
-						}
-					} else if (local.name == "removeObject") {
-						local.method = "updateOne";
-						arguments.missingMethodArguments.where = local.where;
-						$setForeignKeyValues(
-							missingMethodArguments = arguments.missingMethodArguments,
-							keys = local.info.foreignKey,
-							setToNull = true
-						);
-					} else if (local.name == "deleteObject") {
-						local.method = "deleteOne";
-						arguments.missingMethodArguments.where = local.where;
-					} else if (local.name == "setObject") {
-						local.resolved = $resolveAssociationTarget(
-							missingMethodArguments = arguments.missingMethodArguments,
-							componentReference = local.componentReference,
-							argumentName = local.key,
-							methodName = local.name,
-							objectMethod = "update",
-							keyMethod = "updateByKey"
-						);
-						local.method = local.resolved.method;
-						local.componentReference = local.resolved.componentReference;
-						$setForeignKeyValues(missingMethodArguments = arguments.missingMethodArguments, keys = local.info.foreignKey);
-					}
-				} else if (local.info.type == "hasMany") {
-					if (structKeyExists(local.info, "joinKey") AND Len(local.info.joinKey) AND local.info.joinKey NEQ primaryKeys()) {
-						local.where = $keyWhereString(properties = local.info.foreignKey, keys = local.info.joinKey);
-					} else {
-						local.where = $keyWhereString(properties = local.info.foreignKey, keys = primaryKeys());
-					}
-					if (local.isPolymorphic) {
-						local.where = "(#local.where#) AND (#local.info.foreignType# = '#variables.wheels.class.modelName#')";
-					}
-					if (StructKeyExists(arguments.missingMethodArguments, "where") && Len(arguments.missingMethodArguments.where)) {
-						local.where = "(#local.where#) AND (#arguments.missingMethodArguments.where#)";
-					}
-					local.singularKey = singularize(local.key);
-
-					// create a generic method name (example: "hasComments" becomes "hasObjects")
-					local.name = ReplaceNoCase(arguments.missingMethodName, local.key, "objects");
-					if (local.name == arguments.missingMethodName) {
-						// we should never change anything more than once so if the plural version was already replaced we do not need to replace the singular one
-						local.name = ReplaceNoCase(local.name, local.singularKey, "object");
-					}
-
-					if (local.name == "objects") {
-						local.method = "findAll";
-						arguments.missingMethodArguments.where = local.where;
-					} else if (local.name == "addObject") {
-						local.resolved = $resolveAssociationTarget(
-							missingMethodArguments = arguments.missingMethodArguments,
-							componentReference = local.componentReference,
-							argumentName = local.singularKey,
-							methodName = local.name,
-							objectMethod = "update",
-							keyMethod = "updateByKey"
-						);
-						local.method = local.resolved.method;
-						local.componentReference = local.resolved.componentReference;
-						$setForeignKeyValues(missingMethodArguments = arguments.missingMethodArguments, keys = local.info.foreignKey);
-					} else if (local.name == "removeObject") {
-						local.resolved = $resolveAssociationTarget(
-							missingMethodArguments = arguments.missingMethodArguments,
-							componentReference = local.componentReference,
-							argumentName = local.singularKey,
-							methodName = local.name,
-							objectMethod = "update",
-							keyMethod = "updateByKey"
-						);
-						local.method = local.resolved.method;
-						local.componentReference = local.resolved.componentReference;
-						$setForeignKeyValues(
-							missingMethodArguments = arguments.missingMethodArguments,
-							keys = local.info.foreignKey,
-							setToNull = true
-						);
-					} else if (local.name == "deleteObject") {
-						local.resolved = $resolveAssociationTarget(
-							missingMethodArguments = arguments.missingMethodArguments,
-							componentReference = local.componentReference,
-							argumentName = local.singularKey,
-							methodName = local.name,
-							objectMethod = "delete",
-							keyMethod = "deleteByKey"
-						);
-						local.method = local.resolved.method;
-						local.componentReference = local.resolved.componentReference;
-						$setForeignKeyValues(missingMethodArguments = arguments.missingMethodArguments, keys = local.info.foreignKey);
-					} else if (local.name == "hasObjects") {
-						local.method = "exists";
-						arguments.missingMethodArguments.where = local.where;
-					} else if (local.name == "newObject") {
-						local.method = "new";
-						$setForeignKeyValues(missingMethodArguments = arguments.missingMethodArguments, keys = local.info.foreignKey);
-						if (local.isPolymorphic) {
-							arguments.missingMethodArguments[local.info.foreignType] = variables.wheels.class.modelName;
-						}
-					} else if (local.name == "createObject") {
-						local.method = "create";
-						$setForeignKeyValues(missingMethodArguments = arguments.missingMethodArguments, keys = local.info.foreignKey);
-						if (local.isPolymorphic) {
-							arguments.missingMethodArguments[local.info.foreignType] = variables.wheels.class.modelName;
-						}
-					} else if (local.name == "objectCount") {
-						local.method = "count";
-						arguments.missingMethodArguments.where = local.where;
-					} else if (local.name == "findOneObject") {
-						local.method = "findOne";
-						arguments.missingMethodArguments.where = local.where;
-					} else if (local.name == "removeAllObjects") {
-						local.method = "updateAll";
-						arguments.missingMethodArguments.where = local.where;
-						$setForeignKeyValues(
-							missingMethodArguments = arguments.missingMethodArguments,
-							keys = local.info.foreignKey,
-							setToNull = true
-						);
-					} else if (local.name == "deleteAllObjects") {
-						local.method = "deleteAll";
-						arguments.missingMethodArguments.where = local.where;
-					}
-				} else if (local.info.type == "belongsTo") {
-					local.where = $keyWhereString(keys = local.info.foreignKey, properties = local.componentReference.primaryKeys());
-					if (StructKeyExists(arguments.missingMethodArguments, "where") && Len(arguments.missingMethodArguments.where)) {
-						local.where = "(#local.where#) AND (#arguments.missingMethodArguments.where#)";
-					}
-
-					// create a generic method name (example: "hasAuthor" becomes "hasObject")
-					local.name = ReplaceNoCase(arguments.missingMethodName, local.key, "object");
-
-					if (local.name == "object") {
-						local.method = "findByKey";
-						arguments.missingMethodArguments.key = $propertyValue(name = local.info.foreignKey);
-					} else if (local.name == "hasObject") {
-						local.method = "exists";
-						arguments.missingMethodArguments.key = $propertyValue(name = local.info.foreignKey);
-					}
-				}
+				local.resolved = $associationMethodResolve(
+					key = local.key,
+					missingMethodName = arguments.missingMethodName,
+					missingMethodArguments = arguments.missingMethodArguments
+				);
+				local.method = local.resolved.method;
+				local.componentReference = local.resolved.componentReference;
 			}
 			if (Len(local.method)) {
 				local.rv = $invoke(
@@ -549,6 +433,310 @@ component {
 		if (StructKeyExists(local, "rv")) {
 			return local.rv;
 		}
+	}
+
+	/**
+	 * Internal function. Resolves a polymorphic `belongsTo` association method, reading
+	 * the type column to choose the target model. Returns `{ handled, rv }` where
+	 * `handled` is true only when the original code would have set `local.rv` (either
+	 * `false` for an empty key or the `$invoke` result).
+	 */
+	public any function $associationMethodResolvePolymorphicBelongsTo(
+		required string missingMethodName,
+		required string key,
+		required struct assoc,
+		required struct missingMethodArguments
+	) {
+		local.result = { handled = false, rv = "" };
+		local.name = ReplaceNoCase(arguments.missingMethodName, arguments.key, "object");
+		local.foreignKeyProp = arguments.assoc.foreignKey;
+		local.foreignTypeProp = arguments.assoc.foreignType;
+		local.method = "";
+
+		if (local.name == "object") {
+			// Read the type column to determine which model to query.
+			if (StructKeyExists(this, local.foreignTypeProp) && Len(this[local.foreignTypeProp])
+				&& StructKeyExists(this, local.foreignKeyProp) && Len(this[local.foreignKeyProp])) {
+				local.componentReference = model(this[local.foreignTypeProp]);
+				local.method = "findByKey";
+				arguments.missingMethodArguments.key = this[local.foreignKeyProp];
+			}
+		} else if (local.name == "hasObject") {
+			// Check if the foreign key is non-empty.
+			if (StructKeyExists(this, local.foreignKeyProp) && Len(this[local.foreignKeyProp])
+				&& StructKeyExists(this, local.foreignTypeProp) && Len(this[local.foreignTypeProp])) {
+				local.componentReference = model(this[local.foreignTypeProp]);
+				local.method = "exists";
+				arguments.missingMethodArguments.key = this[local.foreignKeyProp];
+			} else {
+				local.result.rv = false;
+				local.result.handled = true;
+			}
+		}
+
+		if (Len(local.method) && StructKeyExists(local, "componentReference")) {
+			local.result.rv = $invoke(
+				componentReference = local.componentReference,
+				method = local.method,
+				invokeArgs = arguments.missingMethodArguments
+			);
+			local.result.handled = true;
+		}
+		return local.result;
+	}
+
+	/**
+	 * Internal function. Resolves a non-polymorphic association method by expanding the
+	 * association, resolving the target component, and dispatching on the association
+	 * type. Returns `{ method, componentReference }`.
+	 */
+	public any function $associationMethodResolve(
+		required string key,
+		required string missingMethodName,
+		required struct missingMethodArguments
+	) {
+		local.info = $expandedAssociations(include = arguments.key);
+		local.info = local.info[1];
+		local.componentReference = model(local.info.modelName);
+		if (local.info.type == "hasOne") {
+			return $associationMethodResolveHasOne(
+				info = local.info,
+				componentReference = local.componentReference,
+				missingMethodArguments = arguments.missingMethodArguments,
+				key = arguments.key,
+				missingMethodName = arguments.missingMethodName
+			);
+		} else if (local.info.type == "hasMany") {
+			return $associationMethodResolveHasMany(
+				info = local.info,
+				componentReference = local.componentReference,
+				missingMethodArguments = arguments.missingMethodArguments,
+				key = arguments.key,
+				missingMethodName = arguments.missingMethodName
+			);
+		} else if (local.info.type == "belongsTo") {
+			return $associationMethodResolveBelongsTo(
+				info = local.info,
+				componentReference = local.componentReference,
+				missingMethodArguments = arguments.missingMethodArguments,
+				key = arguments.key,
+				missingMethodName = arguments.missingMethodName
+			);
+		}
+		return { method = "", componentReference = local.componentReference };
+	}
+
+	/**
+	 * Internal function. Resolves a `hasOne` association method. Mutates
+	 * `missingMethodArguments` in place and returns `{ method, componentReference }`.
+	 */
+	public any function $associationMethodResolveHasOne(
+		required struct info,
+		required any componentReference,
+		required struct missingMethodArguments,
+		required string key,
+		required string missingMethodName
+	) {
+		local.componentReference = arguments.componentReference;
+		local.isPolymorphic = StructKeyExists(arguments.info, "as") && Len(arguments.info.as) && StructKeyExists(arguments.info, "foreignType");
+		local.method = "";
+		local.where = $keyWhereString(properties = arguments.info.foreignKey, keys = primaryKeys());
+		if (local.isPolymorphic) {
+			local.where = "(#local.where#) AND (#arguments.info.foreignType# = '#variables.wheels.class.modelName#')";
+		}
+		if (StructKeyExists(arguments.missingMethodArguments, "where") && Len(arguments.missingMethodArguments.where)) {
+			local.where = "(#local.where#) AND (#arguments.missingMethodArguments.where#)";
+		}
+
+		// create a generic method name (example: "hasProfile" becomes "hasObject")
+		local.name = ReplaceNoCase(arguments.missingMethodName, arguments.key, "object");
+
+		if (local.name == "object") {
+			local.method = "findOne";
+			arguments.missingMethodArguments.where = local.where;
+		} else if (local.name == "hasObject") {
+			local.method = "exists";
+			arguments.missingMethodArguments.where = local.where;
+		} else if (local.name == "newObject") {
+			local.method = "new";
+			$setForeignKeyValues(missingMethodArguments = arguments.missingMethodArguments, keys = arguments.info.foreignKey);
+			if (local.isPolymorphic) {
+				arguments.missingMethodArguments[arguments.info.foreignType] = variables.wheels.class.modelName;
+			}
+		} else if (local.name == "createObject") {
+			local.method = "create";
+			$setForeignKeyValues(missingMethodArguments = arguments.missingMethodArguments, keys = arguments.info.foreignKey);
+			if (local.isPolymorphic) {
+				arguments.missingMethodArguments[arguments.info.foreignType] = variables.wheels.class.modelName;
+			}
+		} else if (local.name == "removeObject") {
+			local.method = "updateOne";
+			arguments.missingMethodArguments.where = local.where;
+			$setForeignKeyValues(
+				missingMethodArguments = arguments.missingMethodArguments,
+				keys = arguments.info.foreignKey,
+				setToNull = true
+			);
+		} else if (local.name == "deleteObject") {
+			local.method = "deleteOne";
+			arguments.missingMethodArguments.where = local.where;
+		} else if (local.name == "setObject") {
+			local.resolved = $resolveAssociationTarget(
+				missingMethodArguments = arguments.missingMethodArguments,
+				componentReference = local.componentReference,
+				argumentName = arguments.key,
+				methodName = local.name,
+				objectMethod = "update",
+				keyMethod = "updateByKey"
+			);
+			local.method = local.resolved.method;
+			local.componentReference = local.resolved.componentReference;
+			$setForeignKeyValues(missingMethodArguments = arguments.missingMethodArguments, keys = arguments.info.foreignKey);
+		}
+		return { method = local.method, componentReference = local.componentReference };
+	}
+
+	/**
+	 * Internal function. Resolves a `hasMany` association method. Mutates
+	 * `missingMethodArguments` in place and returns `{ method, componentReference }`.
+	 */
+	public any function $associationMethodResolveHasMany(
+		required struct info,
+		required any componentReference,
+		required struct missingMethodArguments,
+		required string key,
+		required string missingMethodName
+	) {
+		local.componentReference = arguments.componentReference;
+		local.isPolymorphic = StructKeyExists(arguments.info, "as") && Len(arguments.info.as) && StructKeyExists(arguments.info, "foreignType");
+		local.method = "";
+		if (structKeyExists(arguments.info, "joinKey") AND Len(arguments.info.joinKey) AND arguments.info.joinKey NEQ primaryKeys()) {
+			local.where = $keyWhereString(properties = arguments.info.foreignKey, keys = arguments.info.joinKey);
+		} else {
+			local.where = $keyWhereString(properties = arguments.info.foreignKey, keys = primaryKeys());
+		}
+		if (local.isPolymorphic) {
+			local.where = "(#local.where#) AND (#arguments.info.foreignType# = '#variables.wheels.class.modelName#')";
+		}
+		if (StructKeyExists(arguments.missingMethodArguments, "where") && Len(arguments.missingMethodArguments.where)) {
+			local.where = "(#local.where#) AND (#arguments.missingMethodArguments.where#)";
+		}
+		local.singularKey = singularize(arguments.key);
+
+		// create a generic method name (example: "hasComments" becomes "hasObjects")
+		local.name = ReplaceNoCase(arguments.missingMethodName, arguments.key, "objects");
+		if (local.name == arguments.missingMethodName) {
+			// we should never change anything more than once so if the plural version was already replaced we do not need to replace the singular one
+			local.name = ReplaceNoCase(local.name, local.singularKey, "object");
+		}
+
+		if (local.name == "objects") {
+			local.method = "findAll";
+			arguments.missingMethodArguments.where = local.where;
+		} else if (local.name == "addObject") {
+			local.resolved = $resolveAssociationTarget(
+				missingMethodArguments = arguments.missingMethodArguments,
+				componentReference = local.componentReference,
+				argumentName = local.singularKey,
+				methodName = local.name,
+				objectMethod = "update",
+				keyMethod = "updateByKey"
+			);
+			local.method = local.resolved.method;
+			local.componentReference = local.resolved.componentReference;
+			$setForeignKeyValues(missingMethodArguments = arguments.missingMethodArguments, keys = arguments.info.foreignKey);
+		} else if (local.name == "removeObject") {
+			local.resolved = $resolveAssociationTarget(
+				missingMethodArguments = arguments.missingMethodArguments,
+				componentReference = local.componentReference,
+				argumentName = local.singularKey,
+				methodName = local.name,
+				objectMethod = "update",
+				keyMethod = "updateByKey"
+			);
+			local.method = local.resolved.method;
+			local.componentReference = local.resolved.componentReference;
+			$setForeignKeyValues(
+				missingMethodArguments = arguments.missingMethodArguments,
+				keys = arguments.info.foreignKey,
+				setToNull = true
+			);
+		} else if (local.name == "deleteObject") {
+			local.resolved = $resolveAssociationTarget(
+				missingMethodArguments = arguments.missingMethodArguments,
+				componentReference = local.componentReference,
+				argumentName = local.singularKey,
+				methodName = local.name,
+				objectMethod = "delete",
+				keyMethod = "deleteByKey"
+			);
+			local.method = local.resolved.method;
+			local.componentReference = local.resolved.componentReference;
+			$setForeignKeyValues(missingMethodArguments = arguments.missingMethodArguments, keys = arguments.info.foreignKey);
+		} else if (local.name == "hasObjects") {
+			local.method = "exists";
+			arguments.missingMethodArguments.where = local.where;
+		} else if (local.name == "newObject") {
+			local.method = "new";
+			$setForeignKeyValues(missingMethodArguments = arguments.missingMethodArguments, keys = arguments.info.foreignKey);
+			if (local.isPolymorphic) {
+				arguments.missingMethodArguments[arguments.info.foreignType] = variables.wheels.class.modelName;
+			}
+		} else if (local.name == "createObject") {
+			local.method = "create";
+			$setForeignKeyValues(missingMethodArguments = arguments.missingMethodArguments, keys = arguments.info.foreignKey);
+			if (local.isPolymorphic) {
+				arguments.missingMethodArguments[arguments.info.foreignType] = variables.wheels.class.modelName;
+			}
+		} else if (local.name == "objectCount") {
+			local.method = "count";
+			arguments.missingMethodArguments.where = local.where;
+		} else if (local.name == "findOneObject") {
+			local.method = "findOne";
+			arguments.missingMethodArguments.where = local.where;
+		} else if (local.name == "removeAllObjects") {
+			local.method = "updateAll";
+			arguments.missingMethodArguments.where = local.where;
+			$setForeignKeyValues(
+				missingMethodArguments = arguments.missingMethodArguments,
+				keys = arguments.info.foreignKey,
+				setToNull = true
+			);
+		} else if (local.name == "deleteAllObjects") {
+			local.method = "deleteAll";
+			arguments.missingMethodArguments.where = local.where;
+		}
+		return { method = local.method, componentReference = local.componentReference };
+	}
+
+	/**
+	 * Internal function. Resolves a non-polymorphic `belongsTo` association method.
+	 * Mutates `missingMethodArguments` in place and returns `{ method, componentReference }`.
+	 */
+	public any function $associationMethodResolveBelongsTo(
+		required struct info,
+		required any componentReference,
+		required struct missingMethodArguments,
+		required string key,
+		required string missingMethodName
+	) {
+		local.method = "";
+		local.where = $keyWhereString(keys = arguments.info.foreignKey, properties = arguments.componentReference.primaryKeys());
+		if (StructKeyExists(arguments.missingMethodArguments, "where") && Len(arguments.missingMethodArguments.where)) {
+			local.where = "(#local.where#) AND (#arguments.missingMethodArguments.where#)";
+		}
+
+		// create a generic method name (example: "hasAuthor" becomes "hasObject")
+		local.name = ReplaceNoCase(arguments.missingMethodName, arguments.key, "object");
+
+		if (local.name == "object") {
+			local.method = "findByKey";
+			arguments.missingMethodArguments.key = $propertyValue(name = arguments.info.foreignKey);
+		} else if (local.name == "hasObject") {
+			local.method = "exists";
+			arguments.missingMethodArguments.key = $propertyValue(name = arguments.info.foreignKey);
+		}
+		return { method = local.method, componentReference = arguments.componentReference };
 	}
 
 	/**

--- a/vendor/wheels/model/sql.cfc
+++ b/vendor/wheels/model/sql.cfc
@@ -1413,76 +1413,12 @@ component {
 			// below); the lock is only taken before the marker exists so the hot path stays
 			// lock-free, and the values are derived solely from class data so filling them
 			// once per application lifetime is equivalent to the previous per-call rewrite
-			if (!StructKeyExists(local.classAssociations[local.name], "expandedMetadataFilled")) {
-				lock name="wheelsJoinMemo#application.applicationName#" type="exclusive" timeout="10" {
-					if (!StructKeyExists(local.classAssociations[local.name], "expandedMetadataFilled")) {
-						if (!Len(local.classAssociations[local.name].foreignKey)) {
-							// The foreign key column lives on a different side depending on the association
-							// type: for `belongsTo` it is a column on THIS model's table, for `hasMany` /
-							// `hasOne` it is a column on the ASSOCIATED model's table. Resolve the default
-							// against whichever side actually owns it so both the legacy `<modelName><key>`
-							// form and the `<modelName>_<key>` form that `useUnderscoreReferenceColumns`
-							// makes the migrator emit are honoured (#3337).
-							if (local.classAssociations[local.name].type == "belongsTo") {
-								local.fkNameSource = local.associatedClass;
-								local.fkColumnOwner = local.class;
-							} else {
-								local.fkNameSource = local.class;
-								local.fkColumnOwner = local.associatedClass;
-							}
-							local.classAssociations[local.name].foreignKey = $deriveAssociationForeignKey(
-								columnOwner = local.fkColumnOwner,
-								modelName = local.fkNameSource.$classData().modelName,
-								keys = local.fkNameSource.$classData().keys
-							);
-							// A derived default matching no column on the owning side can only fail later,
-							// deep inside the join builder, as `key [xxx] doesn't exist` — a message naming
-							// neither the association nor the `foreignKey=` argument that fixes it. Report it
-							// here instead, while both candidate shapes are still in hand (#3337). Runs inside
-							// the memo so the success path costs one check per application lifetime, and only
-							// for defaults derived here — an explicit `foreignKey=` is the developer's call.
-							if (application.wheels.showErrorInformation) {
-								$assertDerivedForeignKeyResolves(
-									associationName = local.name,
-									foreignKey = local.classAssociations[local.name].foreignKey,
-									columnOwner = local.fkColumnOwner,
-									modelName = local.fkNameSource.$classData().modelName,
-									keys = local.fkNameSource.$classData().keys
-								);
-							}
-						}
-						if (!Len(local.classAssociations[local.name].joinKey)) {
-							if (local.classAssociations[local.name].type == "belongsTo") {
-								local.classAssociations[local.name].joinKey = local.associatedClass.$classData().keys;
-							} else {
-								local.classAssociations[local.name].joinKey = local.class.$classData().keys;
-							}
-						}
-						local.classAssociations[local.name].tableName = local.associatedClass.$classData().tableName;
-						local.classAssociations[local.name].columnList = local.associatedClass.$classData().columnList;
-						local.classAssociations[local.name].properties = local.associatedClass.$classData().properties;
-						local.classAssociations[local.name].propertyList = local.associatedClass.$classData().propertyList;
-
-						/*
-							To fix the issue below:
-							https://github.com/wheels-dev/wheels/issues/580
-
-							Add aliasedPropertyList in the associated class that will be used to check the duplicate column
-						*/
-						local.classAssociations[local.name].aliasedPropertyList = local.associatedClass.$classData().aliasedPropertyList;
-
-						local.classAssociations[local.name].calculatedProperties = local.associatedClass.$classData().calculatedProperties;
-						local.classAssociations[local.name].calculatedPropertyList = local.associatedClass.$classData().calculatedPropertyList;
-						// TODO: deprecate the lists above in favour of these structs to avoid listFind
-						local.classAssociations[local.name].columnStruct = local.associatedClass.$classData().columnStruct;
-						local.classAssociations[local.name].propertyStruct = local.associatedClass.$classData().propertyStruct;
-
-						// the marker is written last so readers that skip the lock only ever
-						// observe a fully-populated metadata set
-						local.classAssociations[local.name].expandedMetadataFilled = true;
-					}
-				}
-			}
+			$expandedAssociationsMetadata(
+				associationName = local.name,
+				association = local.classAssociations[local.name],
+				ownerClass = local.class,
+				associatedClass = local.associatedClass
+			);
 
 			// the JOIN string depends on the calling context (soft-delete handling and whether the
 			// table needs to be aliased), so memoize it per context variant instead of globally
@@ -1490,91 +1426,14 @@ component {
 			local.joinVariantKey = "sd" & (arguments.includeSoftDeletes ? 1 : 0) & "_alias" & (local.aliasJoin ? 1 : 0);
 
 			// create the join string if it hasn't already been done for this context variant
-			if (
-				!StructKeyExists(local.classAssociations[local.name], "joinVariants")
-				|| !StructKeyExists(local.classAssociations[local.name].joinVariants, local.joinVariantKey)
-			) {
-				local.joinType = UCase(ReplaceNoCase(local.classAssociations[local.name].joinType, "outer", "left outer", "one"));
-				local.join = local.joinType & " JOIN " & variables.wheels.class.adapter.$quoteIdentifier(local.classAssociations[local.name].tableName);
-				// alias the table as the association name when joining to itself
-				if (local.aliasJoin) {
-					local.join = variables.wheels.class.adapter.$tableAlias(
-						local.join,
-						local.classAssociations[local.name].pluralizedName
-					);
-				}
-
-				local.join &= " ON ";
-				local.toAppend = "";
-				local.jEnd = ListLen(local.classAssociations[local.name].foreignKey);
-				for (local.j = 1; local.j <= local.jEnd; local.j++) {
-					local.key1 = ListGetAt(local.classAssociations[local.name].foreignKey, local.j);
-					if (local.classAssociations[local.name].type == "belongsTo") {
-						local.key2 = ListFindNoCase(local.classAssociations[local.name].joinKey, local.key1);
-						if (local.key2) {
-							local.key2 = ListGetAt(local.classAssociations[local.name].joinKey, local.key2);
-						} else {
-							local.key2 = ListGetAt(local.classAssociations[local.name].joinKey, local.j);
-						}
-						local.first = local.key1;
-						local.second = local.key2;
-					} else {
-						local.key2 = ListFindNoCase(local.classAssociations[local.name].joinKey, local.key1);
-						if (local.key2) {
-							local.key2 = ListGetAt(local.classAssociations[local.name].joinKey, local.key2);
-						} else {
-							local.key2 = ListGetAt(local.classAssociations[local.name].joinKey, local.j);
-						}
-						local.first = local.key2;
-						local.second = local.key1;
-					}
-
-					// alias the table as the association name when joining to itself
-					local.tableName = local.classAssociations[local.name].tableName;
-					if (local.aliasJoin) {
-						local.tableName = local.classAssociations[local.name].pluralizedName;
-					}
-					local.toAppend = ListAppend(
-						local.toAppend,
-						"#variables.wheels.class.adapter.$quoteIdentifier(local.class.$classData().tableName)#.#variables.wheels.class.adapter.$quoteIdentifier(local.class.$classData().properties[local.first].column)# = #variables.wheels.class.adapter.$quoteIdentifier(local.tableName)#.#variables.wheels.class.adapter.$quoteIdentifier(local.associatedClass.$classData().properties[local.second].column)#"
-					);
-					if (!arguments.includeSoftDeletes && local.associatedClass.$softDeletion()) {
-						local.toAppend = ListAppend(
-							local.toAppend,
-							"#variables.wheels.class.adapter.$quoteIdentifier(local.associatedClass.tableName())#.#variables.wheels.class.adapter.$quoteIdentifier(local.associatedClass.$softDeleteColumn())# IS NULL"
-						);
-					}
-				}
-
-				// Polymorphic hasMany/hasOne with `as`: add type discriminator to JOIN ON clause.
-				if (
-					StructKeyExists(local.classAssociations[local.name], "as")
-					&& Len(local.classAssociations[local.name].as)
-					&& StructKeyExists(local.classAssociations[local.name], "foreignType")
-				) {
-					local.typeColumn = local.classAssociations[local.name].foreignType;
-					local.typeValue = local.class.$classData().modelName;
-					local.toAppend = ListAppend(
-						local.toAppend,
-						"#variables.wheels.class.adapter.$quoteIdentifier(local.tableName)#.#variables.wheels.class.adapter.$quoteIdentifier(local.typeColumn)# = '#local.typeValue#'"
-					);
-				}
-
-				// store the built string under a double-checked named lock so a concurrent first hit
-				// for another context cannot poison the shared application-scoped association struct;
-				// the lock is only taken on memo miss so the hot path stays lock-free
-				lock name="wheelsJoinMemo#application.applicationName#" type="exclusive" timeout="10" {
-					if (!StructKeyExists(local.classAssociations[local.name], "joinVariants")) {
-						local.classAssociations[local.name].joinVariants = {};
-					}
-					local.classAssociations[local.name].joinVariants[local.joinVariantKey] = local.join & Replace(
-						local.toAppend,
-						",",
-						" AND ",
-						"all"
-					);
-				}
-			}
+			$expandedAssociationsJoin(
+				association = local.classAssociations[local.name],
+				aliasJoin = local.aliasJoin,
+				joinVariantKey = local.joinVariantKey,
+				includeSoftDeletes = arguments.includeSoftDeletes,
+				ownerClass = local.class,
+				associatedClass = local.associatedClass
+			);
 
 			// loop over each character in the delimiter sequence and move up / down the levels as appropriate
 			local.jEnd = Len(local.delimSequence);
@@ -1616,6 +1475,191 @@ component {
 			ArrayAppend(local.rv, local.entry);
 		}
 		return local.rv;
+	}
+
+	/**
+	 * Internal function. Fills the context-independent association metadata (foreignKey, joinKey,
+	 * tableName, column/property lists and the computed-property structs) under a double-checked
+	 * named lock so a concurrent first hit cannot interleave partial writes into the shared
+	 * application-scoped association struct. Values are derived solely from class data, so filling
+	 * them once per application lifetime is equivalent to the previous per-call rewrite.
+	 */
+	public void function $expandedAssociationsMetadata(
+		required string associationName,
+		required struct association,
+		required any ownerClass,
+		required any associatedClass
+	) {
+		if (!StructKeyExists(arguments.association, "expandedMetadataFilled")) {
+			lock name="wheelsJoinMemo#application.applicationName#" type="exclusive" timeout="10" {
+				if (!StructKeyExists(arguments.association, "expandedMetadataFilled")) {
+					if (!Len(arguments.association.foreignKey)) {
+						// The foreign key column lives on a different side depending on the association
+						// type: for `belongsTo` it is a column on THIS model's table, for `hasMany` /
+						// `hasOne` it is a column on the ASSOCIATED model's table. Resolve the default
+						// against whichever side actually owns it so both the legacy `<modelName><key>`
+						// form and the `<modelName>_<key>` form that `useUnderscoreReferenceColumns`
+						// makes the migrator emit are honoured (#3337).
+						if (arguments.association.type == "belongsTo") {
+							local.fkNameSource = arguments.associatedClass;
+							local.fkColumnOwner = arguments.ownerClass;
+						} else {
+							local.fkNameSource = arguments.ownerClass;
+							local.fkColumnOwner = arguments.associatedClass;
+						}
+						arguments.association.foreignKey = $deriveAssociationForeignKey(
+							columnOwner = local.fkColumnOwner,
+							modelName = local.fkNameSource.$classData().modelName,
+							keys = local.fkNameSource.$classData().keys
+						);
+						// A derived default matching no column on the owning side can only fail later,
+						// deep inside the join builder, as `key [xxx] doesn't exist` — a message naming
+						// neither the association nor the `foreignKey=` argument that fixes it. Report it
+						// here instead, while both candidate shapes are still in hand (#3337). Runs inside
+						// the memo so the success path costs one check per application lifetime, and only
+						// for defaults derived here — an explicit `foreignKey=` is the developer's call.
+						if (application.wheels.showErrorInformation) {
+							$assertDerivedForeignKeyResolves(
+								associationName = arguments.associationName,
+								foreignKey = arguments.association.foreignKey,
+								columnOwner = local.fkColumnOwner,
+								modelName = local.fkNameSource.$classData().modelName,
+								keys = local.fkNameSource.$classData().keys
+							);
+						}
+					}
+					if (!Len(arguments.association.joinKey)) {
+						if (arguments.association.type == "belongsTo") {
+							arguments.association.joinKey = arguments.associatedClass.$classData().keys;
+						} else {
+							arguments.association.joinKey = arguments.ownerClass.$classData().keys;
+						}
+					}
+					arguments.association.tableName = arguments.associatedClass.$classData().tableName;
+					arguments.association.columnList = arguments.associatedClass.$classData().columnList;
+					arguments.association.properties = arguments.associatedClass.$classData().properties;
+					arguments.association.propertyList = arguments.associatedClass.$classData().propertyList;
+
+					/*
+						To fix the issue below:
+						https://github.com/wheels-dev/wheels/issues/580
+
+						Add aliasedPropertyList in the associated class that will be used to check the duplicate column
+					*/
+					arguments.association.aliasedPropertyList = arguments.associatedClass.$classData().aliasedPropertyList;
+
+					arguments.association.calculatedProperties = arguments.associatedClass.$classData().calculatedProperties;
+					arguments.association.calculatedPropertyList = arguments.associatedClass.$classData().calculatedPropertyList;
+					// TODO: deprecate the lists above in favour of these structs to avoid listFind
+					arguments.association.columnStruct = arguments.associatedClass.$classData().columnStruct;
+					arguments.association.propertyStruct = arguments.associatedClass.$classData().propertyStruct;
+
+					// the marker is written last so readers that skip the lock only ever
+					// observe a fully-populated metadata set
+					arguments.association.expandedMetadataFilled = true;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Internal function. Builds and memoizes the JOIN fragment for one association/context variant.
+	 * The join string depends on the calling context (soft-delete handling and whether the table
+	 * needs to be aliased), so it is stored per variant under a double-checked named lock.
+	 */
+	public void function $expandedAssociationsJoin(
+		required struct association,
+		required boolean aliasJoin,
+		required string joinVariantKey,
+		required boolean includeSoftDeletes,
+		required any ownerClass,
+		required any associatedClass
+	) {
+		if (
+			!StructKeyExists(arguments.association, "joinVariants")
+			|| !StructKeyExists(arguments.association.joinVariants, arguments.joinVariantKey)
+		) {
+			local.joinType = UCase(ReplaceNoCase(arguments.association.joinType, "outer", "left outer", "one"));
+			local.join = local.joinType & " JOIN " & variables.wheels.class.adapter.$quoteIdentifier(arguments.association.tableName);
+			// alias the table as the association name when joining to itself
+			if (arguments.aliasJoin) {
+				local.join = variables.wheels.class.adapter.$tableAlias(
+					local.join,
+					arguments.association.pluralizedName
+				);
+			}
+
+			local.join &= " ON ";
+			local.toAppend = "";
+			local.jEnd = ListLen(arguments.association.foreignKey);
+			for (local.j = 1; local.j <= local.jEnd; local.j++) {
+				local.key1 = ListGetAt(arguments.association.foreignKey, local.j);
+				if (arguments.association.type == "belongsTo") {
+					local.key2 = ListFindNoCase(arguments.association.joinKey, local.key1);
+					if (local.key2) {
+						local.key2 = ListGetAt(arguments.association.joinKey, local.key2);
+					} else {
+						local.key2 = ListGetAt(arguments.association.joinKey, local.j);
+					}
+					local.first = local.key1;
+					local.second = local.key2;
+				} else {
+					local.key2 = ListFindNoCase(arguments.association.joinKey, local.key1);
+					if (local.key2) {
+						local.key2 = ListGetAt(arguments.association.joinKey, local.key2);
+					} else {
+						local.key2 = ListGetAt(arguments.association.joinKey, local.j);
+					}
+					local.first = local.key2;
+					local.second = local.key1;
+				}
+
+				// alias the table as the association name when joining to itself
+				local.tableName = arguments.association.tableName;
+				if (arguments.aliasJoin) {
+					local.tableName = arguments.association.pluralizedName;
+				}
+				local.toAppend = ListAppend(
+					local.toAppend,
+					"#variables.wheels.class.adapter.$quoteIdentifier(arguments.ownerClass.$classData().tableName)#.#variables.wheels.class.adapter.$quoteIdentifier(arguments.ownerClass.$classData().properties[local.first].column)# = #variables.wheels.class.adapter.$quoteIdentifier(local.tableName)#.#variables.wheels.class.adapter.$quoteIdentifier(arguments.associatedClass.$classData().properties[local.second].column)#"
+				);
+				if (!arguments.includeSoftDeletes && arguments.associatedClass.$softDeletion()) {
+					local.toAppend = ListAppend(
+						local.toAppend,
+						"#variables.wheels.class.adapter.$quoteIdentifier(arguments.associatedClass.tableName())#.#variables.wheels.class.adapter.$quoteIdentifier(arguments.associatedClass.$softDeleteColumn())# IS NULL"
+					);
+				}
+			}
+
+			// Polymorphic hasMany/hasOne with `as`: add type discriminator to JOIN ON clause.
+			if (
+				StructKeyExists(arguments.association, "as")
+				&& Len(arguments.association.as)
+				&& StructKeyExists(arguments.association, "foreignType")
+			) {
+				local.typeColumn = arguments.association.foreignType;
+				local.typeValue = arguments.ownerClass.$classData().modelName;
+				local.toAppend = ListAppend(
+					local.toAppend,
+					"#variables.wheels.class.adapter.$quoteIdentifier(local.tableName)#.#variables.wheels.class.adapter.$quoteIdentifier(local.typeColumn)# = '#local.typeValue#'"
+				);
+			}
+
+			// store the built string under a double-checked named lock so a concurrent first hit
+			// for another context cannot poison the shared application-scoped association struct;
+			// the lock is only taken on memo miss so the hot path stays lock-free
+			lock name="wheelsJoinMemo#application.applicationName#" type="exclusive" timeout="10" {
+				if (!StructKeyExists(arguments.association, "joinVariants")) {
+					arguments.association.joinVariants = {};
+				}
+				arguments.association.joinVariants[arguments.joinVariantKey] = local.join & Replace(
+					local.toAppend,
+					",",
+					" AND ",
+					"all"
+				);
+			}
+		}
 	}
 
 	/**

--- a/vendor/wheels/tests/specs/database/DatabaseAdapterHardenerSpec.cfc
+++ b/vendor/wheels/tests/specs/database/DatabaseAdapterHardenerSpec.cfc
@@ -134,21 +134,24 @@ component extends="wheels.WheelsTest" {
 
 			it("MySQL emits DEFAULT for text and float", () => {
 				var mysql = CreateObject("component", "wheels.databaseAdapters.MySQL.MySQLMigrator");
-				expect(mysql.optionsIncludeDefault(type = "text", default = "long body")).toBeTrue();
-				expect(mysql.optionsIncludeDefault(type = "float", default = "1.25")).toBeTrue();
-				expect(mysql.optionsIncludeDefault(type = "string", default = "hello")).toBeTrue();
+				// Positional args: Adobe's parser rejects `default` as a named
+				// argument (reserved word — MissingNameException at compile time).
+				expect(mysql.optionsIncludeDefault("text", "long body")).toBeTrue();
+				expect(mysql.optionsIncludeDefault("float", "1.25")).toBeTrue();
+				expect(mysql.optionsIncludeDefault("string", "hello")).toBeTrue();
 				var sql = mysql.addColumnOptions(
 					sql = "",
-					options = {type: "text", default: "long body", allowNull: true}
+					options = {type: "text", "default": "long body", allowNull: true}
 				);
 				expect(sql).toInclude("DEFAULT");
 			});
 
 			it("Abstract optionsIncludeDefault stays always true", () => {
-				var abstract = CreateObject("component", "wheels.databaseAdapters.Abstract");
-				expect(abstract.optionsIncludeDefault(type = "text", default = "long body")).toBeTrue();
-				expect(abstract.optionsIncludeDefault(type = "float", default = "1.25")).toBeTrue();
-				expect(abstract.optionsIncludeDefault()).toBeTrue();
+				// "abstract" is a reserved word on Adobe CF — use a safe variable name.
+				var abstractMigrator = CreateObject("component", "wheels.databaseAdapters.Abstract");
+				expect(abstractMigrator.optionsIncludeDefault("text", "long body")).toBeTrue();
+				expect(abstractMigrator.optionsIncludeDefault("float", "1.25")).toBeTrue();
+				expect(abstractMigrator.optionsIncludeDefault()).toBeTrue();
 			});
 
 		});
@@ -252,7 +255,7 @@ component extends="wheels.WheelsTest" {
 				try {
 					state.adapter.addColumnOptions(
 						sql = "",
-						options = {type: "string", default: "", allowNull: true}
+						options = {type: "string", "default": "", allowNull: true}
 					);
 				} catch (any e) {
 					state.type = e.type;
@@ -268,7 +271,7 @@ component extends="wheels.WheelsTest" {
 				try {
 					state.adapter.addColumnOptions(
 						sql = "",
-						options = {type: "string", default: "", allowNull: true}
+						options = {type: "string", "default": "", allowNull: true}
 					);
 				} catch (any e) {
 					state.type = e.type;

--- a/vendor/wheels/view/forms.cfc
+++ b/vendor/wheels/view/forms.cfc
@@ -63,7 +63,6 @@ component {
 		any encode
 	) {
 		$args(name = "startFormTag", args = arguments);
-		local.routeAndMethodMatch = false;
 
 		// Encode all prepend / append type arguments if specified.
 		$encodeArgsForHtml(args = arguments, keys = "prepend,append");
@@ -72,82 +71,9 @@ component {
 		// sets a flag to indicate whether we use get or post on this form, used when obfuscating params
 		request.wheels.currentFormMethod = arguments.method;
 
-		// Check to see if a route exists if not specified.
-		// The linear scan over all routes is memoized per request (mirroring URLFor's `urlForCache`).
-		// Only successful lookups are cached, and a cached route name is re-validated against the
-		// current route table so route changes within a request (e.g. the test suite) stay correct.
-		if (!Len(arguments.route) && Len(arguments.controller) && Len(arguments.action) && Len(arguments.method)) {
-			if (!StructKeyExists(request.wheels, "startFormTagRouteCache")) {
-				request.wheels.startFormTagRouteCache = {};
-			}
-			local.routeCache = request.wheels.startFormTagRouteCache;
-			local.routeCacheKey = arguments.controller & "##" & arguments.action & "##" & arguments.method;
-			if (
-				StructKeyExists(local.routeCache, local.routeCacheKey)
-				&& StructKeyExists(application.wheels.namedRoutePositions, local.routeCache[local.routeCacheKey])
-			) {
-				arguments.route = local.routeCache[local.routeCacheKey];
-				local.routeAndMethodMatch = true;
-			} else {
-				for (local.route in application.wheels.routes) {
-					if (
-						StructKeyExists(local.route, "controller")
-						&& local.route.controller == arguments.controller
-						&& StructKeyExists(local.route, "action")
-						&& local.route.action == arguments.action
-						&& ListFindNoCase(local.route.methods, arguments.method)
-					) {
-						arguments.route = local.route.name;
-						local.routeAndMethodMatch = true;
-						local.routeCache[local.routeCacheKey] = local.route.name;
-						break;
-					}
-				}
-			}
-		}
-
-		// if we have a route and method, tap
-		if (Len(arguments.route) && StructKeyExists(arguments, "method")) {
-			// Throw error if no route was found.
-			if (!StructKeyExists(application.wheels.namedRoutePositions, arguments.route)) {
-				$throwErrorOrShow404Page(
-					type = "Wheels.RouteNotFound",
-					message = "Could not find the `#arguments.route#` route.",
-					extendedInfo = "Make sure there is a route configured in your `config/routes.cfm` file named `#arguments.route#`."
-				);
-			}
-
-			// check to see if the route specified has a method to match the one passed in
-			if (!local.routeAndMethodMatch) {
-				for (local.position in ListToArray(application.wheels.namedRoutePositions[arguments.route])) {
-					if (
-						StructKeyExists(application.wheels.routes[local.position], "methods")
-						&& ListFindNoCase(application.wheels.routes[local.position].methods, arguments.method)
-					) {
-						local.routeAndMethodMatch = true;
-					}
-				}
-			}
-
-			if (local.routeAndMethodMatch) {
-				// save the method passed in
-				local.method = arguments.method;
-
-				if (arguments.method != "get") {
-					arguments.method = "post";
-				}
-			}
-		}
-
-		// HTML forms only support the `get` and `post` verbs. When the route / verb match above did
-		// not run (or did not match), other verbs (`put`, `patch`, `delete`) were previously rendered
-		// verbatim, causing browsers to silently fall back to a `get` submission - leaking the
-		// authenticity token into the URL and bypassing non-GET CSRF verification. Always rewrite
-		// them to `post` plus a `_method` hidden field instead.
-		if (!StructKeyExists(local, "method") && Len(arguments.method) && !ListFindNoCase("get,post", arguments.method)) {
-			local.method = arguments.method;
-			arguments.method = "post";
-		}
+		// Resolve the route and method (mutating arguments.route / arguments.method) and remember
+		// the original verb for the `_method` hidden field (empty string when none applies).
+		local.method = $startFormTagMethod(args = arguments);
 
 		// set the form's action attribute to the URL that we want to send to
 		local.encodeExcept = "";
@@ -199,7 +125,7 @@ component {
 		) {
 			local.rv &= authenticityTokenField();
 		}
-		if (StructKeyExists(local, "method") && local.method != "get") {
+		if (Len(local.method) && local.method != "get") {
 			local.methodField = hiddenFieldTag(name = "_method", value = local.method);
 			// Delete the id="_method" part of the string.
 			// There could be multiple forms on a page and duplicate "id" attributes are not allowed in HTML.
@@ -207,6 +133,97 @@ component {
 			local.rv &= local.methodField;
 		}
 		return local.rv;
+	}
+
+	/**
+	 * Internal function. Resolves the route and method for startFormTag: finds a named route
+	 * matching controller/action/method, verifies the route's method, and rewrites non-get/post
+	 * verbs to `post` while remembering the original verb for the `_method` hidden field.
+	 * Mutates `args.route` and `args.method` in place and returns the original verb (empty string
+	 * when none applies).
+	 */
+	public string function $startFormTagMethod(required struct args) {
+		local.routeAndMethodMatch = false;
+
+		// Check to see if a route exists if not specified.
+		// The linear scan over all routes is memoized per request (mirroring URLFor's `urlForCache`).
+		// Only successful lookups are cached, and a cached route name is re-validated against the
+		// current route table so route changes within a request (e.g. the test suite) stay correct.
+		if (!Len(args.route) && Len(args.controller) && Len(args.action) && Len(args.method)) {
+			if (!StructKeyExists(request.wheels, "startFormTagRouteCache")) {
+				request.wheels.startFormTagRouteCache = {};
+			}
+			local.routeCache = request.wheels.startFormTagRouteCache;
+			local.routeCacheKey = args.controller & "##" & args.action & "##" & args.method;
+			if (
+				StructKeyExists(local.routeCache, local.routeCacheKey)
+				&& StructKeyExists(application.wheels.namedRoutePositions, local.routeCache[local.routeCacheKey])
+			) {
+				args.route = local.routeCache[local.routeCacheKey];
+				local.routeAndMethodMatch = true;
+			} else {
+				for (local.route in application.wheels.routes) {
+					if (
+						StructKeyExists(local.route, "controller")
+						&& local.route.controller == args.controller
+						&& StructKeyExists(local.route, "action")
+						&& local.route.action == args.action
+						&& ListFindNoCase(local.route.methods, args.method)
+					) {
+						args.route = local.route.name;
+						local.routeAndMethodMatch = true;
+						local.routeCache[local.routeCacheKey] = local.route.name;
+						break;
+					}
+				}
+			}
+		}
+
+		// if we have a route and method, tap
+		if (Len(args.route) && StructKeyExists(args, "method")) {
+			// Throw error if no route was found.
+			if (!StructKeyExists(application.wheels.namedRoutePositions, args.route)) {
+				$throwErrorOrShow404Page(
+					type = "Wheels.RouteNotFound",
+					message = "Could not find the `#args.route#` route.",
+					extendedInfo = "Make sure there is a route configured in your `config/routes.cfm` file named `#args.route#`."
+				);
+			}
+
+			// check to see if the route specified has a method to match the one passed in
+			if (!local.routeAndMethodMatch) {
+				for (local.position in ListToArray(application.wheels.namedRoutePositions[args.route])) {
+					if (
+						StructKeyExists(application.wheels.routes[local.position], "methods")
+						&& ListFindNoCase(application.wheels.routes[local.position].methods, args.method)
+					) {
+						local.routeAndMethodMatch = true;
+					}
+				}
+			}
+
+			if (local.routeAndMethodMatch) {
+				// save the method passed in
+				local.method = args.method;
+
+				if (args.method != "get") {
+					args.method = "post";
+				}
+				return local.method;
+			}
+		}
+
+		// HTML forms only support the `get` and `post` verbs. When the route / verb match above did
+		// not run (or did not match), other verbs (`put`, `patch`, `delete`) were previously rendered
+		// verbatim, causing browsers to silently fall back to a `get` submission - leaking the
+		// authenticity token into the URL and bypassing non-GET CSRF verification. Always rewrite
+		// them to `post` plus a `_method` hidden field instead.
+		if (Len(args.method) && !ListFindNoCase("get,post", args.method)) {
+			local.method = args.method;
+			args.method = "post";
+			return local.method;
+		}
+		return "";
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Second burn-down wave on the framework's complexity hotspots. Extract-method / table-driven refactors only — no behavior change.

## Before → after (cyclomatic complexity)

| Function | Before | After |
|---|---|---|
| `$getType` H2 adapter | 66 | **2** |
| `$getType` PostgreSQL adapter | 56 | **2** |
| `$getType` MySQL adapter | 43 | **6** (keeps the unsigned branch) |
| `$getType` MSSQL adapter | 34 | **2** |
| `$dbTypeToMigrationType` (AutoMigrator) | 52 | **2** |
| `$associationMethod` (onmissingmethod) | 61 | **11** |
| `onMissingMethod` | 46 | **7** |
| `URLFor` (routing.cfm) | 45 | **11** |
| `$checkMinimumVersion` (plugins.cfm) | 37 | **8** |
| `startFormTag` (forms.cfc) | 39 | **14** |
| `$expandedAssociations` (sql.cfc) | 35 | **14** |
| `migrateTo` (Migrator.cfc) | 35 | **25** |

Repo-wide: functions over complexity 50 drop **7 → 3** (remaining are .cfm templates + $createSQLFieldList); functions at 10 or under rise to **2429**.

## How it was verified

- Four parallel subagents (one per file group), extract-method only, with the round-1 lessons as hard rules: no typed returns that could receive a cfcatch (Adobe return-type validation), struct-by-reference for arguments mutation, public `$`-prefixed mixin helpers, hardener-spec awareness.
- **Independent parity audit of the adapter maps**: every original switch case label present exactly once with identical result (65/55/38/33/51 entries; the only delta is H2 `UUID`→`uuid` covered by the LCase-normalized lookup, matching the case-insensitive original switch).
- Local Lucee 7 + SQLite area suites — global 219/0, view 581/0, database 105/0, security 290/0, dispatch 168/0, controller 529/0, events 87/0, hardener 247/0, interfaces 58/0, internal 92/0, channel 43/0, model 979/0, migrator 292/0 — all green.
- Adapter maps proven non-regressive on Adobe 2023 + MySQL: database specs 101/0; model specs identical to develop's baseline (the 8 fail / 2 error there are a pre-existing Adobe+MySQL leg issue, reproduced byte-for-byte with develop's original adapters).
- Complexity gate PASS on both trees.

## Also fixed along the way (separate PR #3436, already merged)

- Adobe compile break in `DatabaseAdapterHardenerSpec.cfc` (`var abstract`, `default =` named args, unquoted `default:` keys)
- `wheels_events.id` widened to varchar(255) for MySQL channel specs

No changelog fragment: internal refactor, no user-facing change.