### PR TITLE
fix(test,cli,ci): clear the CI-linux RustCFML failures and promote the engine leg to PR CI

### DIFF
--- a/.github/workflows/rustcfml-ci.yml
+++ b/.github/workflows/rustcfml-ci.yml
@@ -1,0 +1,52 @@
+name: RustCFML
+
+# JVM-free RustCFML engine leg on pull requests and develop pushes.
+#
+# Runs the core suite against the engine pinned in tools/rustcfml/ENGINE_VERSION
+# and compares failures against tools/rustcfml/baseline.json: the leg fails only
+# on NEW failures (or a totals regression), so upstream engine bugs tracked in
+# the baseline do not block work. To bump the pin: update ENGINE_VERSION, run
+#   bash tools/rustcfml/run-suite.sh --write-baseline
+# on Linux, and commit both files together.
+
+on:
+  pull_request:
+    paths:
+      - "vendor/wheels/**"
+      - "app/**"
+      - "config/**"
+      - "cli/**"
+      - "tools/rustcfml/**"
+      - ".github/workflows/rustcfml-ci.yml"
+  push:
+    branches: [develop]
+    paths:
+      - "vendor/wheels/**"
+      - "app/**"
+      - "config/**"
+      - "cli/**"
+      - "tools/rustcfml/**"
+      - ".github/workflows/rustcfml-ci.yml"
+
+jobs:
+  rustcfml:
+    name: "RustCFML (Linux)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+
+      - name: Read pinned engine version
+        id: engine
+        run: echo "version=$(tr -d '[:space:]' < tools/rustcfml/ENGINE_VERSION)" >> $GITHUB_OUTPUT
+
+      - name: Cache engine binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/wheels-rustcfml
+          key: rustcfml-${{ steps.engine.outputs.version }}-linux-x86_64
+
+      - name: Run core suite against pinned RustCFML
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash tools/rustcfml/run-suite.sh

--- a/cli/lucli/services/packages/Installer.cfc
+++ b/cli/lucli/services/packages/Installer.cfc
@@ -84,8 +84,14 @@ component {
 			DirectoryCreate(local.vendorDir, true);
 		}
 
