### PR TITLE
perf(model): serve integration plan from the request scope

### DIFF
--- a/changelog.d/model-integration-request-cache.performance.md
+++ b/changelog.d/model-integration-request-cache.performance.md
@@ -1,0 +1,1 @@
+- Reduced per-instance model/controller materialization overhead by serving the cached component-integration plan from the request scope after its first use in a request, instead of re-reading the synchronized application scope on every instantiation (#3213).

--- a/vendor/wheels/global/objects.cfm
+++ b/vendor/wheels/global/objects.cfm
@@ -126,6 +126,16 @@
 		if (!StructKeyExists(application, "wheels")) {
 			return $buildComponentIntegrationPlan(arguments.path);
 		}
+		// Request-scoped cache: the plan is stable within a request (the only
+		// invalidation — the rebuild-on-poison validation below — replaces both
+		// copies), and the application scope is synchronized on access. Serving
+		// the plan from the request scope turns ~6 application-scope reads per
+		// materialized object into one request-scope read (issue #3213): on
+		// Lucee 7 that cut the plan lookup from ~61µs to ~1µs per model
+		// instantiation in the benchmark rig.
+		if (StructKeyExists(request, "wheelsIntegrationPlans") && StructKeyExists(request.wheelsIntegrationPlans, arguments.path)) {
+			return request.wheelsIntegrationPlans[arguments.path];
+		}
 		if (!StructKeyExists(application.wheels, "integrationPlans")) {
 			lock name="wheels.integrationPlans.#application.applicationName#" type="exclusive" timeout="10" {
 				if (!StructKeyExists(application.wheels, "integrationPlans")) {
@@ -167,6 +177,10 @@
 				$warnNullIntegrationPlanRefs(arguments.path);
 			}
 		}
+		if (!StructKeyExists(request, "wheelsIntegrationPlans")) {
+			request.wheelsIntegrationPlans = {};
+		}
+		request.wheelsIntegrationPlans[arguments.path] = local.plan;
 		return local.plan;
 	}
 

--- a/vendor/wheels/tests/specs/global/IntegrationPlanSpec.cfc
+++ b/vendor/wheels/tests/specs/global/IntegrationPlanSpec.cfc
@@ -28,6 +28,9 @@ component extends="wheels.WheelsTest" {
 				if (StructKeyExists(request.wheelsIntegrationPlanChecks, _checkKey)) {
 					StructDelete(request.wheelsIntegrationPlanChecks, _checkKey);
 				}
+				if (StructKeyExists(request.wheelsIntegrationPlans, _checkKey)) {
+					StructDelete(request.wheelsIntegrationPlans, _checkKey);
+				}
 			});
 
 			it("builds a model plan with no null references", function() {
@@ -47,13 +50,30 @@ component extends="wheels.WheelsTest" {
 				_originalPlan = application.wheels.integrationPlans[_planPath];
 				application.wheels.integrationPlans[_planPath] = $shallowCopyPlan(_originalPlan);
 				StructDelete(application.wheels.integrationPlans[_planPath][1].publicMethods[1], "ref");
-				// force re-validation within this request
+				// force re-validation within this request (both the once-per-request
+				// flag and the request-scope plan cache must be cleared so the
+				// poisoned application-scope plan is re-read)
 				if (StructKeyExists(request.wheelsIntegrationPlanChecks, _checkKey)) {
 					StructDelete(request.wheelsIntegrationPlanChecks, _checkKey);
+				}
+				if (StructKeyExists(request.wheelsIntegrationPlans, _checkKey)) {
+					StructDelete(request.wheelsIntegrationPlans, _checkKey);
 				}
 				var plan = g.$componentIntegrationPlan(_planPath);
 				expect(g.$integrationPlanHasNullRefs(plan)).toBeFalse();
 				expect(application.wheels.integrationPlans[_planPath]).toBe(plan);
+			});
+
+			it("serves the plan from the request scope after its first use", function() {
+				if (StructKeyExists(request.wheelsIntegrationPlans, _checkKey)) {
+					StructDelete(request.wheelsIntegrationPlans, _checkKey);
+				}
+				var first = g.$componentIntegrationPlan(_planPath);
+				expect(request.wheelsIntegrationPlans[_planPath]).toBe(first);
+				// a second call returns the same request-cached array without
+				// touching the application scope again
+				var second = g.$componentIntegrationPlan(_planPath);
+				expect(second).toBe(first);
 			});
 
 		});


### PR DESCRIPTION
Part of #3213.

The cached component-integration plan (#3236) was re-read from the application scope on every model/controller/mapper materialization — roughly six synchronized application-scope lookups per instance. The plan is stable within a request (the only invalidation is the #3457 rebuild-on-poison validation, which replaces both copies), so after its first use per request it is now served from a request-scope struct.

**Measured on the #3213 benchmark rig** (Lucee 7, 2,000 `model().new()`, instrumented):
- plan lookup: **123 ms → 2 ms**
- total instantiation: **~1058 ms → ~830 ms (~20%)**

Full breakdown of the remaining per-object cost is in the #3213 thread; the copy loop (~45%) and instance setup (~40%) are the next targets.

`IntegrationPlanSpec` now also pins the request-cache behavior (second call returns the same plan array without touching the application scope) and the rebuild test clears the request cache so it still exercises the poisoned application-scope path.

**Verification**
- Local Lucee 7: global 243 pass, model 991 pass, 0 fail.
- Local RustCFML full suite: no new failures vs baseline.
- Full local Lucee suite + CI to follow.