### PR TITLE
refactor: burn down wave 4 — view templates, assertion equalizer, app-template request handling

### DIFF
--- a/cli/lucli/templates/app/public/Application.cfc
+++ b/cli/lucli/templates/app/public/Application.cfc
@@ -225,12 +225,7 @@ component output="false" {
 
 	public boolean function onRequestStart( string targetPage ) {
 
-		if(structKeyExists(url, "format") && listFindNoCase("junit,json,txt", url.format))
-		{
-			application.contentOnly = true;
-		}else{
-			application.contentOnly = false;
-		}
+		this.$setContentOnlyForFormat();
 
 		local.lockName = "reloadLock" & this.name;
 
@@ -245,6 +240,39 @@ component output="false" {
 		// Need to setup the wheels struct up here since it's used to store debugging info below if this is a reload request.
 		application.wo.$initializeRequestScope();
 
+		this.$applyDebugIpAccessOverrides();
+
+		local.environmentSwitchAlreadyApplied = this.$isEnvironmentSwitchAlreadyApplied();
+
+		local.reloadAuthorized = this.$authorizeReload(local.environmentSwitchAlreadyApplied);
+		if (local.reloadAuthorized) {
+			this.$restartAppRequest(local.lockName);
+			return false;
+		}
+
+		// Run the rest of the request start code.
+		arguments.componentReference = "wheels.events.EventMethods";
+		application.wo.$simpleLock(
+			name = local.lockName,
+			execute = "$runOnRequestStart",
+			executeArgs = arguments,
+			type = "readOnly",
+			timeout = 180
+		);
+
+		return true;
+	}
+
+	public void function $setContentOnlyForFormat() {
+		if(structKeyExists(url, "format") && listFindNoCase("junit,json,txt", url.format))
+		{
+			application.contentOnly = true;
+		}else{
+			application.contentOnly = false;
+		}
+	}
+
+	public void function $applyDebugIpAccessOverrides() {
 		// IP-based access to public Component/debug GUI (only if allowed in settings)
 		if (!structKeyExists(application.wheels, "debugIPAccess")) {
 			application.wheels.debugIPAccess.originalEnablePublicComponent = application.wheels.enablePublicComponent;
@@ -286,7 +314,9 @@ component output="false" {
 				application.wheels.showErrorInformation = application.wheels.debugIPAccess.originalShowErrorInformation;
 			}
 		}
+	}
 
+	public boolean function $isEnvironmentSwitchAlreadyApplied() {
 		// Loop-break for URL environment switches (issue #3030): $buildRedirectUrl()
 		// keeps ?reload=<environment>&password=... on the post-restart redirect so the
 		// framework's switch code (vendor/wheels/events/onapplicationstart.cfc) can see
@@ -296,12 +326,55 @@ component output="false" {
 		// already active, skip the restart and serve the request normally.
 		// Trade-off: ?reload=<current-environment> is a no-op — use ?reload=true for a
 		// same-environment restart.
-		local.environmentSwitchAlreadyApplied = StructKeyExists(url, "reload")
+		return StructKeyExists(url, "reload")
 			&& !IsBoolean(url.reload)
 			&& StructKeyExists(application, "wheels")
 			&& StructKeyExists(application.wheels, "environment")
 			&& application.wheels.environment == url.reload;
+	}
 
+	public boolean function $reloadRateLimited(required string clientIp) {
+		// Same per-IP store and window as wheels/events/onapplicationstart.cfc, so
+		// warm-path and cold-start attempts count against one shared bucket.
+		if (!StructKeyExists(application, "$reloadRateLimit")) {
+			application.$reloadRateLimit = {};
+		}
+		local.reloadRateLimited = false;
+		if (StructKeyExists(application.$reloadRateLimit, arguments.clientIp)) {
+			local.reloadRateLimitEntry = application.$reloadRateLimit[arguments.clientIp];
+			if (local.reloadRateLimitEntry.count >= 5 && DateDiff("n", local.reloadRateLimitEntry.firstAttempt, Now()) < 5) {
+				local.reloadRateLimited = true;
+			}
+			if (DateDiff("n", local.reloadRateLimitEntry.firstAttempt, Now()) >= 5) {
+				StructDelete(application.$reloadRateLimit, arguments.clientIp);
+			}
+		}
+		return local.reloadRateLimited;
+	}
+
+	public void function $recordReloadRefusalReason(required boolean reloadAuthorized) {
+		// Record WHY a requested reload did not fire so the framework's debug
+		// bar can render a development-only notice instead of a silent no-op
+		// (issue #3311). Recording is environment-agnostic — a request-scope
+		// flag, no output; the message text and the development-environment
+		// gate live framework-side in vendor/wheels/events/onrequestend/debug.cfm
+		// so wording can improve without template drift. Wrong-password and
+		// rate-limited attempts deliberately collapse into one generic reason
+		// so the notice adds no oracle on top of $secureCompare().
+		if (!arguments.reloadAuthorized && StructKeyExists(request, "wheels")) {
+			local.reloadPasswordConfigured = StructKeyExists(application.wheels, "reloadPassword")
+				&& Len(application.wheels.reloadPassword);
+			if (!local.reloadPasswordConfigured) {
+				request.wheels.reloadRefusedReason = "emptyPassword";
+			} else if (!StructKeyExists(url, "password")) {
+				request.wheels.reloadRefusedReason = "missingPasswordParam";
+			} else {
+				request.wheels.reloadRefusedReason = "refused";
+			}
+		}
+	}
+
+	public boolean function $authorizeReload(required boolean environmentSwitchAlreadyApplied) {
 		// Reload application properly using applicationStop() if requested.
 		// SECURITY (issue #3062): the gate FAILS CLOSED. A URL-based reload requires a
 		// non-empty configured reloadPassword AND a matching password parameter — an
@@ -311,25 +384,11 @@ component output="false" {
 		// attempts are logged to wheels_security.log with the trusted client IP and
 		// feed the same per-IP rate limit as the cold-start path (5 failed attempts
 		// within 5 minutes locks the source out).
-		local.reloadRequested = StructKeyExists(url, "reload") && !local.environmentSwitchAlreadyApplied;
+		local.reloadRequested = StructKeyExists(url, "reload") && !arguments.environmentSwitchAlreadyApplied;
 		local.reloadAuthorized = false;
 		if (local.reloadRequested && StructKeyExists(application, "wheels") && StructKeyExists(application, "wo")) {
-			// Same per-IP store and window as wheels/events/onapplicationstart.cfc, so
-			// warm-path and cold-start attempts count against one shared bucket.
 			local.reloadClientIp = application.wo.$trustedClientIp();
-			if (!StructKeyExists(application, "$reloadRateLimit")) {
-				application.$reloadRateLimit = {};
-			}
-			local.reloadRateLimited = false;
-			if (StructKeyExists(application.$reloadRateLimit, local.reloadClientIp)) {
-				local.reloadRateLimitEntry = application.$reloadRateLimit[local.reloadClientIp];
-				if (local.reloadRateLimitEntry.count >= 5 && DateDiff("n", local.reloadRateLimitEntry.firstAttempt, Now()) < 5) {
-					local.reloadRateLimited = true;
-				}
-				if (DateDiff("n", local.reloadRateLimitEntry.firstAttempt, Now()) >= 5) {
-					StructDelete(application.$reloadRateLimit, local.reloadClientIp);
-				}
-			}
+			local.reloadRateLimited = this.$reloadRateLimited(local.reloadClientIp);
 			if (
 				!local.reloadRateLimited
 				&& StructKeyExists(application.wheels, "reloadPassword")
@@ -359,51 +418,22 @@ component output="false" {
 					// Fail silently if logging fails
 				}
 			}
-			// Record WHY a requested reload did not fire so the framework's debug
-			// bar can render a development-only notice instead of a silent no-op
-			// (issue #3311). Recording is environment-agnostic — a request-scope
-			// flag, no output; the message text and the development-environment
-			// gate live framework-side in vendor/wheels/events/onrequestend/debug.cfm
-			// so wording can improve without template drift. Wrong-password and
-			// rate-limited attempts deliberately collapse into one generic reason
-			// so the notice adds no oracle on top of $secureCompare().
-			if (!local.reloadAuthorized && StructKeyExists(request, "wheels")) {
-				local.reloadPasswordConfigured = StructKeyExists(application.wheels, "reloadPassword")
-					&& Len(application.wheels.reloadPassword);
-				if (!local.reloadPasswordConfigured) {
-					request.wheels.reloadRefusedReason = "emptyPassword";
-				} else if (!StructKeyExists(url, "password")) {
-					request.wheels.reloadRefusedReason = "missingPasswordParam";
-				} else {
-					request.wheels.reloadRefusedReason = "refused";
-				}
-			}
+			this.$recordReloadRefusalReason(local.reloadAuthorized);
 		}
-		if (local.reloadAuthorized) {
-			application.wo.$debugPoint("total,reload");
-			if (StructKeyExists(url, "lock") && !url.lock) {
-				this.$handleRestartAppRequest();
-			} else {
-				// Case-exact "Application" — see the matching comment in onSessionStart().
-				// A lowercase reference turns every authorized reload into an HTTP 500 on
-				// Adobe CF + case-sensitive filesystems (issue #3053 follow-up).
-				local.executeArgs = {"componentReference" = "Application"};
-				application.wo.$simpleLock(name = local.lockName, execute = "$handleRestartAppRequest", type = "exclusive", timeout = 180, executeArgs = local.executeArgs);
-			}
-			return false;
+		return local.reloadAuthorized;
+	}
+
+	public void function $restartAppRequest(required string lockName) {
+		application.wo.$debugPoint("total,reload");
+		if (StructKeyExists(url, "lock") && !url.lock) {
+			this.$handleRestartAppRequest();
+		} else {
+			// Case-exact "Application" — see the matching comment in onSessionStart().
+			// A lowercase reference turns every authorized reload into an HTTP 500 on
+			// Adobe CF + case-sensitive filesystems (issue #3053 follow-up).
+			local.executeArgs = {"componentReference" = "Application"};
+			application.wo.$simpleLock(name = arguments.lockName, execute = "$handleRestartAppRequest", type = "exclusive", timeout = 180, executeArgs = local.executeArgs);
 		}
-
-		// Run the rest of the request start code.
-		arguments.componentReference = "wheels.events.EventMethods";
-		application.wo.$simpleLock(
-			name = local.lockName,
-			execute = "$runOnRequestStart",
-			executeArgs = arguments,
-			type = "readOnly",
-			timeout = 180
-		);
-
-		return true;
 	}
 
 	public boolean function onRequest( string targetPage ) {

--- a/vendor/wheels/events/onerror/cfmlerror.cfm
+++ b/vendor/wheels/events/onerror/cfmlerror.cfm
@@ -1,3 +1,64 @@
+<cfscript>
+	function $cfmlErrorTagContext(required struct exception) {
+		if (
+			StructKeyExists(arguments.exception, "cause")
+			&& StructKeyExists(arguments.exception.cause, "tagContext")
+			&& ArrayLen(arguments.exception.cause.tagContext)
+		) {
+			return Duplicate(arguments.exception.cause.tagContext);
+		} else if (
+			StructKeyExists(arguments.exception, "rootCause")
+			&& StructKeyExists(arguments.exception.rootCause, "tagContext")
+			&& ArrayLen(arguments.exception.rootCause.tagContext)
+		) {
+			return Duplicate(arguments.exception.rootCause.tagContext);
+		} else if (
+			StructKeyExists(arguments.exception, "tagContext")
+			&& ArrayLen(arguments.exception.tagContext)
+		) {
+			return Duplicate(arguments.exception.tagContext);
+		}
+		return [];
+	}
+
+	function $cfmlErrorNormalizePath(required string path) {
+		local.norm = arguments.path;
+		local.norm = ReReplace(local.norm, "[" & Chr(92) & "(.*?)" & Chr(92) & "]", "." & Chr(92) & "1", "all");
+		local.norm = ReReplace(local.norm, "^" & Chr(92) & ".", "", "one");
+		return local.norm;
+	}
+
+	function $cfmlErrorSanitizeScope(required struct scope, required string skip, required string scopeName) {
+		local.hide = "wheels";
+		local.sanitizedScope = Duplicate(arguments.scope);
+		for (local.j in ListToArray(arguments.skip)) {
+			local.normalizedPath = $cfmlErrorNormalizePath(local.j);
+			if (local.normalizedPath CONTAINS "." AND ListFirst(local.normalizedPath, ".") EQ arguments.scopeName) {
+				local.relativePath = ListRest(local.normalizedPath, ".");
+				local.keyList = ListToArray(local.relativePath, ".");
+				local.ref = local.sanitizedScope;
+				local.depth = ArrayLen(local.keyList);
+				for (local.k = 1; local.k LTE local.depth; local.k++) {
+					local.key = local.keyList[local.k];
+					if (local.k EQ local.depth) {
+						if (StructKeyExists(local.ref, local.key)) {
+							StructDelete(local.ref, local.key);
+						}
+					} else {
+						if (StructKeyExists(local.ref, local.key) AND IsStruct(local.ref[local.key])) {
+							local.ref = local.ref[local.key];
+						} else {
+							break;
+						}
+					}
+				}
+			} else if (ListFindNoCase(arguments.skip, arguments.scopeName)) {
+				local.hide = ListAppend(local.hide, local.j);
+			}
+		}
+		return {hide = local.hide, sanitizedScope = local.sanitizedScope};
+	}
+</cfscript>
 <cfoutput>
 	<!--- cfformat-ignore-start --->
 	<div class="ui container" style="padding-bottom:2em;">
@@ -23,24 +84,7 @@
 		</h1>
 
 		<!--- Tag Context / Location --->
-		<cfif
-			StructKeyExists(arguments.exception, "cause")
-			&& StructKeyExists(arguments.exception.cause, "tagContext")
-			&& ArrayLen(arguments.exception.cause.tagContext)
-		>
-			<cfset local.tagContext = Duplicate(arguments.exception.cause.tagContext)>
-		<cfelseif
-			StructKeyExists(arguments.exception, "rootCause")
-			&& StructKeyExists(arguments.exception.rootCause, "tagContext")
-			&& ArrayLen(arguments.exception.rootCause.tagContext)
-		>
-			<cfset local.tagContext = Duplicate(arguments.exception.rootCause.tagContext)>
-		<cfelseif
-			StructKeyExists(arguments.exception, "tagContext")
-			&& ArrayLen(arguments.exception.tagContext)
-		>
-			<cfset local.tagContext = Duplicate(arguments.exception.tagContext)>
-		</cfif>
+		<cfset local.tagContext = $cfmlErrorTagContext(arguments.exception)>
 
 		<cfif StructKeyExists(local, "tagContext") AND ArrayLen(local.tagContext)>
 			<div style="margin:1.5em 0;">
@@ -140,38 +184,9 @@
 						<cfset local.scope = local.scopeMap[local.i]>
 						<cfif IsStruct(local.scope)>
 							<cfset local.scopeIdx = local.scopeIdx + 1>
-							<cfset local.hide = "wheels">
-							<cfset local.sanitizedScope = duplicate(local.scope)>
-
-							<cfloop list="#local.skip#" index="local.j">
-								<!--- Normalize the key path --->
-								<cfset local.normalizedPath = $normalizePath(local.j)>
-								<cfif local.normalizedPath CONTAINS "." AND ListFirst(local.normalizedPath, ".") EQ local.scopeName>
-									<!--- Get nested path relative to the scope --->
-									<cfset local.relativePath = ListRest(local.normalizedPath, ".")>
-									<cfset local.keyList = ListToArray(local.relativePath, ".")>
-
-									<!--- Walk into the sanitized struct and mask the nested key --->
-									<cfset local.ref = local.sanitizedScope>
-									<cfset local.depth = ArrayLen(local.keyList)>
-									<cfloop from="1" to="#local.depth#" index="local.k">
-										<cfset local.key = local.keyList[local.k]>
-										<cfif local.k EQ local.depth>
-											<cfif StructKeyExists(local.ref, local.key)>
-												<cfset StructDelete(local.ref, local.key)>
-											</cfif>
-										<cfelse>
-											<cfif StructKeyExists(local.ref, local.key) AND isStruct(local.ref[local.key])>
-												<cfset local.ref = local.ref[local.key]>
-											<cfelse>
-												<cfbreak>
-											</cfif>
-										</cfif>
-									</cfloop>
-								<cfelseif ListFindNoCase(local.skip, local.scopeName)>
-									<cfset local.hide = ListAppend(local.hide, local.j)>
-								</cfif>
-							</cfloop>
+							<cfset local.scopeMask = $cfmlErrorSanitizeScope(local.scope, local.skip, local.scopeName)>
+							<cfset local.hide = local.scopeMask.hide>
+							<cfset local.sanitizedScope = local.scopeMask.sanitizedScope>
 
 							<div style="margin-bottom:8px;">
 								<div onclick="var el=document.getElementById('scope-#LCase(local.scopeName)#');el.style.display=el.style.display==='none'?'block':'none';this.querySelector('svg').style.transform=el.style.display==='none'?'':'rotate(90deg)';" style="cursor:pointer;display:flex;align-items:center;gap:8px;padding:10px 16px;background:##181825;border:1px solid ##45475a;border-radius:6px;user-select:none;">

--- a/vendor/wheels/events/onrequestend/debug.cfm
+++ b/vendor/wheels/events/onrequestend/debug.cfm
@@ -1,10 +1,67 @@
+<cfscript>
+	function $debugBarSkipRequest(required struct reqHeaders) {
+		return (StructKeyExists(arguments.reqHeaders, "X-Requested-With") AND arguments.reqHeaders["X-Requested-With"] IS "XMLHttpRequest")
+			OR (StructKeyExists(arguments.reqHeaders, "HX-Request"))
+			OR (StructKeyExists(arguments.reqHeaders, "Turbo-Frame"))
+			OR (StructKeyExists(arguments.reqHeaders, "X-Fetch") AND arguments.reqHeaders["X-Fetch"] IS "true")
+			OR (StructKeyExists(url, "format") AND ListFindNoCase("json,xml,csv,pdf", url.format));
+	}
+
+	function $debugEnvColor(required string envClass) {
+		if (arguments.envClass IS "production") {
+			return "##dc3545";
+		} else if (arguments.envClass IS "testing") {
+			return "##fd7e14";
+		} else if (arguments.envClass IS "maintenance") {
+			return "##ffc107";
+		}
+		return "##28a745";
+	}
+
+	function $debugTimingBreakdown(required struct execution) {
+		local.timingBreakdown = [];
+		if (arguments.execution.total GT 0) {
+			local.keys = StructSort(arguments.execution, "numeric", "desc");
+			for (local.ti = 1; local.ti LTE ArrayLen(local.keys); local.ti++) {
+				local.tkey = local.keys[local.ti];
+				if (local.tkey IS NOT "total" AND arguments.execution[local.tkey] GT 0) {
+					ArrayAppend(
+						local.timingBreakdown,
+						{
+							name = LCase(local.tkey),
+							ms = arguments.execution[local.tkey],
+							pct = Round((arguments.execution[local.tkey] / arguments.execution.total) * 100)
+						}
+					);
+				}
+			}
+		}
+		return local.timingBreakdown;
+	}
+
+	function $debugParamsList(required struct params) {
+		local.paramsList = [];
+		for (local.pi in arguments.params) {
+			if (local.pi IS NOT "fieldnames" AND local.pi IS NOT "route" AND local.pi IS NOT "controller" AND local.pi IS NOT "action" AND local.pi IS NOT "key") {
+				if (IsSimpleValue(arguments.params[local.pi])) {
+					ArrayAppend(
+						local.paramsList,
+						{name = LCase(local.pi), value = arguments.params[local.pi], type = "string"}
+					);
+				} else if (IsStruct(arguments.params[local.pi]) OR IsArray(arguments.params[local.pi])) {
+					ArrayAppend(
+						local.paramsList,
+						{name = LCase(local.pi), value = SerializeJSON(arguments.params[local.pi]), type = "json"}
+					);
+				}
+			}
+		}
+		return local.paramsList;
+	}
+</cfscript>
 <!--- Skip debug bar for AJAX, HTMX, Turbo, and fetch requests to avoid breaking partial responses --->
 <cfset local.reqHeaders = GetHTTPRequestData().headers>
-<cfif (StructKeyExists(local.reqHeaders, "X-Requested-With") AND local.reqHeaders["X-Requested-With"] IS "XMLHttpRequest")
-OR (StructKeyExists(local.reqHeaders, "HX-Request"))
-OR (StructKeyExists(local.reqHeaders, "Turbo-Frame"))
-OR (StructKeyExists(local.reqHeaders, "X-Fetch") AND local.reqHeaders["X-Fetch"] IS "true")
-OR (StructKeyExists(url, "format") AND ListFindNoCase("json,xml,csv,pdf", url.format))>
+<cfif $debugBarSkipRequest(local.reqHeaders)>
 	<cfexit>
 </cfif>
 <!---
@@ -26,50 +83,11 @@ OR (StructKeyExists(url, "format") AND ListFindNoCase("json,xml,csv,pdf", url.fo
 	GetDirectoryFromPath(GetBaseTemplatePath()) & ".git/HEAD"
 ) : "">
 <cfset local.envClass = LCase($get("environment"))>
-<cfif local.envClass IS "production">
-	<cfset local.envColor = "##dc3545">
-	<cfelseif local.envClass IS "testing">
-	<cfset local.envColor = "##fd7e14">
-	<cfelseif local.envClass IS "maintenance">
-	<cfset local.envColor = "##ffc107">
-	<cfelse>
-	<cfset local.envColor = "##28a745">
-</cfif>
+<cfset local.envColor = $debugEnvColor(local.envClass)>
 <!--- Collect execution timing breakdown --->
-<cfset local.timingBreakdown = []>
-<cfif request.wheels.execution.total GT 0>
-	<cfset local.keys = StructSort(request.wheels.execution, "numeric", "desc")>
-	<cfloop from="1" to="#ArrayLen(local.keys)#" index="local.ti">
-		<cfset local.tkey = local.keys[local.ti]>
-		<cfif local.tkey IS NOT "total" AND request.wheels.execution[local.tkey] GT 0>
-			<cfset ArrayAppend(
-				local.timingBreakdown,
-				{
-					name = LCase(local.tkey),
-					ms = request.wheels.execution[local.tkey],
-					pct = Round((request.wheels.execution[local.tkey] / request.wheels.execution.total) * 100)
-				}
-			)>
-		</cfif>
-	</cfloop>
-</cfif>
+<cfset local.timingBreakdown = $debugTimingBreakdown(request.wheels.execution)>
 <!--- Collect parameters --->
-<cfset local.paramsList = []>
-<cfloop collection="#request.wheels.params#" item="local.pi">
-	<cfif local.pi IS NOT "fieldnames" AND local.pi IS NOT "route" AND local.pi IS NOT "controller" AND local.pi IS NOT "action" AND local.pi IS NOT "key">
-		<cfif IsSimpleValue(request.wheels.params[local.pi])>
-			<cfset ArrayAppend(
-				local.paramsList,
-				{name = LCase(local.pi), value = request.wheels.params[local.pi], type = "string"}
-			)>
-		<cfelseif IsStruct(request.wheels.params[local.pi]) OR IsArray(request.wheels.params[local.pi])>
-			<cfset ArrayAppend(
-				local.paramsList,
-				{name = LCase(local.pi), value = SerializeJSON(request.wheels.params[local.pi]), type = "json"}
-			)>
-		</cfif>
-	</cfif>
-</cfloop>
+<cfset local.paramsList = $debugParamsList(request.wheels.params)>
 <!--- Code complexity (static, cached in CodeComplexity.load; a failure degrades
 	to an empty summary so the debug bar never breaks the request). --->
 <cfset local.codeComplexityAnalyzer = CreateObject("component", "wheels.wheelstest.system.CodeComplexity")>

--- a/vendor/wheels/public/migrator/command.cfm
+++ b/vendor/wheels/public/migrator/command.cfm
@@ -11,118 +11,142 @@ param name="request.wheels.params.version";
  * developer merely visits cannot auto-submit a command.
  */
 
-// ── Security: localhost only ────────────────────
-local.remoteAddr = cgi.REMOTE_ADDR;
-local.isLocalhost = false;
-try {
-	local.remoteInet = createObject("java", "java.net.InetAddress").getByName(local.remoteAddr);
-	local.isLocalhost = local.remoteInet.isLoopbackAddress();
-} catch (any e) {
+function $migratorEnforceLocalhost() {
+	// ── Security: localhost only ────────────────────
+	local.remoteAddr = cgi.REMOTE_ADDR;
 	local.isLocalhost = false;
-}
-if (!local.isLocalhost) {
-	cfheader(statuscode=403);
-	cfcontent(type="text/plain", reset=true);
-	writeOutput("Migrator commands are restricted to localhost");
-	abort;
+	try {
+		local.remoteInet = createObject("java", "java.net.InetAddress").getByName(local.remoteAddr);
+		local.isLocalhost = local.remoteInet.isLoopbackAddress();
+	} catch (any e) {
+		local.isLocalhost = false;
+	}
+	if (!local.isLocalhost) {
+		cfheader(statuscode=403);
+		cfcontent(type="text/plain", reset=true);
+		writeOutput("Migrator commands are restricted to localhost");
+		abort;
+	}
 }
 
-// ── Security: X-Forwarded-For proxy bypass prevention ──
-if (len(trim(cgi.HTTP_X_FORWARDED_FOR))) {
-	local.forwardedIps = listToArray(cgi.HTTP_X_FORWARDED_FOR);
-	for (local.ip in local.forwardedIps) {
-		try {
-			local.fwdInet = createObject("java", "java.net.InetAddress").getByName(trim(local.ip));
-			if (!local.fwdInet.isLoopbackAddress()) {
+function $migratorEnforceNoForwardedClients() {
+	// ── Security: X-Forwarded-For proxy bypass prevention ──
+	if (len(trim(cgi.HTTP_X_FORWARDED_FOR))) {
+		local.forwardedIps = listToArray(cgi.HTTP_X_FORWARDED_FOR);
+		for (local.ip in local.forwardedIps) {
+			try {
+				local.fwdInet = createObject("java", "java.net.InetAddress").getByName(trim(local.ip));
+				if (!local.fwdInet.isLoopbackAddress()) {
+					cfheader(statuscode=403);
+					cfcontent(type="text/plain", reset=true);
+					writeOutput("Migrator commands are restricted to localhost");
+					abort;
+				}
+			} catch (any e) {
 				cfheader(statuscode=403);
 				cfcontent(type="text/plain", reset=true);
 				writeOutput("Migrator commands are restricted to localhost");
 				abort;
 			}
-		} catch (any e) {
-			cfheader(statuscode=403);
-			cfcontent(type="text/plain", reset=true);
-			writeOutput("Migrator commands are restricted to localhost");
-			abort;
 		}
 	}
 }
 
-// ── Security: anti-CSRF token via custom request header ──
-// The token is generated when the migrator GUI renders (../views/migrator.cfm)
-// and must round-trip in the X-Wheels-Csrf-Token header. Cross-site pages
-// cannot set custom headers without a CORS preflight (which this endpoint
-// never approves), so auto-submitted GET/form requests are blocked. Fails
-// closed when no token has been issued yet.
-local.suppliedCsrfToken = "";
-local.requestHeaders = GetHTTPRequestData().headers;
-if (structKeyExists(local.requestHeaders, "X-Wheels-Csrf-Token") && isSimpleValue(local.requestHeaders["X-Wheels-Csrf-Token"])) {
-	local.suppliedCsrfToken = local.requestHeaders["X-Wheels-Csrf-Token"];
-}
-local.csrfTokenValid = false;
-if (
-	len(local.suppliedCsrfToken)
-	&& structKeyExists(application, "wheels")
-	&& structKeyExists(application.wheels, "$migratorCsrfToken")
-	&& len(application.wheels.$migratorCsrfToken)
-) {
-	// Constant-time comparison to prevent timing attacks
-	local.inputBytes = Hash(local.suppliedCsrfToken, "SHA-256").getBytes("UTF-8");
-	local.expectedBytes = Hash(application.wheels.$migratorCsrfToken, "SHA-256").getBytes("UTF-8");
-	local.csrfTokenValid = CreateObject("java", "java.security.MessageDigest").isEqual(local.inputBytes, local.expectedBytes);
-}
-if (!local.csrfTokenValid) {
-	cfheader(statuscode=403);
-	cfcontent(type="text/plain", reset=true);
-	writeOutput("Missing or invalid migrator CSRF token. Open /wheels/migrator and use the GUI buttons.");
-	abort;
-}
-
-executeAction = StructKeyExists(request.wheels.params, "confirm") && request.wheels.params.confirm ? true : false;
-missingMigFlag = StructKeyExists(request.wheels.params, "missingMigFlag") && request.wheels.params.missingMigFlag ? true : false;
-
-message = "";
-result = "";
-
-// To actually perform a destructive action, we need ?confirm=1 in the URL
-// So POST to /wheels/migrator/migrateto/[VERSION] will request confirmation of that action
-if (executeAction) {
-	migrator = application.wheels.migrator;
-	switch (request.wheels.params.command) {
-		case "migrateTo":
-			result = migrator.migrateTo(request.wheels.params.version, missingMigFlag);
-			break;
-		case "migrateTolatest":
-			result = migrator.migrateToLatest();
-			break;
-		case "undoMigration":
-			result = migrator.migrateTo(request.wheels.params.version);
-			break;
-		case "redoMigration":
-			result = migrator.redoMigration(request.wheels.params.version);
-			break;
-		case "migrateIndividual":
-			result = migrator.migrateIndividual(request.wheels.params.version);
-			break;
-		default:
+function $migratorVerifyCsrfToken() {
+	// ── Security: anti-CSRF token via custom request header ──
+	// The token is generated when the migrator GUI renders (../views/migrator.cfm)
+	// and must round-trip in the X-Wheels-Csrf-Token header. Cross-site pages
+	// cannot set custom headers without a CORS preflight (which this endpoint
+	// never approves), so auto-submitted GET/form requests are blocked. Fails
+	// closed when no token has been issued yet.
+	local.suppliedCsrfToken = "";
+	local.requestHeaders = GetHTTPRequestData().headers;
+	if (structKeyExists(local.requestHeaders, "X-Wheels-Csrf-Token") && isSimpleValue(local.requestHeaders["X-Wheels-Csrf-Token"])) {
+		local.suppliedCsrfToken = local.requestHeaders["X-Wheels-Csrf-Token"];
 	}
-} else {
-	switch (request.wheels.params.command) {
-		case "migrateTo":
-			message = "This will migrate the database schema to #request.wheels.params.version#";
-			break;
-		case "migrateTolatest":
-			message = "This will migrate the database schema to the latest version";
-			break;
-		case "redoMigration":
-			message = "This will redo the database migration at #request.wheels.params.version#";
-			break;
-		case "migrateIndividual":
-			message = "This will run migration #request.wheels.params.version# individually (out of sequence)";
-			break;
-		default:
+	local.csrfTokenValid = false;
+	if (
+		len(local.suppliedCsrfToken)
+		&& structKeyExists(application, "wheels")
+		&& structKeyExists(application.wheels, "$migratorCsrfToken")
+		&& len(application.wheels.$migratorCsrfToken)
+	) {
+		// Constant-time comparison to prevent timing attacks
+		local.inputBytes = Hash(local.suppliedCsrfToken, "SHA-256").getBytes("UTF-8");
+		local.expectedBytes = Hash(application.wheels.$migratorCsrfToken, "SHA-256").getBytes("UTF-8");
+		local.csrfTokenValid = CreateObject("java", "java.security.MessageDigest").isEqual(local.inputBytes, local.expectedBytes);
+	}
+	if (!local.csrfTokenValid) {
+		cfheader(statuscode=403);
+		cfcontent(type="text/plain", reset=true);
+		writeOutput("Missing or invalid migrator CSRF token. Open /wheels/migrator and use the GUI buttons.");
+		abort;
 	}
 }
+
+function $migratorComputeResult() {
+	local.executeAction = StructKeyExists(request.wheels.params, "confirm") && request.wheels.params.confirm ? true : false;
+	local.missingMigFlag = StructKeyExists(request.wheels.params, "missingMigFlag") && request.wheels.params.missingMigFlag ? true : false;
+
+	local.message = "";
+	local.result = "";
+
+	// To actually perform a destructive action, we need ?confirm=1 in the URL
+	// So POST to /wheels/migrator/migrateto/[VERSION] will request confirmation of that action
+	if (local.executeAction) {
+		local.migrator = application.wheels.migrator;
+		switch (request.wheels.params.command) {
+			case "migrateTo":
+				local.result = local.migrator.migrateTo(request.wheels.params.version, local.missingMigFlag);
+				break;
+			case "migrateTolatest":
+				local.result = local.migrator.migrateToLatest();
+				break;
+			case "undoMigration":
+				local.result = local.migrator.migrateTo(request.wheels.params.version);
+				break;
+			case "redoMigration":
+				local.result = local.migrator.redoMigration(request.wheels.params.version);
+				break;
+			case "migrateIndividual":
+				local.result = local.migrator.migrateIndividual(request.wheels.params.version);
+				break;
+			default:
+		}
+	} else {
+		switch (request.wheels.params.command) {
+			case "migrateTo":
+				local.message = "This will migrate the database schema to #request.wheels.params.version#";
+				break;
+			case "migrateTolatest":
+				local.message = "This will migrate the database schema to the latest version";
+				break;
+			case "redoMigration":
+				local.message = "This will redo the database migration at #request.wheels.params.version#";
+				break;
+			case "migrateIndividual":
+				local.message = "This will run migration #request.wheels.params.version# individually (out of sequence)";
+				break;
+			default:
+		}
+	}
+
+	return {
+		executeAction: local.executeAction,
+		missingMigFlag: local.missingMigFlag,
+		message: local.message,
+		result: local.result
+	};
+}
+
+$migratorEnforceLocalhost();
+$migratorEnforceNoForwardedClients();
+$migratorVerifyCsrfToken();
+local.computed = $migratorComputeResult();
+executeAction = local.computed.executeAction;
+missingMigFlag = local.computed.missingMigFlag;
+message = local.computed.message;
+result = local.computed.result;
 </cfscript>
 <!--- cfformat-ignore-start --->
 <cfoutput>

--- a/vendor/wheels/public/views/consoleeval.cfm
+++ b/vendor/wheels/public/views/consoleeval.cfm
@@ -11,158 +11,175 @@
 cfheader(statuscode="200");
 cfcontent(type="application/json");
 
-// ── Security: POST only (defense-in-depth) ─────
-if (cgi.REQUEST_METHOD != "POST") {
-	cfheader(statuscode="405");
-	writeOutput(serializeJSON({success: false, error: "Method not allowed. Use POST."}));
-	abort;
+function $consoleEvalEnforcePostMethod() {
+	// ── Security: POST only (defense-in-depth) ─────
+	if (cgi.REQUEST_METHOD != "POST") {
+		cfheader(statuscode="405");
+		writeOutput(serializeJSON({success: false, error: "Method not allowed. Use POST."}));
+		abort;
+	}
 }
 
-// ── Security: localhost only ────────────────────
-local.remoteAddr = cgi.REMOTE_ADDR;
-local.isLocalhost = false;
-try {
-	local.remoteInet = createObject("java", "java.net.InetAddress").getByName(local.remoteAddr);
-	local.isLocalhost = local.remoteInet.isLoopbackAddress();
-} catch (any e) {
+function $consoleEvalEnforceLocalhost() {
+	// ── Security: localhost only ────────────────────
+	local.remoteAddr = cgi.REMOTE_ADDR;
 	local.isLocalhost = false;
-}
-if (!local.isLocalhost) {
-	writeOutput(serializeJSON({success: false, error: "Console access restricted to localhost"}));
-	abort;
+	try {
+		local.remoteInet = createObject("java", "java.net.InetAddress").getByName(local.remoteAddr);
+		local.isLocalhost = local.remoteInet.isLoopbackAddress();
+	} catch (any e) {
+		local.isLocalhost = false;
+	}
+	if (!local.isLocalhost) {
+		writeOutput(serializeJSON({success: false, error: "Console access restricted to localhost"}));
+		abort;
+	}
 }
 
-// ── Security: X-Forwarded-For proxy bypass prevention ──
-if (len(trim(cgi.HTTP_X_FORWARDED_FOR))) {
-	local.forwardedIps = listToArray(cgi.HTTP_X_FORWARDED_FOR);
-	for (local.ip in local.forwardedIps) {
-		try {
-			local.fwdInet = createObject("java", "java.net.InetAddress").getByName(trim(local.ip));
-			if (!local.fwdInet.isLoopbackAddress()) {
+function $consoleEvalEnforceNoForwardedClients() {
+	// ── Security: X-Forwarded-For proxy bypass prevention ──
+	if (len(trim(cgi.HTTP_X_FORWARDED_FOR))) {
+		local.forwardedIps = listToArray(cgi.HTTP_X_FORWARDED_FOR);
+		for (local.ip in local.forwardedIps) {
+			try {
+				local.fwdInet = createObject("java", "java.net.InetAddress").getByName(trim(local.ip));
+				if (!local.fwdInet.isLoopbackAddress()) {
+					writeOutput(serializeJSON({success: false, error: "Console access restricted to localhost"}));
+					abort;
+				}
+			} catch (any e) {
 				writeOutput(serializeJSON({success: false, error: "Console access restricted to localhost"}));
 				abort;
 			}
-		} catch (any e) {
-			writeOutput(serializeJSON({success: false, error: "Console access restricted to localhost"}));
-			abort;
 		}
 	}
 }
 
-// ── Security: development mode only ─────────────
-if (
-	structKeyExists(application, "wheels")
-	&& structKeyExists(application.wheels, "environment")
-	&& application.wheels.environment != "development"
-) {
-	writeOutput(serializeJSON({success: false, error: "Console only available in development mode. Current: " & application.wheels.environment}));
-	abort;
-}
-
-// ── Security: Content-Type must be JSON ─────────
-local.contentType = cgi.CONTENT_TYPE ?: "";
-if (!FindNoCase("application/json", local.contentType)) {
-	writeOutput(serializeJSON({success: false, error: "Content-Type must be application/json"}));
-	abort;
-}
-
-// ── Parse request body ──────────────────────────
-local.requestBody = toString(getHTTPRequestData().content);
-if (!isJSON(local.requestBody)) {
-	writeOutput(serializeJSON({success: false, error: "Invalid request: expected JSON body"}));
-	abort;
-}
-
-local.payload = deserializeJSON(local.requestBody);
-local.expression = local.payload.expression ?: "";
-local.password = local.payload.password ?: "";
-
-if (!len(trim(local.expression))) {
-	writeOutput(serializeJSON({success: false, error: "Empty expression"}));
-	abort;
-}
-
-// ── Security: reload password (fail closed) ────
-if (
-	!structKeyExists(application.wheels, "reloadPassword")
-	|| !len(trim(application.wheels.reloadPassword))
-) {
-	writeOutput(serializeJSON({
-		success: false,
-		error: "Console requires a reload password. Set WHEELS_RELOAD_PASSWORD in .env"
-	}));
-	abort;
-}
-
-// Rate limit: lock out IP after 5 failed attempts within 5 minutes
-if (!structKeyExists(application, "$consoleRateLimit")) {
-	application.$consoleRateLimit = {};
-}
-local.rateLimitKey = cgi.REMOTE_ADDR;
-if (structKeyExists(application.$consoleRateLimit, local.rateLimitKey)) {
-	local.rl = application.$consoleRateLimit[local.rateLimitKey];
-	if (local.rl.count >= 5 && dateDiff("n", local.rl.firstAttempt, now()) < 5) {
-		writeOutput(serializeJSON({success: false, error: "Too many failed attempts. Try again later."}));
+function $consoleEvalEnforceDevelopmentMode() {
+	// ── Security: development mode only ─────────────
+	if (
+		structKeyExists(application, "wheels")
+		&& structKeyExists(application.wheels, "environment")
+		&& application.wheels.environment != "development"
+	) {
+		writeOutput(serializeJSON({success: false, error: "Console only available in development mode. Current: " & application.wheels.environment}));
 		abort;
 	}
-	if (dateDiff("n", local.rl.firstAttempt, now()) >= 5) {
-		structDelete(application.$consoleRateLimit, local.rateLimitKey);
+}
+
+function $consoleEvalEnforceJsonContentType() {
+	// ── Security: Content-Type must be JSON ─────────
+	local.contentType = cgi.CONTENT_TYPE ?: "";
+	if (!FindNoCase("application/json", local.contentType)) {
+		writeOutput(serializeJSON({success: false, error: "Content-Type must be application/json"}));
+		abort;
 	}
 }
 
-// Constant-time comparison to prevent timing attacks
-local.inputBytes = Hash(local.password, "SHA-256").getBytes("UTF-8");
-local.expectedBytes = Hash(application.wheels.reloadPassword, "SHA-256").getBytes("UTF-8");
-if (!CreateObject("java", "java.security.MessageDigest").isEqual(local.inputBytes, local.expectedBytes)) {
-	if (!structKeyExists(application.$consoleRateLimit, local.rateLimitKey)) {
-		application.$consoleRateLimit[local.rateLimitKey] = {count: 0, firstAttempt: now()};
+function $consoleEvalParseBody() {
+	// ── Parse request body ──────────────────────────
+	local.requestBody = toString(getHTTPRequestData().content);
+	if (!isJSON(local.requestBody)) {
+		writeOutput(serializeJSON({success: false, error: "Invalid request: expected JSON body"}));
+		abort;
 	}
-	application.$consoleRateLimit[local.rateLimitKey].count++;
-	writeOutput(serializeJSON({
-		success: false,
-		error: "Invalid reload password. Set WHEELS_RELOAD_PASSWORD in .env or pass --password to wheels console"
-	}));
-	abort;
-}
 
-// ── Built-in commands ───────────────────────────
-if (local.expression == "__ping__") {
-	writeOutput(serializeJSON({
-		success: true,
-		result: "pong",
-		type: "string",
-		output: "",
-		environment: application.wheels.environment ?: "unknown",
-		version: application.wheels.version ?: "unknown"
-	}));
-	abort;
-}
-
-if (local.expression == "__env__") {
-	local.envInfo = {
-		environment: application.wheels.environment ?: "unknown",
-		version: application.wheels.version ?: "unknown",
-		datasource: application.wheels.dataSourceName ?: "unknown",
-		urlRewriting: application.wheels.URLRewriting ?: "unknown"
+	local.payload = deserializeJSON(local.requestBody);
+	return {
+		expression: local.payload.expression ?: "",
+		password: local.payload.password ?: ""
 	};
-	writeOutput(serializeJSON({
-		success: true,
-		result: serializeJSON(local.envInfo),
-		type: "struct",
-		output: ""
-	}));
-	abort;
 }
 
-// ── Evaluate expression ─────────────────────────
-local.response = {success: true, output: "", result: "", type: "void", error: ""};
-
-try {
-	local.captured = "";
-	savecontent variable="local.captured" {
-		local.evalResult = evaluate(local.expression);
+function $consoleEvalRequireExpression(required expression) {
+	if (!len(trim(arguments.expression))) {
+		writeOutput(serializeJSON({success: false, error: "Empty expression"}));
+		abort;
 	}
-	local.response.output = local.captured;
+}
+
+function $consoleEvalRequireReloadPassword() {
+	// ── Security: reload password (fail closed) ────
+	if (
+		!structKeyExists(application.wheels, "reloadPassword")
+		|| !len(trim(application.wheels.reloadPassword))
+	) {
+		writeOutput(serializeJSON({
+			success: false,
+			error: "Console requires a reload password. Set WHEELS_RELOAD_PASSWORD in .env"
+		}));
+		abort;
+	}
+}
+
+function $consoleEvalCheckRateLimit(required rateLimitKey) {
+	// Rate limit: lock out IP after 5 failed attempts within 5 minutes
+	if (!structKeyExists(application, "$consoleRateLimit")) {
+		application.$consoleRateLimit = {};
+	}
+	if (structKeyExists(application.$consoleRateLimit, arguments.rateLimitKey)) {
+		local.rl = application.$consoleRateLimit[arguments.rateLimitKey];
+		if (local.rl.count >= 5 && dateDiff("n", local.rl.firstAttempt, now()) < 5) {
+			writeOutput(serializeJSON({success: false, error: "Too many failed attempts. Try again later."}));
+			abort;
+		}
+		if (dateDiff("n", local.rl.firstAttempt, now()) >= 5) {
+			structDelete(application.$consoleRateLimit, arguments.rateLimitKey);
+		}
+	}
+}
+
+function $consoleEvalVerifyPassword(required password, required rateLimitKey) {
+	// Constant-time comparison to prevent timing attacks
+	local.inputBytes = Hash(arguments.password, "SHA-256").getBytes("UTF-8");
+	local.expectedBytes = Hash(application.wheels.reloadPassword, "SHA-256").getBytes("UTF-8");
+	if (!CreateObject("java", "java.security.MessageDigest").isEqual(local.inputBytes, local.expectedBytes)) {
+		if (!structKeyExists(application.$consoleRateLimit, arguments.rateLimitKey)) {
+			application.$consoleRateLimit[arguments.rateLimitKey] = {count: 0, firstAttempt: now()};
+		}
+		application.$consoleRateLimit[arguments.rateLimitKey].count++;
+		writeOutput(serializeJSON({
+			success: false,
+			error: "Invalid reload password. Set WHEELS_RELOAD_PASSWORD in .env or pass --password to wheels console"
+		}));
+		abort;
+	}
+}
+
+function $consoleEvalHandleBuiltInCommands(required expression) {
+	// ── Built-in commands ───────────────────────────
+	if (arguments.expression == "__ping__") {
+		writeOutput(serializeJSON({
+			success: true,
+			result: "pong",
+			type: "string",
+			output: "",
+			environment: application.wheels.environment ?: "unknown",
+			version: application.wheels.version ?: "unknown"
+		}));
+		abort;
+	}
+
+	if (arguments.expression == "__env__") {
+		local.envInfo = {
+			environment: application.wheels.environment ?: "unknown",
+			version: application.wheels.version ?: "unknown",
+			datasource: application.wheels.dataSourceName ?: "unknown",
+			urlRewriting: application.wheels.URLRewriting ?: "unknown"
+		};
+		writeOutput(serializeJSON({
+			success: true,
+			result: serializeJSON(local.envInfo),
+			type: "struct",
+			output: ""
+		}));
+		abort;
+	}
+}
+
+function $consoleEvalFormatResult(required evalResult, required response) {
+	local.evalResult = arguments.evalResult;
+	local.response = arguments.response;
 
 	if (!isNull(local.evalResult)) {
 		// Query objects (from findAll, etc.)
@@ -246,14 +263,45 @@ try {
 			}
 		}
 	}
-} catch (any e) {
-	local.response.success = false;
-	local.response.error = e.message;
-	if (len(e.detail ?: "")) {
-		local.response.error &= " -- " & e.detail;
-	}
 }
 
-writeOutput(serializeJSON(local.response));
+function $consoleEvalEvaluate(required expression) {
+	// ── Evaluate expression ─────────────────────────
+	local.response = {success: true, output: "", result: "", type: "void", error: ""};
+
+	try {
+		local.captured = "";
+		savecontent variable="local.captured" {
+			local.evalResult = evaluate(arguments.expression);
+		}
+		local.response.output = local.captured;
+
+		$consoleEvalFormatResult(local.evalResult, local.response);
+	} catch (any e) {
+		local.response.success = false;
+		local.response.error = e.message;
+		if (len(e.detail ?: "")) {
+			local.response.error &= " -- " & e.detail;
+		}
+	}
+
+	return local.response;
+}
+
+// ── Request pipeline ─────────────────────────────
+$consoleEvalEnforcePostMethod();
+$consoleEvalEnforceLocalhost();
+$consoleEvalEnforceNoForwardedClients();
+$consoleEvalEnforceDevelopmentMode();
+$consoleEvalEnforceJsonContentType();
+local.payload = $consoleEvalParseBody();
+local.expression = local.payload.expression;
+local.password = local.payload.password;
+$consoleEvalRequireExpression(local.expression);
+$consoleEvalRequireReloadPassword();
+$consoleEvalCheckRateLimit(cgi.REMOTE_ADDR);
+$consoleEvalVerifyPassword(local.password, cgi.REMOTE_ADDR);
+$consoleEvalHandleBuiltInCommands(local.expression);
+writeOutput(serializeJSON($consoleEvalEvaluate(local.expression)));
 abort;
 </cfscript>

--- a/vendor/wheels/public/views/mcp.cfm
+++ b/vendor/wheels/public/views/mcp.cfm
@@ -16,239 +16,255 @@
 // a future release. See:
 //   https://guides.wheels.dev/v4-0-0/command-line-tools/mcp-integration
 
-// Log one-time deprecation warning per JVM
-if (!structKeyExists(application, "mcpHttpDeprecationLogged")) {
-	try {
-		writeLog(
-			file="wheels_mcp",
-			type="warning",
-			text="The in-dev-server MCP endpoint at /wheels/mcp is deprecated. "
-				& "Use 'wheels mcp wheels' (LuCLI stdio MCP) instead. "
-				& "See https://guides.wheels.dev/v4-0-0/command-line-tools/mcp-integration"
-		);
-	} catch (any ignored) { /* logging is best-effort */ }
-	application.mcpHttpDeprecationLogged = true;
-}
-
-// ── Security: development mode only ─────────────
-if (
-	structKeyExists(application, "wheels")
-	&& structKeyExists(application.wheels, "environment")
-	&& application.wheels.environment != "development"
-) {
-	cfheader(statusCode="403");
-	cfheader(name="Content-Type", value="application/json");
-	local.errorResponse = {
-		"jsonrpc": "2.0",
-		"error": {
-			"code": -32001,
-			"message": "MCP endpoint is only available in development mode"
-		}
-	};
-	local.errorResponse["id"] = javaCast("null", "");
-	writeOutput(serializeJSON(local.errorResponse));
-	abort;
-}
-
-// ── Security: localhost only ────────────────────
-// Use InetAddress.isLoopbackAddress() instead of a literal-string list so
-// every loopback form matches (all of 127.0.0.0/8, ::1, and IPv4-mapped IPv6
-// like ::ffff:127.0.0.1), failing closed when the address cannot be parsed.
-local.remoteAddr = cgi.REMOTE_ADDR;
-local.isLocalhost = false;
-try {
-	local.isLocalhost = createObject("java", "java.net.InetAddress").getByName(local.remoteAddr).isLoopbackAddress();
-} catch (any e) {
-	local.isLocalhost = false;
-}
-if (!local.isLocalhost) {
-	cfheader(statusCode="403");
-	cfheader(name="Content-Type", value="application/json");
-	local.errorResponse = {
-		"jsonrpc": "2.0",
-		"error": {
-			"code": -32001,
-			"message": "MCP endpoint is restricted to localhost"
-		}
-	};
-	local.errorResponse["id"] = javaCast("null", "");
-	writeOutput(serializeJSON(local.errorResponse));
-	abort;
-}
-
-// Handle OPTIONS requests — CORS is unnecessary since endpoint is localhost-only
-if (cgi.request_method == "OPTIONS") {
-	cfheader(statusCode="405");
-	cfheader(name="Content-Type", value="application/json");
-	writeOutput(serializeJSON({"error": "OPTIONS method not supported"}));
-	abort;
-}
-
-// For POST requests that get routed as GET due to internal routing restrictions,
-// check if there's form data in the body that indicates this is actually a JSON-RPC POST
-local.actualMethod = cgi.request_method;
-if (cgi.request_method == "GET") {
-	// Check if this is actually a POST request that was routed as GET
-	local.httpData = getHTTPRequestData();
-	local.bodyContent = toString(local.httpData.content);
-	if (len(trim(local.bodyContent)) > 0) {
+function $mcpLogDeprecationWarning() {
+	// Log one-time deprecation warning per JVM
+	if (!structKeyExists(application, "mcpHttpDeprecationLogged")) {
 		try {
-			local.testJson = deserializeJSON(local.bodyContent);
-			if (structKeyExists(local.testJson, "jsonrpc") && structKeyExists(local.testJson, "method")) {
-				// This looks like a JSON-RPC request sent via POST
-				local.actualMethod = "POST";
-			}
-		} catch (any e) {
-			// Not JSON, continue as GET
-		}
+			writeLog(
+				file="wheels_mcp",
+				type="warning",
+				text="The in-dev-server MCP endpoint at /wheels/mcp is deprecated. "
+					& "Use 'wheels mcp wheels' (LuCLI stdio MCP) instead. "
+					& "See https://guides.wheels.dev/v4-0-0/command-line-tools/mcp-integration"
+			);
+		} catch (any ignored) { /* logging is best-effort */ }
+		application.mcpHttpDeprecationLogged = true;
 	}
 }
 
-try {
-	// Initialize or get session manager
-	if (!structKeyExists(application, "mcpSessionManager")) {
-		application.mcpSessionManager = createObject("component", "wheels.public.mcp.SessionManager").init();
-	}
-	local.sessionManager = application.mcpSessionManager;
-
-	// Initialize MCP server instance
-	if (!structKeyExists(application, "mcpServer")) {
-		application.mcpServer = createObject("component", "wheels.public.mcp.McpServer").init();
-	}
-	local.mcpServer = application.mcpServer;
-
-	// Handle GET requests (SSE support or query-based testing)
-	if (local.actualMethod == "GET") {
-		// Check if this is a query-based JSON-RPC request for testing
-		if (structKeyExists(url, "method") && url.method == "POST" && structKeyExists(url, "body")) {
-			// Decode the body and treat as POST
-			local.actualMethod = "POST";
-			local.requestBody = urlDecode(url.body);
-			local.sessionId = structKeyExists(cgi, "http_mcp_session_id") ? cgi.http_mcp_session_id : local.sessionManager.createSession();
-		} else {
-			// Check if client accepts SSE
-			local.acceptHeader = cgi.http_accept ?: "";
-			if (find("text/event-stream", local.acceptHeader)) {
-				// Return SSE stream
-				cfheader(name="Content-Type", value="text/event-stream");
-				cfheader(name="Cache-Control", value="no-cache");
-				cfheader(name="Connection", value="keep-alive");
-
-				// Create or get session
-				local.sessionId = local.sessionManager.createSession();
-				cfheader(name="Mcp-Session-Id", value=local.sessionId);
-
-				// Send initial SSE message
-				writeOutput("data: " & serializeJSON({
-					"type": "connection",
-					"sessionId": local.sessionId,
-					"status": "connected"
-				}) & chr(10) & chr(10));
-				cfflush();
-				abort;
-			} else {
-				// Return 405 Method Not Allowed for non-SSE GET requests
-				cfheader(statusCode="405");
-				writeOutput("GET requests must accept text/event-stream");
-				abort;
-			}
-		}
-	}
-
-	// Handle POST requests (JSON-RPC messages)
-	if (local.actualMethod == "POST") {
-		// Get session ID from header or create new one (may already be set for query-based requests)
-		if (!structKeyExists(local, "sessionId")) {
-			local.sessionId = structKeyExists(cgi, "http_mcp_session_id") ? cgi.http_mcp_session_id : local.sessionManager.createSession();
-		}
-
-		// Get request body (may have already been read for method detection or query params)
-		if (!structKeyExists(local, "requestBody")) {
-			if (structKeyExists(local, "bodyContent")) {
-				local.requestBody = local.bodyContent;
-			} else {
-				local.httpData = getHTTPRequestData();
-				local.requestBody = toString(local.httpData.content);
-			}
-		}
-
-		if (len(trim(local.requestBody)) == 0) {
-			// Return 400 Bad Request for empty body
-			cfheader(statusCode="400");
-			cfheader(name="Content-Type", value="application/json");
-			local.errorResponse = {
-				"jsonrpc": "2.0",
-				"error": {
-					"code": -32600,
-					"message": "Invalid Request",
-					"data": "Request body is empty"
-				}
-			};
-			local.errorResponse["id"] = javaCast("null", "");
-			writeOutput(serializeJSON(local.errorResponse));
-			abort;
-		}
-
-		// Parse JSON-RPC request
-		try {
-			local.jsonRpcRequest = deserializeJSON(local.requestBody);
-		} catch (any e) {
-			// Return 400 Bad Request for invalid JSON
-			cfheader(statusCode="400");
-			cfheader(name="Content-Type", value="application/json");
-			local.errorResponse = {
-				"jsonrpc": "2.0",
-				"error": {
-					"code": -32700,
-					"message": "Parse error",
-					"data": "Request body is not valid JSON"
-				}
-			};
-			local.errorResponse["id"] = javaCast("null", "");
-			writeOutput(serializeJSON(local.errorResponse));
-			abort;
-		}
-
-		// Process the JSON-RPC request
-		local.response = local.mcpServer.handleRequest(local.jsonRpcRequest, local.sessionId);
-
-		// Set response headers
-		cfheader(name="Mcp-Session-Id", value=local.sessionId);
+function $mcpEnforceDevelopmentMode() {
+	// ── Security: development mode only ─────────────
+	if (
+		structKeyExists(application, "wheels")
+		&& structKeyExists(application.wheels, "environment")
+		&& application.wheels.environment != "development"
+	) {
+		cfheader(statusCode="403");
 		cfheader(name="Content-Type", value="application/json");
-		cfheader(statusCode="200");
-
-		// Return JSON-RPC response
-		writeOutput(serializeJSON(local.response));
+		local.errorResponse = {
+			"jsonrpc": "2.0",
+			"error": {
+				"code": -32001,
+				"message": "MCP endpoint is only available in development mode"
+			}
+		};
+		local.errorResponse["id"] = javaCast("null", "");
+		writeOutput(serializeJSON(local.errorResponse));
 		abort;
 	}
-
-	// Return 405 Method Not Allowed for other methods
-	cfheader(statusCode="405");
-	cfheader(name="Content-Type", value="application/json");
-	writeOutput(serializeJSON({
-		"error": "Only GET and POST methods are supported",
-		"supportedMethods": ["GET", "POST"]
-	}));
-
-} catch (any e) {
-	try {
-		writeLog(
-			file="wheels_mcp",
-			type="error",
-			text="MCP error: " & e.message & " | Detail: " & (structKeyExists(e, "detail") ? e.detail : "")
-		);
-	} catch (any logErr) {
-		// Fail silently if logging fails
-	}
-	cfheader(statusCode="500");
-	cfheader(name="Content-Type", value="application/json");
-	writeOutput(serializeJSON({
-		"jsonrpc": "2.0",
-		"error": {
-			"code": -32603,
-			"message": "Internal error"
-		},
-		"id": javaCast("null", "")
-	}));
 }
+
+function $mcpEnforceLocalhost() {
+	// ── Security: localhost only ────────────────────
+	// Use InetAddress.isLoopbackAddress() instead of a literal-string list so
+	// every loopback form matches (all of 127.0.0.0/8, ::1, and IPv4-mapped IPv6
+	// like ::ffff:127.0.0.1), failing closed when the address cannot be parsed.
+	local.remoteAddr = cgi.REMOTE_ADDR;
+	local.isLocalhost = false;
+	try {
+		local.isLocalhost = createObject("java", "java.net.InetAddress").getByName(local.remoteAddr).isLoopbackAddress();
+	} catch (any e) {
+		local.isLocalhost = false;
+	}
+	if (!local.isLocalhost) {
+		cfheader(statusCode="403");
+		cfheader(name="Content-Type", value="application/json");
+		local.errorResponse = {
+			"jsonrpc": "2.0",
+			"error": {
+				"code": -32001,
+				"message": "MCP endpoint is restricted to localhost"
+			}
+		};
+		local.errorResponse["id"] = javaCast("null", "");
+		writeOutput(serializeJSON(local.errorResponse));
+		abort;
+	}
+}
+
+function $mcpRejectOptions() {
+	// Handle OPTIONS requests — CORS is unnecessary since endpoint is localhost-only
+	if (cgi.request_method == "OPTIONS") {
+		cfheader(statusCode="405");
+		cfheader(name="Content-Type", value="application/json");
+		writeOutput(serializeJSON({"error": "OPTIONS method not supported"}));
+		abort;
+	}
+}
+
+function $mcpHandleRequest() {
+	// For POST requests that get routed as GET due to internal routing restrictions,
+	// check if there's form data in the body that indicates this is actually a JSON-RPC POST
+	local.actualMethod = cgi.request_method;
+	if (cgi.request_method == "GET") {
+		// Check if this is actually a POST request that was routed as GET
+		local.httpData = getHTTPRequestData();
+		local.bodyContent = toString(local.httpData.content);
+		if (len(trim(local.bodyContent)) > 0) {
+			try {
+				local.testJson = deserializeJSON(local.bodyContent);
+				if (structKeyExists(local.testJson, "jsonrpc") && structKeyExists(local.testJson, "method")) {
+					// This looks like a JSON-RPC request sent via POST
+					local.actualMethod = "POST";
+				}
+			} catch (any e) {
+				// Not JSON, continue as GET
+			}
+		}
+	}
+
+	try {
+		// Initialize or get session manager
+		if (!structKeyExists(application, "mcpSessionManager")) {
+			application.mcpSessionManager = createObject("component", "wheels.public.mcp.SessionManager").init();
+		}
+		local.sessionManager = application.mcpSessionManager;
+
+		// Initialize MCP server instance
+		if (!structKeyExists(application, "mcpServer")) {
+			application.mcpServer = createObject("component", "wheels.public.mcp.McpServer").init();
+		}
+		local.mcpServer = application.mcpServer;
+
+		// Handle GET requests (SSE support or query-based testing)
+		if (local.actualMethod == "GET") {
+			// Check if this is a query-based JSON-RPC request for testing
+			if (structKeyExists(url, "method") && url.method == "POST" && structKeyExists(url, "body")) {
+				// Decode the body and treat as POST
+				local.actualMethod = "POST";
+				local.requestBody = urlDecode(url.body);
+				local.sessionId = structKeyExists(cgi, "http_mcp_session_id") ? cgi.http_mcp_session_id : local.sessionManager.createSession();
+			} else {
+				// Check if client accepts SSE
+				local.acceptHeader = cgi.http_accept ?: "";
+				if (find("text/event-stream", local.acceptHeader)) {
+					// Return SSE stream
+					cfheader(name="Content-Type", value="text/event-stream");
+					cfheader(name="Cache-Control", value="no-cache");
+					cfheader(name="Connection", value="keep-alive");
+
+					// Create or get session
+					local.sessionId = local.sessionManager.createSession();
+					cfheader(name="Mcp-Session-Id", value=local.sessionId);
+
+					// Send initial SSE message
+					writeOutput("data: " & serializeJSON({
+						"type": "connection",
+						"sessionId": local.sessionId,
+						"status": "connected"
+					}) & chr(10) & chr(10));
+					cfflush();
+					abort;
+				} else {
+					// Return 405 Method Not Allowed for non-SSE GET requests
+					cfheader(statusCode="405");
+					writeOutput("GET requests must accept text/event-stream");
+					abort;
+				}
+			}
+		}
+
+		// Handle POST requests (JSON-RPC messages)
+		if (local.actualMethod == "POST") {
+			// Get session ID from header or create new one (may already be set for query-based requests)
+			if (!structKeyExists(local, "sessionId")) {
+				local.sessionId = structKeyExists(cgi, "http_mcp_session_id") ? cgi.http_mcp_session_id : local.sessionManager.createSession();
+			}
+
+			// Get request body (may have already been read for method detection or query params)
+			if (!structKeyExists(local, "requestBody")) {
+				if (structKeyExists(local, "bodyContent")) {
+					local.requestBody = local.bodyContent;
+				} else {
+					local.httpData = getHTTPRequestData();
+					local.requestBody = toString(local.httpData.content);
+				}
+			}
+
+			if (len(trim(local.requestBody)) == 0) {
+				// Return 400 Bad Request for empty body
+				cfheader(statusCode="400");
+				cfheader(name="Content-Type", value="application/json");
+				local.errorResponse = {
+					"jsonrpc": "2.0",
+					"error": {
+						"code": -32600,
+						"message": "Invalid Request",
+						"data": "Request body is empty"
+					}
+				};
+				local.errorResponse["id"] = javaCast("null", "");
+				writeOutput(serializeJSON(local.errorResponse));
+				abort;
+			}
+
+			// Parse JSON-RPC request
+			try {
+				local.jsonRpcRequest = deserializeJSON(local.requestBody);
+			} catch (any e) {
+				// Return 400 Bad Request for invalid JSON
+				cfheader(statusCode="400");
+				cfheader(name="Content-Type", value="application/json");
+				local.errorResponse = {
+					"jsonrpc": "2.0",
+					"error": {
+						"code": -32700,
+						"message": "Parse error",
+						"data": "Request body is not valid JSON"
+					}
+				};
+				local.errorResponse["id"] = javaCast("null", "");
+				writeOutput(serializeJSON(local.errorResponse));
+				abort;
+			}
+
+			// Process the JSON-RPC request
+			local.response = local.mcpServer.handleRequest(local.jsonRpcRequest, local.sessionId);
+
+			// Set response headers
+			cfheader(name="Mcp-Session-Id", value=local.sessionId);
+			cfheader(name="Content-Type", value="application/json");
+			cfheader(statusCode="200");
+
+			// Return JSON-RPC response
+			writeOutput(serializeJSON(local.response));
+			abort;
+		}
+
+		// Return 405 Method Not Allowed for other methods
+		cfheader(statusCode="405");
+		cfheader(name="Content-Type", value="application/json");
+		writeOutput(serializeJSON({
+			"error": "Only GET and POST methods are supported",
+			"supportedMethods": ["GET", "POST"]
+		}));
+
+	} catch (any e) {
+		try {
+			writeLog(
+				file="wheels_mcp",
+				type="error",
+				text="MCP error: " & e.message & " | Detail: " & (structKeyExists(e, "detail") ? e.detail : "")
+			);
+		} catch (any logErr) {
+			// Fail silently if logging fails
+		}
+		cfheader(statusCode="500");
+		cfheader(name="Content-Type", value="application/json");
+		writeOutput(serializeJSON({
+			"jsonrpc": "2.0",
+			"error": {
+				"code": -32603,
+				"message": "Internal error"
+			},
+			"id": javaCast("null", "")
+		}));
+	}
+}
+
+$mcpLogDeprecationWarning();
+$mcpEnforceDevelopmentMode();
+$mcpEnforceLocalhost();
+$mcpRejectOptions();
+$mcpHandleRequest();
 </cfscript>

--- a/vendor/wheels/public/views/plugins.cfm
+++ b/vendor/wheels/public/views/plugins.cfm
@@ -2,13 +2,15 @@
 // Check for JSON format request
 param name="request.wheels.params.format" default="html";
 
-if(!application.wheels.enablePluginsComponent)
-	throw(type="wheels.plugins", message="The Wheels Plugin component is disabled...");
+function $pluginsEnsureEnabled() {
+	if(!application.wheels.enablePluginsComponent)
+		throw(type="wheels.plugins", message="The Wheels Plugin component is disabled...");
+}
 
-loadedPlugins = application.wheels.plugins;
+function $pluginsRenderJson() {
+	loadedPlugins = application.wheels.plugins;
 
-// If JSON format is requested, return JSON response
-if (request.wheels.params.format == "json") {
+	// If JSON format is requested, return JSON response
 	local.pluginsData = {
 		"version": application.wheels.version,
 		"timestamp": now(),
@@ -64,6 +66,11 @@ if (request.wheels.params.format == "json") {
 	abort;
 }
 
+$pluginsEnsureEnabled();
+
+if (request.wheels.params.format == "json") {
+	$pluginsRenderJson();
+}
 </cfscript>
 <cfinclude template="../layout/_header.cfm">
 <cfoutput>

--- a/vendor/wheels/tests/specs/cli/ReloadEnvironmentSwitchParitySpec.cfc
+++ b/vendor/wheels/tests/specs/cli/ReloadEnvironmentSwitchParitySpec.cfc
@@ -137,7 +137,7 @@ component extends="wheels.WheelsTest" {
 						var content = fileRead(absolute);
 
 						expect(
-							reFind('local\.environmentSwitchAlreadyApplied\s*=\s*StructKeyExists\(url,\s*"reload"\)', content) > 0
+							reFind('local\.environmentSwitchAlreadyApplied\s*=\s*(this\.\$isEnvironmentSwitchAlreadyApplied\(\)|StructKeyExists\(url,\s*"reload"\))', content) > 0
 						).toBeTrue(
 							relPath & " must compute environmentSwitchAlreadyApplied before the reload "
 							& "gate (issue ##3030)."
@@ -149,7 +149,7 @@ component extends="wheels.WheelsTest" {
 							& "redirected request does not restart again (issue ##3030)."
 						);
 						expect(
-							reFind("&&\s*!local\.environmentSwitchAlreadyApplied", content) > 0
+							reFind("&&\s*!(local|arguments)\.environmentSwitchAlreadyApplied", content) > 0
 						).toBeTrue(
 							relPath & " must skip the applicationStop() gate when the requested "
 							& "environment is already active — without this the preserved parameters "

--- a/vendor/wheels/wheelstest/system/Assertion.cfc
+++ b/vendor/wheels/wheelstest/system/Assertion.cfc
@@ -1262,12 +1262,8 @@ component {
 
 	private boolean function equalize( any expected, any actual ){
 		// Null values
-		if ( isNull( arguments.expected ) && isNull( arguments.actual ) ) {
-			return true;
-		}
-
 		if ( isNull( arguments.expected ) || isNull( arguments.actual ) ) {
-			return false;
+			return isNull( arguments.expected ) && isNull( arguments.actual );
 		}
 
 		// Numerics
@@ -1279,14 +1275,7 @@ component {
 			return true;
 		}
 
-		// Simple values
-		if (
-			isSimpleValue( arguments.actual ) && isSimpleValue( arguments.expected ) && arguments.actual eq arguments.expected
-		) {
-			return true;
-		}
-
-		// Two simple values that did not match above are unequal, and saying so here
+		// Simple values that did not match above are unequal, and saying so here
 		// is what keeps them away from the `.equals()` fallback at the bottom of this
 		// function. That fallback is meant for objects; on BoxLang a simple value
 		// resolves `.equals()` to the DateTime member function and throws
@@ -1294,126 +1283,146 @@ component {
 		// reported as an ERROR carrying a cast message instead of a FAILURE reading
 		// "Expected [2] but received [0]" (#3302).
 		if ( isSimpleValue( arguments.actual ) && isSimpleValue( arguments.expected ) ) {
-			return false;
+			return $equalizeSimpleValues( arguments.expected, arguments.actual );
 		}
 
 		// Queries
 		if ( isQuery( arguments.actual ) && isQuery( arguments.expected ) ) {
-			// Check number of records
-			if ( arguments.actual.recordCount != arguments.expected.recordCount ) {
-				return false;
-			}
-
-			// Get both column lists and sort them the same
-			var actualColumnList   = listSort( arguments.actual.columnList, "textNoCase" );
-			var expectedColumnList = listSort( arguments.expected.columnList, "textNoCase" );
-
-			// Check column lists
-			if ( actualColumnList != expectedColumnList ) {
-				return false;
-			}
-
-			// Loop over each row
-			var i = 0;
-			while ( ++i <= arguments.actual.recordCount ) {
-				// Loop over each column
-				for ( var column in listToArray( actualColumnList ) ) {
-					// Compare each value
-					if ( arguments.actual[ column ][ i ] != arguments.expected[ column ][ i ] ) {
-						// At the first sign of trouble, bail!
-						return false;
-					}
-				}
-			}
-
-			// We made it here so nothing looked wrong
-			return true;
+			return $equalizeQueries( arguments.expected, arguments.actual );
 		}
 
 		// UDFs
-		if (
-			isCustomFunction( arguments.actual ) && isCustomFunction( arguments.expected ) &&
-			arguments.actual.toString() eq arguments.expected.toString()
-		) {
-			return true;
+		if ( isCustomFunction( arguments.actual ) && isCustomFunction( arguments.expected ) ) {
+			return $equalizeFunctions( arguments.expected, arguments.actual );
 		}
 
 		// XML
-		if (
-			isXMLDoc( arguments.actual ) && isXMLDoc( arguments.expected ) &&
-			toString( arguments.actual ) eq toString( arguments.expected )
-		) {
-			return true;
+		if ( isXMLDoc( arguments.actual ) && isXMLDoc( arguments.expected ) ) {
+			return $equalizeXml( arguments.expected, arguments.actual );
 		}
 
 		// Arrays
 		if ( isArray( arguments.actual ) && isArray( arguments.expected ) ) {
-			// Confirm both arrays are the same length
-			if ( arrayLen( arguments.actual ) neq arrayLen( arguments.expected ) ) {
-				return false;
-			}
-
-			for ( var i = 1; i lte arrayLen( arguments.actual ); i++ ) {
-				// check for both being defined
-				if ( arrayIsDefined( arguments.actual, i ) and arrayIsDefined( arguments.expected, i ) ) {
-					// check for both nulls
-					if ( isNull( arguments.actual[ i ] ) and isNull( arguments.expected[ i ] ) ) {
-						continue;
-					}
-					// check if one is null mismatch
-					if ( isNull( arguments.actual[ i ] ) OR isNull( arguments.expected[ i ] ) ) {
-						return false;
-					}
-					// And make sure they match
-					if ( !equalize( arguments.actual[ i ], arguments.expected[ i ] ) ) {
-						return false;
-					}
-					continue;
-				}
-				// check if both not defined, then continue to next element
-				if ( !arrayIsDefined( arguments.actual, i ) and !arrayIsDefined( arguments.expected, i ) ) {
-					continue;
-				} else {
-					return false;
-				}
-			}
-
-			// If we made it here, we couldn't find anything different
-			return true;
+			return $equalizeArrays( arguments.expected, arguments.actual );
 		}
 
 		// Structs / Object
 		if ( isStruct( arguments.actual ) && isStruct( arguments.expected ) ) {
-			var actualKeys   = listSort( structKeyList( arguments.actual ), "textNoCase" );
-			var expectedKeys = listSort( structKeyList( arguments.expected ), "textNoCase" );
-			var key          = "";
-
-			// Confirm both structs have the same keys
-			if ( actualKeys neq expectedKeys ) {
-				return false;
-			}
-
-			// Loop over each key
-			for ( key in arguments.actual ) {
-				// check for both nulls
-				if ( isNull( arguments.actual[ key ] ) and isNull( arguments.expected[ key ] ) ) {
-					continue;
-				}
-				// check if one is null mismatch
-				if ( isNull( arguments.actual[ key ] ) OR isNull( arguments.expected[ key ] ) ) {
-					return false;
-				}
-				// And make sure they match when actual values exist
-				if ( !equalize( arguments.actual[ key ], arguments.expected[ key ] ) ) {
-					return false;
-				}
-			}
-
-			// If we made it here, we couldn't find anything different
-			return true;
+			return $equalizeStructs( arguments.expected, arguments.actual );
 		}
 
 		return arguments.actual.equals( arguments.expected );
+	}
+
+	private boolean function $equalizeSimpleValues( any expected, any actual ){
+		// Both arguments are simple values (guaranteed by the caller) that did not
+		// match the numeric check above, so plain equality decides.
+		return arguments.actual eq arguments.expected;
+	}
+
+	private boolean function $equalizeQueries( any expected, any actual ){
+		// Check number of records
+		if ( arguments.actual.recordCount != arguments.expected.recordCount ) {
+			return false;
+		}
+
+		// Get both column lists and sort them the same
+		var actualColumnList   = listSort( arguments.actual.columnList, "textNoCase" );
+		var expectedColumnList = listSort( arguments.expected.columnList, "textNoCase" );
+
+		// Check column lists
+		if ( actualColumnList != expectedColumnList ) {
+			return false;
+		}
+
+		// Loop over each row
+		var i = 0;
+		while ( ++i <= arguments.actual.recordCount ) {
+			// Loop over each column
+			for ( var column in listToArray( actualColumnList ) ) {
+				// Compare each value
+				if ( arguments.actual[ column ][ i ] != arguments.expected[ column ][ i ] ) {
+					// At the first sign of trouble, bail!
+					return false;
+				}
+			}
+		}
+
+		// We made it here so nothing looked wrong
+		return true;
+	}
+
+	private boolean function $equalizeArrays( any expected, any actual ){
+		// Confirm both arrays are the same length
+		if ( arrayLen( arguments.actual ) neq arrayLen( arguments.expected ) ) {
+			return false;
+		}
+
+		for ( var i = 1; i lte arrayLen( arguments.actual ); i++ ) {
+			// check for both being defined
+			if ( arrayIsDefined( arguments.actual, i ) and arrayIsDefined( arguments.expected, i ) ) {
+				// check for both nulls
+				if ( isNull( arguments.actual[ i ] ) and isNull( arguments.expected[ i ] ) ) {
+					continue;
+				}
+				// check if one is null mismatch
+				if ( isNull( arguments.actual[ i ] ) OR isNull( arguments.expected[ i ] ) ) {
+					return false;
+				}
+				// And make sure they match
+				if ( !equalize( arguments.actual[ i ], arguments.expected[ i ] ) ) {
+					return false;
+				}
+				continue;
+			}
+			// check if both not defined, then continue to next element
+			if ( !arrayIsDefined( arguments.actual, i ) and !arrayIsDefined( arguments.expected, i ) ) {
+				continue;
+			} else {
+				return false;
+			}
+		}
+
+		// If we made it here, we couldn't find anything different
+		return true;
+	}
+
+	private boolean function $equalizeStructs( any expected, any actual ){
+		var actualKeys   = listSort( structKeyList( arguments.actual ), "textNoCase" );
+		var expectedKeys = listSort( structKeyList( arguments.expected ), "textNoCase" );
+		var key          = "";
+
+		// Confirm both structs have the same keys
+		if ( actualKeys neq expectedKeys ) {
+			return false;
+		}
+
+		// Loop over each key
+		for ( key in arguments.actual ) {
+			// check for both nulls
+			if ( isNull( arguments.actual[ key ] ) and isNull( arguments.expected[ key ] ) ) {
+				continue;
+			}
+			// check if one is null mismatch
+			if ( isNull( arguments.actual[ key ] ) OR isNull( arguments.expected[ key ] ) ) {
+				return false;
+			}
+			// And make sure they match when actual values exist
+			if ( !equalize( arguments.actual[ key ], arguments.expected[ key ] ) ) {
+				return false;
+			}
+		}
+
+		// If we made it here, we couldn't find anything different
+		return true;
+	}
+
+	private boolean function $equalizeFunctions( any expected, any actual ){
+		return arguments.actual.toString() eq arguments.expected.toString();
+	}
+
+	private boolean function $equalizeXml( any expected, any actual ){
+		return toString( arguments.actual ) eq toString( arguments.expected );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fourth burn-down wave: the procedural view templates, the test-assertion equalizer, and the scaffolded Application.cfc template.

## Before → after (cyclomatic complexity)

| File | Function | Before | After |
|---|---|---|---|
| events/onrequestend/debug.cfm | template | 64 | **max 5** (4 helpers) |
| public/views/consoleeval.cfm | template | 60 | **24** |
| public/views/mcp.cfm | template | 33 | **25** |
| public/views/plugins.cfm | template | 30 | **12** |
| public/migrator/command.cfm | template | 30 | **15** |
| events/onerror/cfmlerror.cfm | template | 34 | **max 9** (3 helpers) |
| wheelstest/system/Assertion.cfc | equalize | 46 | **19** |
| templates/app/public/Application.cfc | onRequestStart | 44 | **4** |

**vendor/wheels now has ZERO functions over complexity 50** (max is 30); ≤10 functions rose to 2,468. The CLI tree's max is 26.

## Approach

- Templates: branchy data logic extracted into local `$`-prefixed functions in the same file; the HTML markup stays byte-identical. Live-verified: debug-bar panels match the pre-change baseline, plugins headings match, console eval POST returns `{TYPE:number, RESULT:5}`, `wheels migrate info` works through the command bridge.
- `equalize`: six private type helpers; every `expect()` in the suite flows through it (model suite 979/0).
- Template Application.cfc: seven public `$`-prefixed helpers (request guards, reload gate, restart path). The onboarding harness shows the identical 34/10/3 result with the original and the refactored template — the 10 failures are pre-existing environmental (migration empty-string-default hardening vs. the harness fixture + sandbox cache denials).

## Fixes made during verification

- **`#`-escaping**: the debug-bar env-color extraction initially used single-`#` hex literals — `#` interpolates in CFScript strings too, which 500'd every page with the debug bar. Fixed to `##dc3545` etc.
- **Parity spec**: `ReloadEnvironmentSwitchParitySpec`'s environment-switch source pins now accept both the inline shape and the delegated-helper shape (computed before the gate; gate skips when already applied).

## Verification

- Local: hardener 247/0, cli 151 + parity 24/0, security 290/0, events 87/0 on a fresh server; model 979/0; debug bar/plugins/console/migrator hand-tests above.
- Both complexity gates PASS.
- CI runs the full Lucee suite + smokes on this PR.

No changelog fragment: internal refactor, no user-facing change.