### PR TITLE
ci(rustcfml): run the RustCFML leg on every PR so it can be a required check

### DIFF
--- a/.github/workflows/rustcfml-ci.yml
+++ b/.github/workflows/rustcfml-ci.yml
@@ -10,14 +10,12 @@ name: RustCFML
 # on Linux, and commit both files together.
 
 on:
+  # No path filter on pull_request: the leg is a required branch-protection
+  # check, and a path-gated required check would block merges whenever the
+  # workflow skips. The pinned-engine suite is ~2 minutes, so running it on
+  # every PR to develop is cheap.
   pull_request:
-    paths:
-      - "vendor/wheels/**"
-      - "app/**"
-      - "config/**"
-      - "cli/**"
-      - "tools/rustcfml/**"
-      - ".github/workflows/rustcfml-ci.yml"
+    branches: [develop]
   push:
     branches: [develop]
     paths:


### PR DESCRIPTION
The leg is about to become a branch-protection required check; a path-gated required check would block merges whenever the workflow skips, so run the pinned-engine suite on every PR to develop. The develop-push trigger keeps its path filter.