-		// Download to a temp file.
-		local.tmpFile = GetTempDirectory() & "wheels-pkg-" & CreateUUID() & ".tar.gz";
+		// Download to a temp file. Normalize the separator: engines differ on
+		// whether GetTempDirectory() carries a trailing slash (RustCFML does
+		// not), and a bare concatenation would target the filesystem root.
+		local.tmpDir = GetTempDirectory();
+		if (Right(local.tmpDir, 1) != "/" && Right(local.tmpDir, 1) != "\") {
+			local.tmpDir &= "/";
+		}
+		local.tmpFile = local.tmpDir & "wheels-pkg-" & CreateUUID() & ".tar.gz";
 		try {
 			variables.http.download(arguments.version.tarball, local.tmpFile);
 

--- a/tools/rustcfml/baseline.json
+++ b/tools/rustcfml/baseline.json
@@ -2,30 +2,12 @@
   "engineVersion": "v0.635.2",
   "totals": {
     "totalSpecs": 5375,
-    "totalPass": 5332,
+    "totalPass": 5350,
     "totalFail": 1,
-    "totalError": 20,
+    "totalError": 2,
     "totalSkipped": 22
   },
   "failing": [
-    "wheels.tests.specs.cli.RewriteConfigInstallerSpec :: cli.lucli.services.RewriteConfigInstaller :: emits a rewrite.config that passes 3.x-convention static-asset dirs through to the default servlet",
-    "wheels.tests.specs.cli.RewriteConfigInstallerSpec :: cli.lucli.services.RewriteConfigInstaller :: emits a rewrite.config using positive-match [L]-flagged passthrough rules, not negated RewriteCond chains",
-    "wheels.tests.specs.cli.RewriteConfigInstallerSpec :: cli.lucli.services.RewriteConfigInstaller :: is a no-op when the project already ships its own rewrite.config (idempotent)",
-    "wheels.tests.specs.cli.RewriteConfigInstallerSpec :: cli.lucli.services.RewriteConfigInstaller :: returns installed=false with a reason when the source template can't be read",
-    "wheels.tests.specs.cli.RewriteConfigInstallerSpec :: cli.lucli.services.RewriteConfigInstaller :: writes the project-level rewrite.config when the project doesn't have one",
-    "wheels.tests.specs.controller.miscellaneousSpec :: Tests that sendfile :: does not rewrite an absolute directory containing the '/wheels' substring",
-    "wheels.tests.specs.controller.miscellaneousSpec :: Tests that sendfile :: serves a file from an absolute directory outside the web root",
-    "wheels.tests.specs.migrator.migrationSpec :: Tests addIndex :: creates an index on multiple columns",
-    "wheels.tests.specs.packages.LoadRegistryPackagesSpec :: Public.$loadRegistryPackages :: captures registry errors into the error field without throwing",
-    "wheels.tests.specs.packages.LoadRegistryPackagesSpec :: Public.$loadRegistryPackages :: lets non-Wheels.Packages errors bubble up as real bugs",
-    "wheels.tests.specs.packages.LoadRegistryPackagesSpec :: Public.$loadRegistryPackages :: returns empty packages and no error in staging (gate allows development only)",
-    "wheels.tests.specs.packages.LoadRegistryPackagesSpec :: Public.$loadRegistryPackages :: returns empty packages and no error when environment is production",
-    "wheels.tests.specs.packages.LoadRegistryPackagesSpec :: Public.$loadRegistryPackages :: returns packages from the registry in development",
-    "wheels.tests.specs.packages.ManifestCacheEnsureDirSpec :: ManifestCache directory creation :: creates deeply nested cache directories whose parents do not yet exist",
-    "wheels.tests.specs.packages.ManifestCacheEnsureDirSpec :: ManifestCache directory creation :: creates the manifests subdirectory when only the root exists",
-    "wheels.tests.specs.packages.RegistryFetchManifestSpec :: Registry.fetchManifest validation :: listAll() skips a malformed manifest instead of crashing",
-    "wheels.tests.specs.packages.RegistryFetchManifestSpec :: Registry.fetchManifest validation :: rejects a stale on-disk cache entry that fails the versions invariant (B's nuance)",
-    "wheels.tests.specs.wheelstest.BrowserTestArtifactDirSpec :: BrowserTest artifact directory creation :: creates deeply nested artifact directories whose parents do not yet exist (regression #2614)",
-    "wheels.tests.specs.wheelstest.BrowserTestArtifactDirSpec :: BrowserTest artifact directory creation :: is a no-op when the artifact directory already exists"
+    "wheels.tests.specs.migrator.migrationSpec :: Tests addIndex :: creates an index on multiple columns"
   ]
 }

--- a/tools/rustcfml/run-suite.sh
+++ b/tools/rustcfml/run-suite.sh
@@ -97,11 +97,16 @@ except Exception as exc:
 totals = {k: int(data.get(k, 0)) for k in
           ("totalSpecs", "totalPass", "totalFail", "totalError", "totalSkipped")}
 
-failing = set()
+failing = {}
 def walk(node, bundle, path):
     for spec in node.get("specStats", []):
         if spec.get("status") not in ("Passed", "Skipped"):
-            failing.add(f"{bundle} :: {path} :: {spec.get('name', '?')}")
+            key = f"{bundle} :: {path} :: {spec.get('name', '?')}"
+            failing[key] = {
+                "status": spec.get("status", "?"),
+                "message": str(spec.get("failMessage") or "").replace("\n", " | "),
+                "detail": str(spec.get("failDetail") or "").replace("\n", " | "),
+            }
     for nested in node.get("nestedSuiteStats", []) or []:
         walk(nested, bundle, f"{path} > {nested.get('name', '?')}")
 
@@ -109,7 +114,11 @@ for b in data.get("bundleStats", []):
     name = b.get("name", "?")
     ge = b.get("globalException") or {}
     if isinstance(ge, dict) and ge.get("message"):
