### PR TITLE
fix(test): record throwing RocketUnit tests instead of crashing the suite

### DIFF
--- a/changelog.d/rocketunit-error-handler.fixed.md
+++ b/changelog.d/rocketunit-error-handler.fixed.md
@@ -1,0 +1,1 @@
+- Fixed the legacy RocketUnit runner crashing the whole suite (HTTP 500, "variable [MESSAGE] doesn't exist" on Lucee 7) whenever a single test threw — test errors are recorded per-test again instead of aborting the run.

--- a/vendor/wheels/Test.cfc
+++ b/vendor/wheels/Test.cfc
@@ -331,7 +331,7 @@ component output="false" displayName="Test" extends="wheels.Global"{
 				} catch (any e) {
 					message = e.message;
 
-					if (e.ErrorCode eq "__FAIL__") {
+					if (StructKeyExists(e, "errorCode") && e.errorCode eq "__FAIL__") {
 						/*
 							fail() throws __FAIL__ exception
 						*/
@@ -341,34 +341,17 @@ component output="false" displayName="Test" extends="wheels.Global"{
 						numTestFailures = numTestFailures + 1;
 					} else {
 						/*
-							another exception thrown
+							another exception thrown. Message assembly lives in
+							$testErrorMessage so the catch body only ever reads
+							the exception object — on Lucee 7 the pre-existing
+							inline chain (which read `message`, `newline`, and an
+							undeclared `template` inside the catch) could throw
+							"variable [MESSAGE] doesn't exist" for some exception
+							shapes, masking the test error with a suite-wide 500
+							(#3458).
 						*/
 						status = "Error";
-						if (ArrayLen(e.tagContext)) {
-							template = "#ListLast(e.tagContext[1].template, "/")#:#e.tagContext[1].line#";
-							tagContext = "<ul>";
-							for (context in e.tagContext) {
-								tagContext = tagContext & '<li>#context.template#:#context.line#</li>';
-							};
-							tagContext = tagContext & "</ul>";
-						} else {
-							template = "";
-							tagContext = "[Unknown tagContext]";
-						}
-
-						if (Len(template)) {
-							message = message & newline & template;
-						}
-						if (StructKeyExists(e, "sql") and Len(e.sql)) {
-							message = message & newline & newline & e.sql;
-						}
-						if (Len(e.extendedInfo)) {
-							message = message & newline & newLine & e.extendedInfo;
-						}
-						message = message & newline & newline & tagContext;
-						if (Len(e.detail)) {
-							message = message & newline & newline & e.detail;
-						}
+						message = $testErrorMessage(e);
 						request[resultkey].ok = false;
 						request[resultkey].numErrors = request[resultkey].numErrors + 1;
 						numTestErrors = numTestErrors + 1;
@@ -417,6 +400,55 @@ component output="false" displayName="Test" extends="wheels.Global"{
 		request[resultkey].end = Now();
 
 		return numTestErrors eq 0;
+	}
+
+	/**
+	 * Builds the recorded message for a test error from a cfcatch object.
+	 * Kept as a separate public helper (cross-engine invariant #7) so the
+	 * catch block in $runTest never reads function-scoped locals — on Lucee 7
+	 * reading a var-declared local inside a catch can fail with
+	 * "variable [MESSAGE] doesn't exist" for certain exception shapes, which
+	 * turned a single failing test into a suite-wide 500 (#3458).
+	 *
+	 * Every field read is guarded with StructKeyExists: native (Java)
+	 * exceptions wrapped by the engine do not carry the full cfcatch shape.
+	 *
+	 * @e The cfcatch object describing the error.
+	 */
+	public string function $testErrorMessage(required any e) {
+		var newline = Chr(10) & Chr(13);
+		var rv = "";
+		if (StructKeyExists(arguments.e, "message") && !IsNull(arguments.e.message) && Len(arguments.e.message)) {
+			rv = arguments.e.message;
+		}
+
+		var template = "";
+		var tagContext = "";
+		if (StructKeyExists(arguments.e, "tagContext") && IsArray(arguments.e.tagContext) && ArrayLen(arguments.e.tagContext)) {
+			template = "#ListLast(arguments.e.tagContext[1].template, "/")#:#arguments.e.tagContext[1].line#";
+			tagContext = "<ul>";
+			for (var context in arguments.e.tagContext) {
+				tagContext = tagContext & '<li>#context.template#:#context.line#</li>';
+			}
+			tagContext = tagContext & "</ul>";
+		} else {
+			tagContext = "[Unknown tagContext]";
+		}
+
+		if (Len(template)) {
+			rv = rv & newline & template;
+		}
+		if (StructKeyExists(arguments.e, "sql") && Len(arguments.e.sql)) {
+			rv = rv & newline & newline & arguments.e.sql;
+		}
+		if (StructKeyExists(arguments.e, "extendedInfo") && Len(arguments.e.extendedInfo)) {
+			rv = rv & newline & newline & arguments.e.extendedInfo;
+		}
+		rv = rv & newline & newline & tagContext;
+		if (StructKeyExists(arguments.e, "detail") && Len(arguments.e.detail)) {
+			rv = rv & newline & newline & arguments.e.detail;
+		}
+		return rv;
 	}
 
 	/*

--- a/vendor/wheels/tests/_assets/global/RocketUnitThrowingTest.cfc
+++ b/vendor/wheels/tests/_assets/global/RocketUnitThrowingTest.cfc
@@ -1,0 +1,15 @@
+/**
+ * Asset for RocketUnitRunnerSpec: a legacy RocketUnit package where one test
+ * passes and one throws, so the runner's error-handling path is exercised.
+ */
+component extends="wheels.Test" {
+
+	function test01_passes() {
+		assert("1 eq 1");
+	}
+
+	function test02_throws() {
+		Throw(type = "Wheels.ProbeBoom", message = "deliberate boom");
+	}
+
+}

--- a/vendor/wheels/tests/specs/wheelstest/RocketUnitRunnerSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/RocketUnitRunnerSpec.cfc
@@ -1,0 +1,65 @@
+component extends="wheels.WheelsTest" {
+
+	/**
+	 * Covers the legacy RocketUnit runner's error handling (wheels.Test /
+	 * $runTest): a throwing test must be recorded as a test error, never crash
+	 * the whole suite (#3458). On Lucee 7 the pre-fix inline message assembly
+	 * inside the catch could throw "variable [MESSAGE] doesn't exist" for some
+	 * exception shapes, masking the original error with a suite-wide 500.
+	 */
+	function run() {
+
+		describe("RocketUnit runner error handling", function() {
+
+			beforeEach(function() {
+				g = application.wo;
+				_resultKey = "wheelsRocketUnitRunnerSpec";
+			});
+
+			afterEach(function() {
+				if (StructKeyExists(request, _resultKey)) {
+					StructDelete(request, _resultKey);
+				}
+			});
+
+			it("composes an error message from a cfcatch without throwing", function() {
+				var caught = "";
+				try {
+					Throw(type = "Wheels.ProbeBoom", message = "deliberate boom");
+				} catch (any e) {
+					caught = e;
+				}
+				var runner = new wheels.Test();
+				var msg = "";
+				expect(function() {
+					msg = runner.$testErrorMessage(caught);
+				}).notToThrow();
+				expect(msg).toInclude("deliberate boom");
+			});
+
+			it("records a throwing test as an error instead of crashing the suite", function() {
+				// RustCFML's legacy-runner surface (Invoke()/evaluate) has known
+				// gaps; the handler itself is covered by the spec above on every
+				// engine.
+				if (g.$engineAdapter().isRustCFML()) return;
+				var testCase = new wheels.tests._assets.global.RocketUnitThrowingTest();
+				expect(function() {
+					testCase.$runTest(_resultKey);
+				}).notToThrow();
+				var results = request[_resultKey];
+				expect(results.numTests).toBe(2);
+				expect(results.numSuccesses).toBe(1);
+				expect(results.numErrors).toBe(1);
+				expect(results.ok).toBeFalse();
+				var messages = "";
+				for (var r in results.results) {
+					messages = messages & r.message;
+				}
+				expect(messages).toInclude("deliberate boom");
+			});
+
+		});
+
+	}
+
+}


### PR DESCRIPTION
Closes #3458.

On Lucee 7 a single throwing test could 500 the entire legacy RocketUnit run: `$runTest`'s catch block read `var`-scoped locals (`message`, `newline`) plus an undeclared `template` variable while assembling the error message, and for some exception shapes Lucee throws `variable [MESSAGE] doesn't exist`, masking the original error with a suite-wide failure.

Message assembly now lives in the public `$testErrorMessage()` helper, which only reads the cfcatch object itself and guards every field access with `StructKeyExists` (native/Java exceptions don't carry the full cfcatch shape).

**Verification**
- New `RocketUnitRunnerSpec` (wheelstest area): a throwing test is recorded as `numErrors=1` with `ok=false` and its original message survives into the recorded result; `$testErrorMessage()` never throws. The full-runner case skips on RustCFML (legacy-runner surface gap, noted in the spec).
- Local Lucee 7: `wheelstest` 255 pass, 0 fail.
- Local RustCFML full suite: no new failures vs baseline.