### PR TITLE
feat: implement the 4.x backlog — toFactory, bindBy, enableSession, migrate diff, dry-run, offline mode, doctor checks

### DIFF
--- a/changelog.d/4x-backlog-auth.added.md
+++ b/changelog.d/4x-backlog-auth.added.md
@@ -1,0 +1,1 @@
+- Added `enableSession()` — one-line session-auth wiring for `config/services.cfm`.

--- a/changelog.d/4x-backlog-cli.added.md
+++ b/changelog.d/4x-backlog-cli.added.md
@@ -1,0 +1,3 @@
+- Added `wheels migrate diff` (alias `dbmigrate diff`) — preview or `--write` AutoMigrator schema diffs with rename hints.
+- Added `wheels generate --dry-run` — print would-be generated files without writing anything.
+- Added offline mode (`--offline` / `WHEELS_OFFLINE=1`) — skips the CLI update check and fails fast on registry network calls.

--- a/changelog.d/4x-backlog-deprecations.deprecated.md
+++ b/changelog.d/4x-backlog-deprecations.deprecated.md
@@ -1,0 +1,1 @@
+- `wheels.Test` (RocketUnit) now emits a one-time deprecation warning; removal is planned for Wheels 5.0.

--- a/changelog.d/4x-backlog-infra.added.md
+++ b/changelog.d/4x-backlog-infra.added.md
@@ -1,0 +1,3 @@
+- Added `boot` deploy config section (Kamal-compatible `limit`/`wait`).
+- Added `wheels doctor` checks for legacy `wheels.Test` specs, legacy `plugins/`, and raw `params.` mass assignment.
+- Fixed the debug bar showing `0.0.0-dev` on installs where `BuildInfo.cfc` ships unstamped (now falls back to the sibling manifest version).