-        failing.add(f"{name} :: (bundle-level exception)")
+        failing[f"{name} :: (bundle-level exception)"] = {
+            "status": "Exception",
+            "message": str(ge.get("message") or "").replace("\n", " | "),
+            "detail": str(ge.get("detail") or "").replace("\n", " | "),
+        }
     for su in b.get("suiteStats", []):
         walk(su, name, su.get("name", "?"))
 
@@ -127,7 +136,7 @@ if mode == "write":
     payload = {
         "engineVersion": version,
         "totals": totals,
-        "failing": sorted(failing),
+        "failing": sorted(failing.keys()),
     }
     with open(baseline_path, "w") as fh:
         json.dump(payload, fh, indent=2)
@@ -142,8 +151,8 @@ except Exception:
     sys.exit(1)
 
 known = set(baseline.get("failing", []))
-new = sorted(failing - known)
-fixed = sorted(known - failing)
+new = sorted(failing.keys() - known)
+fixed = sorted(known - failing.keys())
 
 # Coarse totals backstop: the failing[] walk only sees per-spec entries and
 # bundle-level exceptions, so a regression surfacing through a response shape
@@ -164,7 +173,15 @@ if fixed:
     summary_lines.append("  (baseline can be refreshed with --write-baseline)")
 if new:
     summary_lines.append(f"NEW FAILURES vs baseline ({len(new)}):")
-    summary_lines += [f"  - {item}" for item in new]
+    for item in new:
+        summary_lines.append(f"  - {item}")
+        info = failing.get(item, {})
+        msg = info.get("message", "")
+        if msg:
+            summary_lines.append(f"      [{info.get('status', '?')}] {msg[:400]}")
+        detail = info.get("detail", "")
+        if detail and detail != msg:
+            summary_lines.append(f"      detail: {detail[:400]}")
 if totals_worse:
     summary_lines.append("TOTALS REGRESSION vs baseline (no named entry — check response shape):")
     summary_lines += [f"  - {item}" for item in totals_worse]

--- a/tools/rustcfml/run-suite.sh
+++ b/tools/rustcfml/run-suite.sh
@@ -171,6 +171,15 @@ if fixed:
     summary_lines.append(f"NEWLY PASSING vs baseline ({len(fixed)}):")
     summary_lines += [f"  + {item}" for item in fixed]
     summary_lines.append("  (baseline can be refreshed with --write-baseline)")
+if failing:
+    known_now = sorted(failing.keys())
+    summary_lines.append(f"FAILING SPECS (all {len(known_now)}):")
+    for item in known_now:
+        summary_lines.append(f"  * {item}")
+        info = failing.get(item, {})
+        msg = info.get("message", "")
+        if msg:
+            summary_lines.append(f"      [{info.get('status', '?')}] {msg[:400]}")
 if new:
     summary_lines.append(f"NEW FAILURES vs baseline ({len(new)}):")
     for item in new:

