### PR TITLE
chore: bump develop snapshot target to 4.1.0

### DIFF
--- a/wheels.json
+++ b/wheels.json
@@ -2,7 +2,7 @@
   "$schema": "https://wheels.dev/schema/wheels.json/v1.json",
   "name": "Wheels.fw",
   "version": "4.1.0",
-  "description": "Wheels \u2014 CFML MVC framework",
+  "description": "Wheels — CFML MVC framework",
   "homepage": "https://wheels.dev",
   "documentation": "https://wheels.dev/guides/",
   "license": "Apache-2.0",

--- a/wheels.json
+++ b/wheels.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://wheels.dev/schema/wheels.json/v1.json",
   "name": "Wheels.fw",
-  "version": "4.0.7",
-  "description": "Wheels — CFML MVC framework",
+  "version": "4.1.0",
+  "description": "Wheels \u2014 CFML MVC framework",
   "homepage": "https://wheels.dev",
   "documentation": "https://wheels.dev/guides/",
   "license": "Apache-2.0",


### PR DESCRIPTION
Bumps the develop snapshot target from 4.0.7 to 4.1.0, per the 4.0.7-vs-4.1.0 decision: the work merged since 4.0.6 (4.x backlog features + the #3213 performance series) adds public API surface, which warrants a minor rather than a patch.

Pure metadata change (wheels.json version field only).