### PR TITLE
fix: close out compat-matrix null params, BoxLang leg debt, and quality items

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,8 @@ The framework must run on Lucee 5/6/7, Adobe CF 2018/2021/2023/2025, and BoxLang
 
     The same torn-down-scope rule applies to `onSessionEnd()`. Adobe's `SessionTracker.SessionCleanUpAgent` can call it after the live application scope is already reclaimed, so bare `application.wo.$simpleLock` throws the same `Element wo is undefined...` error. Route through `arguments.applicationScope.wo` and guard with `StructKeyExists(arguments.applicationScope, "wo")` only — this path uses `$simpleLock`, not `$include`, so do not add the `wheels` / `eventPath` checks used by `onApplicationEnd()`. Existing 4.0.x apps must paste the same edit into their own `public/Application.cfc`.
 
+20. **BoxLang's `DirectoryList()` returns a fixed-size array — `ArrayAppend` on it throws with NO message.** The exception surfaces as an `Error`-status spec with an empty `failMessage`/`failDetail`, and TestBox blames the closure's first line rather than the append. Copy into a fresh array before appending: `var files = []; for (var f in DirectoryList(...)) { ArrayAppend(files, f); }`. Iterating the result directly (`for (var f in DirectoryList(...))`) is fine. Hit by `BareCfabortGuardSpec` (Aug 29 matrix dispatch — BoxLang mysql+sqlite legs). Also note BoxLang's loose `==` coerces boolean-ish strings numerically — `"1" == "yes"` and `"0" == "no"` are TRUE, and `ListFindNoCase("yes,no", "1")` returns 1 / `("yes,no", "0")` returns 2 for the same reason. Use `CompareNoCase(a, b) == 0` (or `Compare`) for string equality decisions; hit by `QuoteValueSpec`.
+
 Verify Adobe CF fixes locally before pushing — don't iterate via CI:
 ```bash
 curl -s "http://localhost:62023/wheels/core/tests?db=mysql&format=json" | \

--- a/changelog.d/matrix-nullparams-boxlang.fixed.md
+++ b/changelog.d/matrix-nullparams-boxlang.fixed.md
@@ -1,0 +1,3 @@
+- Fixed the remaining compatibility-matrix failures: `IS NULL` / `IS NOT NULL` and null parameters now render as inline SQL NULL on every engine (PostgreSQL, CockroachDB, and SQL Server rejected the bound-parameter form), Adobe CF no longer binds SQL NULL for `"Null"`-valued string properties, and BoxLang legs no longer fail on boolean quoting, `DirectoryList` array appends, apostrophe values in `seedOnce`, or channel event ordering (microsecond `createdAt` precision).
+- `JobWorker.getMonitorData().oldestPending` now always returns a CFML date, including on Adobe CF + SQLite where the driver returns epoch-millis longs.
+- The onboarding harness and the tutorial docs no longer use `default=""` on string columns, matching the empty-string-default hardening.

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -571,40 +571,32 @@ component extends="modules.BaseModule" {
 	 * `wheels generate MODEL User` behaving identically to `model`.
 	 */
 	private any function $generateDispatch(required string type, required array remaining) {
-		switch (lCase(arguments.type)) {
+		var canonical = $canonicalGeneratorType(lCase(arguments.type));
+
+		switch (canonical) {
 			case "app":
-			case "a":
 				// Delegate to wheels new — pass remaining args as __arguments
 				__arguments = arguments.remaining;
 				return new();
 			case "model":
-			case "m":
 				return generateModel(arguments.remaining);
 			case "controller":
-			case "c":
 				return generateController(arguments.remaining);
 			case "view":
-			case "v":
 				return generateView(arguments.remaining);
 			case "migration":
-			case "migrate":
 				return generateMigration(arguments.remaining);
 			case "scaffold":
-			case "s":
 				return generateScaffold(arguments.remaining);
 			case "api-resource":
-			case "api":
 				return generateApiResource(arguments.remaining);
 			case "route":
-			case "r":
 				return generateRoute(arguments.remaining);
 			case "test":
 				return generateTest(arguments.remaining);
 			case "property":
-			case "prop":
 				return generateProperty(arguments.remaining);
 			case "helper":
-			case "h":
 				return generateHelper(arguments.remaining);
 			case "policy":
 				return generatePolicy(arguments.remaining);
@@ -619,6 +611,27 @@ component extends="modules.BaseModule" {
 				out("Run 'wheels generate' for available types.");
 				// throw maps to non-zero exit; return "" would silently succeed.
 				throw(type = "Wheels.InvalidArguments", message = "Unknown generator type: #arguments.type#");
+		}
+	}
+
+	/**
+	 * Normalize a generator type (or its single-letter alias) to its canonical
+	 * handler key so $generateDispatch can switch over the 15 real generators
+	 * instead of 25 type+alias labels.
+	 */
+	private string function $canonicalGeneratorType(required string type) {
+		switch (arguments.type) {
+			case "a": return "app";
+			case "m": return "model";
+			case "c": return "controller";
+			case "v": return "view";
+			case "migrate": return "migration";
+			case "s": return "scaffold";
+			case "api": return "api-resource";
+			case "r": return "route";
+			case "prop": return "property";
+			case "h": return "helper";
+			default: return arguments.type;
 		}
 	}
 
@@ -2816,24 +2829,24 @@ component extends="modules.BaseModule" {
 			return $packagesHelp();
 		}
 
-		switch (sub) {
+		return $dispatchPackages(sub, positional, opts);
+	}
+
+	/**
+	 * Dispatch a `wheels packages` subcommand to the matching Packages CLI.
+	 * opts is mutated in place (by struct reference) so the caller's options
+	 * carry the resolved query/name/target before the CLI sees them.
+	 */
+	private any function $dispatchPackages(required string sub, required array positional, required struct opts) {
+		switch (arguments.sub) {
 			case "list":
-				var mainCli = new modules.wheels.services.packages.PackagesMainCli();
-				return mainCli.list(opts);
+				return $packagesMainCli().list(arguments.opts);
 			case "search":
-				if (arrayLen(positional) < 2) {
-					throw(message="search requires a query: wheels packages search <query>");
-				}
-				opts.query = positional[2];
-				var mainCli = new modules.wheels.services.packages.PackagesMainCli();
-				return mainCli.search(opts);
+				arguments.opts.query = $packagesRequireArg(arguments.positional, "search requires a query: wheels packages search <query>");
+				return $packagesMainCli().search(arguments.opts);
 			case "show":
-				if (arrayLen(positional) < 2) {
-					throw(message="show requires a name: wheels packages show <name>");
-				}
-				opts.name = positional[2];
-				var mainCli = new modules.wheels.services.packages.PackagesMainCli();
-				return mainCli.show(opts);
+				arguments.opts.name = $packagesRequireArg(arguments.positional, "show requires a name: wheels packages show <name>");
+				return $packagesMainCli().show(arguments.opts);
 			case "install":
 				// LuCLI's built-in extension installer intercepts the
 				// literal verb `install` on the user-facing CLI surface
@@ -2849,36 +2862,51 @@ component extends="modules.BaseModule" {
 				// Fall through to the `add` branch (same validation,
 				// same error shape, same install behavior).
 			case "add":
-				if (arrayLen(positional) < 2) {
-					throw(message="add requires a name: wheels packages add <name>[@<version>]");
-				}
-				opts.target = positional[2];
-				var mainCli = new modules.wheels.services.packages.PackagesMainCli();
-				return mainCli.add(opts);
+				arguments.opts.target = $packagesRequireArg(arguments.positional, "add requires a name: wheels packages add <name>[@<version>]");
+				return $packagesMainCli().add(arguments.opts);
 			case "update":
-				opts.target = arrayLen(positional) >= 2 ? positional[2] : "";
-				var mainCli = new modules.wheels.services.packages.PackagesMainCli();
-				return mainCli.update(opts);
+				arguments.opts.target = arrayLen(arguments.positional) >= 2 ? arguments.positional[2] : "";
+				return $packagesMainCli().update(arguments.opts);
 			case "remove":
-				if (arrayLen(positional) < 2) {
-					throw(message="remove requires a name: wheels packages remove <name>");
-				}
-				opts.target = positional[2];
-				var mainCli = new modules.wheels.services.packages.PackagesMainCli();
-				return mainCli.remove(opts);
+				arguments.opts.target = $packagesRequireArg(arguments.positional, "remove requires a name: wheels packages remove <name>");
+				return $packagesMainCli().remove(arguments.opts);
 			case "registry":
-				if (arrayLen(positional) < 2) {
-					throw(message="wheels packages registry requires a verb (refresh or info)");
-				}
-				var regVerb = positional[2];
-				if (!listFindNoCase("refresh,info", regVerb)) {
-					throw(message="Unknown wheels packages registry verb: #regVerb#");
-				}
-				var regCli = new modules.wheels.services.packages.PackagesRegistryCli();
-				return invoke(regCli, regVerb, [opts]);
+				return $dispatchPackagesRegistry(arguments.positional, arguments.opts);
 			default:
-				throw(message="Unknown packages subcommand: #sub#. The install verb is `add` (not `install`): wheels packages add <name>");
+				throw(message="Unknown packages subcommand: #arguments.sub#. The install verb is `add` (not `install`): wheels packages add <name>");
 		}
+	}
+
+	/**
+	 * Return a fresh PackagesMainCli for a single subcommand dispatch.
+	 */
+	private any function $packagesMainCli() {
+		return new modules.wheels.services.packages.PackagesMainCli();
+	}
+
+	/**
+	 * Return positional[2] or throw the verb's missing-argument message.
+	 */
+	private string function $packagesRequireArg(required array positional, required string message) {
+		if (arrayLen(arguments.positional) < 2) {
+			throw(message = arguments.message);
+		}
+		return arguments.positional[2];
+	}
+
+	/**
+	 * Dispatch the `registry` sub-verb (refresh|info) to PackagesRegistryCli.
+	 */
+	private any function $dispatchPackagesRegistry(required array positional, required struct opts) {
+		if (arrayLen(arguments.positional) < 2) {
+			throw(message="wheels packages registry requires a verb (refresh or info)");
+		}
+		var regVerb = arguments.positional[2];
+		if (!listFindNoCase("refresh,info", regVerb)) {
+			throw(message="Unknown wheels packages registry verb: #regVerb#");
+		}
+		var regCli = new modules.wheels.services.packages.PackagesRegistryCli();
+		return invoke(regCli, regVerb, [arguments.opts]);
 	}
 
 	// Hand-written help for `wheels packages`. Owned by the module rather than
@@ -4706,44 +4734,11 @@ component extends="modules.BaseModule" {
 		// here didn't honor (#3080).
 		var mutatingAction = listFindNoCase("latest,up,down", arguments.action) > 0;
 
-		var serverPort = 0;
-		if (mutatingAction) {
-			serverPort = $requireRunningServer(
-				hints = [
-					"Migrations require a running server bound to this project.",
-					"Set 'port' in lucee.json (or PORT in .env), then start with: wheels start"
-				],
-				requireProjectConfig = true
-			);
-		} else {
-			serverPort = $requireRunningServer(
-				hints = ["Start one with: wheels start"],
-				requireProjectConfig = false
-			);
-			// Transparency for the fallback attach: with no project-bound port
-			// we cannot prove the server on a common port belongs to this
-			// project — a sibling app's server would report the WRONG
-			// project's migration state. Say which port we attached to and
-			// how to pin it.
-			if (!detectServerPort(requireProjectConfig = true)) {
-				out(
-					"Attached to localhost:#serverPort# via the common-port fallback (no project-bound port in lucee.json / .env).",
-					"yellow"
-				);
-				out("If this is not this project's server, set 'port' in lucee.json (or PORT in .env) and re-run.", "yellow");
-			}
-		}
+		var serverPort = $resolveMigrationServerPort(mutatingAction);
 
 		out("Running migration: #action#...", "cyan");
 
-		var command = "";
-		switch (action) {
-			case "latest": command = "migrateToLatest"; break;
-			case "up":     command = "migrateUp"; break;
-			case "down":   command = "migrateDown"; break;
-			case "info":   command = "info"; break;
-			case "doctor": command = "doctor"; break;
-		}
+		var command = $migrationCommand(action);
 
 		var migrateUrl = "http://localhost:#serverPort#/wheels/cli?command=#command#&format=json";
 
@@ -4796,6 +4791,55 @@ component extends="modules.BaseModule" {
 			out("Migration #action# completed.", color);
 		}
 
+		return "";
+	}
+
+	/**
+	 * Resolve the server to target for a migration run. Schema-mutating
+	 * actions (latest/up/down) require a server bound to this project's own
+	 * port; read-only actions (info/doctor) keep the common-port fallback.
+	 */
+	private numeric function $resolveMigrationServerPort(required boolean mutatingAction) {
+		if (arguments.mutatingAction) {
+			return $requireRunningServer(
+				hints = [
+					"Migrations require a running server bound to this project.",
+					"Set 'port' in lucee.json (or PORT in .env), then start with: wheels start"
+				],
+				requireProjectConfig = true
+			);
+		}
+
+		var serverPort = $requireRunningServer(
+			hints = ["Start one with: wheels start"],
+			requireProjectConfig = false
+		);
+		// Transparency for the fallback attach: with no project-bound port
+		// we cannot prove the server on a common port belongs to this
+		// project — a sibling app's server would report the WRONG
+		// project's migration state. Say which port we attached to and
+		// how to pin it.
+		if (!detectServerPort(requireProjectConfig = true)) {
+			out(
+				"Attached to localhost:#serverPort# via the common-port fallback (no project-bound port in lucee.json / .env).",
+				"yellow"
+			);
+			out("If this is not this project's server, set 'port' in lucee.json (or PORT in .env) and re-run.", "yellow");
+		}
+		return serverPort;
+	}
+
+	/**
+	 * Map a migration action to its /wheels/cli bridge command.
+	 */
+	private string function $migrationCommand(required string action) {
+		switch (arguments.action) {
+			case "latest": return "migrateToLatest";
+			case "up": return "migrateUp";
+			case "down": return "migrateDown";
+			case "info": return "info";
+			case "doctor": return "doctor";
+		}
 		return "";
 	}
 
@@ -4909,14 +4953,10 @@ component extends="modules.BaseModule" {
 
 		var parsed = isJSON(httpResult) ? deserializeJSON(httpResult) : {};
 		var success = parsed.success ?: false;
-		var message = parsed.message ?: "";
 		var renameResult = parsed.renameResult ?: {renamed: [], errors: [], sql: [], skipped: ""};
 
 		if (!success) {
-			out("Rename failed.", "red");
-			for (var err in (renameResult.errors ?: [])) {
-				out("  #err#", "red");
-			}
+			$printRenameFailures(renameResult);
 			return "";
 		}
 
@@ -4928,24 +4968,48 @@ component extends="modules.BaseModule" {
 
 		// Dry-run path: print SQL.
 		if (arguments.dryRun) {
-			if (ArrayLen(renameResult.sql ?: [])) {
-				out("Would execute:");
-				for (var sql in renameResult.sql) {
-					out("  " & sql, "cyan");
-				}
-			}
+			$printRenameDryRunSql(renameResult);
 			return "";
 		}
 
 		// Success path: print what was renamed.
+		$printRenameSuccess(renameResult);
+
+		return "";
+	}
+
+	/**
+	 * Print the rename failure summary (plus any per-table errors).
+	 */
+	private void function $printRenameFailures(required struct renameResult) {
+		out("Rename failed.", "red");
+		for (var err in (arguments.renameResult.errors ?: [])) {
+			out("  #err#", "red");
+		}
+	}
+
+	/**
+	 * Print the dry-run SQL preview.
+	 */
+	private void function $printRenameDryRunSql(required struct renameResult) {
+		if (ArrayLen(arguments.renameResult.sql ?: [])) {
+			out("Would execute:");
+			for (var sql in arguments.renameResult.sql) {
+				out("  " & sql, "cyan");
+			}
+		}
+	}
+
+	/**
+	 * Print the success summary (tables renamed + the cosmetic FK-name note).
+	 */
+	private void function $printRenameSuccess(required struct renameResult) {
 		out("Renamed:", "green");
-		for (var rename in (renameResult.renamed ?: [])) {
+		for (var rename in (arguments.renameResult.renamed ?: [])) {
 			out("  " & rename, "green");
 		}
 		out("");
 		out("Note: the foreign-key constraint name is still `fk_core_level`. Constraint names are scoped to their table and only rename via DROP/CREATE; this is cosmetic and will not affect functionality.", "yellow");
-
-		return "";
 	}
 
 	// ── Seed Execution ──────────────────────────────
@@ -8554,23 +8618,7 @@ component extends="modules.BaseModule" {
 		var specs = arguments.suite.specStats ?: [];
 		for (var sp in specs) {
 			if (listFindNoCase("Failed,Error", sp.status ?: "")) {
-				arguments.ctx.failureCount++;
-				out("  #sp.status ?: ''#: #sp.name ?: 'unknown'#", "red");
-				var msg = sp.failMessage ?: "";
-				if (len(msg)) {
-					// Print failMessage by default. Without --verbose
-					// truncate to 400 chars (enough to see the
-					// assertion + selector context). With --verbose
-					// dump the whole thing.
-					var shown = arguments.ctx.verbose ? msg : left(msg, 400);
-					out("    #shown#", "yellow");
-					if (!arguments.ctx.verbose && len(msg) > 400) {
-						out("    (truncated; pass --verbose for full output)", "yellow");
-					}
-				}
-				if (len(sp.failOrigin ?: "")) {
-					out("    at: #sp.failOrigin#", "yellow");
-				}
+				$browserPrintSpecFailure(sp, arguments.ctx);
 			}
 		}
 		// Suite-level errors (no spec ever ran — e.g. compile error,
@@ -8579,19 +8627,53 @@ component extends="modules.BaseModule" {
 			arrayIsEmpty(specs)
 			&& listFindNoCase("Failed,Error", arguments.suite.status ?: "")
 		) {
-			arguments.ctx.failureCount++;
-			out("  #arguments.suite.status#: #arguments.suite.name ?: '(unnamed suite)'# (suite-level)", "red");
-			var sg = arguments.suite.globalException ?: "";
-			if (len(sg)) {
-				var shown = arguments.ctx.verbose ? sg : left(sg, 400);
-				out("    #shown#", "yellow");
-				if (!arguments.ctx.verbose && len(sg) > 400) {
-					out("    (truncated; pass --verbose for full output)", "yellow");
-				}
-			}
+			$browserPrintSuiteFailure(arguments.suite, arguments.ctx);
 		}
 		for (var inner in (arguments.suite.suiteStats ?: [])) {
 			$browserWalkSuite(inner, arguments.ctx);
+		}
+	}
+
+	/**
+	 * Print one failed/error spec and bump the shared failure counter.
+	 */
+	private void function $browserPrintSpecFailure(required any sp, required struct ctx) {
+		arguments.ctx.failureCount++;
+		out("  #arguments.sp.status ?: ''#: #arguments.sp.name ?: 'unknown'#", "red");
+		var msg = arguments.sp.failMessage ?: "";
+		if (len(msg)) {
+			$browserPrintFailureDetail(msg, arguments.ctx.verbose);
+		}
+		if (len(arguments.sp.failOrigin ?: "")) {
+			out("    at: #arguments.sp.failOrigin#", "yellow");
+		}
+	}
+
+	/**
+	 * Print a suite-level error (no spec ever ran) and bump the shared counter.
+	 */
+	private void function $browserPrintSuiteFailure(required any suite, required struct ctx) {
+		arguments.ctx.failureCount++;
+		out("  #arguments.suite.status#: #arguments.suite.name ?: '(unnamed suite)'# (suite-level)", "red");
+		var sg = arguments.suite.globalException ?: "";
+		if (len(sg)) {
+			$browserPrintFailureDetail(sg, arguments.ctx.verbose);
+		}
+	}
+
+	/**
+	 * Print a failure message, truncated to 400 chars unless verbose. Kept as a
+	 * helper because the spec-failure and suite-failure paths share this exact
+	 * truncate-and-annotate shape.
+	 */
+	private void function $browserPrintFailureDetail(required string message, required boolean verbose) {
+		// Print failMessage by default. Without --verbose truncate to 400
+		// chars (enough to see the assertion + selector context). With
+		// --verbose dump the whole thing.
+		var shown = arguments.verbose ? arguments.message : left(arguments.message, 400);
+		out("    #shown#", "yellow");
+		if (!arguments.verbose && len(arguments.message) > 400) {
+			out("    (truncated; pass --verbose for full output)", "yellow");
 		}
 	}
 

--- a/tools/rustcfml/baseline.json
+++ b/tools/rustcfml/baseline.json
@@ -1,9 +1,9 @@
 {
   "engineVersion": "v0.635.2",
   "totals": {
-    "totalSpecs": 5354,
-    "totalPass": 5250,
-    "totalFail": 24,
+    "totalSpecs": 5375,
+    "totalPass": 5272,
+    "totalFail": 23,
     "totalError": 58,
     "totalSkipped": 22
   },
@@ -13,7 +13,6 @@
     "wheels.tests.specs.channel.ChannelHardenerSpec :: S5 memory lastEventId replay :: returns an empty array when lastEventId is the newest event",
     "wheels.tests.specs.dispatch.setCorsHeadersSpec :: B3 $setCORSHeaders default is deny-all :: does not emit Access-Control-Allow-Origin=* when allowOrigin is the empty default",
     "wheels.tests.specs.global.GlobalHardenerSpec :: B3 $setCORSHeaders default allowOrigin is deny-all, not Origin=* :: does not emit Access-Control-Allow-Origin=* on the default call",
-    "wheels.tests.specs.global.GlobalSurfaceIdentitySpec :: Global.cfc public mixin surface (issue #3241) :: invalid-request guard is deeper than the front controller, not the include file",
     "wheels.tests.specs.global.reloadGlobalsSpec :: Reload \u2014 global includes mtime tracking (issue #2792) :: $globalIncludesChanged returns false when no files changed",
     "wheels.tests.specs.global.reloadGlobalsSpec :: Reload \u2014 global includes mtime tracking (issue #2792) :: $globalIncludesChanged returns true when a new cfm file appears",
     "wheels.tests.specs.global.reloadGlobalsSpec :: Reload \u2014 global includes mtime tracking (issue #2792) :: $globalIncludesChanged returns true when a tracked cfm file is modified",

--- a/tools/test-onboarding.sh
+++ b/tools/test-onboarding.sh
@@ -496,8 +496,8 @@ component extends="wheels.migrator.Migration" hint="Create posts table" {
         transaction {
             try {
                 t = createTable(name="posts");
-                t.string(columnNames="title", default="", allowNull=true, limit=255);
-                t.text(columnNames="body", default="", allowNull=true);
+                t.string(columnNames="title", allowNull=true, limit=255);
+                t.text(columnNames="body", allowNull=true);
                 t.string(columnNames="status", default="draft", allowNull=false, limit=20);
                 t.datetime(columnNames="publishedAt", allowNull=true);
                 t.timestamps();

--- a/vendor/wheels/JobWorker.cfc
+++ b/vendor/wheels/JobWorker.cfc
@@ -304,7 +304,15 @@ component {
 			local.oldestSql &= " ORDER BY createdAt ASC";
 			local.oldestRow = queryExecute(local.oldestSql, local.oldestParams, {datasource = variables.$datasource, maxrows = 1});
 			if (local.oldestRow.recordCount) {
-				local.result.oldestPending = local.oldestRow.createdAt;
+				// This reads through a raw queryExecute, so the Wheels adapter's
+				// date canonicalization never runs. Adobe's JDBC driver returns
+				// timestamp columns as epoch-millis longs (java.lang.Long) on
+				// SQLite — normalize them so the public oldestPending contract
+				// is always a CFML date. Lucee/MySQL/etc. return real date
+				// objects, which IsNumeric() leaves untouched.
+				local.result.oldestPending = IsNumeric(local.oldestRow.createdAt)
+					? DateAdd("s", Int(local.oldestRow.createdAt / 1000), CreateDate(1970, 1, 1))
+					: local.oldestRow.createdAt;
 			}
 		} catch (any e) {
 			// Ignore

--- a/vendor/wheels/channel/DatabaseAdapter.cfc
+++ b/vendor/wheels/channel/DatabaseAdapter.cfc
@@ -288,10 +288,20 @@ component {
 				local.varcharType = "VARCHAR";
 				local.textType = "CLOB";
 				local.datetimeType = "TIMESTAMP";
+			} else if (local.dbType == "sqlserver") {
+				local.varcharType = "VARCHAR";
+				local.textType = "TEXT";
+				local.datetimeType = "DATETIME2";
 			} else {
 				local.varcharType = "VARCHAR";
 				local.textType = "TEXT";
-				local.datetimeType = "DATETIME";
+				// DATETIME(6): sub-second precision so poll() can order events
+				// by createdAt deterministically. Plain DATETIME keeps only
+				// second precision — two publishes within the same second tie,
+				// and the (channel, createdAt) index then falls back to
+				// primary-key (UUID) order, which is arbitrary (BoxLang legs
+				// observed the reversal; Lucee/Adobe were just lucky).
+				local.datetimeType = "DATETIME(6)";
 			}
 
 			queryExecute("

--- a/vendor/wheels/databaseAdapters/Base.cfc
+++ b/vendor/wheels/databaseAdapters/Base.cfc
@@ -27,19 +27,17 @@ component output=false extends="wheels.Global"{
 				if (isStruct(part)) {
 					local.qp = $queryParams(part);
 
-					// The literal string "null" after IS / IS NOT stays a bound
-					// parameter. Do not coerce that string to SQL NULL. A missing
-					// value (cfqueryparam null=true, or a CFML/Java null) is a
-					// different thing and must still bind as SQL NULL.
+					// A missing value (unquoted NULL keyword after IS / IS NOT,
+					// cfqueryparam null=true, or a CFML/Java null) renders as the
+					// inline SQL NULL literal — never as a bound parameter.
+					// PostgreSQL, CockroachDB, and SQL Server all reject a bound
+					// parameter in `IS $1` position ("syntax error at or near
+					// "$1""), and `= $1` with a NULL parameter silently matches
+					// nothing on most engines. The quoted literal 'null' is a
+					// different thing: it has qp.null=false and stays a bound
+					// string parameter in the normal branch below.
 					if (structKeyExists(qp, "null") && qp.null) {
-						if (args.parameterize) {
-							if (!structKeyExists(qp, "value") || IsNull(qp.value) || !Len(ToString(qp.value))) {
-								qp.value = "";
-							}
-							cfqueryParam(attributeCollection = qp);
-						} else {
-							writeOutput("NULL");
-						}
+						writeOutput("NULL");
 					} else if (structKeyExists(qp, "list")) {
 						writeOutput("(");
 						if (args.parameterize) {
@@ -613,7 +611,7 @@ component output=false extends="wheels.Global"{
 		if (
 			!ListFindNoCase("integer,float,boolean", arguments.type)
 			|| !Len(arguments.str)
-			|| (arguments.type == "boolean" && ListFindNoCase("yes,no", arguments.str))
+			|| (arguments.type == "boolean" && (CompareNoCase(arguments.str, "yes") == 0 || CompareNoCase(arguments.str, "no") == 0))
 		) {
 			local.rv = "'#Replace(arguments.str, "'", "''", "all")#'";
 		} else {

--- a/vendor/wheels/model/sql.cfc
+++ b/vendor/wheels/model/sql.cfc
@@ -1212,10 +1212,19 @@ component {
 							local.processedValue = Mid(local.processedValue, 2, Len(local.processedValue) - 2);
 						}
 						if (Find("'", local.processedValue) > 0 || Find(Chr(34), local.processedValue) > 0) {
-							local.cleanedValue = local.processedValue;							
-							local.cleanedValue = ReReplace(local.cleanedValue, "'([^']*)'", "\1", "ALL");
+							local.cleanedValue = local.processedValue;
+							// Unquote token delimiters only: fold quote-comma-quote
+							// separators into plain commas first (IN-lists), then strip
+							// one pair of outer quotes. The previous `'([^']*)'`
+							// regex-strip ate inner apostrophes — "O'Brien" came back
+							// as "OBrien" with a leaked trailing quote.
+							local.cleanedValue = ReReplace(local.cleanedValue, "'\s*,\s*'", ",", "ALL");
 							local.doubleQuote = Chr(34);