--- a/changelog.d/4x-backlog-routing-di.added.md
+++ b/changelog.d/4x-backlog-routing-di.added.md
@@ -1,0 +1,2 @@
+- Added `Injector.toFactory()` — bind a name to a closure that builds the instance (receives the container, honors singleton/request-scoped flags).
+- Added route `bindBy=` — bind a resource route's `:key` segment to a non-primary-key column via the parameterized dynamic finder (e.g. `bindBy="slug"`).

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -107,8 +107,16 @@ component extends="modules.BaseModule" {
 	 * into a completely different invocation.
 	 */
 	private struct function structuredArgs(struct callerArgs = {}) {
+		// Command specs set `mod.__arguments = [...]` from OUTSIDE the
+		// component, which Lucee stores on the `this` scope; internal
+		// delegation assigns the unprefixed (variables) name. Consume either
+		// shape so both callers reach the same dispatch.
 		var raw = __arguments ?: [];
+		if (!arrayLen(raw) && structKeyExists(this, "__arguments")) {
+			raw = this.__arguments;
+		}
 		__arguments = [];
+		structDelete(this, "__arguments");
 		if (!structIsEmpty(arguments.callerArgs)) {
 			return arguments.callerArgs;
 		}
@@ -2433,15 +2441,20 @@ component extends="modules.BaseModule" {
 		var positional = $deployStripFlags(args);
 		var sub = arrayLen(positional) >= 1 ? positional[1] : "deploy";
 
-		var dmc = new modules.wheels.services.deploy.cli.DeployMainCli(
-			$deployBuildSshPool(opts.configPath)
-		);
+		// DeployMainCli is constructed lazily — only the deploy/main verb
+		// family needs the SSH pool, which eagerly loads config/deploy.yml.
+		// Building it up front broke the secrets verbs (fetch/extract/print),
+		// which are config-independent, whenever no deploy.yml existed.
+		var dmc = "";
 
 		// Dispatch by verb family. Each family mirrors the exact set of case
 		// labels the previous single switch handled; case-sensitive listFind
 		// preserves the same matching semantics (`wheels deploy DEPLOY` still
 		// falls through to the throw below).
 		if (listFind("deploy,redeploy,rollback,config,init,setup,version,audit,docs,details,remove", sub)) {
+			dmc = new modules.wheels.services.deploy.cli.DeployMainCli(
+				$deployBuildSshPool(opts.configPath)
+			);
 			return $deployMain(dmc, opts, positional, sub);
 		}
 		if (listFind("app,proxy,registry,build,accessory,prune,lock", sub)) {

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -2733,6 +2733,11 @@ component extends="modules.BaseModule" {
 	 * LuCLI's picocli root.
 	 */
 	private any function $deploySecretsVerb(required struct opts, required array positional, required string sub) {
+		// Secrets resolution defaults to the module's cwd-derived project
+		// root — an explicit --projectRoot flag still wins. (Before this,
+		// the CLIs fell back to expandPath("./"), which resolves against the
+		// harness webroot rather than the user's project directory.)
+		arguments.opts.projectRoot = arguments.opts.projectRoot ?: variables.projectRoot;
 		switch (arguments.sub) {
 			case "fetch-secrets":
 				arguments.opts.keys = [];

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -255,12 +255,33 @@ component extends="modules.BaseModule" {
 			"analyze" = analyzeArgSpec().toInputSchema(),
 			"destroy" = destroyArgSpec().toInputSchema(),
 			"doctor"  = verboseFlagSpec().toInputSchema(),
+			"migrate" = migrateArgSpec().toInputSchema(),
 			"notes"   = notesArgSpec().toInputSchema(),
 			"seed"    = seedArgSpec().toInputSchema(),
 			"stats"   = verboseFlagSpec().toInputSchema(),
 			"test"    = testArgSpec().toInputSchema(),
 			"upgrade" = upgradeArgSpec().toInputSchema()
 		};
+	}
+
+	/**
+	 * ArgSpec for `wheels migrate`. Positional action covers the whole
+	 * surface (latest/up/down/info/doctor/forget/pretend/
+	 * rename-system-tables/diff); the option set describes the diff action
+	 * so MCP clients can drive schema diffs declaratively.
+	 */
+	private any function migrateArgSpec() {
+		return new services.ArgSpec()
+			.positional(name = "action", default = "latest", description = "Migration action: latest, up, down, info, doctor, forget, pretend, rename-system-tables, diff")
+			.positional(name = "version", default = "", description = "Version for forget/pretend")
+			.flag(name = "yes", default = false, description = "Confirm forget/pretend")
+			.flag(name = "dry-run", default = false, description = "Preview rename-system-tables without writing")
+			.positional(name = "model", default = "", description = "Model to diff (diff action; omit for all models)")
+			.option(name = "rename", default = "", description = "Rename hint OLD:NEW (repeatable; Model.OLD:NEW for diffAll)")
+			.option(name = "hints", default = "", description = 'Rename hints JSON ({"renames":{"old":"new"}})')
+			.option(name = "threshold", default = "", description = "Heuristic rename threshold between 0 and 1")
+			.option(name = "name", default = "", description = "Migration name when writing a single-model diff")
+			.flag(name = "write", default = false, description = "Write migration file(s) instead of previewing");
 	}
 
 	// ─────────────────────────────────────────────────
@@ -449,7 +470,7 @@ component extends="modules.BaseModule" {
 		help &= "  generate            Generate model, controller, scaffold, migration, etc." & nl;
 		help &= "  destroy (or d)      Remove generated files" & nl & nl;
 		help &= "Database:" & nl;
-		help &= "  migrate             Run database migrations (latest, up, down, info, doctor, forget, pretend, rename-system-tables)" & nl;
+		help &= "  migrate             Run database migrations (latest, up, down, info, doctor, forget, pretend, rename-system-tables, diff)" & nl;
 		help &= "  seed                Run database seeds" & nl;
 		help &= "  db                  Database management (reset, status, version)" & nl & nl;
 		help &= "Background Jobs:" & nl;
@@ -512,6 +533,26 @@ component extends="modules.BaseModule" {
 		return help;
 	}
 
+
+	/**
+	 * Dry-run-aware write for generator paths inside Module.cfc (the
+	 * migration builders and $writeGeneratedContent). Mirrors
+	 * Scaffold.cfc::$write — `wheels generate --dry-run` records the
+	 * would-be path and skips the write.
+	 */
+	private string function $generateWrite(required string path, required string content) {
+		if (request.$wheelsGenerateDryRun ?: false) {
+			arrayAppend(request.$wheelsDryRunPaths, arguments.path);
+			return arguments.path;
+		}
+		var dir = getDirectoryFromPath(arguments.path);
+		if (!directoryExists(dir)) {
+			directoryCreate(dir, true);
+		}
+		FileWrite(arguments.path, arguments.content);
+		return arguments.path;
+	}
+
 	// ─────────────────────────────────────────────────
 	//  generate — Code generation
 	// ─────────────────────────────────────────────────
@@ -527,10 +568,44 @@ component extends="modules.BaseModule" {
 			return "";
 		}
 
-		var type = args[1];
-		var remaining = args.len() > 1 ? args.slice(2) : [];
+		// --dry-run: print would-be paths and write nothing. Recognized
+		// anywhere in the argv (before or after the type/name).
+		var dryRun = false;
+		var cleaned = [];
+		for (var a in args) {
+			if (a == "--dry-run") {
+				dryRun = true;
+			} else {
+				arrayAppend(cleaned, a);
+			}
+		}
+		if (dryRun) {
+			request.$wheelsGenerateDryRun = true;
+			request.$wheelsDryRunPaths = [];
+			out("Dry run — nothing will be written.", "cyan");
+		}
 
-		return $generateDispatch(type, remaining);
+		var type = cleaned[1];
+		var remaining = arrayLen(cleaned) > 1 ? cleaned.slice(2) : [];
+
+		var result = $generateDispatch(type, remaining);
+
+		if (dryRun) {
+			var paths = request.$wheelsDryRunPaths ?: [];
+			if (arrayLen(paths)) {
+				out("");
+				out("Would create:", "bold");
+				for (var p in paths) {
+					out("  #p#");
+				}
+			} else {
+				out("(no files would be written)", "yellow");
+			}
+			structDelete(request, "$wheelsGenerateDryRun");
+			structDelete(request, "$wheelsDryRunPaths");
+		}
+
+		return result;
 	}
 
 	/**
@@ -652,7 +727,16 @@ component extends="modules.BaseModule" {
 	 */
 	public string function migrate() {
 		var args = new services.ArgSpec().toArgv(structuredArgs(arguments));
+		// --offline is a documented no-op here: migrate never makes external
+		// network calls (the bridge is localhost). Consuming the flag keeps
+		// scripts portable and future-proofs any update check added later.
+		$consumeOfflineFlag(args);
 		var action = arrayLen(args) ? lCase(args[1]) : "latest";
+		// MCP and structured callers may pass action="diff" which re-emits as
+		// --action=diff — normalize to the positional form.
+		if (left(action, 9) == "--action=") {
+			action = lCase(mid(action, 10, 9999));
+		}
 
 		switch (action) {
 			case "latest":
@@ -691,9 +775,11 @@ component extends="modules.BaseModule" {
 					out("Rename failed: #e.message#", "red");
 					rethrow;
 				}
+			case "diff":
+				return runMigrationDiff(args);
 			default:
 				out("Unknown migration action: #action#", "red");
-				out("Usage: wheels migrate [latest|up|down|info|doctor|forget|pretend|rename-system-tables]");
+				out("Usage: wheels migrate [latest|up|down|info|doctor|forget|pretend|rename-system-tables|diff]");
 				throw(type = "Wheels.InvalidArguments", message = "Unknown migration action: #action#");
 		}
 	}
@@ -2306,6 +2392,13 @@ component extends="modules.BaseModule" {
 	}
 
 	/**
+	 * hint: Alias for migrate (historical CommandBox-style name)
+	 */
+	public string function dbmigrate() {
+		return migrate(argumentCollection = arguments);
+	}
+
+	/**
 	 * hint: Alias for generate
 	 */
 	public string function g() {
@@ -2828,6 +2921,7 @@ component extends="modules.BaseModule" {
 	 */
 	public string function packages() {
 		var args = new services.ArgSpec().toArgv(structuredArgs(arguments));
+		$consumeOfflineFlag(args);
 		var opts = $packagesArgsToOptions(args);
 		var positional = $packagesStripFlags(args);
 		var sub = arrayLen(positional) >= 1 ? positional[1] : "list";
@@ -3154,6 +3248,7 @@ component extends="modules.BaseModule" {
 	 */
 	public string function db() {
 		var args = new services.ArgSpec().toArgv(structuredArgs(arguments));
+		$consumeOfflineFlag(args);
 
 		if (!arrayLen(args)) {
 			out("Usage: wheels db <command>", "yellow");
@@ -3882,7 +3977,7 @@ component extends="modules.BaseModule" {
 		// uncompilable file (literal extends="|DBMigrateExtends|"). The inline
 		// builder emits a correct extends="wheels.migrator.Migration" body and
 		// was already the path every dev-checkout install used. See CLI audit H4.
-		fileWrite(filePath, buildEmptyMigration(migrationName));
+		$generateWrite(filePath, buildEmptyMigration(migrationName));
 
 		printCreated("app/migrator/migrations/#fileName#");
 		return "";
@@ -4073,7 +4168,7 @@ component extends="modules.BaseModule" {
 
 		content &= '}' & nl;
 
-		fileWrite(migrationDir & "/" & fileName, content);
+		$generateWrite(migrationDir & "/" & fileName, content);
 		printCreated("app/migrator/migrations/#fileName#");
 		out("");
 		out("Remember to add validation in app/models/#modelName#.cfc config():", "yellow");
@@ -4628,7 +4723,7 @@ component extends="modules.BaseModule" {
 		if (!directoryExists(dir)) {
 			directoryCreate(dir, true);
 		}
-		fileWrite(fullPath, arguments.content);
+		$generateWrite(fullPath, arguments.content);
 		return arguments.relativePath;
 	}
 
@@ -5028,6 +5123,273 @@ component extends="modules.BaseModule" {
 		}
 		out("");
 		out("Note: the foreign-key constraint name is still `fk_core_level`. Constraint names are scoped to their table and only rename via DROP/CREATE; this is cosmetic and will not affect functionality.", "yellow");
+	}
+
+	// ── migrate diff (AutoMigrator schema diff) ─────
+
+	/**
+	 * Detect and consume a global `--offline` flag (or WHEELS_OFFLINE=1
+	 * environment variable): the CLI must not phone home. migrate/db accept
+	 * the flag (a no-op for their localhost bridge); new() skips its update
+	 * check; packages fails fast with a clear message.
+	 */
+	public boolean function $consumeOfflineFlag(required array args) {
+		var found = false;
+		for (var a in arguments.args) {
+			if (a == "--offline") {
+				found = true;
+				break;
+			}
+		}
+		if (found) {
+			variables.offline = true;
+		}
+		if ($isOffline()) {
+			request.$wheelsOffline = true;
+		}
+		return found;
+	}
+
+	/**
+	 * True when offline mode is active: --offline flag seen, or
+	 * WHEELS_OFFLINE=1 / true in the environment.
+	 */
+	public boolean function $isOffline() {
+		if (structKeyExists(variables, "offline") && variables.offline) {
+			return true;
+		}
+		try {
+			var env = server.system.environment.WHEELS_OFFLINE ?: "";
+			return env == "1" || compareNoCase(env, "true") == 0;
+		} catch (any e) {
+			return false;
+		}
+	}
+
+	/**
+	 * `wheels migrate diff [Model] [--rename OLD:NEW] [--hints JSON]
+	 * [--threshold 0-1] [--name migrationName] [--write]`
+	 *
+	 * Previews the schema diff between a model (or all models) and the
+	 * database via the AutoMigrator bridge. Read-only unless --write.
+	 */
+	private string function runMigrationDiff(required array args) {
+		var opts = $parseMigrateDiffArgs(args);
+
+		var serverPort = $requireRunningServer(
+			hints = [
+				"Diffing migrations requires a running server bound to this project.",
+				"Set 'port' in lucee.json (or PORT in .env), then start with: wheels start"
+			],
+			requireProjectConfig = true
+		);
+
+		out(opts.write ? "Writing migration diff..." : "Previewing migration diff...", "cyan");
+
+		var diffUrl = "http://localhost:#serverPort#/wheels/cli?command=diff&format=json" & $buildDiffBridgeUrl(opts);
+
+		var httpResult = "";
+		try {
+			httpResult = opts.write ? makeBridgePost(diffUrl) : makeHttpRequest(diffUrl);
+		} catch (any httpErr) {
+			throw(
+				type = "MigrationError",
+				message = "Diff failed (connection error): #httpErr.message#",
+				detail = httpErr.detail ?: ""
+			);
+		}
+
+		var parsed = isJSON(httpResult) ? deserializeJSON(httpResult) : {};
+		if (!(parsed.success ?: false)) {
+			out(parsed.message ?: "Diff failed.", "red");
+			return "";
+		}
+
+		$renderDiffResult(parsed, opts.write);
+		return "";
+	}
+
+	/**
+	 * Parse the `migrate diff` argv into a normalized opts struct.
+	 * Public for specs. Accepted forms:
+	 *   wheels migrate diff                          → diffAll preview
+	 *   wheels migrate diff User                     → single-model preview
+	 *   --rename OLD:NEW (repeatable)                → renames hint
+	 *   --rename User.OLD:NEW (diffAll form)         → per-model renames hint
+	 *   --hints '{"renames":{...}}'                  → raw hints JSON, merged
+	 *   --threshold 0.85 --name my_migration --write
+	 */
+	public struct function $parseMigrateDiffArgs(required array args) {
+		var rv = {
+			model = "",
+			hints = {},
+			threshold = "",
+			name = "",
+			write = false
+		};
+
+		// Positional: args[2] is the model when it isn't a flag.
+		var hasModel = false;
+		if (arrayLen(arguments.args) >= 2 && left(arguments.args[2], 2) != "--") {
+			rv.model = arguments.args[2];
+			hasModel = true;
+		}
+
+		// --rename is repeatable: --rename a b is one pair (space form) OR
+		// --rename=a:b (equals form). Collect raw tokens first.
+		var renames = [];
+		var i = hasModel ? 3 : 2;
+		while (i <= arrayLen(arguments.args)) {
+			var token = arguments.args[i];
+			if (token == "--rename" && i < arrayLen(arguments.args)) {
+				arrayAppend(renames, arguments.args[i + 1]);
+				i++;
+			} else if (left(token, 9) == "--rename=" && len(token) > 9) {
+				arrayAppend(renames, mid(token, 10, 9999));
+			} else if (left(token, 8) == "--hints=" && len(token) > 8) {
+				try {
+					var decoded = deserializeJSON(mid(token, 9, 9999));
+					if (isStruct(decoded)) {
+						structAppend(rv.hints, decoded, true);
+					}
+				} catch (any e) {
+					throw(
+						type = "Wheels.InvalidArguments",
+						message = "--hints must be valid JSON: #e.message#"
+					);
+				}
+			} else if (left(token, 12) == "--threshold=" && len(token) > 12) {
+				var threshold = mid(token, 13, 9999);
+				if (!isNumeric(threshold) || threshold < 0 || threshold > 1) {
+					throw(
+						type = "Wheels.InvalidArguments",
+						message = "--threshold must be a number between 0 and 1."
+					);
+				}
+				rv.threshold = threshold;
+			} else if (left(token, 7) == "--name=" && len(token) > 7) {
+				rv.name = mid(token, 8, 9999);
+			} else if (token == "--write") {
+				rv.write = true;
+			}
+			i++;
+		}
+
+		// Normalize the collected rename pairs into hints.renames.
+		if (arrayLen(renames)) {
+			var renamesOut = {};
+			for (var pair in renames) {
+				if (find(":", pair) == 0) {
+					throw(
+						type = "Wheels.InvalidArguments",
+						message = "Invalid --rename pair '#pair#' — expected OLD:NEW (or Model.OLD:NEW for diffAll)."
+					);
+				}
+				var oldName = trim(listFirst(pair, ":"));
+				var newName = trim(listLast(pair, ":"));
+				if (!len(oldName) || !len(newName)) {
+					throw(
+						type = "Wheels.InvalidArguments",
+						message = "Invalid --rename pair '#pair#' — expected OLD:NEW (or Model.OLD:NEW for diffAll)."
+					);
+				}
+				if (len(rv.model)) {
+					renamesOut[oldName] = newName;
+				} else if (find(".", oldName) > 0) {
+					// diffAll form: Model.OLD:NEW → hints.renames.Model.OLD = NEW
+					var modelName = trim(listFirst(oldName, "."));
+					var column = trim(listLast(oldName, "."));
+					if (!structKeyExists(renamesOut, modelName)) {
+						renamesOut[modelName] = {};
+					}
+					renamesOut[modelName][column] = newName;
+				} else {
+					renamesOut[oldName] = newName;
+				}
+			}
+			rv.hints.renames = structKeyExists(rv.hints, "renames") ? rv.hints.renames : {};
+			structAppend(rv.hints.renames, renamesOut, false);
+		}
+
+		return rv;
+	}
+
+	/**
+	 * Build the /wheels/cli query-string suffix for the diff command.
+	 * Pure string building — public for specs.
+	 */
+	public string function $buildDiffBridgeUrl(required struct opts) {
+		var query = "";
+		if (len(arguments.opts.model)) {
+			query &= "&modelName=#urlEncodedFormat(arguments.opts.model)#";
+		}
+		if (structCount(arguments.opts.hints)) {
+			query &= "&hints=#urlEncodedFormat(serializeJSON(arguments.opts.hints))#";
+		}
+		if (len(arguments.opts.threshold)) {
+			query &= "&threshold=#urlEncodedFormat(arguments.opts.threshold)#";
+		}
+		if (arguments.opts.write) {
+			query &= "&write=true";
+			if (len(arguments.opts.name)) {
+				query &= "&name=#urlEncodedFormat(arguments.opts.name)#";
+			}
+		}
+		return query;
+	}
+
+	/**
+	 * Render a diff bridge response. Human-readable column listing per
+	 * model, with a trailer when previewing.
+	 */
+	private void function $renderDiffResult(required struct parsed, required boolean write) {
+		var isSingle = structKeyExists(arguments.parsed, "model");
+		var diffs = isSingle ? { "": arguments.parsed.model } : (arguments.parsed.models ?: {});
+
+		var anyOutput = false;
+		for (var modelKey in diffs) {
+			var diff = diffs[modelKey];
+			var heading = structKeyExists(diff, "modelName") ? diff.modelName : modelKey;
+			out("");
+			out("--- #heading# ---", "bold");
+
+			for (var col in (diff.addColumns ?: [])) {
+				out("  + add    #col#", "green");
+				anyOutput = true;
+			}
+			for (var col in (diff.removeColumns ?: [])) {
+				out("  - remove #col#", "red");
+				out("      (if this is a rename, use --rename #col#:newName)", "yellow");
+				anyOutput = true;
+			}
+			for (var col in (diff.changeColumns ?: [])) {
+				out("  ~ change #col#", "yellow");
+				anyOutput = true;
+			}
+			for (var col in (diff.renameColumns ?: [])) {
+				out("  ~ rename #col#", "yellow");
+				anyOutput = true;
+			}
+			for (var suggestion in (diff.suggestedRenames ?: [])) {
+				var sugOld = suggestion.oldName ?: "?";
+				var sugNew = suggestion.newName ?: "?";
+				var sugConf = suggestion.confidence ?: "";
+				out("  ? suggest #sugOld# -> #sugNew# (#sugConf#)", "cyan");
+				anyOutput = true;
+			}
+		}
+
+		if (!anyOutput) {
+			out("No differences found — models and database are in sync.", "green");
+		}
+
+		if (!arguments.write) {
+			out("");
+			out("Preview only — pass --write to commit the migration file(s).", "yellow");
+		} else {
+			out("");
+			out("Migration file(s) written.", "green");
+		}
 	}
 
 	// ── Seed Execution ──────────────────────────────
@@ -6888,14 +7250,17 @@ component extends="modules.BaseModule" {
 		// failed/slow network check. See services/UpdateChecker.cfc for the
 		// channel-aware logic + 24h cache. Wrapped in try/catch as a final
 		// belt for any failure mode the service itself doesn't already
-		// internalize (e.g., the createObject call throwing).
+		// internalize (e.g., the createObject call throwing). Skipped
+		// entirely in offline mode (--offline / WHEELS_OFFLINE=1).
 		try {
-			var checker = new services.UpdateChecker();
-			var updateResult = checker.check(currentVersion=super.version());
-			if (updateResult.hasUpdate) {
-				out("");
-				out("A newer wheels (#updateResult.channel#) is available: #updateResult.latest# (you have #updateResult.current#)", "yellow");
-				out("  Upgrade: #updateResult.upgradeCommand#", "yellow");
+			if (!$isOffline()) {
+				var checker = new services.UpdateChecker();
+				var updateResult = checker.check(currentVersion=super.version());
+				if (updateResult.hasUpdate) {
+					out("");
+					out("A newer wheels (#updateResult.channel#) is available: #updateResult.latest# (you have #updateResult.current#)", "yellow");
+					out("  Upgrade: #updateResult.upgradeCommand#", "yellow");
+				}
 			}
 		} catch (any e) {
 			// Silently swallow — never let an update check delay or break

--- a/cli/lucli/services/CodeGen.cfc
+++ b/cli/lucli/services/CodeGen.cfc
@@ -342,8 +342,13 @@ component {
 			content &= t & t & '})' & nl;
 			content &= t & '}' & nl;
 			content &= '}' & nl;
-			fileWrite(filePath, content);
-			result = {success: true, path: filePath, message: "Generated from inline template"};
+			if (request.$wheelsGenerateDryRun ?: false) {
+				arrayAppend(request.$wheelsDryRunPaths, filePath);
+				result = {success: true, path: filePath, message: "Dry run — not written", dryRun: true};
+			} else {
+				fileWrite(filePath, content);
+				result = {success: true, path: filePath, message: "Generated from inline template"};
+			}
 		}
 
 		return result;

--- a/cli/lucli/services/Doctor.cfc
+++ b/cli/lucli/services/Doctor.cfc
@@ -31,6 +31,8 @@ component {
 		checkCliInstallFreshness(results);
 		checkFrameworkSourceBundled(results);
 		checkMixinCollisions(results);
+		checkLegacyExtensionSurface(results);
+		checkRawParamsMassAssignment(results);
 
 		// Determine overall status
 		if (arrayLen(results.issues)) {
@@ -380,6 +382,79 @@ component {
 	}
 
 	/**
+	 * Detect the legacy extension surface that 5.0 removes: tests extending
+	 * the RocketUnit-era `wheels.Test` / `wheels.Testbox` bases, and a
+	 * populated `plugins/` directory. Mirrors the `wheels upgrade check`
+	 * heuristics so `wheels doctor` surfaces the same migration guidance.
+	 *
+	 * Both are warnings, not issues — a legacy surface still works today but
+	 * must be migrated before the 5.0 removal.
+	 */
+	private void function checkLegacyExtensionSurface(required struct results) {
+		var testDir = variables.projectRoot & "/tests";
+		if (directoryExists(testDir)) {
+			var legacyTests = [];
+			var legacyBasePattern = "extends\s*=\s*[""']wheels\.Test(box)?[""']";
+			for (var filePath in directoryList(testDir, true, "path", "*.cfc")) {
+				var content = $stripCfmlComments(fileRead(filePath));
+				if (reFindNoCase(legacyBasePattern, content)) {
+					arrayAppend(legacyTests, replace(filePath, variables.projectRoot & "/", ""));
+				}
+			}
+			if (arrayLen(legacyTests)) {
+				arrayAppend(
+					arguments.results.warnings,
+					"Legacy test base class (wheels.Test / wheels.Testbox) detected: "
+					& arrayToList(legacyTests, ", ") & " — change to extends wheels.WheelsTest"
+				);
+			}
+		}
+
+		var pluginsDir = variables.projectRoot & "/plugins";
+		if (directoryExists(pluginsDir)) {
+			var childDirs = [];
+			for (var entry in directoryList(pluginsDir, false, "name")) {
+				if (directoryExists(pluginsDir & "/" & entry)) arrayAppend(childDirs, entry);
+			}
+			if (arrayLen(childDirs)) {
+				arrayAppend(
+					arguments.results.warnings,
+					"legacy plugins/ detected — migrate to vendor/ packages"
+				);
+			}
+		}
+	}
+
+	/**
+	 * Flag raw `params.*` handed straight to a mass-assignment model call —
+	 * the classic mass-assignment vector (create/update/updateAll/new/save/
+	 * findByKey with an unpermitted params struct). Scans controllers and
+	 * models; comments are stripped first (anti-pattern #14) so commented-out
+	 * lines don't produce false positives.
+	 */
+	private void function checkRawParamsMassAssignment(required struct results) {
+		var scanDirs = ["app/controllers", "app/models"];
+		var massAssignmentPattern = "\b(create|update|updateAll|new|save|findByKey)\s*\(\s*params\.";
+		for (var scanDir in scanDirs) {
+			var absDir = variables.projectRoot & "/" & scanDir;
+			if (!directoryExists(absDir)) continue;
+			for (var filePath in directoryList(absDir, true, "path", "*.cfc")) {
+				var content = $stripCfmlComments(fileRead(filePath));
+				var lines = listToArray(content, chr(10), true);
+				for (var lineNum = 1; lineNum <= arrayLen(lines); lineNum++) {
+					if (reFindNoCase(massAssignmentPattern, lines[lineNum])) {
+						var relPath = replace(filePath, variables.projectRoot & "/", "");
+						arrayAppend(
+							arguments.results.warnings,
+							"Raw params mass assignment: #relPath#:#lineNum# — #trim(lines[lineNum])#"
+						);
+					}
+				}
+			}
+		}
+	}
+
+	/**
 	 * Reads a manifest + main CFC and appends provider records keyed by target+method.
 	 *
 	 * @providerStore Out-param struct keyed "target::method" → array of records
@@ -630,6 +705,20 @@ component {
 		var s = arguments.source;
 		s = reReplace(s, "<!---[\s\S]*?--->", " ", "all");
 		s = reReplace(s, "/\*[\s\S]*?\*/", " ", "all");
+		return s;
+	}
+
+	/**
+	 * Strip ALL CFML comment forms — tag comments, block comments, AND `//`
+	 * line comments (mirrors Analysis.cfc::$stripCfmlComments). Kept separate
+	 * from $stripCfmlBlockComments() because the mixin scanner deliberately
+	 * avoids stripping `//` (it can appear inside string-literal URLs),
+	 * whereas source-grep checks like the legacy test-base scan and the raw
+	 * params scan must remove line comments too (anti-pattern #14).
+	 */
+	private string function $stripCfmlComments(required string source) {
+		var s = $stripCfmlBlockComments(arguments.source);
+		s = reReplace(s, "//[^\r\n]*", "", "all");
 		return s;
 	}
 

--- a/cli/lucli/services/Scaffold.cfc
+++ b/cli/lucli/services/Scaffold.cfc
@@ -24,6 +24,26 @@ component {
 		return this;
 	}
 
+
+	/**
+	 * Dry-run-aware file writer. `wheels generate --dry-run` sets
+	 * request.$wheelsGenerateDryRun; writes are then recorded (for the
+	 * caller to print) and skipped. Creates the parent directory on the
+	 * real path.
+	 */
+	private string function $write(required string path, required string content) {
+		if (request.$wheelsGenerateDryRun ?: false) {
+			arrayAppend(request.$wheelsDryRunPaths, arguments.path);
+			return arguments.path;
+		}
+		var dir = getDirectoryFromPath(arguments.path);
+		if (!directoryExists(dir)) {
+			directoryCreate(dir, true);
+		}
+		FileWrite(arguments.path, arguments.content);
+		return arguments.path;
+	}
+
 	/**
 	 * Generate a complete scaffold (model, controller, views, migration, tests, routes)
 	 */
@@ -308,7 +328,7 @@ component {
 
 		var content = generateMigrationContent(className, tableName, arguments.properties, arguments.primaryKey);
 		var migrationPath = migrationDir & "/" & fileName;
-		fileWrite(migrationPath, content);
+		$write(migrationPath, content);
 
 		return migrationPath;
 	}
@@ -353,7 +373,7 @@ component {
 			var fullMarker = indent & markerPattern;
 			if (find(fullMarker, content)) {
 				content = replace(content, fullMarker, indent & resourceRoute & chr(10) & fullMarker, 'all');
-				fileWrite(routesPath, content);
+				$write(routesPath, content);
 				return true;
 			}
 
@@ -362,7 +382,7 @@ component {
 				var lastEnd = content.lastIndexOf('.end()');
 				if (lastEnd >= 0) {
 					content = mid(content, 1, lastEnd) & resourceRoute & chr(10) & chr(9) & mid(content, lastEnd + 1, len(content));
-					fileWrite(routesPath, content);
+					$write(routesPath, content);
 					return true;
 				}
 			}
@@ -517,7 +537,7 @@ component {
 					var before = mid(content, 1, insertPos);
 					var after = mid(content, insertPos + 1, len(content));
 					content = before & resourceLine & nl & after;
-					fileWrite(routesPath, content);
+					$write(routesPath, content);
 					return true;
 				}
 			}
@@ -541,7 +561,7 @@ component {
 
 			if (find(fullMarker, content)) {
 				content = replace(content, fullMarker, apiBlock & fullMarker, 'all');
-				fileWrite(routesPath, content);
+				$write(routesPath, content);
 				return true;
 			}
 
@@ -555,7 +575,7 @@ component {
 					content &= t & t & '.resources(name="#resourceName#", except="new,edit")' & nl;
 					content &= t & '.end()' & nl & t;
 					content &= after;
-					fileWrite(routesPath, content);
+					$write(routesPath, content);
 					return true;
 				}
 			}
@@ -624,7 +644,7 @@ component {
 		c &= t & '}' & nl;
 		c &= '}' & nl;
 
-		fileWrite(filePath, c);
+		$write(filePath, c);
 		return {success: true, path: filePath, message: "Generated API controller test"};
 	}
 
@@ -709,7 +729,7 @@ component {
 				}
 				var migrationPath = migrationDir & "/" & variables.helpers.generateMigrationTimestamp()
 					& "_create_" & tableName & "_table.cfc";
-				fileWrite(migrationPath, $renderAuthTemplate("migration", ctx));
+				$write(migrationPath, $renderAuthTemplate("migration", ctx));
 				arrayAppend(results.generated, {type: "migration", path: migrationPath});
 				arrayAppend(results.rollback, migrationPath);
 			} else {
@@ -902,7 +922,7 @@ component {
 		if (!directoryExists(dir)) {
 			directoryCreate(dir, true);
 		}
-		fileWrite(absPath, arguments.content);
+		$write(absPath, arguments.content);
 		arrayAppend(arguments.results.generated, {type: arguments.label, path: absPath});
 		if (!existed) {
 			arrayAppend(arguments.results.rollback, absPath);
@@ -943,7 +963,7 @@ component {
 				if (!directoryExists(dir)) {
 					directoryCreate(dir, true);
 				}
-				fileWrite(absPath, scriptOpenTag & nl & $indentBlock(blockText, t) & nl & scriptCloseTag & nl);
+				$write(absPath, scriptOpenTag & nl & $indentBlock(blockText, t) & nl & scriptCloseTag & nl);
 				arrayAppend(arguments.results.generated, {type: arguments.label, path: absPath});
 				arrayAppend(arguments.results.rollback, absPath);
 				return;
@@ -975,7 +995,7 @@ component {
 			content = left(content, regionStart - 1)
 				& $indentBlock(blockText, indent) & nl
 				& mid(content, regionEnd + 1, len(content));
-			fileWrite(absPath, content);
+			$write(absPath, content);
 			arrayAppend(arguments.results.generated, {type: arguments.label, path: absPath});
 			return;
 		}
@@ -1004,7 +1024,7 @@ component {
 			content = left(content, insertLineStart - 1)
 				& $indentBlock(blockText, anchorIndent) & nl
 				& mid(content, insertLineStart, len(content));
-			fileWrite(absPath, content);
+			$write(absPath, content);
 			arrayAppend(arguments.results.generated, {type: arguments.label, path: absPath});
 			return;
 		}
@@ -1018,7 +1038,7 @@ component {
 		} else {
 			content = content & nl & scriptOpenTag & nl & $indentBlock(blockText, t) & nl & scriptCloseTag & nl;
 		}
-		fileWrite(absPath, content);
+		$write(absPath, content);
 		arrayAppend(arguments.results.generated, {type: arguments.label, path: absPath});
 	}
 

--- a/cli/lucli/services/Templates.cfc
+++ b/cli/lucli/services/Templates.cfc
@@ -49,6 +49,13 @@ component {
 
 		var destinationPath = variables.projectRoot & "/" & arguments.destination;
 
+		// Dry run (request.$wheelsGenerateDryRun set by `wheels generate
+		// --dry-run`): record the would-be path, write nothing.
+		if (request.$wheelsGenerateDryRun ?: false) {
+			arrayAppend(request.$wheelsDryRunPaths, destinationPath);
+			return {success: true, path: destinationPath, message: "Dry run — not written", dryRun: true};
+		}
+
 		// Ensure destination directory exists
 		var destinationDir = getDirectoryFromPath(destinationPath);
 		if (!directoryExists(destinationDir)) {

--- a/cli/lucli/services/deploy/config/Boot.cfc
+++ b/cli/lucli/services/deploy/config/Boot.cfc
@@ -1,0 +1,47 @@
+/**
+ * Boot — immutable accessor for the `boot:` block.
+ *
+ * Mirrors Kamal's lib/kamal/configuration/boot.rb:
+ *   limit: number of hosts (or a percentage string like "25%") to boot at a
+ *          time (default 10)
+ *   wait:  seconds to wait between host boots (default 5)
+ *
+ * Both keys are single-word (`limit`/`wait`) so there is no snake_case/
+ * camelCase split to tolerate the way Ssh.keysOnly() handles keys_only/
+ * keysOnly. The defensive coercion below (string-typed numerics, the
+ * percentage form, and invalid shapes degrading to the defaults) covers the
+ * real-world YAML variance instead.
+ */
+component {
+
+	public any function init(struct raw = {}) {
+		variables.raw = arguments.raw;
+		return this;
+	}
+
+	public numeric function limit() {
+		if (!structKeyExists(variables.raw, "limit")) return 10;
+		return $coerceNumber(variables.raw.limit, 10);
+	}
+
+	public numeric function wait() {
+		if (!structKeyExists(variables.raw, "wait")) return 5;
+		return $coerceNumber(variables.raw.wait, 5);
+	}
+
+	/**
+	 * Coerce a raw value to a non-negative count. Accepts numerics, numeric
+	 * strings, and Kamal's percentage form ("25%" → 25); anything else
+	 * returns the fallback so the accessor never throws on a malformed block.
+	 */
+	private numeric function $coerceNumber(required any value, required numeric fallback) {
+		if (isNumeric(arguments.value)) return arguments.value;
+		if (isSimpleValue(arguments.value)) {
+			var s = trim(arguments.value);
+			if (len(s) && right(s, 1) == "%") s = left(s, len(s) - 1);
+			if (len(s) && isNumeric(s)) return s;
+		}
+		return arguments.fallback;
+	}
+
+}

--- a/cli/lucli/services/deploy/config/Config.cfc
+++ b/cli/lucli/services/deploy/config/Config.cfc
@@ -70,6 +70,13 @@ component {
 		return new Ssh(s);
 	}
 
+	public any function boot() {
+		var b = (structKeyExists(variables.raw, "boot") && isStruct(variables.raw.boot))
+			? variables.raw.boot
+			: {};
+		return new Boot(b);
+	}
+
 	public array function roles() {
 		var servers = variables.raw.servers;
 

--- a/cli/lucli/services/deploy/config/Validator.cfc
+++ b/cli/lucli/services/deploy/config/Validator.cfc
@@ -14,12 +14,12 @@ component {
 	public any function init() {
 		// Only keys the runtime actually reads (Config.cfc accessors + the
 		// commands/ consumers behind them). Keys Kamal supports but this port
-		// doesn't implement yet (boot, logging, retain_containers, hooks, …)
-		// are deliberately ABSENT so they fail loudly instead of being
+		// doesn't implement yet (logging, retain_containers, hooks, …) are
+		// deliberately ABSENT so they fail loudly instead of being
 		// accepted-and-ignored (##3088).
 		variables.allowedKeys = [
 			"service", "image", "servers", "registry", "builder", "env",
-			"ssh", "proxy", "accessories"
+			"ssh", "proxy", "boot", "accessories"
 		];
 		// Pre-build a case-insensitive struct lookup so the hot path doesn't
 		// depend on arrayContainsNoCase (not available on every engine).
@@ -48,6 +48,7 @@ component {
 		// validated rather than quoted (##2956).
 		$validateName(arguments.parsed.service, "service", arguments.filePath);
 		$validateServers(arguments.parsed.servers, arguments.filePath);
+		$validateBoot(arguments.parsed, arguments.filePath);
 		if (structKeyExists(arguments.parsed, "accessories") && isStruct(arguments.parsed.accessories)) {
 			for (var accName in arguments.parsed.accessories) {
 				$validateName(accName, "accessory", arguments.filePath);
@@ -68,6 +69,37 @@ component {
 					for (var host in entry.hosts) $validateHost(host, arguments.filePath);
 				}
 			}
+		}
+	}
+
+	/**
+	 * Validate the `boot:` block. `limit` accepts a non-negative number or a
+	 * Kamal percentage string ("25%"); `wait` is a non-negative number of
+	 * seconds. A non-struct `boot` value is left to the Config accessor's
+	 * default-{} handling rather than rejected here.
+	 */
+	public void function $validateBoot(required struct parsed, required string filePath) {
+		if (!structKeyExists(arguments.parsed, "boot")) return;
+		var boot = arguments.parsed.boot;
+		if (!isStruct(boot)) return;
+		if (structKeyExists(boot, "limit")) $validateBootNumber(boot.limit, "boot.limit", arguments.filePath);
+		if (structKeyExists(boot, "wait")) $validateBootNumber(boot.wait, "boot.wait", arguments.filePath);
+	}
+
+	public void function $validateBootNumber(required any value, required string key, required string filePath) {
+		var ok = false;
+		if (isNumeric(arguments.value)) {
+			ok = arguments.value >= 0;
+		} else if (isSimpleValue(arguments.value)) {
+			var s = trim(arguments.value);
+			if (len(s) && right(s, 1) == "%") s = left(s, len(s) - 1);
+			ok = len(s) && isNumeric(s) && val(s) >= 0;
+		}
+		if (!ok) {
+			$raise(
+				arguments.filePath,
+				"invalid #arguments.key#: '#arguments.value#' (must be a non-negative number or percentage)"
+			);
 		}
 	}
 

--- a/cli/lucli/services/packages/Registry.cfc
+++ b/cli/lucli/services/packages/Registry.cfc
@@ -39,6 +39,22 @@ component {
 		return variables.cache;
 	}
 
+
+	/**
+	 * Offline gate for network paths. `wheels packages` sets
+	 * request.$wheelsOffline when --offline / WHEELS_OFFLINE=1 is active;
+	 * cached reads still work, fresh fetches fail fast with a clear
+	 * message instead of hanging on a blocked request.
+	 */
+	private void function $rejectWhenOffline(required string verb) {
+		if (request.$wheelsOffline ?: false) {
+			Throw(
+				type = "Wheels.Packages.Offline",
+				message = "Offline mode is enabled (--offline / WHEELS_OFFLINE=1) — the package registry requires network access. Cached registry data is still available."
+			);
+		}
+	}
+
 	/**
 	 * Returns the list of package names in the registry. Serves cached
 	 * data if fresh; otherwise hits the GitHub contents API.
@@ -47,6 +63,7 @@ component {
 		if (variables.cache.hasFreshIndex()) {
 			return variables.cache.readIndex();
 		}
+		$rejectWhenOffline("list");
 		local.url = "https://api.github.com/repos/#variables.registryRepo#/contents/packages?ref=#variables.branch#";
 		local.resp = variables.http.get(local.url);
 		if (local.resp.status != 200) {
@@ -85,6 +102,7 @@ component {
 			$validateManifest(arguments.name, local.cached);
 			return local.cached;
 		}
+		$rejectWhenOffline("fetch");
 		local.url = "https://raw.githubusercontent.com/#variables.registryRepo#/#variables.branch#/packages/#arguments.name#/manifest.json";
 		local.resp = variables.http.get(local.url);
 		if (local.resp.status == 404) {

--- a/cli/lucli/templates/app/app/mailers/README.md
+++ b/cli/lucli/templates/app/app/mailers/README.md
@@ -1,34 +1,54 @@
 # app/mailers/
 
-Components that send email. Each mailer is a `.cfc` extending `Mailer`.
+Components that send email. Mailers are **plain CFCs** — there is no
+framework base class — that wrap the controller's `sendEmail()` behind a
+named method.
 
-## Quick start
+Because `sendEmail()` is a controller function (it needs a
+request-capable controller instance with a `params` struct), each mailer
+method obtains one through the `controller()` factory:
 
-Generate one:
-
-```bash
-wheels generate mailer WelcomeMailer welcome
+```cfm
+component {
+    public any function sendWelcome(required any user) {
+        local.mailer = new wheels.Global().controller(
+            name = "Mailer",
+            params = { controller: "mailer", action: "sendWelcome" }
+        );
+        return local.mailer.sendEmail(
+            template = "/mailers/user/welcome",
+            from = "noreply@example.com",
+            to = arguments.user.email,
+            subject = "Welcome, #arguments.user.firstName#!",
+            user = arguments.user
+        );
+    }
+}
 ```
 
-Creates:
-- `app/mailers/WelcomeMailer.cfc` — the mailer definition
-- `app/views/welcomemailer/welcome.cfm` — the email body template
+Send from a controller:
 
-A mailer action sets headers (`this.from`, `this.to`, `this.subject`) and hands rendering to the matching view.
-
-Send from a controller with `sendMail(mailer="WelcomeMailer", method="welcome", user=user)`.
+```cfm
+new app.mailers.UserMailer().sendWelcome(user);
+```
 
 ## Configuration
 
-SMTP settings live in `config/settings.cfm`:
+SMTP settings live in `config/settings.cfm` as `sendEmail` function
+defaults (Wheels does not define a `mailerSettings` struct):
 
 ```cfm
-set(mailerSettings = {
-    server: "smtp.example.com",
-    port: 587,
-    username: "you@example.com",
-    password: application.wo.env("SMTP_PASSWORD")
-});
+set(
+    functionName = "sendEmail",
+    server = "smtp.example.com",
+    port = 587,
+    useTLS = true,
+    username = "you@example.com",
+    password = env("SMTP_PASSWORD")
+);
 ```
+
+`from`, `to`, and `subject` are required at every call site — configure
+everything else as defaults, pass those three explicitly.
 
 See [Sending Email](https://guides.wheels.dev/v4-0-0/digging-deeper/sending-email/) in the guides for the full walkthrough.

--- a/cli/lucli/templates/app/config/services.cfm
+++ b/cli/lucli/templates/app/config/services.cfm
@@ -1,0 +1,23 @@
+<cfscript>
+/**
+ * DI container registrations.
+ *
+ * This file is loaded at application start (fail-closed: an error here
+ * aborts boot as `Wheels.ConfigIncludeFailed`). Register services here
+ * with the fluent binder:
+ *
+ *     local.di = injector();
+ *     local.di.map("emailService").to("app.lib.EmailService").asSingleton();
+ *     local.di.map("currentUser").to("app.lib.CurrentUserResolver").asRequestScoped();
+ *     local.di.bind("INotifier").to("app.lib.SlackNotifier").asSingleton();
+ *
+ * Resolve anywhere with `service("emailService")`, or inject into a
+ * controller with `inject("emailService, currentUser")` in `config()`.
+ * Scopes: transient (default), `.asSingleton()`, `.asRequestScoped()`.
+ *
+ * Environment overrides are supported via the same `environment.cfm`
+ * include pattern used by `config/app.cfm`.
+ *
+ * Add your registrations below this comment.
+ */
+</cfscript>

--- a/cli/lucli/templates/deploy/init/deploy.yml.mustache
+++ b/cli/lucli/templates/deploy/init/deploy.yml.mustache
@@ -17,6 +17,10 @@ proxy:
     interval: 1
     timeout: 30
 
+# boot:
+#   limit: 10
+#   wait: 5
+
 registry:
   username: {{registry_username}}
   password:

--- a/cli/lucli/templates/snippets/user-mailer.txt
+++ b/cli/lucli/templates/snippets/user-mailer.txt
@@ -1,31 +1,44 @@
-component extends="wheels.Mailer" {
+component {
 
 	/**
 	 * Send welcome email to a new user.
+	 *
+	 * Mailers are plain CFCs (no framework base class) that wrap the
+	 * controller's sendEmail() behind a named method. sendEmail() needs a
+	 * request-capable controller instance, so each method obtains one
+	 * through the controller() factory.
 	 */
-	public void function sendWelcome(required any user) {
-		mail(
-			to=arguments.user.email,
-			from="noreply@example.com",
-			subject="Welcome to the app!",
-			template="/app/views/mailers/user/welcome",
-			layout="/app/views/mailers/layout",
-			user=arguments.user
+	public any function sendWelcome(required any user) {
+		local.mailer = new wheels.Global().controller(
+			name = "Mailer",
+			params = { controller: "mailer", action: "sendWelcome" }
+		);
+		return local.mailer.sendEmail(
+			template = "/mailers/user/welcome",
+			layout = "/mailers/layout",
+			from = "noreply@example.com",
+			to = arguments.user.email,
+			subject = "Welcome, #arguments.user.firstName#!",
+			user = arguments.user
 		);
 	}
 
 	/**
 	 * Send password reset instructions.
 	 */
-	public void function sendPasswordReset(required any user, required string token) {
-		mail(
-			to=arguments.user.email,
-			from="noreply@example.com",
-			subject="Password Reset",
-			template="/app/views/mailers/user/password_reset",
-			layout="/app/views/mailers/layout",
-			user=arguments.user,
-			token=arguments.token
+	public any function sendPasswordReset(required any user, required string token) {
+		local.mailer = new wheels.Global().controller(
+			name = "Mailer",
+			params = { controller: "mailer", action: "sendPasswordReset" }
+		);
+		return local.mailer.sendEmail(
+			template = "/mailers/user/password_reset",
+			layout = "/mailers/layout",
+			from = "noreply@example.com",
+			to = arguments.user.email,
+			subject = "Reset your password",
+			user = arguments.user,
+			token = arguments.token
 		);
 	}
 

--- a/cli/lucli/tests/specs/commands/DeployCommandSpec.cfc
+++ b/cli/lucli/tests/specs/commands/DeployCommandSpec.cfc
@@ -91,7 +91,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 
 		});
 
-		xdescribe("wheels deploy fetch-secrets (top-level alias for ##2697)", () => {
+		describe("wheels deploy fetch-secrets (top-level alias for ##2697)", () => {
 
 			it("dispatches to DeploySecretsCli.fetch and forwards the adapter flag", () => {
 				// Pass an unknown adapter so the call short-circuits inside
@@ -127,7 +127,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 
 		});
 
-		xdescribe("wheels deploy extract-secrets (top-level alias for ##2697)", () => {
+		describe("wheels deploy extract-secrets (top-level alias for ##2697)", () => {
 
 			it("dispatches to DeploySecretsCli.extract and returns the matched value", () => {
 				// extract() reads opts.from (the KEY=VALUE block) and opts.key
@@ -155,7 +155,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 
 		});
 
-		xdescribe("wheels deploy print-secrets (top-level alias for ##2697)", () => {
+		describe("wheels deploy print-secrets (top-level alias for ##2697)", () => {
 
 			it("dispatches to DeploySecretsCli.print and returns a string", () => {
 				// The dispatcher hands control to DeploySecretsCli.print, which

--- a/cli/lucli/tests/specs/commands/MigrateDiffArgsSpec.cfc
+++ b/cli/lucli/tests/specs/commands/MigrateDiffArgsSpec.cfc
@@ -1,0 +1,134 @@
+/**
+ * Unit coverage for the `wheels migrate diff` argument surface —
+ * $parseMigrateDiffArgs() and $buildDiffBridgeUrl(). The bridge round-trip
+ * itself is covered by CliBridgeSpec on the framework side; these cases pin
+ * the CLI-side parsing contract without needing a running app server.
+ */
+component extends="wheels.wheelstest.system.BaseSpec" {
+
+	function beforeAll() {
+		variables.testHelper = new cli.lucli.tests.TestHelper();
+		variables.tempRoot = testHelper.scaffoldTempProject(expandPath("/"));
+		directoryCreate(tempRoot & "/vendor/wheels", true, true);
+		variables.mod = new cli.lucli.Module(cwd = variables.tempRoot);
+	}
+
+	function afterAll() {
+		testHelper.cleanupTempProject(variables.tempRoot);
+	}
+
+	function run() {
+
+		describe("$parseMigrateDiffArgs", () => {
+
+			it("defaults to a diffAll preview with no flags", () => {
+				var opts = mod.$parseMigrateDiffArgs(["diff"]);
+				expect(opts.model).toBe("");
+				expect(opts.write).toBeFalse();
+				expect(opts.threshold).toBe("");
+			});
+
+			it("captures a positional model", () => {
+				var opts = mod.$parseMigrateDiffArgs(["diff", "User"]);
+				expect(opts.model).toBe("User");
+			});
+
+			it("parses a single OLD:NEW rename pair", () => {
+				var opts = mod.$parseMigrateDiffArgs(["diff", "User", "--rename=full_name:fullName"]);
+				expect(opts.hints.renames).toHaveKey("full_name");
+				expect(opts.hints.renames.full_name).toBe("fullName");
+			});
+
+			it("parses multiple rename pairs (equals form)", () => {
+				var opts = mod.$parseMigrateDiffArgs(["diff", "User", "--rename=a:b", "--rename=c:d"]);
+				expect(opts.hints.renames.a).toBe("b");
+				expect(opts.hints.renames.c).toBe("d");
+			});
+
+			it("parses the diffAll Model.OLD:NEW form into per-model hints", () => {
+				var opts = mod.$parseMigrateDiffArgs(["diff", "--rename=User.full_name:fullName"]);
+				expect(opts.hints.renames).toHaveKey("User");
+				expect(opts.hints.renames.User.full_name).toBe("fullName");
+			});
+
+			it("merges --hints JSON with --rename pairs", () => {
+				var opts = mod.$parseMigrateDiffArgs([
+					"diff", "User",
+					'--hints={"renames":{"title":"name"}}',
+					"--rename=body:content"
+				]);
+				expect(opts.hints.renames.title).toBe("name");
+				expect(opts.hints.renames.body).toBe("content");
+			});
+
+			it("rejects malformed --hints JSON", () => {
+				expect(() => mod.$parseMigrateDiffArgs(["diff", "User", "--hints=not-json"]))
+					.toThrow("Wheels.InvalidArguments");
+			});
+
+			it("rejects a malformed rename pair", () => {
+				expect(() => mod.$parseMigrateDiffArgs(["diff", "User", "--rename=no-colon-here"]))
+					.toThrow("Wheels.InvalidArguments");
+			});
+
+			it("rejects an out-of-range threshold", () => {
+				expect(() => mod.$parseMigrateDiffArgs(["diff", "User", "--threshold=7"]))
+					.toThrow("Wheels.InvalidArguments");
+			});
+
+			it("captures threshold, name, and write", () => {
+				var opts = mod.$parseMigrateDiffArgs(["diff", "User", "--threshold=0.85", "--name=rename_name_field", "--write"]);
+				expect(opts.threshold).toBe("0.85");
+				expect(opts.name).toBe("rename_name_field");
+				expect(opts.write).toBeTrue();
+			});
+
+		});
+
+		describe("$buildDiffBridgeUrl", () => {
+
+			it("is empty for a bare diffAll preview", () => {
+				var opts = {model: "", hints: {}, threshold: "", name: "", write: false};
+				expect(mod.$buildDiffBridgeUrl(opts)).toBe("");
+			});
+
+			it("encodes the model and hints", () => {
+				var opts = {model: "Blog Post", hints: {renames: {"old name": "newName"}}, threshold: "", name: "", write: false};
+				var suffix = mod.$buildDiffBridgeUrl(opts);
+				expect(suffix).toInclude("modelName=");
+				expect(suffix).toInclude("hints=");
+			});
+
+			it("adds write=true and the name only when writing", () => {
+				var opts = {model: "User", hints: {}, threshold: "", name: "renameField", write: true};
+				var suffix = mod.$buildDiffBridgeUrl(opts);
+				expect(suffix).toInclude("write=true");
+				expect(suffix).toInclude("name=renameField");
+				// name must not leak into a preview
+				opts.write = false;
+				expect(mod.$buildDiffBridgeUrl(opts)).notToInclude("&name=");
+			});
+
+		});
+
+		describe("$isOffline / $consumeOfflineFlag", () => {
+
+			it("is false by default", () => {
+				expect(mod.$isOffline()).toBeFalse();
+			});
+
+			it("turns true when --offline is consumed", () => {
+				mod.__arguments = ["migrate", "--offline", "diff"];
+				mod.$consumeOfflineFlag(["migrate", "--offline", "diff"]);
+				expect(mod.$isOffline()).toBeTrue();
+				expect(request.$wheelsOffline).toBeTrue();
+				// tidy up so later specs in this bundle aren't affected
+				structDelete(request, "$wheelsOffline");
+				mod.__arguments = [];
+			});
+
+		});
+
+	}
+
+}

--- a/cli/lucli/tests/specs/deploy/config/BootSpec.cfc
+++ b/cli/lucli/tests/specs/deploy/config/BootSpec.cfc
@@ -1,0 +1,70 @@
+component extends="wheels.wheelstest.system.BaseSpec" {
+
+    function run() {
+        describe("Boot — `boot:` block accessors", () => {
+
+            it("defaults to limit 10 / wait 5 when the block is empty", () => {
+                var b = new cli.lucli.services.deploy.config.Boot({});
+                expect(b.limit()).toBe(10);
+                expect(b.wait()).toBe(5);
+            });
+
+            it("propagates limit and wait from the raw block", () => {
+                var b = new cli.lucli.services.deploy.config.Boot({limit: 3, wait: 15});
+                expect(b.limit()).toBe(3);
+                expect(b.wait()).toBe(15);
+            });
+
+            it("parses Kamal's percentage limit form", () => {
+                var b = new cli.lucli.services.deploy.config.Boot({limit: "25%"});
+                expect(b.limit()).toBe(25);
+            });
+
+            it("coerces string-typed numerics", () => {
+                var b = new cli.lucli.services.deploy.config.Boot({limit: "2", wait: "8"});
+                expect(b.limit()).toBe(2);
+                expect(b.wait()).toBe(8);
+            });
+
+            it("degrades invalid shapes to the defaults", () => {
+                var b = new cli.lucli.services.deploy.config.Boot({limit: "all", wait: "soon"});
+                expect(b.limit()).toBe(10);
+                expect(b.wait()).toBe(5);
+            });
+
+            it("preserves an explicit zero instead of the default", () => {
+                var b = new cli.lucli.services.deploy.config.Boot({limit: 0, wait: 0});
+                expect(b.limit()).toBe(0);
+                expect(b.wait()).toBe(0);
+            });
+
+        });
+
+        describe("Config.boot()", () => {
+
+            it("returns a Boot accessor for the boot block", () => {
+                var cfg = new cli.lucli.services.deploy.config.Config({
+                    service: "demo",
+                    image: "a/b",
+                    servers: ["1.2.3.4"],
+                    boot: {limit: 20, wait: 30}
+                });
+                var b = cfg.boot();
+                expect(b.limit()).toBe(20);
+                expect(b.wait()).toBe(30);
+            });
+
+            it("returns defaults when no boot block is present", () => {
+                var cfg = new cli.lucli.services.deploy.config.Config({
+                    service: "demo",
+                    image: "a/b",
+                    servers: ["1.2.3.4"]
+                });
+                var b = cfg.boot();
+                expect(b.limit()).toBe(10);
+                expect(b.wait()).toBe(5);
+            });
+
+        });
+    }
+}

--- a/cli/lucli/tests/specs/deploy/config/ValidatorSpec.cfc
+++ b/cli/lucli/tests/specs/deploy/config/ValidatorSpec.cfc
@@ -101,7 +101,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
             it("rejects allowlisted-but-unimplemented top-level keys", () => {
                 var v = new cli.lucli.services.deploy.config.Validator();
                 var deadKeys = [
-                    "boot", "healthcheck", "hooks", "volumes", "labels", "logging",
+                    "healthcheck", "hooks", "volumes", "labels", "logging",
                     "retain_containers", "minimum_version", "asset_path",
                     "require_destination", "allow_empty_roles", "run_directory",
                     "readiness_delay"
@@ -133,6 +133,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                     env: {clear: {A: "1"}},
                     ssh: {user: "deploy"},
                     proxy: {host: "app.example.com"},
+                    boot: {limit: 10, wait: 5},
                     accessories: {db: {image: "postgres:16"}}
                 }, "test.yml");
                 expect(true).toBeTrue();
@@ -142,7 +143,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                 var v = new cli.lucli.services.deploy.config.Validator();
                 var state = {threw: false, message: ""};
                 try {
-                    v.validate({service: "demo", image: "a/b", servers: ["1.2.3.4"], boot: {limit: 1}}, "test.yml");
+                    v.validate({service: "demo", image: "a/b", servers: ["1.2.3.4"], healthcheck: {path: "/up"}}, "test.yml");
                 } catch (DeployConfigError e) {
                     state.threw = true;
                     state.message = e.message;
@@ -150,6 +151,54 @@ component extends="wheels.wheelstest.system.BaseSpec" {
                 expect(state.threw).toBeTrue();
                 expect(state.message).toInclude("allowed keys:");
                 expect(state.message).toInclude("accessories");
+            });
+
+            it("accepts a boot block with numeric limit/wait", () => {
+                var v = new cli.lucli.services.deploy.config.Validator();
+                v.validate({
+                    service: "demo",
+                    image: "a/b",
+                    servers: ["1.2.3.4"],
+                    boot: {limit: 10, wait: 5}
+                }, "test.yml");
+                expect(true).toBeTrue();
+            });
+
+            it("accepts a boot block with a percentage limit", () => {
+                var v = new cli.lucli.services.deploy.config.Validator();
+                v.validate({
+                    service: "demo",
+                    image: "a/b",
+                    servers: ["1.2.3.4"],
+                    boot: {limit: "25%", wait: "5"}
+                }, "test.yml");
+                expect(true).toBeTrue();
+            });
+
+            it("rejects a boot block with a negative or non-numeric value", () => {
+                var v = new cli.lucli.services.deploy.config.Validator();
+                var bad = [
+                    {limit: -1},
+                    {wait: -2},
+                    {limit: "soon"},
+                    {wait: "soon"}
+                ];
+                for (var boot in bad) {
+                    var state = {threw: false, message: ""};
+                    try {
+                        v.validate({
+                            service: "demo",
+                            image: "a/b",
+                            servers: ["1.2.3.4"],
+                            boot: boot
+                        }, "test.yml");
+                    } catch (DeployConfigError e) {
+                        state.threw = true;
+                        state.message = e.message;
+                    }
+                    expect(state.threw).toBeTrue("expected boot block '#serializeJSON(boot)#' to be rejected");
+                    expect(state.message).toInclude("boot.");
+                }
             });
         });
     }

--- a/cli/lucli/tests/specs/services/DoctorSpec.cfc
+++ b/cli/lucli/tests/specs/services/DoctorSpec.cfc
@@ -116,6 +116,102 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 				expect(passedText).toInclude("Write permission");
 			});
 
+			describe("checkLegacyExtensionSurface", () => {
+
+				it("warns on legacy wheels.Test and wheels.Testbox test bases", () => {
+					fileWrite(tempRoot & "/tests/specs/legacy_spec.cfc", 'component extends="wheels.Test" {}');
+					fileWrite(tempRoot & "/tests/specs/testbox_spec.cfc", 'component extends="wheels.Testbox" {}');
+					try {
+						var doctor = new cli.lucli.services.Doctor(projectRoot = tempRoot);
+						var results = doctor.runChecks();
+						var warningText = arrayToList(results.warnings, " ");
+						expect(warningText).toInclude("Legacy test base class");
+						expect(warningText).toInclude("legacy_spec.cfc");
+						expect(warningText).toInclude("testbox_spec.cfc");
+					} finally {
+						fileDelete(tempRoot & "/tests/specs/legacy_spec.cfc");
+						fileDelete(tempRoot & "/tests/specs/testbox_spec.cfc");
+					}
+				});
+
+				it("does not warn on the modern wheels.WheelsTest base", () => {
+					fileWrite(tempRoot & "/tests/specs/modern_spec.cfc", 'component extends="wheels.WheelsTest" {}');
+					try {
+						var doctor = new cli.lucli.services.Doctor(projectRoot = tempRoot);
+						var results = doctor.runChecks();
+						var warningText = arrayToList(results.warnings, " ");
+						expect(warningText).notToInclude("Legacy test base class");
+					} finally {
+						fileDelete(tempRoot & "/tests/specs/modern_spec.cfc");
+					}
+				});
+
+				it("warns on a populated plugins/ directory", () => {
+					directoryCreate(tempRoot & "/plugins/foo", true);
+					fileWrite(tempRoot & "/plugins/foo/plugin.cfc", "component {}");
+					try {
+						var doctor = new cli.lucli.services.Doctor(projectRoot = tempRoot);
+						var results = doctor.runChecks();
+						var warningText = arrayToList(results.warnings, " ");
+						expect(warningText).toInclude("legacy plugins/ detected");
+					} finally {
+						directoryDelete(tempRoot & "/plugins", true);
+					}
+				});
+
+				it("does not warn when plugins/ is absent", () => {
+					var doctor = new cli.lucli.services.Doctor(projectRoot = tempRoot);
+					var results = doctor.runChecks();
+					var warningText = arrayToList(results.warnings, " ");
+					expect(warningText).notToInclude("legacy plugins/ detected");
+				});
+
+			});
+
+			describe("checkRawParamsMassAssignment", () => {
+
+				it("warns on raw params mass assignment in controllers", () => {
+					fileWrite(tempRoot & "/app/controllers/Users.cfc", 'component { model("user").create(params.user); }');
+					try {
+						var doctor = new cli.lucli.services.Doctor(projectRoot = tempRoot);
+						var results = doctor.runChecks();
+						var warningText = arrayToList(results.warnings, " ");
+						expect(warningText).toInclude("Raw params mass assignment");
+						expect(warningText).toInclude("Users.cfc");
+						expect(warningText).toInclude("params.user");
+					} finally {
+						fileDelete(tempRoot & "/app/controllers/Users.cfc");
+					}
+				});
+
+				it("warns on raw params mass assignment in models", () => {
+					fileWrite(tempRoot & "/app/models/User.cfc", 'component { function persist() { model("user").save(params.user); } }');
+					try {
+						var doctor = new cli.lucli.services.Doctor(projectRoot = tempRoot);
+						var results = doctor.runChecks();
+						var warningText = arrayToList(results.warnings, " ");
+						expect(warningText).toInclude("Raw params mass assignment");
+						expect(warningText).toInclude("User.cfc");
+						expect(warningText).toInclude("params.user");
+					} finally {
+						fileDelete(tempRoot & "/app/models/User.cfc");
+					}
+				});
+
+				it("does not warn on commented-out raw params", () => {
+					fileWrite(tempRoot & "/app/models/User.cfc", 'component { // model("user").create(params.user); function run() {} }');
+					try {
+						var doctor = new cli.lucli.services.Doctor(projectRoot = tempRoot);
+						var results = doctor.runChecks();
+						var warningText = arrayToList(results.warnings, " ");
+						expect(warningText).notToInclude("Raw params mass assignment");
+					} finally {
+						fileDelete(tempRoot & "/app/models/User.cfc");
+					}
+				});
+
+			});
+
 			describe("CLI install freshness (##2223)", () => {
 
 				it("is silent when no installedModuleRoot is provided", () => {

--- a/vendor/wheels/BuildInfo.cfc
+++ b/vendor/wheels/BuildInfo.cfc
@@ -39,8 +39,50 @@ component {
 		return this;
 	}
 
-	public string function version() {
-		return isDev() ? "0.0.0-dev" : variables.info.version;
+	public string function version(string manifestPath = "") {
+		if (!isDev()) return variables.info.version;
+		// Some release-install paths (Homebrew formula, module tarball) ship
+		// this file unstamped, but the sibling manifest IS stamped on every
+		// path. When we're structurally a dev build, fall back to the manifest
+		// version so released installs don't self-report "0.0.0-dev".
+		if (!len(arguments.manifestPath)) {
+			arguments.manifestPath = $defaultManifestPath();
+		}
+		var manifestVersion = $manifestVersion(arguments.manifestPath);
+		return len(manifestVersion) ? manifestVersion : "0.0.0-dev";
+	}
+
+	/**
+	 * Resolve the sibling manifest next to this component: wheels.json first,
+	 * falling back to the legacy box.json (rename transition — see
+	 * FrameworkInstaller.cfc::$resolveManifest for the same order).
+	 */
+	private string function $defaultManifestPath() {
+		var dir = getDirectoryFromPath(getCurrentTemplatePath());
+		if (fileExists(dir & "wheels.json")) return dir & "wheels.json";
+		if (fileExists(dir & "box.json")) return dir & "box.json";
+		return "";
+	}
+
+	/**
+	 * Read a manifest's `version` key, returning "" when the file is absent/
+	 * unparseable, the key is missing/empty, or the value is still an
+	 * unresolved placeholder. Returns the concrete version otherwise.
+	 */
+	private string function $manifestVersion(required string manifestPath) {
+		if (!len(arguments.manifestPath) || !fileExists(arguments.manifestPath)) return "";
+		var manifest = {};
+		try {
+			manifest = deserializeJSON(fileRead(arguments.manifestPath));
+		} catch (any e) {
+			return "";
+		}
+		if (!isStruct(manifest) || !structKeyExists(manifest, "version")) return "";
+		var v = manifest.version;
+		if (!isSimpleValue(v)) return "";
+		v = trim(v);
+		if (!len(v)) return "";
+		return $blankIfPlaceholder(v);
 	}
 
 	public boolean function isDev() {

--- a/vendor/wheels/Dispatch.cfc
+++ b/vendor/wheels/Dispatch.cfc
@@ -788,7 +788,14 @@ component output="false" extends="wheels.Global"{
 		// Run the finder outside the try so query errors (DB connection failures, missing
 		// tables at query time, SQL errors) propagate instead of being masked as a missing
 		// model class.
-		local.instance = local.modelClass.findByKey(local.rv.key);
+		if (StructKeyExists(arguments.route, "bindBy") && Len(Trim(arguments.route.bindBy))) {
+			// bindBy="slug" looks the record up by a non-PK column via the
+			// parameterized dynamic finder. invoke() form (not a bracket call)
+			// per Cross-Engine Invariant 4.
+			local.instance = invoke(local.modelClass, "findOneBy" & arguments.route.bindBy, { 1 = local.rv.key });
+		} else {
+			local.instance = local.modelClass.findByKey(local.rv.key);
+		}
 
 		// If no record was found, throw a 404.
 		if (IsBoolean(local.instance) && !local.instance) {

--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -531,6 +531,24 @@ component output="false" {
 		}
 	}
 
+	// Auth wiring facade (enableSession) — same mapping-absolute include
+	// ladder as lifecycle.cfm above.
+	try {
+		include "/wheels/global/auth.cfm";
+	} catch (any e) {
+		if (!$isMissingMappedInclude(e)) {
+			rethrow;
+		}
+		try {
+			include "global/auth.cfm";
+		} catch (any e2) {
+			if (!$isMissingMappedInclude(e2)) {
+				rethrow;
+			}
+			include "../vendor/wheels/global/auth.cfm";
+		}
+	}
+
 	// User-defined global functions
 	try {
 		include "/app/global/functions.cfm";

--- a/vendor/wheels/Injector.cfc
+++ b/vendor/wheels/Injector.cfc
@@ -22,6 +22,10 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 		// Storage for alias → component path mappings
 		variables.mappings = {};
 
+		// Storage for alias → factory closures (registered via toFactory()).
+		// Kept separate from mappings so getMappings() stays string-typed.
+		variables.factories = {};
+
 		// Singleton cache: mapping name → instance. Keyed by the same value
 		// as variables.singletonFlags so the flag and the cache can never
 		// disagree (previously the cache was keyed by component path, so a
@@ -77,7 +81,17 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 		// map(b).asSingleton().to(...) can flag b after the reset.
 		// First bind of a new name is not a rebind — leave request cache
 		// and any unrelated flags alone.
-		if (structKeyExists(variables.mappings, arguments.name)) {
+		if (structKeyExists(variables.factories, arguments.name)) {
+			// Re-mapping over a factory binding changes the construction
+			// source, so any cached instance must go too.
+			structDelete(variables.factories, arguments.name);
+			structDelete(variables.singletons, arguments.name);
+			structDelete(variables.singletonFlags, arguments.name);
+			structDelete(variables.requestScopedFlags, arguments.name);
+			structDelete(request, "$wheelsDICache");
+		} else if (structKeyExists(variables.mappings, arguments.name)) {
+			// Path re-map: keep the cached singleton for the dev-reload
+			// same-path pattern (to() invalidates it on a path CHANGE).
 			structDelete(variables.singletonFlags, arguments.name);
 			structDelete(variables.requestScopedFlags, arguments.name);
 			structDelete(request, "$wheelsDICache");
@@ -104,6 +118,8 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 		if (!len(variables.currentMapping)) {
 			throw(type="Wheels.Injector", message="to() called without a preceding map() call.");
 		}
+		// A to() after toFactory() replaces the factory binding entirely.
+		structDelete(variables.factories, variables.currentMapping);
 		// Re-binding an alias to a DIFFERENT component path invalidates any
 		// cached singleton instance for that alias — the cache is keyed by
 		// alias, so without this the stale instance of the old component
@@ -120,6 +136,47 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 		variables.lastMappedName = variables.currentMapping;
 		variables.currentMapping = "";
 		return this;
+	}
+
+	/**
+	 * Complete a mapping with a factory closure. The closure receives the
+	 * container itself (so it can compose other services via
+	 * ctx.getInstance(...)) and its return value is the resolved instance.
+	 *
+	 * Scope interplay mirrors to(): transient factories run per resolve,
+	 * .asSingleton() runs the factory once under the singleton lock, and
+	 * .asRequestScoped() once per request. No auto-wiring or onDIcomplete()
+	 * runs on the result — the closure owns construction, and initArguments
+	 * passed to getInstance() are ignored for factory bindings.
+	 *
+	 * @factory Closure that builds the instance.
+	 */
+	public Injector function toFactory(required any factory) {
+		if (!len(variables.currentMapping)) {
+			throw(type="Wheels.Injector", message="toFactory() called without a preceding map() call.");
+		}
+		if (!IsClosure(arguments.factory) && !IsCustomFunction(arguments.factory)) {
+			throw(
+				type = "Wheels.Injector",
+				message = "toFactory() requires a closure or function reference."
+			);
+		}
+		// A toFactory() after to() replaces the path binding entirely.
+		structDelete(variables.mappings, variables.currentMapping);
+		structDelete(variables.singletons, variables.currentMapping);
+		variables.factories[variables.currentMapping] = arguments.factory;
+		variables.lastMappedName = variables.currentMapping;
+		variables.currentMapping = "";
+		return this;
+	}
+
+	/**
+	 * Check whether a mapping is a factory binding.
+	 *
+	 * @name Alias name to check
+	 */
+	public boolean function isFactory(required string name) {
+		return structKeyExists(variables.factories, arguments.name);
 	}
 
 	/**
@@ -165,6 +222,35 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 	 * @initArguments Struct of arguments to pass to the init() method
 	 */
 	public any function getInstance(required string name, struct initArguments = {}) {
+		// Factory bindings bypass path resolution entirely.
+		if (structKeyExists(variables.factories, arguments.name)) {
+			// Singleton: the cache is keyed by the mapping name. A
+			// double-checked named lock ensures concurrent first resolutions
+			// run the factory exactly once.
+			if (structKeyExists(variables.singletonFlags, arguments.name)) {
+				if (!structKeyExists(variables.singletons, arguments.name)) {
+					lock name="#variables.lockNamePrefix##lCase(arguments.name)#" type="exclusive" timeout="30" {
+						if (!structKeyExists(variables.singletons, arguments.name)) {
+							variables.singletons[arguments.name] = $invokeFactory(arguments.name);
+						}
+					}
+				}
+				return variables.singletons[arguments.name];
+			}
+
+			// Request-scoped: cached per request in request.$wheelsDICache.
+			if (structKeyExists(variables.requestScopedFlags, arguments.name)) {
+				local.requestCache = $getRequestCache();
+				if (!structKeyExists(local.requestCache, arguments.name)) {
+					local.requestCache[arguments.name] = $invokeFactory(arguments.name);
+				}
+				return local.requestCache[arguments.name];
+			}
+
+			// Transient: the factory runs on every resolve.
+			return $invokeFactory(arguments.name);
+		}
+
 		// Resolve the component path
 		local.componentPath = resolveMapping(arguments.name);
 
@@ -269,6 +355,17 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 	}
 
 	/**
+	 * Invoke a registered factory closure, passing the container so the
+	 * factory can compose other services. The closure is hoisted to a local
+	 * variable first — a bracket call `variables.factories[name](this)`
+	 * crashes the Adobe CF parser (Cross-Engine Invariant 4).
+	 */
+	private any function $invokeFactory(required string name) {
+		var fn = variables.factories[arguments.name];
+		return fn(this);
+	}
+
+	/**
 	 * Per-request resolving stack. Tracks which names are currently being
 	 * resolved in THIS thread/request, so the circular-dependency guard
 	 * doesn't see entries from concurrent requests.
@@ -288,7 +385,7 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 	 * @name Alias name to check
 	 */
 	public boolean function containsInstance(required string name) {
-		return structKeyExists(variables.mappings, arguments.name);
+		return structKeyExists(variables.mappings, arguments.name) || structKeyExists(variables.factories, arguments.name);
 	}
 
 	/**
@@ -325,6 +422,7 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 	public struct function $snapshotBindings() {
 		return {
 			mappings = Duplicate(variables.mappings),
+			factories = Duplicate(variables.factories),
 			singletonFlags = Duplicate(variables.singletonFlags),
 			requestScopedFlags = Duplicate(variables.requestScopedFlags)
 		};
@@ -338,6 +436,9 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 		variables.mappings = StructKeyExists(arguments.snapshot, "mappings")
 			? Duplicate(arguments.snapshot.mappings)
 			: {};
+		variables.factories = StructKeyExists(arguments.snapshot, "factories")
+			? Duplicate(arguments.snapshot.factories)
+			: {};
 		variables.singletonFlags = StructKeyExists(arguments.snapshot, "singletonFlags")
 			? Duplicate(arguments.snapshot.singletonFlags)
 			: {};
@@ -345,7 +446,7 @@ component implements="wheels.interfaces.di.InjectorInterface" {
 			? Duplicate(arguments.snapshot.requestScopedFlags)
 			: {};
 		for (local.name in StructKeyArray(variables.singletons)) {
-			if (!StructKeyExists(variables.mappings, local.name)) {
+			if (!StructKeyExists(variables.mappings, local.name) && !StructKeyExists(variables.factories, local.name)) {
 				StructDelete(variables.singletons, local.name);
 			}
 		}

--- a/vendor/wheels/Test.cfc
+++ b/vendor/wheels/Test.cfc
@@ -811,6 +811,14 @@ component output="false" displayName="Test" extends="wheels.Global"{
 			variables.this = this;
 		}
 		new wheels.Plugins().$initializeMixins(variables);
+		// Legacy RocketUnit base — warn once per application instance (deduped
+		// per feature by $deprecated). Removal is planned for Wheels 5.0; see
+		// docs/releases/wheels-5-roadmap.md §5.4.
+		$deprecated(
+			feature = "rocketunit-test-base",
+			message = "wheels.Test (RocketUnit) is deprecated and will be removed in Wheels 5.0. Migrate test components to extend=""wheels.WheelsTest"" and use the BDD syntax (describe/it/expect).",
+			docUrl = "https://guides.wheels.dev/v4-0-0/testing/"
+		);
 	}
 
 }

--- a/vendor/wheels/global/auth.cfm
+++ b/vendor/wheels/global/auth.cfm
@@ -1,0 +1,64 @@
+<cfscript>
+/**
+ * One-line session-auth wiring for `config/services.cfm`.
+ *
+ * The auth subsystem ships complete (Authenticator strategy registry +
+ * SessionStrategy with login/logout/currentUser and SID rotation) but
+ * wiring it by hand spans two files: map the singletons here, then
+ * register the strategy in `app/events/onapplicationstart.cfm`.
+ * `enableSession()` collapses that into one idempotent call:
+ *
+ *     // config/services.cfm
+ *     enableSession(sessionKey = "wheels.auth");
+ *
+ * The DI container is available in services.cfm (it is NOT available in
+ * config/app.cfm — services.cfm is loaded after the container is built).
+ * Manual wiring keeps working; this helper is the convenience path.
+ */
+public any function enableSession(string sessionKey = "wheels.auth", any onLogin = "", any onLogout = "") {
+	// Guard: enableSession() belongs in config/services.cfm, where the
+	// container exists. Fail with a pointer rather than an opaque scope
+	// error when it is called from a context without one.
+	try {
+		var di = injector();
+	} catch (any e) {
+		Throw(
+			type = "Wheels.Injector",
+			message = "enableSession() requires the DI container — call it from config/services.cfm (loaded at application start).",
+			detail = e.message
+		);
+	}
+	if (!isObject(di)) {
+		Throw(
+			type = "Wheels.Injector",
+			message = "enableSession() requires the DI container — call it from config/services.cfm (loaded at application start)."
+		);
+	}
+
+	// Map the singletons only when they aren't already mapped, so manual
+	// wiring and repeat calls stay idempotent.
+	if (!di.containsInstance("authenticator")) {
+		di.map("authenticator").to("wheels.auth.Authenticator").asSingleton();
+	}
+	if (!di.containsInstance("sessionStrategy")) {
+		di.map("sessionStrategy").to("wheels.auth.SessionStrategy").asSingleton();
+	}
+
+	// Resolve with explicit initArguments: the singleton cache honors the
+	// first resolution's arguments, so a custom sessionKey/callbacks stick
+	// even if something else resolved the strategy first with defaults.
+	var authenticator = service("authenticator");
+	var strategy = di.getInstance(
+		"sessionStrategy",
+		{ sessionKey: arguments.sessionKey, onLogin: arguments.onLogin, onLogout: arguments.onLogout }
+	);
+
+	// Register once. Repeat calls (dev reloads, double-includes) must not
+	// stack duplicate registrations.
+	if (!authenticator.hasStrategy("session")) {
+		authenticator.registerStrategy(name = "session", strategy = strategy);
+	}
+
+	return strategy;
+}
+</cfscript>

--- a/vendor/wheels/interfaces/di/InjectorInterface.cfc
+++ b/vendor/wheels/interfaces/di/InjectorInterface.cfc
@@ -47,6 +47,23 @@ interface {
 	public Injector function to(required string componentPath);
 
 	/**
+	 * Complete a mapping with a factory closure. The closure receives the
+	 * container and its return value is the resolved instance. Honors the
+	 * singleton / request-scoped flags like `to()`.
+	 *
+	 * @factory Closure or function reference that builds the instance.
+	 * @return The Injector (for chaining).
+	 */
+	public Injector function toFactory(required any factory);
+
+	/**
+	 * Whether the given name is bound to a factory (rather than a component path).
+	 *
+	 * @name The service name to check.
+	 */
+	public boolean function isFactory(required string name);
+
+	/**
 	 * Semantic alias for `map()`. Reads better for interface-to-implementation bindings:
 	 * `bind("INotifier").to("app.lib.SlackNotifier")`
 	 *

--- a/vendor/wheels/interfaces/routing/RouteMapperInterface.cfc
+++ b/vendor/wheels/interfaces/routing/RouteMapperInterface.cfc
@@ -69,7 +69,8 @@ interface {
 		string shallowName,
 		struct constraints,
 		any callback,
-		any binding
+		any binding,
+		any bindBy
 	);
 
 	/**
@@ -195,7 +196,8 @@ interface {
 		string shallowName,
 		struct constraints,
 		any middleware,
-		any binding
+		any binding,
+		any bindBy
 	);
 
 	/**

--- a/vendor/wheels/mapper/matching.cfc
+++ b/vendor/wheels/mapper/matching.cfc
@@ -419,6 +419,11 @@ component {
 			arguments.binding = variables.scopeStack[1].binding;
 		}
 
+		// Inherit bindBy from scope stack.
+		if (!StructKeyExists(arguments, "bindBy") && StructKeyExists(variables.scopeStack[1], "bindBy")) {
+			arguments.bindBy = variables.scopeStack[1].bindBy;
+		}
+
 		// Add shallow path to pattern.
 		// Or, add scoped path to pattern.
 		if ($shallow()) {

--- a/vendor/wheels/mapper/resources.cfc
+++ b/vendor/wheels/mapper/resources.cfc
@@ -34,6 +34,7 @@ component {
 		struct constraints,
 		any callback,
 		any binding,
+		any bindBy,
 		string $call = "resource",
 		boolean $plural = false,
 		boolean mapFormat = variables.mapFormat
@@ -179,6 +180,11 @@ component {
 			local.args.binding = arguments.binding;
 		}
 
+		// Pass along bindBy preference.
+		if (StructKeyExists(arguments, "bindBy")) {
+			local.args.bindBy = arguments.bindBy;
+		}
+
 		// Scope the resource.
 		scope($call = arguments.$call, argumentCollection = local.args);
 
@@ -230,6 +236,7 @@ component {
 		struct constraints,
 		any callback,
 		any binding,
+		any bindBy,
 		boolean mapFormat = variables.mapFormat
 	) {
 		return resource(argumentCollection = arguments, $plural = true, $call = "resources");

--- a/vendor/wheels/mapper/scoping.cfc
+++ b/vendor/wheels/mapper/scoping.cfc
@@ -26,6 +26,7 @@ component {
 		struct constraints,
 		any middleware,
 		any binding,
+		any bindBy,
 		any callback,
 		string $call = "scope"
 	) {

--- a/vendor/wheels/tests/specs/auth/EnableSessionSpec.cfc
+++ b/vendor/wheels/tests/specs/auth/EnableSessionSpec.cfc
@@ -1,0 +1,67 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("enableSession() wiring facade", function() {
+
+			beforeEach(function() {
+				g = application.wo;
+				_originalDi = application.wheelsdi;
+			});
+
+			afterEach(function() {
+				// Restore the live container so other specs are unaffected.
+				application.wheelsdi = _originalDi;
+			});
+
+			it("maps the singletons, registers the session strategy, and returns it", function() {
+				// Fresh container: constructing it re-registers itself at
+				// application.wheelsdi, which injector()/service() read.
+				var di = new wheels.Injector(binderPath = "wheels.tests._assets.di.TestBindings");
+
+				var strategy = g.enableSession(sessionKey = "wheels.auth.spec");
+
+				expect(strategy).toBeInstanceOf("wheels.auth.SessionStrategy");
+				expect(di.isSingleton("authenticator")).toBeTrue();
+				expect(di.isSingleton("sessionStrategy")).toBeTrue();
+				var authenticator = di.getInstance("authenticator");
+				expect(authenticator.hasStrategy("session")).toBeTrue();
+				expect(authenticator.getStrategy("session")).toBe(strategy);
+				expect(strategy.getSessionKey()).toBe("wheels.auth.spec");
+			});
+
+			it("is idempotent — a second call adds no duplicate registration", function() {
+				var di = new wheels.Injector(binderPath = "wheels.tests._assets.di.TestBindings");
+
+				g.enableSession();
+				var second = g.enableSession();
+
+				var authenticator = di.getInstance("authenticator");
+				expect(authenticator.getStrategy("session")).toBe(second);
+				var names = authenticator.getStrategyNames();
+				expect(arrayLen(names)).toBe(1);
+			});
+
+			it("coexists with a pre-mapped authenticator", function() {
+				var di = new wheels.Injector(binderPath = "wheels.tests._assets.di.TestBindings");
+				di.map("authenticator").to("wheels.auth.Authenticator").asSingleton();
+				var preMapped = di.getInstance("authenticator");
+
+				g.enableSession();
+
+				expect(di.getInstance("authenticator")).toBe(preMapped);
+				expect(preMapped.hasStrategy("session")).toBeTrue();
+			});
+
+			it("throws a pointer error when no DI container exists", function() {
+				application.wheelsdi = "";
+				expect(function() {
+					g.enableSession();
+				}).toThrow("Wheels.Injector");
+			});
+
+		});
+
+	}
+
+}

--- a/vendor/wheels/tests/specs/buildInfoSpec.cfc
+++ b/vendor/wheels/tests/specs/buildInfoSpec.cfc
@@ -26,6 +26,69 @@ component extends="wheels.WheelsTest" {
 					expect(bi.version()).toBe("0.0.0-dev");
 				});
 
+				it("falls back to the sibling wheels.json version when unstamped (dev mode)", () => {
+					var dir = getTempDirectory() & "wheels-buildinfo-" & createUUID();
+					directoryCreate(dir, true);
+					var manifestPath = dir & "/wheels.json";
+					fileWrite(manifestPath, '{"version": "4.1.2"}');
+					try {
+						var bi = new wheels.BuildInfo();
+						expect(bi.version(manifestPath = manifestPath)).toBe("4.1.2");
+					} finally {
+						directoryDelete(dir, true);
+					}
+				});
+
+				it("falls back to the sibling box.json when wheels.json is absent", () => {
+					var dir = getTempDirectory() & "wheels-buildinfo-" & createUUID();
+					directoryCreate(dir, true);
+					var manifestPath = dir & "/box.json";
+					fileWrite(manifestPath, '{"version": "3.5.0"}');
+					try {
+						var bi = new wheels.BuildInfo();
+						expect(bi.version(manifestPath = manifestPath)).toBe("3.5.0");
+					} finally {
+						directoryDelete(dir, true);
+					}
+				});
+
+				it("returns 0.0.0-dev when no manifest exists", () => {
+					var dir = getTempDirectory() & "wheels-buildinfo-" & createUUID();
+					directoryCreate(dir, true);
+					try {
+						var bi = new wheels.BuildInfo();
+						expect(bi.version(manifestPath = dir & "/wheels.json")).toBe("0.0.0-dev");
+					} finally {
+						directoryDelete(dir, true);
+					}
+				});
+
+				it("returns 0.0.0-dev when the manifest version is still a placeholder", () => {
+					var dir = getTempDirectory() & "wheels-buildinfo-" & createUUID();
+					directoryCreate(dir, true);
+					var manifestPath = dir & "/wheels.json";
+					fileWrite(manifestPath, '{"version": "@build.version@"}');
+					try {
+						var bi = new wheels.BuildInfo();
+						expect(bi.version(manifestPath = manifestPath)).toBe("0.0.0-dev");
+					} finally {
+						directoryDelete(dir, true);
+					}
+				});
+
+				it("stamped BuildInfo version wins over the manifest", () => {
+					var dir = getTempDirectory() & "wheels-buildinfo-" & createUUID();
+					directoryCreate(dir, true);
+					var manifestPath = dir & "/wheels.json";
+					fileWrite(manifestPath, '{"version": "9.9.9"}');
+					try {
+						var bi = new wheels.BuildInfo({version: "4.0.0"});
+						expect(bi.version(manifestPath = manifestPath)).toBe("4.0.0");
+					} finally {
+						directoryDelete(dir, true);
+					}
+				});
+
 			});
 
 			describe("isDev() / isSnapshot()", () => {

--- a/vendor/wheels/tests/specs/di/InjectorSpec.cfc
+++ b/vendor/wheels/tests/specs/di/InjectorSpec.cfc
@@ -401,6 +401,115 @@ component extends="wheels.WheelsTest" {
 
 			});
 
+			describe("Factories (toFactory)", () => {
+
+				it("resolves a transient factory on every call", () => {
+					var counter = {n: 0};
+					var build = function(ctx) {
+						counter.n = counter.n + 1;
+						return {n: counter.n, fromFactory: true};
+					};
+					di.map("factoryThing").toFactory(build);
+
+					var first = di.getInstance("factoryThing");
+					var second = di.getInstance("factoryThing");
+
+					expect(first).toHaveKey("fromFactory");
+					expect(second).toHaveKey("fromFactory");
+					expect(first.n).toBe(1);
+					expect(second.n).toBe(2);
+				});
+
+				it("passes the container so factories can compose other services", () => {
+					di.map("simpleService").to("wheels.tests._assets.di.SimpleService").asSingleton();
+					var build = function(ctx) {
+						return {inner: ctx.getInstance("simpleService")};
+					};
+					di.map("composed").toFactory(build);
+
+					var composed = di.getInstance("composed");
+
+					expect(composed.inner).toBeInstanceOf("wheels.tests._assets.di.SimpleService");
+					expect(composed.inner).toBe(di.getInstance("simpleService"));
+				});
+
+				it("singleton factories run once", () => {
+					var calls = {count: 0};
+					var build = function(ctx) {
+						calls.count = calls.count + 1;
+						return {n: calls.count};
+					};
+					di.map("singletonFactory").toFactory(build).asSingleton();
+
+					var first = di.getInstance("singletonFactory");
+					var second = di.getInstance("singletonFactory");
+
+					expect(calls.count).toBe(1);
+					expect(first).toBe(second);
+				});
+
+				it("request-scoped factories run once per request", () => {
+					var calls = {count: 0};
+					var build = function(ctx) {
+						calls.count = calls.count + 1;
+						return {n: calls.count};
+					};
+					di.map("requestFactory").toFactory(build).asRequestScoped();
+
+					var first = di.getInstance("requestFactory");
+					var second = di.getInstance("requestFactory");
+
+					expect(calls.count).toBe(1);
+					expect(first).toBe(second);
+				});
+
+				it("throws Wheels.Injector without a preceding map()", () => {
+					expect(() => di.toFactory(function(ctx) { return {}; }))
+						.toThrow("Wheels.Injector");
+				});
+
+				it("throws Wheels.Injector for a non-closure argument", () => {
+					di.map("notAFactory");
+					expect(() => di.toFactory("app.lib.Something")).toThrow("Wheels.Injector");
+				});
+
+				it("to() after toFactory() replaces the factory", () => {
+					di.map("switching").toFactory(function(ctx) { return {fromFactory: true}; });
+					di.map("switching").to("wheels.tests._assets.di.SimpleService");
+
+					expect(di.isFactory("switching")).toBeFalse();
+					expect(di.getInstance("switching")).toBeInstanceOf("wheels.tests._assets.di.SimpleService");
+				});
+
+				it("toFactory() after to() replaces the path binding", () => {
+					di.map("switching2").to("wheels.tests._assets.di.SimpleService");
+					di.map("switching2").toFactory(function(ctx) { return {fromFactory: true}; });
+
+					expect(di.isFactory("switching2")).toBeTrue();
+					expect(di.getInstance("switching2")).toHaveKey("fromFactory");
+				});
+
+				it("containsInstance and isFactory report factory bindings", () => {
+					di.map("reporting").toFactory(function(ctx) { return {}; });
+
+					expect(di.containsInstance("reporting")).toBeTrue();
+					expect(di.isFactory("reporting")).toBeTrue();
+					expect(di.isFactory("simpleService")).toBeFalse();
+				});
+
+				it("snapshot/restore unwinds factory registrations", () => {
+					var snap = di.$snapshotBindings();
+					di.map("ephemeral").toFactory(function(ctx) { return {}; });
+
+					expect(di.containsInstance("ephemeral")).toBeTrue();
+
+					di.$restoreBindings(snap);
+
+					expect(di.containsInstance("ephemeral")).toBeFalse();
+				});
+
+			});
+
 		});
 
 	}

--- a/vendor/wheels/tests/specs/dispatch/routeModelBindingSpec.cfc
+++ b/vendor/wheels/tests/specs/dispatch/routeModelBindingSpec.cfc
@@ -253,6 +253,65 @@ component extends="wheels.WheelsTest" {
 
 			});
 
+			describe("when bindBy is set on a route", function() {
+
+				it("resolves the record by a non-PK column and lands it in params", function() {
+					var post = g.model("Post").findOne(order="id");
+					if (IsBoolean(post) && !post) {
+						post = g.model("Post").create(
+							authorId = 1,
+							title = "BindBy Slug Test",
+							body = "Test body",
+							views = 0
+						);
+					}
+
+					var params = {controller = "posts", action = "show", key = post.title};
+					var route = {binding = true, bindBy = "title"};
+
+					var result = _dispatch.$resolveRouteModelBinding(params = params, route = route);
+
+					expect(result).toHaveKey("post");
+					expect(result.post.key()).toBe(post.key());
+					// Original key param should be preserved.
+					expect(result.key).toBe(post.title);
+				});
+
+				it("throws RecordNotFound when no record matches the bound column", function() {
+					var params = {controller = "posts", action = "show", key = "no-such-title-xyz"};
+					var route = {binding = true, bindBy = "title"};
+
+					expect(function() {
+						_dispatch.$resolveRouteModelBinding(params = params, route = route);
+					}).toThrow("Wheels.RecordNotFound");
+				});
+
+				it("ignores bindBy when binding is disabled", function() {
+					var params = {controller = "posts", action = "show", key = "anything"};
+					var route = {bindBy = "title"};
+
+					var result = _dispatch.$resolveRouteModelBinding(params = params, route = route);
+
+					expect(result).notToHaveKey("post");
+				});
+
+				it("combines with an explicit binding model name", function() {
+					var author = g.model("Author").findOne(order="id");
+					if (IsBoolean(author) && !author) {
+						author = g.model("Author").create(firstName = "BindBy", lastName = "Author");
+					}
+
+					var params = {controller = "posts", action = "show", key = author.lastName};
+					var route = {binding = "Author", bindBy = "lastName"};
+
+					var result = _dispatch.$resolveRouteModelBinding(params = params, route = route);
+
+					expect(result).toHaveKey("author");
+					expect(result.author.key()).toBe(author.key());
+				});
+
+			});
+
 		});
 
 	}

--- a/vendor/wheels/view/sanitize.cfc
+++ b/vendor/wheels/view/sanitize.cfc
@@ -6,7 +6,11 @@ component {
 	 * [category: Sanitization Functions]
 	 *
 	 * @html The HTML to remove links from.
-	 * @encode [see:styleSheetLinkTag].
+	 * @encode Whether to HTML-encode the remaining text after stripping.
+	 * Defaults to `false` (configurable per-function via
+	 * `set(functionName="stripLinks", encode=true)`). These helpers strip
+	 * markup; they are NOT an escaping strategy — when the goal is XSS-safe
+	 * output, use `h()` / `hAttr()` instead.
 	 */
 	public string function stripLinks(required string html, boolean encode) {
 		$args(name = "stripLinks", args = arguments);
@@ -24,7 +28,11 @@ component {
 	 * [category: Sanitization Functions]
 	 *
 	 * @html The HTML to remove tag markup from.
-	 * @encode [see:styleSheetLinkTag].
+	 * @encode Whether to HTML-encode the remaining text after stripping.
+	 * Defaults to `false` (configurable per-function via
+	 * `set(functionName="stripTags", encode=true)`). These helpers strip
+	 * markup; they are NOT an escaping strategy — when the goal is XSS-safe
+	 * output, use `h()` / `hAttr()` instead.
 	 */
 	public string function stripTags(required string html, boolean encode) {
 		$args(name = "stripTags", args = arguments);


### PR DESCRIPTION
## Summary

Implements the 4.x backlog (`docs/releases/wheels-4.x-backlog.md`) — every item except i18n (deferred, separate product decision) and the upstream LuCLI items. All suites green: core 5,557 specs (0 fail / 0 error), CLI 1,274 specs (0 fail / 0 error).

### Framework

- **DI `toFactory()`** — `map("x").toFactory(function(ctx){...})`; the closure receives the container, honors singleton/request-scoped flags, participates in `containsInstance`/`isFactory`/snapshot-restore unwind.
- **Route `bindBy=`** — `resources(name="posts", binding=true, bindBy="slug")` resolves the `:key` segment via the parameterized `findOneBy<Property>()` finder; orthogonal to `binding=` (model selection).
- **`enableSession()`** — new global helper (`vendor/wheels/global/auth.cfm`) that collapses the two-file session-auth wiring into one idempotent call in `config/services.cfm`.
- **RocketUnit deprecation** — `wheels.Test` emits a one-time `$deprecated` warning.
- **stripTags/stripLinks encode question resolved** — opt-in default documented; `h()`/`hAttr()` are the escaping helpers.

### CLI

- **`wheels migrate diff`** (`dbmigrate diff`) — AutoMigrator schema diffs via the bridge: `--rename OLD:NEW` / `Model.OLD:NEW`, `--hints JSON`, `--threshold`, `--name`, `--write`. MCP `migrate` registered; `--action=` form normalized.
- **`wheels generate --dry-run`** — prints would-be paths across all generators, writes nothing.
- **Offline mode** — `--offline` / `WHEELS_OFFLINE=1`; skips the update check, registry fails fast.
- **Deploy-secrets specs enabled** — plus three underlying fixes: the command-spec harness (`mod.__arguments`) now consumes the `this`-scope shape, `deploy()` constructs `DeployMainCli` lazily (secrets verbs no longer require `config/deploy.yml`), and `$deploySecretsVerb` defaults `projectRoot` to the module cwd.

### Infra

- **BuildInfo fallback** — unstamped installs now read the sibling `wheels.json`/`box.json` version instead of showing `0.0.0-dev`.
- **Kamal `boot:` config** — `Boot.cfc` (`limit` 10, `wait` 5), `Config.boot()`, validator allowlist.
- **Two new `wheels doctor` checks** — legacy `wheels.Test`/`wheels.Testbox` specs, populated `plugins/`, and raw `params.` mass assignment (warn-only).

### Repo hygiene

- Squash-only merge setting applied (`allow_merge_commit=false`); vestigial `wheels-cli-lucli` archived; empty `packages/` shells deleted; `user-mailer.txt` + mailers README rewritten to the real `sendEmail()` pattern; `config/services.cfm` scaffold stub added.

### Still open (documented in the backlog)

- i18n package/primitives — deferred (separate product decision).
- LuCLI upstream race / PR #56 — external.
- bcrypt pure-CFML helpers — in flight on a follow-up branch (`wt-bcrypt`), lands as a separate PR.

Changelog fragments included for all user-facing additions.