--- a/vendor/wheels/WheelsTest.cfc
+++ b/vendor/wheels/WheelsTest.cfc
@@ -78,6 +78,24 @@ component extends="wheels.wheelstest.system.BaseSpec" {
     }
 
     /**
+     * Join a suffix onto the engine's temp directory with the separator
+     * normalized. RustCFML's GetTempDirectory() omits the trailing slash
+     * (Lucee and Adobe include it), so a bare concatenation produces a path
+     * at the filesystem root on Linux — `/tmpwheels-…` instead of
+     * `/tmp/wheels-…` — and every file operation fails with a permission
+     * error. Use this helper for BOTH construction and cleanup so the
+     * RemoveChars/Replace sweeps in specs' finally blocks key on the same
+     * normalized form.
+     */
+    public string function $tempPath(required string suffix) {
+        local.tmp = GetTempDirectory();
+        if (Right(local.tmp, 1) != "/" && Right(local.tmp, 1) != "\") {
+            local.tmp &= "/";
+        }
+        return local.tmp & arguments.suffix;
+    }
+
+    /**
      * Return a configured TestClient instance.
      * The base URL is auto-detected from the current server port.
      *

--- a/vendor/wheels/tests/specs/cli/RewriteConfigInstallerSpec.cfc
+++ b/vendor/wheels/tests/specs/cli/RewriteConfigInstallerSpec.cfc
@@ -32,7 +32,7 @@ component extends="wheels.WheelsTest" {
 
 			it("writes the project-level rewrite.config when the project doesn't have one", () => {
 				var installer = new cli.lucli.services.RewriteConfigInstaller();
-				var projectRoot = getTempDirectory() & "wheels-rewriteinstaller-#createUUID()#";
+				var projectRoot = $tempPath("wheels-rewriteinstaller-#createUUID()#");
 				directoryCreate(projectRoot);
 				try {
 					expect(fileExists(projectRoot & "/rewrite.config")).toBeFalse(
@@ -54,7 +54,7 @@ component extends="wheels.WheelsTest" {
 
 			it("is a no-op when the project already ships its own rewrite.config (idempotent)", () => {
 				var installer = new cli.lucli.services.RewriteConfigInstaller();
-				var projectRoot = getTempDirectory() & "wheels-rewriteinstaller-#createUUID()#";
+				var projectRoot = $tempPath("wheels-rewriteinstaller-#createUUID()#");
 				directoryCreate(projectRoot);
 				try {
 					fileWrite(projectRoot & "/rewrite.config", "## user-customized rules");
@@ -82,7 +82,7 @@ component extends="wheels.WheelsTest" {
 
 			it("emits a rewrite.config that passes 3.x-convention static-asset dirs through to the default servlet", () => {
 				var installer = new cli.lucli.services.RewriteConfigInstaller();
-				var projectRoot = getTempDirectory() & "wheels-rewriteinstaller-#createUUID()#";
+				var projectRoot = $tempPath("wheels-rewriteinstaller-#createUUID()#");
 				directoryCreate(projectRoot);
 				try {
 					installer.install(projectRoot=projectRoot, sourceTemplate=ctx.templatePath);
@@ -117,7 +117,7 @@ component extends="wheels.WheelsTest" {
 				// every static file 404s. The fix is positive-match skip
 				// rules with the [L] flag.
 				var installer = new cli.lucli.services.RewriteConfigInstaller();
-				var projectRoot = getTempDirectory() & "wheels-rewriteinstaller-#createUUID()#";
+				var projectRoot = $tempPath("wheels-rewriteinstaller-#createUUID()#");
 				directoryCreate(projectRoot);
 				try {
 					installer.install(projectRoot=projectRoot, sourceTemplate=ctx.templatePath);
@@ -147,7 +147,7 @@ component extends="wheels.WheelsTest" {
 
 			it("returns installed=false with a reason when the source template can't be read", () => {
 				var installer = new cli.lucli.services.RewriteConfigInstaller();
-				var projectRoot = getTempDirectory() & "wheels-rewriteinstaller-#createUUID()#";
+				var projectRoot = $tempPath("wheels-rewriteinstaller-#createUUID()#");
 				directoryCreate(projectRoot);
 				try {
 					var missing = getTempDirectory() & "wheels-no-such-template-#createUUID()#.config";

--- a/vendor/wheels/tests/specs/controller/miscellaneousSpec.cfc
+++ b/vendor/wheels/tests/specs/controller/miscellaneousSpec.cfc
@@ -212,7 +212,7 @@ component extends="wheels.WheelsTest" {
 				// https://github.com/wheels-dev/wheels/issues/3077 — an absolute `directory`
 				// outside the web root must be used verbatim, not re-resolved via ExpandPath
 				// (which web-root-prefixes the path on Adobe CF).
-				local.outsideDir = GetTempDirectory() & "dlprobe3077_outside"
+				local.outsideDir = $tempPath("dlprobe3077_outside")
 				if (!DirectoryExists(local.outsideDir)) {
 					// Adobe CF's DirectoryCreate accepts exactly one parameter (the extra
 					// createPath boolean is Lucee-only) and rejects extras at COMPILE time,
@@ -243,7 +243,7 @@ component extends="wheels.WheelsTest" {
 				// https://github.com/wheels-dev/wheels/issues/3077 — the `/wheels` mapping
 				// fallback substring-matched ANY absolute path containing "/wheels"
 				// (e.g. /var/www/wheels/uploads), silently rewriting it.
-				local.wheelsDir = GetTempDirectory() & "wheels3077-dl"
+				local.wheelsDir = $tempPath("wheels3077-dl")
 				if (!DirectoryExists(local.wheelsDir)) {
 					// Single-argument form only: the createPath boolean is Lucee-only and
 					// Adobe rejects it at compile time (crashes the whole bundle).

--- a/vendor/wheels/tests/specs/packages/LoadRegistryPackagesSpec.cfc
+++ b/vendor/wheels/tests/specs/packages/LoadRegistryPackagesSpec.cfc
@@ -2,8 +2,12 @@ component extends="wheels.WheelsTest" {
 
 	function run() {
 		describe("Public.$loadRegistryPackages", () => {
+			// createObject (not `new`) — RustCFML's `new` operator lowercases
+			// the component name before the file lookup, which misses
+			// Public.cfc on case-sensitive filesystems (Linux); the
+			// createObject form resolves with the exact case on every engine.
 			var $newPublic = () => {
-				return new wheels.Public();
+				return createObject("component", "wheels.Public");
 			};
 
 			// Minimal fake registry that returns canned data or throws.

--- a/vendor/wheels/tests/specs/packages/ManifestCacheEnsureDirSpec.cfc
+++ b/vendor/wheels/tests/specs/packages/ManifestCacheEnsureDirSpec.cfc
@@ -13,7 +13,7 @@ component extends="wheels.WheelsTest" {
 			// multi-level parent case the BIF createPath flag was
 			// meant to cover.
 			it("creates deeply nested cache directories whose parents do not yet exist", () => {
-				var nestedRoot = GetTempDirectory() & "wheels-cache-2567-" & CreateUUID() & "/level-a/level-b/level-c/";
+				var nestedRoot = $tempPath("wheels-cache-2567-" & CreateUUID() & "/level-a/level-b/level-c/");
 				try {
 					var cache = new wheels.services.packages.ManifestCache(root = nestedRoot);
 					cache.writeIndex(["wheels-sentry"]);
@@ -23,8 +23,8 @@ component extends="wheels.WheelsTest" {
 				} finally {
 					// Walk up to the unique parent we control, so we
 					// remove only this test's tree.
-					var unique = ListFirst(Replace(nestedRoot, GetTempDirectory(), ""), "/");
-					var sweep = GetTempDirectory() & unique;
+					var unique = ListFirst(Replace(nestedRoot, $tempPath(""), ""), "/");
+					var sweep = $tempPath(unique);
 					if (DirectoryExists(sweep)) {
 						DirectoryDelete(sweep, true);
 					}
@@ -32,7 +32,7 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("creates the manifests subdirectory when only the root exists", () => {
-				var root = GetTempDirectory() & "wheels-cache-2567-" & CreateUUID() & "/";
+				var root = $tempPath("wheels-cache-2567-" & CreateUUID() & "/");
 				try {
 					var cache = new wheels.services.packages.ManifestCache(root = root);
 					cache.writeManifest("wheels-sentry", {name: "wheels-sentry", versions: [{version: "1.0.0"}]});

--- a/vendor/wheels/tests/specs/packages/RegistryFetchManifestSpec.cfc
+++ b/vendor/wheels/tests/specs/packages/RegistryFetchManifestSpec.cfc
@@ -3,7 +3,7 @@ component extends="wheels.WheelsTest" {
 	function run() {
 		describe("Registry.fetchManifest validation", () => {
 			var $freshCache = () => {
-				var root = GetTempDirectory() & "wheels-registry-" & CreateUUID() & "/";
+				var root = $tempPath("wheels-registry-" & CreateUUID() & "/");
 				return new wheels.services.packages.ManifestCache(root = root);
 			};
 

--- a/vendor/wheels/tests/specs/wheelstest/BrowserTestArtifactDirSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/BrowserTestArtifactDirSpec.cfc
@@ -5,7 +5,7 @@ component extends="wheels.WheelsTest" {
 
 			// Regression for #2614: Adobe CF rejects directoryCreate(path, true); routes through File.mkdirs() instead.
 			it("creates deeply nested artifact directories whose parents do not yet exist (regression ##2614)", () => {
-				var nestedRoot = GetTempDirectory() & "wheels-browser-2614-" & CreateUUID() & "/level-a/level-b/level-c";
+				var nestedRoot = $tempPath("wheels-browser-2614-" & CreateUUID() & "/level-a/level-b/level-c");
 				try {
 					var browserTest = new wheels.wheelstest.BrowserTest();
 					browserTest.$ensureArtifactDir(nestedRoot);
@@ -13,8 +13,8 @@ component extends="wheels.WheelsTest" {
 						"expected $ensureArtifactDir to create the nested artifact root"
 					);
 				} finally {
-					var unique = ListFirst(Replace(nestedRoot, GetTempDirectory(), ""), "/");
-					var sweep = GetTempDirectory() & unique;
+					var unique = ListFirst(Replace(nestedRoot, $tempPath(""), ""), "/");
+					var sweep = $tempPath(unique);
 					if (DirectoryExists(sweep)) {
 						DirectoryDelete(sweep, true);
 					}
@@ -22,7 +22,7 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("is a no-op when the artifact directory already exists", () => {
-				var existingDir = GetTempDirectory() & "wheels-browser-2614-" & CreateUUID();
+				var existingDir = $tempPath("wheels-browser-2614-" & CreateUUID());
 				DirectoryCreate(existingDir);
 				try {
 					var browserTest = new wheels.wheelstest.BrowserTest();


### PR DESCRIPTION
Second RustCFML round: the 18 remaining CI-linux-only lane failures are fixed and the engine leg is promoted from the weekly informational matrix to a pull-request workflow.

## Root causes found (via a diagnostic lane dispatch that dumps each failure message)

- **`GetTempDirectory()` separator (12 failures)** — RustCFML omits the trailing slash (Lucee/Adobe include it), so the specs' `GetTempDirectory() & "…"` joins targeted the filesystem root (`/tmpwheels-…`) and every file op failed with `Permission denied`. New `WheelsTest.$tempPath()` helper adopted by the CLI/packages/browser/sendfile specs (setup **and** cleanup sweeps), and the CLI package `Installer` download temp path is normalized the same way.
- **Case-sensitive `new` component lookup (5 failures)** — RustCFML's `new` operator lowercases the component name before the file lookup, so `new wheels.Public()` misses `Public.cfc` on Linux while `createObject("component", "wheels.Public")` resolves ([upstream #381](https://github.com/RustCFML/RustCFML/issues/381)). The spec now uses the resolving form.

Upstream issues filed: [#380](https://github.com/RustCFML/RustCFML/issues/380) (`GetTempDirectory` separator), [#381](https://github.com/RustCFML/RustCFML/issues/381) (`new` casing).

## CI

- `tools/rustcfml/run-suite.sh` now prints each failure's message/detail (always), so Linux-only failures are diagnosable from a dispatch.
- New `.github/workflows/rustcfml-ci.yml` runs the pinned-engine suite on PRs (paths: vendor/app/config/cli/tools) and develop pushes; it fails only on NEW failures vs the baseline.
- Baseline refreshed: **19 entries → 1** — the single remaining entry is the upstream query-of-query `recordCount` bug ([#377](https://github.com/RustCFML/RustCFML/issues/377)) exercised by the migrator's multi-column `addIndex` spec.

## Lane verification (CI-linux)

```
RustCFML v0.635.2: 5350 pass, 1 fail, 2 error, 22 skipped (1 distinct failing entry)
NEWLY PASSING vs baseline (18)
```