-							local.cleanedValue = ReReplace(local.cleanedValue, "#local.doubleQuote#([^#local.doubleQuote#]*)#local.doubleQuote#", "\1", "ALL");
+							local.cleanedValue = ReReplace(local.cleanedValue, "#local.doubleQuote#\s*,\s*#local.doubleQuote#", ",", "ALL");
+							local.cleanedValue = ReReplace(local.cleanedValue, "^'", "", "ONE");
+							local.cleanedValue = ReReplace(local.cleanedValue, "'$", "", "ONE");
+							local.cleanedValue = ReReplace(local.cleanedValue, "^#local.doubleQuote#", "", "ONE");
+							local.cleanedValue = ReReplace(local.cleanedValue, "#local.doubleQuote#$", "", "ONE");
 							ArrayAppend(local.originalValues, local.cleanedValue);
 						} else {
 							ArrayAppend(local.originalValues, local.processedValue);

--- a/vendor/wheels/public/mcp/McpServer.cfc
+++ b/vendor/wheels/public/mcp/McpServer.cfc
@@ -366,91 +366,11 @@ component output="false" displayName="MCP Server" {
 		}
 
 		local.uri = arguments.params.uri;
-		local.content = "";
 
 		try {
-			switch (local.uri) {
-				// Documentation chunks
-				case "wheels://docs/manifest":
-					local.content = fetchFromAIEndpoint("/wheels/ai?mode=manifest");
-					break;
-				case "wheels://docs/models":
-					local.content = fetchFromAIEndpoint("/wheels/ai?mode=chunk&id=models");
-					break;
-				case "wheels://docs/controllers":
-					local.content = fetchFromAIEndpoint("/wheels/ai?mode=chunk&id=controllers");
-					break;
-				case "wheels://docs/views":
-					local.content = fetchFromAIEndpoint("/wheels/ai?mode=chunk&id=views");
-					break;
-				case "wheels://docs/migrations":
-					local.content = fetchFromAIEndpoint("/wheels/ai?mode=chunk&id=migrations");
-					break;
-				case "wheels://docs/routing":
-					local.content = fetchFromAIEndpoint("/wheels/ai?mode=chunk&id=routing");
-					break;
-				case "wheels://docs/testing":
-					local.content = fetchFromAIEndpoint("/wheels/ai?mode=chunk&id=testing");
-					break;
-				case "wheels://docs/cli":
-					local.content = fetchFromAIEndpoint("/wheels/ai?mode=chunk&id=cli");
-					break;
-				case "wheels://docs/patterns":
-					local.content = fetchFromAIEndpoint("/wheels/ai?mode=chunk&id=patterns");
-					break;
-				// Project analysis
-				case "wheels://project/context":
-					local.content = fetchFromAIEndpoint("/wheels/ai?mode=project");
-					break;
-				case "wheels://project/routes":
-					local.content = fetchFromAIEndpoint("/wheels/ai?mode=routes");
-					break;
-				case "wheels://project/migrations":
-					local.content = fetchFromAIEndpoint("/wheels/ai?mode=migrations");
-					break;
-				case "wheels://project/plugins":
-					local.content = fetchFromAIEndpoint("/wheels/ai?mode=plugins");
-					break;
-				case "wheels://project/info":
-					local.content = fetchFromAIEndpoint("/wheels/ai?mode=info");
-					break;
-				// Full documentation
-				case "wheels://api/full":
-					local.content = fetchFromAIEndpoint("/wheels/api?format=json");
-					break;
-				case "wheels://guides/all":
-					local.content = fetchFromAIEndpoint("/wheels/guides?format=json");
-					break;
-				// .ai folder documentation
-				case "wheels://.ai/overview":
-					local.content = readAIDocumentation("README.md");
-					break;
-				case "wheels://.ai/cfml/syntax":
-					local.content = aggregateAIDocumentation(".ai/cfml/syntax/");
-					break;
-				case "wheels://.ai/cfml/best-practices":
-					local.content = aggregateAIDocumentation(".ai/cfml/best-practices/");
-					break;
-				case "wheels://.ai/wheels/models":
-					local.content = aggregateAIDocumentation(".ai/wheels/database/");
-					break;
-				case "wheels://.ai/wheels/controllers":
-					local.content = aggregateAIDocumentation(".ai/wheels/controllers/");
-					break;
-				case "wheels://.ai/wheels/views":
-					local.content = aggregateAIDocumentation(".ai/wheels/views/");
-					break;
-				case "wheels://.ai/wheels/patterns":
-					local.content = aggregateAIDocumentation(".ai/wheels/patterns/");
-					break;
-				case "wheels://.ai/wheels/snippets":
-					local.content = aggregateAIDocumentation(".ai/wheels/snippets/");
-					break;
-				case "wheels://.ai/wheels/security":
-					local.content = aggregateAIDocumentation(".ai/wheels/security/");
-					break;
-				default:
-					return createErrorResponse({"id": arguments.id}, -32602, "Invalid params", "Unknown resource URI: #local.uri#");
+			local.content = $fetchResourceContent(local.uri);
+			if (isNull(local.content)) {
+				return createErrorResponse({"id": arguments.id}, -32602, "Invalid params", "Unknown resource URI: #local.uri#");
 			}
 
 			// Determine correct mime type based on URI
@@ -472,6 +392,67 @@ component output="false" displayName="MCP Server" {
 		} catch (any e) {
 			return createErrorResponse({"id": arguments.id}, -32603, "Internal error", "Failed to read resource: #e.message#");
 		}
+	}
+
+	/**
+	 * Resolve a `wheels://` resource URI to its content. Returns javaCast("null", "")
+	 * for an unknown URI so the caller can emit the -32602 "Unknown resource URI"
+	 * error without tripping the -32603 internal-error catch above.
+	 */
+	private any function $fetchResourceContent(required string uri) {
+		local.handlers = $resourceHandlers();
+		if (!structKeyExists(local.handlers, arguments.uri)) {
+			return javaCast("null", "");
+		}
+
+		local.handler = local.handlers[arguments.uri];
+		if (local.handler.kind == "fetch") {
+			return fetchFromAIEndpoint(local.handler.target);
+		}
+		if (local.handler.kind == "read") {
+			return readAIDocumentation(local.handler.target);
+		}
+		return aggregateAIDocumentation(local.handler.target);
+	}
+
+	/**
+	 * URI → {kind, target} dispatch table for resources/read. Data, not code:
+	 * kind selects the fetch helper (fetch = fetchFromAIEndpoint, read =
+	 * readAIDocumentation, aggregate = aggregateAIDocumentation) so the read
+	 * handler stays decision-light.
+	 */
+	private struct function $resourceHandlers() {
+		return {
+			// Documentation chunks
+			"wheels://docs/manifest": {kind: "fetch", target: "/wheels/ai?mode=manifest"},
+			"wheels://docs/models": {kind: "fetch", target: "/wheels/ai?mode=chunk&id=models"},
+			"wheels://docs/controllers": {kind: "fetch", target: "/wheels/ai?mode=chunk&id=controllers"},
+			"wheels://docs/views": {kind: "fetch", target: "/wheels/ai?mode=chunk&id=views"},
+			"wheels://docs/migrations": {kind: "fetch", target: "/wheels/ai?mode=chunk&id=migrations"},
+			"wheels://docs/routing": {kind: "fetch", target: "/wheels/ai?mode=chunk&id=routing"},
+			"wheels://docs/testing": {kind: "fetch", target: "/wheels/ai?mode=chunk&id=testing"},
+			"wheels://docs/cli": {kind: "fetch", target: "/wheels/ai?mode=chunk&id=cli"},
+			"wheels://docs/patterns": {kind: "fetch", target: "/wheels/ai?mode=chunk&id=patterns"},
+			// Project analysis
+			"wheels://project/context": {kind: "fetch", target: "/wheels/ai?mode=project"},
+			"wheels://project/routes": {kind: "fetch", target: "/wheels/ai?mode=routes"},
+			"wheels://project/migrations": {kind: "fetch", target: "/wheels/ai?mode=migrations"},
+			"wheels://project/plugins": {kind: "fetch", target: "/wheels/ai?mode=plugins"},
+			"wheels://project/info": {kind: "fetch", target: "/wheels/ai?mode=info"},
+			// Full documentation
+			"wheels://api/full": {kind: "fetch", target: "/wheels/api?format=json"},
+			"wheels://guides/all": {kind: "fetch", target: "/wheels/guides?format=json"},
+			// .ai folder documentation
+			"wheels://.ai/overview": {kind: "read", target: "README.md"},
+			"wheels://.ai/cfml/syntax": {kind: "aggregate", target: ".ai/cfml/syntax/"},
+			"wheels://.ai/cfml/best-practices": {kind: "aggregate", target: ".ai/cfml/best-practices/"},
+			"wheels://.ai/wheels/models": {kind: "aggregate", target: ".ai/wheels/database/"},
+			"wheels://.ai/wheels/controllers": {kind: "aggregate", target: ".ai/wheels/controllers/"},
+			"wheels://.ai/wheels/views": {kind: "aggregate", target: ".ai/wheels/views/"},
+			"wheels://.ai/wheels/patterns": {kind: "aggregate", target: ".ai/wheels/patterns/"},
+			"wheels://.ai/wheels/snippets": {kind: "aggregate", target: ".ai/wheels/snippets/"},
+			"wheels://.ai/wheels/security": {kind: "aggregate", target: ".ai/wheels/security/"}
+		};
 	}
 
 	private any function handleToolsList(required struct params, required string sessionId, required any id) {

--- a/vendor/wheels/tests/specs/security/BareCfabortGuardSpec.cfc
+++ b/vendor/wheels/tests/specs/security/BareCfabortGuardSpec.cfc
@@ -46,7 +46,12 @@ component extends="wheels.WheelsTest" {
 
 				var selfName = "BareCfabortGuardSpec.cfc";
 				var root = ExpandPath("/wheels");
-				var files = DirectoryList(root, true, "path", "*.cfc");
+				// Copy into a fresh array: BoxLang returns a fixed-size array from
+				// DirectoryList() and ArrayAppend on it throws with no message.
+				var files = [];
+				for (var listedFile in DirectoryList(root, true, "path", "*.cfc")) {
+					ArrayAppend(files, listedFile);
+				}
 				// Script-context includes compiled into Global.cfc (issue ##3241)
 				// are not `.cfc` files but must obey the same bare-cfabort ban.
 				var globalIncludes = DirectoryList(root & "/global", false, "path", "*.cfm");

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/tutorial/02-first-model.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/tutorial/02-first-model.mdx
@@ -114,8 +114,8 @@ The generator already wrote a migration for you with `title` and `body` columns.
            transaction {
                try {
                    t = createTable(name="posts");
-                   t.string(columnNames="title", default="", allowNull=true, limit=255);
-                   t.text(columnNames="body", default="", allowNull=true);
+                   t.string(columnNames="title", allowNull=true, limit=255);
+                   t.text(columnNames="body", allowNull=true);
                    t.string(columnNames="status", default="draft", allowNull=false, limit=20);
                    t.datetime(columnNames="publishedAt", allowNull=true);
                    t.timestamps();

--- a/web/sites/guides/src/content/docs/v4-0-0/start-here/tutorial/05-comments-streams.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/start-here/tutorial/05-comments-streams.mdx
@@ -123,7 +123,7 @@ On the post show page, a form at the bottom posts to a nested route, `/posts/:po
                try {
                    t = createTable(name="comments");
                    t.integer(columnNames="postId", allowNull=false);
-                   t.string(columnNames="author", default="", allowNull=false, limit=80);
+                   t.string(columnNames="author", allowNull=false, limit=80);
                    t.text(columnNames="body", allowNull=false);
                    t.timestamps();
                    t.create();


### PR DESCRIPTION
## Summary

Closes out the remaining compat-matrix debt from the post-merge dispatch, plus the quality items from the campaign list. Target: every non-Oracle, non-RustCFML matrix leg green.

## Fixes

**Null-parameter binding (item 1)** — `Base.$executeQuery` rendered missing values as a bound `cfqueryparam`, and PostgreSQL/CockroachDB/SQL Server reject a bound parameter in `IS $1` position (5 errors per leg on every engine). Missing values now render as the inline SQL NULL literal; the quoted string `'null'` still binds as a string.

**BoxLang leg debt (item 3)** — three engine quirks fixed:
- `$quoteValue`: BoxLang's loose `==` coerces `"1" == "yes"` / `"0" == "no"` to true — boolean yes/no detection now uses `CompareNoCase`.
- `$addWhereClauseParameters`: the BoxLang branch regex-stripped quote pairs, mangling apostrophes (`O'Brien` → `OBrien'`) so `seedOnce` created duplicates — now unquotes only token delimiters.
- `BareCfabortGuardSpec`: BoxLang's `DirectoryList()` returns a fixed-size array; `ArrayAppend` throws silently — copy into a fresh array first.

**Job monitor B3 (item 2)** — Adobe's SQLite driver returns timestamp columns as epoch-millis longs; `getMonitorData().oldestPending` now normalizes them so the public contract is always a CFML date.

**Channel poll ordering** — MySQL `DATETIME` keeps only second precision; two same-second publishes tie and fall back to UUID primary-key order (arbitrary; BoxLang legs reversed). `wheels_events.createdAt` is now `DATETIME(6)` / `DATETIME2` for new tables.

**Complexity polish (item 8)** — `handleResourcesRead` 30→6, `$generateDispatch` 26→16, `$browserWalkSuite` 22→10, `packages` 20→5, `runMigration` 20→13, `runRenameSystemTables` 20→12; both gates green; CLI suite 1198/0/0.

**Onboarding harness (item 10)** — removed `default=""` from the harness migration fixture and the ch02/ch05 tutorial docs (matching the empty-string-default hardening); harness now 45 pass / 0 fail.

**RustCFML (item 5)** — regenerated `tools/rustcfml/baseline.json` (35 known-failing entries on v0.635.2; the lane failed only because ~21 new specs were added after the last regen).

**Documented** (items 4/6/7): Oracle column remains soft-fail (tracked #2663); the macOS-only artifacts (bind-mount symlink delete, case-insensitive miscased path) are local-environment, not CI; the missing `junit-lucee7` artifact was a transient CI infra race (its job died at "Start all databases" before tests ran). CLAUDE.md gains invariant 20 (BoxLang `DirectoryList` fixed-size array + loose `==` coercion).

## Verification

- Adobe 2023 + PostgreSQL: model area 984/0/0 · Lucee 7 + PostgreSQL: 984/0/0
- BoxLang (SQLite): database 105/0/0, security 290/0/0, jobs 86/0/0, seeder 44/0/0; BoxLang + MySQL: channel 43/0/0
- Lucee 7: database 105/0/0, channel (MySQL) 43/0/0
- CLI suite 1198/0/0; both complexity gates PASS; onboarding harness 45/0
