### PR TITLE
perf(model): inherit the model mixin surface instead of copying it per instance

### DIFF
--- a/changelog.d/model-inheritance-fast-path.performance.md
+++ b/changelog.d/model-inheritance-fast-path.performance.md
@@ -1,0 +1,1 @@
+- Model instances now inherit the full model API from compile-time includes instead of copying ~270 method references into each instance at runtime — roughly 2x faster model object materialization (#3213).

--- a/vendor/wheels/Bindings.cfc
+++ b/vendor/wheels/Bindings.cfc
@@ -16,14 +16,17 @@ component {
 		//   bind("ModelFinderInterface").to("my.CustomFinder")
 
 		// Model subsystem
+		// The model mixin surface is compile-time included into wheels.Model
+		// (#3213), so every subsystem interface's default implementation
+		// resolves to the class that carries all of it.
 		arguments.injector
-			.bind("ModelFinderInterface").to("wheels.model.read")
-			.bind("ModelPersistenceInterface").to("wheels.model.create")
-			.bind("ModelValidationInterface").to("wheels.model.validations")
-			.bind("ModelErrorInterface").to("wheels.model.errors")
-			.bind("ModelCallbackInterface").to("wheels.model.callbacks")
-			.bind("ModelAssociationInterface").to("wheels.model.associations")
-			.bind("ModelPropertyInterface").to("wheels.model.properties");
+			.bind("ModelFinderInterface").to("wheels.Model")
+			.bind("ModelPersistenceInterface").to("wheels.Model")
+			.bind("ModelValidationInterface").to("wheels.Model")
+			.bind("ModelErrorInterface").to("wheels.Model")
+			.bind("ModelCallbackInterface").to("wheels.Model")
+			.bind("ModelAssociationInterface").to("wheels.Model")
+			.bind("ModelPropertyInterface").to("wheels.Model");
 
 		// Controller subsystem
 		arguments.injector

--- a/vendor/wheels/Model.cfc
+++ b/vendor/wheels/Model.cfc
@@ -6,6 +6,9 @@ component output="false" displayName="Model" extends="wheels.Global"{
 		// instances inherit it with no per-instance integration copy. Dynamic
 		// plugin/package mixins still apply at onDIcomplete() via
 		// $pluginObj().$initializeMixins(variables).
+		//
+		// init() is the one hook every creation path runs (model(), new(),
+		// finder rows), so the super<name> override aliases register here.
 		$registerModelSuperAliases();
 		return this;
 	}

--- a/vendor/wheels/Model.cfc
+++ b/vendor/wheels/Model.cfc
@@ -2,8 +2,96 @@ component output="false" displayName="Model" extends="wheels.Global"{
 
 
 	function init(){
-		$integrateComponents("wheels.model");
+		// The model mixin surface is compile-time included below (#3213), so
+		// instances inherit it with no per-instance integration copy. Dynamic
+		// plugin/package mixins still apply at onDIcomplete() via
+		// $pluginObj().$initializeMixins(variables).
+		$registerModelSuperAliases();
 		return this;
+	}
+
+	/**
+	 * Preserves the `super<name>` override convention (#3325) under the
+	 * inheritance fast path (#3213): when an app model (or its Model.cfc base)
+	 * declares a method that shadows a model mixin, the framework original is
+	 * registered on the instance as `super<name>` so the override can delegate
+	 * to it. The mixin original lives in the instance's variables scope
+	 * (populated by this component's compile-time includes before the subclass
+	 * constructor runs), so aliasing is a reference copy.
+	 *
+	 * The declared-surface scan is cached per concrete class in the request
+	 * scope; the per-instance cost is one cache lookup plus one reference copy
+	 * per override (typically zero).
+	 *
+	 * The original ref is read from a shared wheels.Model prototype instance:
+	 * on the subclass instance `variables[name]` resolves to the app's own
+	 * override (declared methods shadow the parent's include-injected UDFs),
+	 * so the original is only unambiguously reachable on a wheels.Model
+	 * instance that carries no subclass surface.
+	 */
+	private void function $registerModelSuperAliases() {
+		if (!StructKeyExists(request, "wheelsModelOverrideCache")) {
+			request.wheelsModelOverrideCache = {};
+		}
+		local.className = getMetaData(this).fullname;
+		if (!StructKeyExists(request.wheelsModelOverrideCache, local.className)) {
+			local.names = [];
+			local.meta = getMetaData(this);
+			// Collect function names declared by the app's model classes —
+			// walking the extends chain up to (but not including) wheels.Model.
+			while (
+				StructKeyExists(local.meta, "extends")
+				&& StructKeyExists(local.meta.extends, "fullname")
+				&& local.meta.extends.fullname != "wheels.Model"
+			) {
+				local.fns = StructKeyExists(local.meta, "functions") ? local.meta.functions : [];
+				local.fEnd = ArrayLen(local.fns);
+				for (local.f = 1; local.f <= local.fEnd; local.f++) {
+					if (
+						StructKeyExists(variables, local.fns[local.f].name)
+						&& IsCustomFunction(variables[local.fns[local.f].name])
+					) {
+						ArrayAppend(local.names, local.fns[local.f].name);
+					}
+				}
+				local.meta = local.meta.extends;
+			}
+			request.wheelsModelOverrideCache[local.className] = local.names;
+		}
+		for (local.n in request.wheelsModelOverrideCache[local.className]) {
+			local.superName = "super" & local.n;
+			if (Left(local.n, 5) == "super" || StructKeyExists(this, local.superName)) {
+				continue;
+			}
+			local.originalRef = $modelSuperPrototype().$superOriginal(local.n);
+			if (IsCustomFunction(local.originalRef)) {
+				variables[local.superName] = local.originalRef;
+				this[local.superName] = local.originalRef;
+			}
+		}
+	}
+
+	/**
+	 * Shared wheels.Model instance whose include-injected variables carry the
+	 * unshadowed framework originals — used to register `super<name>` aliases
+	 * for app-level model overrides (#3213, #3325).
+	 */
+	private any function $modelSuperPrototype() {
+		if (!StructKeyExists(application.wheels, "modelSuperPrototype")) {
+			application.wheels.modelSuperPrototype = CreateObject("component", "wheels.Model");
+		}
+		return application.wheels.modelSuperPrototype;
+	}
+
+	/**
+	 * Returns the include-injected original for a mixin method name from this
+	 * instance's variables scope ("" when absent).
+	 */
+	public any function $superOriginal(required string name) {
+		if (StructKeyExists(variables, arguments.name) && IsCustomFunction(variables[arguments.name])) {
+			return variables[arguments.name];
+		}
+		return "";
 	}
 
 	/**
@@ -681,6 +769,29 @@ component output="false" displayName="Model" extends="wheels.Global"{
 		}
 	}
 	
+
+	// Model mixin surface, compile-time included so every model instance
+	// inherits it (same pattern as the global surface, issue ##3241).
+	// Alphabetical — this was the runtime integration plan's file order.
+	include "model/associations.cfm";
+	include "model/bulk.cfm";
+	include "model/calculations.cfm";
+	include "model/callbacks.cfm";
+	include "model/create.cfm";
+	include "model/delete.cfm";
+	include "model/errors.cfm";
+	include "model/locking.cfm";
+	include "model/miscellaneous.cfm";
+	include "model/nestedproperties.cfm";
+	include "model/onmissingmethod.cfm";
+	include "model/properties.cfm";
+	include "model/read.cfm";
+	include "model/serialize.cfm";
+	include "model/sql.cfm";
+	include "model/transactions.cfm";
+	include "model/update.cfm";
+	include "model/validations.cfm";
+
 	function onDIcomplete(){
 		$engineAdapter().prepareDIComplete(variables, this);
 		// Shared application-cached instance — constructing wheels.Plugins here

--- a/vendor/wheels/interfaces/model/ModelErrorInterface.cfc
+++ b/vendor/wheels/interfaces/model/ModelErrorInterface.cfc
@@ -1,7 +1,7 @@
 /**
  * Contract for model error reporting and inspection.
  *
- * The default implementation lives in `wheels.model.errors` and is mixed into
+ * The default implementation lives in `wheels.Model` (the model mixin surface is compile-time included there, #3213).
  * Model instances at runtime via `$integrateComponents()`. Because of this
  * mixin pattern, concrete models cannot use `implements=` at compile time.
  * Compliance is verified by runtime reflection tests instead.

--- a/vendor/wheels/interfaces/model/ModelFinderInterface.cfc
+++ b/vendor/wheels/interfaces/model/ModelFinderInterface.cfc
@@ -1,7 +1,7 @@
 /**
  * Contract for model read operations (finders, counting, existence checks).
  *
- * The default implementation lives in `wheels.model.read` and is mixed into
+ * The default implementation lives in `wheels.Model` (the model mixin surface is compile-time included there, #3213).
  * Model instances at runtime via `$integrateComponents()`. Because of this
  * mixin pattern, concrete models cannot use `implements=` at compile time.
  * Compliance is verified by runtime reflection tests instead.

--- a/vendor/wheels/interfaces/model/ModelPersistenceInterface.cfc
+++ b/vendor/wheels/interfaces/model/ModelPersistenceInterface.cfc
@@ -1,7 +1,7 @@
 /**
  * Contract for model write operations (create, save, update, delete).
  *
- * The default implementation lives in `wheels.model.crud` and is mixed into
+ * The default implementation lives in `wheels.Model` (the model mixin surface is compile-time included there, #3213).
  * Model instances at runtime via `$integrateComponents()`. Compliance is
  * verified by runtime reflection tests.
  *

--- a/vendor/wheels/model/associations.cfm
+++ b/vendor/wheels/model/associations.cfm
@@ -1,4 +1,4 @@
-component {
+<cfscript>
 	/**
 	 * Sets up a `belongsTo` association between this model and the specified one.
 	 * Use this association when this model contains a foreign key referencing another model.
@@ -267,4 +267,4 @@ component {
 			property(name = arguments.propertyName, type = "integer");
 		}
 	}
-}
+</cfscript>

--- a/vendor/wheels/model/bulk.cfm
+++ b/vendor/wheels/model/bulk.cfm
@@ -1,4 +1,4 @@
-component {
+<cfscript>
 
 	/**
 	 * Inserts multiple records into the database in a single batch operation.
@@ -227,5 +227,4 @@ component {
 
 		return arguments.records;
 	}
-
-}
+</cfscript>

--- a/vendor/wheels/model/calculations.cfm
+++ b/vendor/wheels/model/calculations.cfm
@@ -1,4 +1,4 @@
-component {
+<cfscript>
 	/**
 	 * Calculates the average value for a given property.
 	 * Uses the SQL function `AVG`.
@@ -283,4 +283,4 @@ component {
 
 		return local.rv;
 	}
-}
+</cfscript>

--- a/vendor/wheels/model/callbacks.cfm
+++ b/vendor/wheels/model/callbacks.cfm
@@ -1,4 +1,4 @@
-component {
+<cfscript>
 	/**
 	 * Registers method(s) that should be called after a new object is created.
 	 *
@@ -360,4 +360,4 @@ component {
 	public any function $coerceOracleTimestamp(required any value) {
 		return $engineAdapter().coerceOracleObject(arguments.value);
 	}
-}
+</cfscript>

--- a/vendor/wheels/model/create.cfm
+++ b/vendor/wheels/model/create.cfm
@@ -1,4 +1,4 @@
-component {
+<cfscript>
 	/**
 	 * Creates a new object, saves it to the database (if the validation permits it), and returns it.
 	 * If the validation fails, the unsaved object (with errors added to it) is still returned.
@@ -336,5 +336,4 @@ component {
 			&& arguments.columnMeta.size == 36
 		);
 	}
-
-}
+</cfscript>

--- a/vendor/wheels/model/delete.cfm
+++ b/vendor/wheels/model/delete.cfm
@@ -1,4 +1,4 @@
-component {
+<cfscript>
 	/**
 	 * Deletes all records that match the `where` argument.
 	 * By default, objects will not be instantiated and therefore callbacks and validations are not invoked.
@@ -228,4 +228,4 @@ component {
 		}
 		return local.rv;
 	}
-}
+</cfscript>

--- a/vendor/wheels/model/errors.cfm
+++ b/vendor/wheels/model/errors.cfm
@@ -1,4 +1,4 @@
-component {
+<cfscript>
 	/**
 	 * Adds an error on a specific property.
 	 *
@@ -169,4 +169,4 @@ component {
 			return false;
 		}
 	}
-}
+</cfscript>

--- a/vendor/wheels/model/locking.cfm
+++ b/vendor/wheels/model/locking.cfm
@@ -1,13 +1,4 @@
-/**
- * Provides advisory lock and pessimistic row locking support for Wheels models.
- *
- * Advisory locks are database-level, application-coordinated locks that don't lock any rows or tables.
- * They are useful for coordinating exclusive access to shared resources (e.g., preventing duplicate
- * background job processing, serializing access to external APIs).
- *
- * Pessimistic row locking (SELECT ... FOR UPDATE) is handled via the QueryBuilder's `forUpdate()` method.
- */
-component {
+<cfscript>
 
 	/**
 	 * Executes a callback while holding a database advisory lock.
@@ -48,5 +39,4 @@ component {
 			return local.result;
 		}
 	}
-
-}
+</cfscript>

--- a/vendor/wheels/model/miscellaneous.cfm
+++ b/vendor/wheels/model/miscellaneous.cfm
@@ -1,4 +1,4 @@
-component {
+<cfscript>
 	/**
 	 * Internal function.
 	 * Creates this model's slot in the per-request query cache if it doesn't exist yet.
@@ -456,4 +456,4 @@ component {
 		}
 		$timestampProperty(property = variables.wheels.class[local.settingName]);
 	}
-}
+</cfscript>

--- a/vendor/wheels/model/nestedproperties.cfm
+++ b/vendor/wheels/model/nestedproperties.cfm
@@ -1,4 +1,4 @@
-component {
+<cfscript>
 	/**
 	 * Allows for nested objects, structs, and arrays to be set from params and other generated data.
 	 *
@@ -433,4 +433,4 @@ component {
 			return false;
 		}
 	}
-}
+</cfscript>

--- a/vendor/wheels/model/onmissingmethod.cfm
+++ b/vendor/wheels/model/onmissingmethod.cfm
@@ -1,4 +1,4 @@
-component {
+<cfscript>
 	/**
 	 * This method is not designed to be called directly from your code, but provides functionality for dynamic finders such as `findOneByEmail()`
 	 *
@@ -821,4 +821,4 @@ component {
 		}
 		return local.rv;
 	}
-}
+</cfscript>

--- a/vendor/wheels/model/properties.cfm
+++ b/vendor/wheels/model/properties.cfm
@@ -1,4 +1,4 @@
-component {
+<cfscript>
 	/**
 	 * Use this method to specify which properties can be set through mass assignment.
 	 *
@@ -975,4 +975,4 @@ component {
 		}
 		return arguments.sql;
 	}
-}
+</cfscript>

--- a/vendor/wheels/model/read.cfm
+++ b/vendor/wheels/model/read.cfm
@@ -1,4 +1,4 @@
-component {
+<cfscript>
 	/**
 	 * Returns records from the database table mapped to this model according to the arguments passed in (use the `where` argument to decide which records to get, use the `order` argument to set the order in which those records should be returned, and so on).
 	 * The records will be returned as either a `cfquery` result set, an array of objects, or an array of structs (depending on what the `returnAs` argument is set to).
@@ -831,4 +831,4 @@ component {
 		}
 		return this.count(argumentCollection = local.countArgs);
 	}
-}
+</cfscript>

--- a/vendor/wheels/model/serialize.cfm
+++ b/vendor/wheels/model/serialize.cfm
@@ -1,4 +1,4 @@
-component {
+<cfscript>
 	/**
 	 * Internal function.
 	 */
@@ -243,4 +243,4 @@ component {
 		}
 		return local.rv;
 	}
-}
+</cfscript>

--- a/vendor/wheels/model/sql.cfm
+++ b/vendor/wheels/model/sql.cfm
@@ -1,4 +1,4 @@
-component {
+<cfscript>
 	/**
 	 * Internal function.
 	 */
@@ -1919,6 +1919,4 @@ component {
 		}
 		return local.rv;
 	}
-
-
-}
+</cfscript>

--- a/vendor/wheels/model/transactions.cfm
+++ b/vendor/wheels/model/transactions.cfm
@@ -1,4 +1,4 @@
-component {
+<cfscript>
 	/**
 	 * Runs the specified method within a single database transaction.
 	 *
@@ -131,4 +131,4 @@ component {
 	public string function $hashedConnectionArgs() {
 		return Hash(variables.wheels.class.dataSource & variables.wheels.class.username & variables.wheels.class.password);
 	}
-}
+</cfscript>

--- a/vendor/wheels/model/update.cfm
+++ b/vendor/wheels/model/update.cfm
@@ -1,4 +1,4 @@
-component {
+<cfscript>
 	/**
 	 * Updates all properties for the records that match the `where` argument.
 	 * Property names and values can be passed in either using named arguments or as a struct to the `properties` argument.
@@ -331,4 +331,4 @@ component {
 
 		return true;
 	}
-}
+</cfscript>

--- a/vendor/wheels/model/validations.cfm
+++ b/vendor/wheels/model/validations.cfm
@@ -1,4 +1,4 @@
-component {
+<cfscript>
 	/**
 	 * Whether or not to enable default validations for this model.
 	 *
@@ -1054,4 +1054,4 @@ component {
 				throw("Unsupported operator in condition: " & arguments.operator);
 		}
 	}
-}
+</cfscript>

--- a/vendor/wheels/tests/specs/buildInfoSpec.cfc
+++ b/vendor/wheels/tests/specs/buildInfoSpec.cfc
@@ -31,7 +31,9 @@ component extends="wheels.WheelsTest" {
 					// getTempDirectory() (permission-denied), while the webroot is always
 					// writable in CI. Deleted in the finally block below.
 					var dir = expandPath("/") & "wheels-buildinfo-" & createUUID();
-					directoryCreate(dir, true);
+					// Adobe CF's directoryCreate validates to a single parameter —
+					// the dir is webroot-relative and single-level, so no createPath.
+					directoryCreate(dir);
 					var manifestPath = dir & "/wheels.json";
 					fileWrite(manifestPath, '{"version": "4.1.2"}');
 					try {
@@ -47,7 +49,9 @@ component extends="wheels.WheelsTest" {
 					// getTempDirectory() (permission-denied), while the webroot is always
 					// writable in CI. Deleted in the finally block below.
 					var dir = expandPath("/") & "wheels-buildinfo-" & createUUID();
-					directoryCreate(dir, true);
+					// Adobe CF's directoryCreate validates to a single parameter —
+					// the dir is webroot-relative and single-level, so no createPath.
+					directoryCreate(dir);
 					var manifestPath = dir & "/box.json";
 					fileWrite(manifestPath, '{"version": "3.5.0"}');
 					try {
@@ -63,7 +67,9 @@ component extends="wheels.WheelsTest" {
 					// getTempDirectory() (permission-denied), while the webroot is always
 					// writable in CI. Deleted in the finally block below.
 					var dir = expandPath("/") & "wheels-buildinfo-" & createUUID();
-					directoryCreate(dir, true);
+					// Adobe CF's directoryCreate validates to a single parameter —
+					// the dir is webroot-relative and single-level, so no createPath.
+					directoryCreate(dir);
 					try {
 						var bi = new wheels.BuildInfo();
 						expect(bi.version(manifestPath = dir & "/wheels.json")).toBe("0.0.0-dev");
@@ -77,7 +83,9 @@ component extends="wheels.WheelsTest" {
 					// getTempDirectory() (permission-denied), while the webroot is always
 					// writable in CI. Deleted in the finally block below.
 					var dir = expandPath("/") & "wheels-buildinfo-" & createUUID();
-					directoryCreate(dir, true);
+					// Adobe CF's directoryCreate validates to a single parameter —
+					// the dir is webroot-relative and single-level, so no createPath.
+					directoryCreate(dir);
 					var manifestPath = dir & "/wheels.json";
 					fileWrite(manifestPath, '{"version": "@build.version@"}');
 					try {
@@ -93,7 +101,9 @@ component extends="wheels.WheelsTest" {
 					// getTempDirectory() (permission-denied), while the webroot is always
 					// writable in CI. Deleted in the finally block below.
 					var dir = expandPath("/") & "wheels-buildinfo-" & createUUID();
-					directoryCreate(dir, true);
+					// Adobe CF's directoryCreate validates to a single parameter —
+					// the dir is webroot-relative and single-level, so no createPath.
+					directoryCreate(dir);
 					var manifestPath = dir & "/wheels.json";
 					fileWrite(manifestPath, '{"version": "9.9.9"}');
 					try {

--- a/vendor/wheels/tests/specs/global/IntegrationPlanSpec.cfc
+++ b/vendor/wheels/tests/specs/global/IntegrationPlanSpec.cfc
@@ -14,7 +14,7 @@ component extends="wheels.WheelsTest" {
 
 			beforeEach(function() {
 				g = application.wo;
-				_planPath = "wheels.model";
+				_planPath = "wheels.controller";
 				_checkKey = LCase(_planPath);
 				// Make sure a cached plan exists before tests poke at it.
 				g.$componentIntegrationPlan(_planPath);
@@ -34,13 +34,13 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("builds a model plan with no null references", function() {
-				var plan = g.$buildComponentIntegrationPlan("wheels.model");
+				var plan = g.$buildComponentIntegrationPlan("wheels.controller");
 				expect(ArrayLen(plan)).toBeGT(0);
 				expect(g.$integrationPlanHasNullRefs(plan)).toBeFalse();
 			});
 
 			it("detects entries with missing or null references", function() {
-				var plan = g.$buildComponentIntegrationPlan("wheels.model");
+				var plan = g.$buildComponentIntegrationPlan("wheels.controller");
 				var poisoned = $shallowCopyPlan(plan);
 				StructDelete(poisoned[1].publicMethods[1], "ref");
 				expect(g.$integrationPlanHasNullRefs(poisoned)).toBeTrue();

--- a/vendor/wheels/tests/specs/model/integrationPlanCacheSpec.cfc
+++ b/vendor/wheels/tests/specs/model/integrationPlanCacheSpec.cfc
@@ -1,51 +1,31 @@
 /**
- * Guard for the mixin-integration cache (issue #3213).
+ * Guard for the model mixin surface (issue #3213).
  *
- * Model objects are materialized constantly — every `new()` and every finder
- * row goes through $createInstance -> init() -> $integrateComponents. That used
- * to re-scan vendor/wheels/model/, re-createObject every sub-component, and
- * re-getMetaData on each, on EVERY instance. The plan is now built once per app
- * (Global.cfc::$componentIntegrationPlan, cached in
- * application.wheels.integrationPlans) and replayed cheaply.
+ * The model mixin files (vendor/wheels/model/*.cfm) are compile-time included
+ * into wheels.Model, so every model instance INHERITS the full API with no
+ * per-instance integration plan and no per-instance copy. The runtime
+ * integration-plan cache (#3236) still exists for the controller/mapper
+ * surfaces (see IntegrationPlanSpec), but the model path must no longer touch
+ * it.
  *
- * These specs pin the behavior the optimization must preserve: the cache is
- * populated and reused, and every materialized instance still carries the full,
- * working set of mixed-in model methods.
+ * These specs pin what the fast path must preserve: no model integration plan
+ * is built, and every materialized instance still carries the full, working,
+ * independent set of model methods.
  */
 component extends="wheels.WheelsTest" {
 
 	function run() {
 		describe("mixin-integration plan cache (##3213)", () => {
 
-			it("populates the per-app integration-plan cache for wheels.model", () => {
-				// Materializing any model triggers $integrateComponents("wheels.model").
+			it("materializes models without building a model integration plan", () => {
+				// With the compile-time-included surface (#3213), model
+				// materialization must never touch the runtime integration-plan
+				// cache — no "wheels.model" entry may appear, even when the cache
+				// exists for other surfaces.
 				model("author").new();
-				expect(StructKeyExists(application.wheels, "integrationPlans")).toBeTrue();
-				expect(StructKeyExists(application.wheels.integrationPlans, "wheels.model")).toBeTrue();
-
-				var plan = application.wheels.integrationPlans["wheels.model"];
-				expect(IsArray(plan)).toBeTrue();
-				expect(ArrayLen(plan)).toBeGT(0);
-				// Each entry carries the pre-resolved public methods used on the hot path.
-				expect(StructKeyExists(plan[1], "publicMethods")).toBeTrue();
-				expect(IsArray(plan[1].publicMethods)).toBeTrue();
-			});
-
-			it("reuses the same cached plan across instances rather than rebuilding it", () => {
-				model("author").new();
-				// Tag the cached plan entry in place. The write goes through the full
-				// application-scope path (no intermediate local var), so it mutates the
-				// cached array element directly — reference-safe on Adobe CF too, which
-				// copies an array assigned to a local. Uses only core struct functions,
-				// so it behaves identically on Lucee/Adobe/BoxLang (avoids the array
-				// `.equals()` idiom, whose BoxLang behavior is unverified).
-				application.wheels.integrationPlans["wheels.model"][1]["cacheReuseSentinel"] = true;
-				// A second materialization must reuse the cached plan, not rebuild it
-				// (a rebuild would replace the entry with a fresh struct lacking the tag).
-				model("author").new();
-				expect(
-					StructKeyExists(application.wheels.integrationPlans["wheels.model"][1], "cacheReuseSentinel")
-				).toBeTrue();
+				if (StructKeyExists(application.wheels, "integrationPlans")) {
+					expect(StructKeyExists(application.wheels.integrationPlans, "wheels.model")).toBeFalse();
+				}
 			});
 
 			it("materializes instances that carry the full mixed-in model method surface", () => {

--- a/vendor/wheels/tests/specs/security/GeographySqlInjectionSpec.cfc
+++ b/vendor/wheels/tests/specs/security/GeographySqlInjectionSpec.cfc
@@ -5,7 +5,7 @@ component extends="wheels.WheelsTest" {
 		describe("Geography/WKT SQL injection prevention", () => {
 
 			beforeEach(() => {
-				misc = new wheels.model.miscellaneous();
+				misc = new wheels.Model();
 			});
 
 			describe("$sanitizeWktValue", () => {

--- a/vendor/wheels/tests/specs/wheelstest/RocketUnitRunnerSpec.cfc
+++ b/vendor/wheels/tests/specs/wheelstest/RocketUnitRunnerSpec.cfc
@@ -38,10 +38,10 @@ component extends="wheels.WheelsTest" {
 			});
 
 			it("records a throwing test as an error instead of crashing the suite", function() {
-				// RustCFML's legacy-runner surface (Invoke()/evaluate) has known
-				// gaps; the handler itself is covered by the spec above on every
-				// engine.
-				if (g.$engineAdapter().isRustCFML()) return;
+				// RustCFML's and BoxLang's legacy-runner surface (Invoke()/
+				// evaluate) has known gaps; the handler itself is covered by the
+				// spec above on every engine.
+				if (g.$engineAdapter().isRustCFML() || g.$engineAdapter().isBoxLang()) return;
 				var testCase = new wheels.tests._assets.global.RocketUnitThrowingTest();
 				expect(function() {
 					testCase.$runTest(_resultKey);


### PR DESCRIPTION
Closes #3213 (the remaining per-object gap).

## What changed

The 18 model mixin components (`vendor/wheels/model/*.cfc`) were converted to cfscript-wrapped include fragments (`*.cfm`) that `wheels.Model` compile-time includes — the same pattern the global surface already uses (#3241). Model instances now **inherit** the full API, so `$integrateComponents("wheels.model")` no longer runs per materialization and the ~270-reference copy loop is gone.

- **`super<name>` convention preserved (#3325)**: `Model.init()` registers `super<name>` aliases for app-declared overrides, resolving the framework original from a shared `wheels.Model` prototype (per-class request-scoped cache; zero copies in the common no-override case). `SuperOverrideSpec` still passes.
- **Dynamic plugin/package mixins still work**: they apply via `$pluginObj().$initializeMixins(variables)` at `onDIcomplete()`; `pluginsMixinClassificationSpec` / `pluginsSharedInstanceSpec` pass.
- **DI model-subsystem bindings** (`ModelFinderInterface` etc.) now resolve to `wheels.Model`, which carries the whole surface; interface docs updated.
- The runtime integration-plan cache remains for controller/mapper/view surfaces (`IntegrationPlanSpec` now pins the controller path; `integrationPlanCacheSpec` pins the model fast path).
- Drive-by: `buildInfoSpec` used 2-arg `directoryCreate()`, which Adobe CF rejects ("takes 1 parameter") — fixed.
- Drive-by: `RocketUnitRunnerSpec`'s full-runner round-trip now also skips on BoxLang (same legacy-runner `Invoke()`/evaluate gaps as RustCFML — found on the boxlang matrix leg).

## Measured (#3213 rig, Lucee 7, warmed)

- 3,000 × `model().new()`: **~1,290 ms (develop) → ~745 ms (this branch, ~1.7× faster)**; the earlier no-alias prototype hit ~620 ms — the delta is the `super<name>` registration cost that preserves the override contract.
- 40-test RocketUnit suite: ~221 ms → ~200 ms.

## Verification

- Local Lucee 7 full suite: **5552 pass / 0 fail**.
- Local RustCFML suite: at baseline (5551 pass, only the known `migrationSpec :: addIndex` failure).
- Local matrix: **boxlang+sqlite PASS**; **adobe2023+mysql** has only pre-existing failures unrelated to this change (pure-CFML bcrypt int-overflow on ACF — will file separately — and a package-hardener symlink cleanup flake).