### PR TITLE
docs(blog): 4.1.0 release series + daily scheduled publisher

### DIFF
--- a/.github/scripts/blog-publish-scheduled.sh
+++ b/.github/scripts/blog-publish-scheduled.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Publish scheduled blog posts whose publishedAt date is today or earlier (UTC).
+#
+# Moves each web/content/blog/scheduled/*.md that is due into
+# web/content/blog/posts/, commits as wheels-bot[bot], and pushes. The push
+# triggers the blog deploy workflow (blog_content_changed).
+#
+# Idempotent: after a successful run there is nothing left to move, so
+# re-running the same day is a no-op. Posts whose day was missed (failed or
+# skipped run) publish on the next successful run — catch-up, never stranded.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+SOURCE_DIR="web/content/blog/scheduled"
+TARGET_DIR="web/content/blog/posts"
+
+if [ ! -d "$SOURCE_DIR" ]; then
+  echo "No scheduled directory at $SOURCE_DIR — nothing to do."
+  exit 0
+fi
+
+TODAY="$(date -u +%Y-%m-%d)"
+echo "Publishing scheduled posts due on or before $TODAY (UTC)..."
+
+published=()
+for file in "$SOURCE_DIR"/*.md; do
+  # Skip the README (it has no publishedAt).
+  [ -e "$file" ] || continue
+  [ "$(basename "$file")" = "README.md" ] && continue
+
+  # publishedAt looks like: publishedAt: '2026-09-02T14:00:00.000Z'
+  due_date="$(sed -nE "s/^publishedAt: *'([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/p" "$file" | head -n 1)"
+
+  if [ -z "$due_date" ]; then
+    echo "WARNING: $(basename "$file") has no parseable publishedAt — skipping."
+    continue
+  fi
+
+  # ISO dates compare lexicographically.
+  if [[ "$due_date" > "$TODAY" ]]; then
+    echo "  future: $(basename "$file") (due $due_date)"
+    continue
+  fi
+
+  echo "  publishing: $(basename "$file") (due $due_date)"
+  git mv "$file" "$TARGET_DIR/$(basename "$file")"
+  published+=("$(basename "$file" .md)")
+done
+
+if [ ${#published[@]} -eq 0 ]; then
+  echo "Nothing due today. Done."
+  exit 0
+fi
+
+git config user.name "wheels-bot[bot]"
+git config user.email "wheels-bot[bot]@users.noreply.github.com"
+
+count=${#published[@]}
+slug_list="$(printf ', %s' "${published[@]}")"
+slug_list="${slug_list:2}"
+
+git add "$TARGET_DIR"
+git commit -m "docs(blog): publish $count scheduled post(s)" -m "Published by the scheduled blog publisher.
+
+Slugs: $slug_list" || {
+  echo "Commit failed or nothing to commit — checking status."
+  git status --short
+  exit 1
+}
+
+git push origin HEAD
+
+echo "Published $count post(s): $slug_list"

--- a/.github/workflows/blog-publish-scheduled.yml
+++ b/.github/workflows/blog-publish-scheduled.yml
@@ -1,0 +1,48 @@
+name: Blog — Publish Scheduled Posts
+
+# Every morning (06:00 UTC), moves blog posts whose publishedAt date is
+# today or earlier from web/content/blog/scheduled/ into
+# web/content/blog/posts/, commits as wheels-bot[bot], and pushes. The push
+# triggers the blog deploy (web-deploy.yml detects web/content/blog/posts/
+# changes), so the posts go live without further intervention. Catch-up
+# semantics: a missed day publishes on the next successful run.
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: blog-publish-scheduled
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish posts scheduled for today
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WHEELS_BOT_APP_ID }}
+          private-key: ${{ secrets.WHEELS_BOT_PRIVATE_KEY }}
+
+      # App-token pushes trigger downstream workflows (GITHUB_TOKEN pushes
+      # do not), which is what makes the blog deploy fire.
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Publish due posts
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          chmod +x .github/scripts/blog-publish-scheduled.sh
+          bash .github/scripts/blog-publish-scheduled.sh

--- a/web/content/blog/scheduled/README.md
+++ b/web/content/blog/scheduled/README.md
@@ -1,0 +1,27 @@
+# Scheduled blog posts
+
+Posts in this directory are **not** rendered by the blog site — the Astro
+content loader only globs `web/content/blog/posts/`. They are the staging
+area for scheduled publishing.
+
+## How publishing works
+
+The [Blog — Publish Scheduled Posts](../../.github/workflows/blog-publish-scheduled.yml)
+workflow runs every morning at 06:00 UTC (and on `workflow_dispatch`). It
+moves every post here whose `publishedAt` date is **today or earlier** (UTC)
+into `web/content/blog/posts/`, commits as `wheels-bot[bot]`, and pushes.
+That push triggers the existing blog deploy, which builds and publishes the
+site.
+
+Catch-up semantics are deliberate: if a run fails or is skipped, posts due
+in the past publish on the next successful run instead of being stranded.
+
+## Writing a scheduled post
+
+- Same markdown + frontmatter as `web/content/blog/posts/` (see
+  `web/sites/blog/src/content.config.ts` for the schema).
+- Set `publishedAt` to the intended publication date, in UTC. The date
+  *part* of the timestamp is what the publisher compares against today.
+- Keep the `slug` unique across both directories.
+- Do not edit `publishedAt` after a post has moved to `posts/` without good
+  reason — the site sorts by it.

--- a/web/content/blog/scheduled/bcrypt-password-hashing-in-wheels-4-1.md
+++ b/web/content/blog/scheduled/bcrypt-password-hashing-in-wheels-4-1.md
@@ -1,0 +1,71 @@
+---
+title: 'bcrypt password hashing lands in Wheels 4.1'
+slug: bcrypt-password-hashing-in-wheels-4-1
+publishedAt: '2026-09-02T14:00:00.000Z'
+updatedAt: null
+author: Peter Amiri
+tags:
+  - wheels-4
+  - security
+  - bcrypt
+categories:
+  - Releases
+excerpt: >-
+  Wheels 4.1 ships bcryptHash(), bcryptVerify(), and bcryptNeedsRehash() as
+  global helpers — pure CFML, OpenBSD/htpasswd/jBCrypt-compatible, no Java
+  objects or CFX. Here's how they work, what the cost factor costs you, and
+  how to migrate from the PBKDF2 hashes wheels generate auth produced in 4.0.6.
+coverImage: null
+---
+
+Wheels 4.1 adds a password-hashing primitive the framework hasn't had before: **bcrypt**, directly in the global function namespace, with no dependencies.
+
+```cfm
+hashed = bcryptHash("correct horse battery staple");       // $2b$10$...
+ok = bcryptVerify("correct horse battery staple", hashed); // true
+needsUpgrade = bcryptNeedsRehash(hashed, 12);              // true while cost is 10
+```
+
+The interesting part isn't the API — it's the implementation. There is no Java object, no CFX tag, no bundled JAR. The entire thing is CFML: the Blowfish block cipher, the EksBlowfish ("expensive key schedule") setup, and the 64-round ciphertext phase are implemented in pure CFML so the helpers run identically on Lucee, Adobe ColdFusion, BoxLang, and RustCFML.
+
+## Why bcrypt?
+
+The short version: bcrypt is the boring choice. It has been the default password hash for OpenBSD's `htpasswd` for decades, jBCrypt made it the standard Java implementation, and every language with an opinion has settled on it. Wheels 4.0.6's `wheels generate auth` scaffolds PBKDF2 hashing, which is fine and defensible — but bcrypt is what most teams expect when they hear "password hashing," and it's what existing password databases (htpasswd files, other frameworks' `$2a$`/`$2b$` columns) already contain.
+
+The helpers are format-compatible with all of it:
+
+- `bcryptHash()` produces the standard 60-character `$2b$<cost>$<salt><checksum>` format.
+- `bcryptVerify()` accepts existing `$2$`, `$2a$`, `$2x$`, `$2y$`, and `$2b$` hashes, so migrating from another tool is just a matter of keeping the stored strings.
+- `bcryptNeedsRehash(hash, cost)` tells you whether a stored hash's cost factor no longer matches your current policy — the hook you need to transparently upgrade hashes when a user logs in.
+
+The implementation is pinned against external vectors in the test suite: an OpenBSD `$2b$` checksum produced by Apache's `htpasswd` for "password", and the official jBCrypt `$2a$08$` vector for "abc".
+
+## What the cost factor costs
+
+bcrypt's cost is exponential: every +1 doubles the work. The pure-CFML implementation is honest about that trade-off — a cost-10 hash takes roughly 14 seconds of CFML on Lucee 7. That is not a typo.
+
+What this means in practice:
+
+- **Cost 4–6** is the right neighborhood for test suites and local development.
+- **Cost 10–12** is production-grade for a pure-CFML implementation, but you should measure it on *your* server, because the constant factor matters: the same cost runs several times faster on Adobe ColdFusion than on Lucee.
+- If you need cost 12 *and* sub-second registration times on Lucee, generate the hashes with bcrypt but consider that your traffic pattern is now CPU-bound — which is exactly what bcrypt is designed to do, so size your app servers accordingly.
+
+The helpers validate the cost factor up front and throw `Wheels.InvalidArgument` for anything outside 4–31, so a typo like `bcryptHash(password, 1)` fails loudly instead of silently hashing with an effectively useless cost.
+
+## RustCFML and the Adobe story
+
+Two engine-specific notes worth knowing:
+
+- **RustCFML** ships `bcryptHash()`/`bcryptVerify()` as *native builtins*. Wheels detects that at boot and skips its own definitions, so the same API is served by the engine's native implementation there — and `bcryptNeedsRehash()` (which no engine has) is always the CFML one.
+- Getting the pure-CFML core correct on **Adobe CF 2023** required fixing three genuinely Adobe-shaped bugs: bit functions reject operands above 2³¹−1, `mod` and `BitSHRN` coerce their operands in ways Lucee doesn't, and — the sneaky one — Adobe passes arrays *by value*, which silently discarded every mutation the key schedule made to the P/S arrays. The result was "hashes that computed, but wrongly." The fix made the key schedule return its state instead of relying on by-reference mutation, and the full BcryptSpec now passes on Adobe's matrix leg.
+
+## Migrating from PBKDF2
+
+If you generated auth scaffolding in 4.0.6, you have a `User` model with `PasswordHasher`-style PBKDF2 logic. Moving to bcrypt is a two-step dance:
+
+1. **New passwords** go through `bcryptHash()`.
+2. **Existing hashes** keep verifying through your old routine until the user next logs in, at which point you re-hash with bcrypt and store the new value.
+
+There's no framework migration tool for this, and there shouldn't be — you're replacing a stored secret's format, which is the kind of thing that deserves a code review, not a generator.
+
+If you've never generated auth and just want the helpers, they're already in scope in every Wheels 4.1 app: `bcryptHash`, `bcryptVerify`, `bcryptNeedsRehash`, no configuration required.

--- a/web/content/blog/scheduled/cli-workflow-upgrades-migrate-diff-dry-run-offline.md
+++ b/web/content/blog/scheduled/cli-workflow-upgrades-migrate-diff-dry-run-offline.md
@@ -1,0 +1,77 @@
+---
+title: 'CLI upgrades in 4.1: migrate diff, generate --dry-run, and offline mode'
+slug: cli-workflow-upgrades-migrate-diff-dry-run-offline
+publishedAt: '2026-09-06T14:00:00.000Z'
+updatedAt: null
+author: Peter Amiri
+tags:
+  - wheels-4
+  - CLI
+  - wheels-cli
+categories:
+  - CLI
+excerpt: >-
+  Wheels 4.1 gives the CLI three workflow tools that used to require
+  guesswork: migrate diff previews the schema changes the AutoMigrator would
+  make, generate --dry-run prints generated files without writing them, and
+  offline mode keeps CI and air-gapped builds from hanging on network calls.
+coverImage: null
+---
+
+The Wheels CLI grew up around scaffolding — `wheels generate`, `wheels migrate`, `wheels deploy`. What it was missing was the *what-will-this-do* half of those commands. 4.1 fills that gap with three additions, plus a batch of honesty fixes that make the CLI fail loudly when something is wrong instead of exiting zero.
+
+## `wheels migrate diff`
+
+The AutoMigrator has always been able to reconcile your model definitions with the database. What it couldn't do was *show* you the reconciliation before applying it. Now:
+
+```sh
+wheels migrate diff            # print the diff, change nothing
+wheels migrate diff --write    # apply it
+```
+
+(There's a `dbmigrate diff` alias if your muscle memory predates the rename.)
+
+The diff lists what the migrator would do to each table — new columns, type changes, indexes — and accepts the same knobs the AutoMigrator does, including `--rename` hints for when a column was renamed rather than dropped-and-added (the migrator can't know that on its own), a `--threshold` for how aggressively it matches changed columns, and `--hints` for the comparison settings. The useful workflow this enables:
+
+```sh
+wheels migrate diff           # review in code review
+wheels migrate diff --write   # apply after the review approves
+```
+
+For teams that version migrations by hand, `diff` is a review tool, not a replacement — but for apps living the AutoMigrator life, it turns "trust the magic" into "read the plan."
+
+## `wheels generate --dry-run`
+
+Generators write files. Before 4.1, the only way to see what a generator would write was to run it in a scratch copy and diff. Now every generator accepts `--dry-run`:
+
+```sh
+wheels generate scaffold Post title:string body:text --dry-run
+```
+
+It prints the would-be file list — model, controller, views, migration, tests — and writes nothing. No partial state to clean up, no "wait, it created the migration already?" moment. It's the same mechanism under every generator (`model`, `controller`, `scaffold`, and the rest), so the flag behaves identically everywhere instead of being bolted onto one command.
+
+## Offline mode
+
+CI runners, Docker builds, and air-gapped servers share one failure mode: the CLI reaches for the network and hangs, or fails twenty minutes into a build. 4.1 adds:
+
+```sh
+wheels migrate --offline
+# or, per-environment:
+WHEELS_OFFLINE=1 wheels migrate latest
+```
+
+Two behaviors change: the CLI's update check is skipped entirely, and the package registry fails fast with a clear "offline" message instead of timing out on a socket. Accepted on `migrate` and `db` commands, so your database setup step works identically on a laptop with Wi-Fi and a build server with none.
+
+## Honesty fixes in the same release
+
+Smaller, but they'll save you a bad deploy:
+
+- **`wheels test` now exits non-zero** when the runner reports `directoryRejected`, `bundlesDiscovered=0`, or unloadable specs — a "green" run that silently tested nothing is no longer reported as success. `wheels browser test` similarly exits non-zero on Fail/Error.
+- **`wheels doctor` learned new checks** — legacy `wheels.Test` (RocketUnit) specs in your app, non-empty `plugins/` directories from the deprecated plugin system, and raw `params.` mass assignment into `create`/`update`/`save`. All warn-only, comment-stripped scans, so they're safe to run in CI.
+- **`wheels destroy view` rejects path-join escapes** (`../x` and friends), so deletes stay under `app/views/`.
+
+## The deploy side
+
+One more thing for the `wheels deploy` users: the deploy config now supports a `boot` block — Kamal-compatible `limit` and `wait` settings for how many containers boot at once and how long the healthcheck waits. If you've been deploying with the default boot strategy, this is the knob you've been missing for zero-downtime rolls.
+
+Everything here is documented in the CLI reference in the guides; the `--dry-run` and `--offline` flags in particular are the kind of thing you want in your muscle memory *before* the next incident, not after.

--- a/web/content/blog/scheduled/dependency-injection-factories-with-tofactory.md
+++ b/web/content/blog/scheduled/dependency-injection-factories-with-tofactory.md
@@ -1,0 +1,74 @@
+---
+title: 'Dependency-injection factories with Injector.toFactory()'
+slug: dependency-injection-factories-with-tofactory
+publishedAt: '2026-09-05T14:00:00.000Z'
+updatedAt: null
+author: Peter Amiri
+tags:
+  - wheels-4
+  - dependency-injection
+categories:
+  - Releases
+excerpt: >-
+  Wheels 4.1's toFactory() binds a name to a closure that builds the
+  instance — and the closure receives the container itself, so factories can
+  resolve collaborators. Singletons and request-scoped bindings cache the
+  result; transient bindings re-run the factory on every resolve. Here's
+  when a factory beats a to() binding.
+coverImage: null
+---
+
+Most DI bindings in Wheels are static: `map("mailer").to("app.services.Mailer")` means "construct this component." 4.1 adds the second shape:
+
+```cfm
+injector()
+    .map("storageClient")
+    .toFactory(function(ctx) {
+        var settings = ctx.getInstance("settings");
+        return settings.useS3
+            ? new storage.S3Client(bucket = settings.s3Bucket)
+            : new storage.LocalClient(root = settings.uploadsPath);
+    });
+```
+
+The factory is a closure — it receives **the container** as its argument, and its return value is what `getInstance("storageClient")` resolves to.
+
+## What `to()` can't express
+
+`to("component.path")` answers one question: *which component?* Factories answer *how?* Three situations where the difference matters:
+
+**Conditional construction.** The example above — pick an implementation based on config at resolve time. With `to()` you'd construct both clients and pick at the call site, leaking that decision into every consumer. With a factory, consumers ask for `storageClient` and stay ignorant of the branch.
+
+**Non-component return values.** `to()` always constructs a CFC. A factory can return anything — a Java object, a plain struct of config, a test double. If your binding isn't a component, it's a factory.
+
+**Expensive or racy setup.** Construction that should happen once, under the container's singleton lock, rather than lazily inside whoever happens to resolve it first.
+
+## Lifecycle flags still apply
+
+The factory is a *source of instances*, not a lifecycle. The usual flags do what you'd expect:
+
+```cfm
+// built once, under a double-checked lock, cached forever
+.map("appConfig").toFactory(function(ctx) { return ctx.getInstance("settings").appConfig; }).asSingleton()
+
+// built once per request, cached in request scope
+.map("requestScopedClient").toFactory(function(ctx) { return new api.Client(token = request.headers.apiToken); }).asRequestScoped()
+
+// default: the factory runs on every resolve
+.map("freshQuery").toFactory(function(ctx) { return new query.Builder(); })
+```
+
+And because the factory receives the container, nested resolution is natural: `ctx.getInstance("settings")` inside a factory is the same call your controllers make.
+
+## Gotchas worth internalizing
+
+- **`toFactory()` requires a preceding `map()`.** Just like `to()`, it throws `Wheels.Injector` without one.
+- **The argument must be a closure or function reference.** Passing a string or a component is rejected loudly.
+- **`toFactory()` after `to()` replaces the path binding.** You can rebind a name from component to factory and back; rebinding also resets singleton/request-scoped flags and drops the request-scope cache entry, so stale cached instances don't survive a rebind.
+- **Circulars are guarded.** The container tracks the in-flight resolving stack per request, so a factory that (directly or indirectly) resolves the name it's building gets a clear circular-dependency error rather than a stack overflow.
+
+## What changed under the hood
+
+Factories live in their own registry, checked before path resolution in `getInstance()`. That ordering is what makes the lifecycle flags work: singleton factories are cached by mapping name under a named lock, request-scoped factories land in the request DI cache, and transient factories run every time. The new `hasExplicitMapping()` on the injector rounds out the surface — it's how other framework code (notably the model-construction fast path from the [performance work](https://blog.wheels.dev/posts/how-we-made-model-instantiation-2-5x-faster/)) knows to fall back to the full container path when a name is explicitly mapped.
+
+The complete container surface — `map`, `to`, scopes, rebinding semantics — is documented in the guides under dependency injection, and the 4.0 series' [authentication post](https://blog.wheels.dev/posts/authentication-strategies-wheels-4/) shows `bind()`-style service wiring in a real app context.

--- a/web/content/blog/scheduled/how-we-made-model-instantiation-2-5x-faster.md
+++ b/web/content/blog/scheduled/how-we-made-model-instantiation-2-5x-faster.md
@@ -1,0 +1,69 @@
+---
+title: 'How we made model instantiation 2.5x faster'
+slug: how-we-made-model-instantiation-2-5x-faster
+publishedAt: '2026-09-07T14:00:00.000Z'
+updatedAt: null
+author: Peter Amiri
+tags:
+  - wheels-4
+  - performance
+  - behind-the-scenes
+categories:
+  - Releases
+excerpt: >-
+  A 2.5-era app reported its RocketUnit suite running 6x slower on Wheels 4.
+  That report sent us down a two-month rabbit hole: benchmark rigs, a
+  mixin-architecture refactor, and three targeted hot-path cuts. The result:
+  model instantiation is ~2.5x faster than 4.0.3, and the report was right
+  the whole time.
+coverImage: null
+---
+
+This is the story of [issue #3213](https://github.com/wheels-dev/wheels/issues/3213), which began with a forum post and ended with the model layer's architecture changing shape.
+
+Adam had ported his app from Wheels 2.5 to 4.0.3. Same RocketUnit suite: **274 seconds on 2.5, 1,599 seconds on 4.0.3.** Nearly six times slower. He asked whether we'd done any performance comparisons. We hadn't — not like that.
+
+## The first fix was real but small
+
+The first root cause we found was per-object overhead: every `model().new()` and every finder row re-scanned `vendor/wheels/model/`, re-created each of the ~18 mixin components, and re-resolved ~270 method references — on *every instance*. That became the mixin-plan cache in 4.0.6. It helped: roughly 12% on our loop. But it didn't close six times, and Adam's measurement kept bothering us.
+
+So we did the thing we should have done first: **built an actual benchmark rig.** Identical `wheels new` scaffold, same models, same RocketUnit-style workload. Only `vendor/wheels` swapped. Wheels 2.5.0 on one server, current develop on the other, same Lucee 7 engine.
+
+The result: **Adam was right.** 2.5 materialized model instances ~4.9× faster than develop on the same engine. Not an environment artifact, not Lucee 5, not his app. A real regression hiding in plain sight since the 3.x rewrite.
+
+## The architectural difference
+
+Reading 2.5's source made the cause obvious. In 2.5, `wheels/Model.cfc` *compile-time includes* the model API (`include "model/functions.cfm"`). Every method is part of the class, and every instance **inherits** it for free.
+
+The 3.x/4.x rewrite replaced that with *runtime per-instance mixin integration* — a deliberate feature (it powers the plugin/package mixin system), but one that runs on every object creation even when nothing dynamic is registered. Each instance copied ~270 function references into its `variables` and `this` scopes, with per-method collision checks.
+
+Three targeted changes in 4.1 put the static surface back where it belongs:
+
+1. **Request-scope plan cache.** The integration plan was re-read from the synchronized application scope ~6 times per instance. Serving it from the request scope after first use cut that lookup from ~61µs to ~1µs per instantiation.
+2. **Compile-time inheritance.** The model mixin files became compile-time includes again — instances inherit the API, no per-instance copy. The hard part was preserving the `super<name>` override convention: when an app overrides a model method, the framework original still has to be reachable. It is, via aliases resolved from a shared prototype, and the override specs still pass.
+3. **Direct construction.** `$createObjectFromRoot` now constructs model instances with a direct `CreateObject` + structured call instead of routing every one through the DI container's resolve/auto-wire path plus a reflective `Invoke()`. Models explicitly mapped in the container keep the full path.
+
+## The numbers
+
+Same rig, warmed, 3,000 × `model().new()`:
+
+| version | time |
+|---|---|
+| 4.0.3 | ~1,290 ms |
+| 4.0.6 (+ plan cache) | ~1,290 ms |
+| develop after the 4.1 work | **~508 ms** |
+
+The gap to 2.5 on this workload went from ~4.9× to ~1.9×, and the remaining difference is per-instance setup (`$initModelClass`, property handling, callback dispatch) rather than anything structural. We're treating that as a follow-up, not a mystery.
+
+## What the rabbit hole also produced
+
+Benchmarking this hard surfaced two real bugs that had nothing to do with speed:
+
+- A **flaky bare `NullPointerException`** in model instantiation on Lucee 7 — the cached integration plan could carry null function references, which got copied into instances. Fixed by validating the plan once per request and rebuilding it when poisoned.
+- The **RocketUnit runner crash** — on Lucee 7, *any* failing test 500'd the entire suite ("variable [MESSAGE] doesn't exist") instead of recording the error. Fixed, with specs.
+
+Both are the kind of thing that makes "slow" look like "broken" in the field — worth knowing if you're still on an older 4.0.x.
+
+## The lesson
+
+The framework had been getting faster in ways that didn't move Adam's number, and we'd have kept optimizing the wrong thing if we'd trusted our own micro-benchmarks instead of building a head-to-head rig against the version users actually compare us to. If you run a Wheels app and your test suite got slower across an upgrade: you were probably right. File it. We'll believe you faster next time.

--- a/web/content/blog/scheduled/one-line-session-auth-with-enablesession.md
+++ b/web/content/blog/scheduled/one-line-session-auth-with-enablesession.md
@@ -1,0 +1,69 @@
+---
+title: 'One-line session authentication with enableSession()'
+slug: one-line-session-auth-with-enablesession
+publishedAt: '2026-09-03T14:00:00.000Z'
+updatedAt: null
+author: Peter Amiri
+tags:
+  - wheels-4
+  - authentication
+  - dependency-injection
+categories:
+  - Releases
+excerpt: >-
+  Wheels 4.1's enableSession() facade condenses session authentication setup
+  into one line of config: the authenticator and session strategy singletons
+  get registered, the session strategy is wired into the authenticator, and
+  it all composes cleanly with a pre-existing container. Here's what it does
+  and how it fits with wheels generate auth.
+coverImage: null
+---
+
+Wheels 4.0 introduced the `wheels.auth` primitives — an `Authenticator` that composes named strategies, a `SessionStrategy` that stores a user key in the session, and `authenticateWith()` to route logins through them. What it didn't have was a short path from "new app" to "sessions work."
+
+4.1 adds it. In `config/services.cfm`:
+
+```cfm
+injector().enableSession(sessionKey = "wheels.auth");
+```
+
+That's the entire setup. One line.
+
+## What the line does
+
+`enableSession()` is a facade over three pieces of container wiring that you'd otherwise write by hand (and get subtly wrong):
+
+1. **Maps the singletons** — `authenticator` and `sessionStrategy` are registered as container singletons, so every `injector().getInstance("authenticator")` in your app is the same object.
+2. **Registers the session strategy** — the `session` strategy is added to the authenticator's strategy list, so `authenticateWith("session", ...)` works without any further configuration.
+3. **Returns the strategy** — the call returns the `SessionStrategy` instance, in case you want to hold a reference for further configuration.
+
+It's also **idempotent**. Call it twice — or call it in code that runs during a reload cycle — and you still end up with one `session` strategy, not two. That matters more than it sounds: config files re-execute on reloads, and duplicate strategy registration is exactly the kind of bug that only shows up after the second deploy.
+
+## What it composes with
+
+The facade deliberately doesn't assume it's the only thing in your container:
+
+- **A pre-mapped authenticator is respected.** If your `config/services.cfm` (or a package) already mapped `authenticator` to a subclass, `enableSession()` adds the session strategy to *that* instance instead of replacing it.
+- **A custom `currentUser` resolver still works.** The strategy asks the DI container for `currentUser`; `enableSession()` doesn't take that over. Bind `currentUser` to a closure that looks up your `User` model and both the strategy and your policies use it.
+- **Missing container? You get told.** Calling `enableSession()` with no DI container registered throws a `Wheels.Injector` error rather than half-wiring a session that would fail on the first request.
+
+The signature is small and all-optional:
+
+```cfm
+enableSession(
+    sessionKey = "wheels.auth",  // default
+    onLogin = "",                // optional event/callback
+    onLogout = ""                // optional event/callback
+);
+```
+
+## How it fits with `wheels generate auth`
+
+If you ran `wheels generate auth` in 4.0.6, you already have controllers, views, a `User` model, and a services block — the generator wires session auth up through the same primitives this facade now collapses. For 4.1 apps, the story is simpler:
+
+- **Scaffolded auth:** keep the generated wiring. It is explicit, owned code, and the generator already added the strategy registration for you.
+- **Hand-rolled auth:** start from `enableSession()` and add only what you need — a login controller action calling `authenticateWith("session", user)`, a logout calling `deauthenticate()`, and a `currentUser` binding.
+
+And if you'd rather not write the one line at all, `wheels generate auth` remains the full-featured path. The facade is the middle ground that didn't exist before 4.1: the full power of the auth layer, one line of config.
+
+The complete auth surface — strategies, tokens, JWTs, policies — is covered in the [authentication strategies](https://blog.wheels.dev/posts/authentication-strategies-wheels-4/) post from the 4.0 series, which is still the best tour of the architecture this facade sits on top of.

--- a/web/content/blog/scheduled/pretty-urls-with-route-bindby.md
+++ b/web/content/blog/scheduled/pretty-urls-with-route-bindby.md
@@ -1,0 +1,73 @@
+---
+title: 'Pretty URLs with route bindBy='
+slug: pretty-urls-with-route-bindby
+publishedAt: '2026-09-04T14:00:00.000Z'
+updatedAt: null
+author: Peter Amiri
+tags:
+  - wheels-4
+  - routing
+categories:
+  - Releases
+excerpt: >-
+  Wheels 4.1 routes can bind their :key segment to a non-primary-key column:
+  bindBy="slug" turns /posts/my-first-post into Post.findBySlug("my-first-post")
+  without hand-writing a finder route. Here's how binding works, when to use
+  it, and what to do when the bound column isn't unique.
+coverImage: null
+---
+
+Resource routes in Wheels have always bound their `:key` segment to the model's primary key — `/posts/42` means `Post.findByKey(42)`. That's the right default for internal IDs, but it's the wrong URL for humans. `/posts/42` tells your users nothing; `/posts/wheels-4-1-released` tells them everything, and it's what gets shared, bookmarked, and pasted into chat.
+
+Wheels 4.1 adds the missing piece:
+
+```cfm
+mapper()
+    .resources(name = "posts", bindBy = "slug")
+    .end();
+```
+
+With that one option, every `:key` in the generated routes resolves through the parameterized dynamic finder `findOneBySlug()` instead of `findByKey()`. `/posts/wheels-4-1-released` runs `Post.findOneBySlug("wheels-4-1-released")`, and `linkTo(post)` generates the pretty URL instead of the numeric one.
+
+## What `bindBy` is not
+
+Two terms that are easy to conflate:
+
+- **`binding=`** (existing) maps *extra* route parameters to a model lookup used by `renderPage`-style page binding.
+- **`bindBy=`** (new) changes *which column the key segment binds through*.
+
+They're orthogonal, and they compose. A route can bind its key to a slug and still declare additional bindings for secondary parameters.
+
+## How the lookup happens
+
+Under the hood, binding resolves through the same parameterized finder convention the rest of the model layer uses. `bindBy="slug"` looks for a `findOneBySlug` method on the model — either the one Wheels generates automatically from your column set, or your own:
+
+```cfm
+// app/models/Post.cfc
+component extends="Model" {
+    function findOneBySlug(required string slug) {
+        // case-insensitive, or tenant-scoped, or include-soft-deletes:
+        return this.findOne(where = "slug = '#arguments.slug#'", includeSoftDeletes = true);
+    }
+}
+```
+
+Because it's a normal finder, everything a finder can do is available: scoping, ordering, returning `false` for not-found so the framework 404s correctly. If the finder doesn't exist, you get a clear error at request time — which beats the silent numeric-lookup fallback every day of the week.
+
+## When to reach for it
+
+- **Content models with slugs** — posts, pages, docs. The classic case.
+- **Usernames** — `/users/ada` instead of `/users/4821` for public profiles.
+- **Anything with a natural, stable key** — SKUs, handles, codes.
+
+And when *not* to:
+
+- **Non-unique columns.** If two rows can share the bound value, the finder returns the first match and you've built a confusion generator. `bindBy` is for unique columns — the uniqueness is on you, not the router.
+- **Mutable keys.** If the bound value can change (display names, titles edited in place), your URLs rot. Slugs and usernames are usually stable in a way titles aren't.
+- **Admin surfaces.** Internal CRUD with numeric IDs is fine staying numeric; pretty URLs buy nothing behind the login wall.
+
+## One thing to plan for
+
+Pretty keys interact with pagination, nested resources, and route precedence exactly like numeric keys — the binding is resolved after the route matches, so nothing about matching changes. But your `linkTo` calls change their output, which means one place to check after flipping a resource to `bindBy`: anything that hard-coded `/posts/#id#` as a string instead of using the helpers. Those were always fragile; `bindBy` just makes them visible.
+
+If you want the full tour of the routing layer before adding `bindBy` to your routes file, the [routing deep dive](https://blog.wheels.dev/posts/associations-deep-dive-wheels-4/) and the route-precedence behavior in the guides are the place to start.

--- a/web/content/blog/scheduled/the-wheels-4-1-security-hardening-pass.md
+++ b/web/content/blog/scheduled/the-wheels-4-1-security-hardening-pass.md
@@ -1,0 +1,74 @@
+---
+title: 'The Wheels 4.1 security hardening pass'
+slug: the-wheels-4-1-security-hardening-pass
+publishedAt: '2026-09-08T14:00:00.000Z'
+updatedAt: null
+author: Peter Amiri
+tags:
+  - wheels-4
+  - security
+categories:
+  - Releases
+excerpt: >-
+  4.1 shipped a release-cycle hardening pass across the framework: fail-closed
+  auth and policies, controller retargeting protection, mass-assignment
+  opt-in, zip-slip and path-escape fixes, view-helper encoding, and storage
+  key validation. Here's what changed, area by area, and what (if anything)
+  you need to do about it.
+coverImage: null
+---
+
+Alongside the feature work, 4.1 ran a systematic hardening pass over the framework's trust boundaries. The theme across all of it: **fail closed**. Where 4.0 sometimes guessed, 4.1 refuses — loudly, and with a typed error you can catch.
+
+Here's the tour, area by area.
+
+## Authentication and authorization
+
+- **Session rotation.** `SessionStrategy.login()` and `logout()` rotate or invalidate the session ID, and rotation failures are no longer swallowed by a catch-all.
+- **JWTs require expiry by default.** `JwtService.decode()` now demands an `exp` claim unless you explicitly pass `requireExpiry=false`. A signed token with no expiry was a token with no revocation story.
+- **Policies require true.** `authorize()`/`can()` grant only when a policy method returns boolean `true` — the CFML strings `"yes"` and `"true"` no longer authorize. Unknown actions throw `Wheels.Policy.UnknownAction` instead of treating a typo as a deny (a typo that denies is a bug that hides).
+- **`authenticateWith()` fails closed** when the restriction list names a strategy that doesn't exist, instead of silently skipping the typo.
+- **Empty policy scopes return a no-rows chain** rather than calling `whereIn("id", [])` — which, per the anti-pattern we've burned on before, was a SQL syntax error waiting for an empty collection.
+
+## Controllers and requests
+
+- **Controller/action retargeting is gone.** Query strings, form fields, or JSON bodies can no longer retarget the routed `controller`/`action` — `$ensureControllerAndAction` pins them. Wildcard path names are unchanged.
+- **`form._method` is honored only on POST**, and only for `PUT`/`PATCH`/`DELETE` — GET can't become a state-changing verb.
+- **Before filters that return `false` now halt** the action and remaining filters (redirects and renders still halt as before). The authz fail-closed signal actually fails closed.
+- **Client-supplied rewrite headers** (`X-Rewrite-URL`, `X-Original-URL`) are ignored unless you opt in with `set(trustProxyHeaders=true)`.
+- **`$wildcardDomainMatch` compares every host label**, so `https://*.example.com` no longer matches `https://evil.com`.
+
+## Models and mass assignment
+
+- **Strict mode.** `set(massAssignmentStrict=true)` fail-closes `create`/`update`/`save` for models with neither `accessibleProperties()` nor `protectedProperties()`. The default remains open for compatibility — flip it on new apps and never look back.
+- **`create()` no longer leaks properties onto the shared class model** before instantiating the record, and nested `hasMany` keys no longer use a `GetTickCount` window to decide "new" vs existing (form identities use a `new-` prefix).
+- **Uniqueness scopes now exclude soft-deleted rows by default** (`includeSoftDeletes=false`), so a soft-deleted value can be reused.
+
+## Plugins and packages
+
+- **Zip-slip is fixed.** Plugin zip extraction rejects absolute paths, `..` segments, and canonical escapes before writing a single file.
+- **Package manifests with empty `wheelsVersion` are rejected**; invalid `plugin.json` skips the plugin instead of half-loading it.
+- **Admin pages no longer `cfinclude` on-disk `index.cfm` files** from packages, and homepage links are `EncodeForHTML`-encoded http(s)-only.
+- **PackageLoader refuses dotted/traversed directory names** and mappings whose realpath lands outside the package — including symlink escapes.
+
+## Views and output
+
+- **Breakout attribute names are rejected** in view helpers, `errorElement`/`wrapperElement` are restricted to safe tags, and `encode` is honored on date option bodies and `csrfMetaTags`.
+- **`linkTo(sanitizeHref=true)` blanks `javascript:`/`data:` hrefs** (opt-in; the default stays `false`).
+- **Pagination and asset helpers encode interpolated paths**, collapse `..` on local sources, and stop double-encoding pagination params.
+
+## Middleware and storage
+
+- **`Pipeline.getMiddleware()` returns a copy** — callers can't mutate the live stack.
+- **RateLimiter honors `trustProxy`** before a client-supplied `remoteAddr`.
+- **Circular middleware dependencies throw** `Wheels.Middleware.CircularDependency` instead of silently falling back to priority ordering.
+- **LocalDisk refuses empty and slash-only keys** so `put()` can't write the disk root, and S3 `put()` sends a signed `x-amz-acl` so visibility settings are actually enforced.
+
+## What you need to do
+
+For most apps: **nothing**. The changes are either opt-in (strict mass assignment, `sanitizeHref`, `genericErrors`) or bug fixes that make existing defaults behave the way they were always documented to. The two things worth a look on an upgrade:
+
+1. Grep for `whereIn`/`whereNotIn` with possibly-empty arrays and for `form._method` usage — both now behave more strictly.
+2. If you wrote policy methods returning `"yes"` strings, they deny now. That's the point.
+
+The full list is in the 4.1.0 changelog. Security releases shouldn't be exciting; this one's excitement is that the checks you always assumed existed now actually exist.

--- a/web/content/blog/scheduled/wheels-4-1-0-released.md
+++ b/web/content/blog/scheduled/wheels-4-1-0-released.md
@@ -1,0 +1,61 @@
+---
+title: 'Wheels 4.1.0 released: bcrypt, session auth, pretty routes, and a faster core'
+slug: wheels-4-1-0-released
+publishedAt: '2026-09-10T14:00:00.000Z'
+updatedAt: null
+author: Peter Amiri
+tags:
+  - wheels-4
+  - release-notes
+  - frameworks
+categories:
+  - Releases
+excerpt: >-
+  Wheels 4.1.0 is out — the release where the 4.x backlog shipped and the
+  framework got faster. bcrypt password hashing, one-line session auth, route
+  bindBy, DI factories, CLI diff/dry-run/offline workflows, a security
+  hardening pass, and model instantiation ~2.5x faster than 4.0.3.
+coverImage: null
+---
+
+Wheels 4.1.0 is out. This release closes the 4.x backlog and lands the performance work that started with a single bug report — plus a hardening pass that makes a lot of things you already assumed were safe actually safe.
+
+Full notes: [GitHub Release v4.1.0](https://github.com/wheels-dev/wheels/releases/tag/v4.1.0) · [CHANGELOG](https://github.com/wheels-dev/wheels/blob/main/CHANGELOG.md)
+
+## The headline features
+
+**bcrypt password hashing.** `bcryptHash()`, `bcryptVerify()`, and `bcryptNeedsRehash()` are now global helpers — pure CFML, no Java objects, OpenBSD/htpasswd/jBCrypt-compatible, and correct on every supported engine including the ones that made it hard. [Deep dive](https://blog.wheels.dev/posts/bcrypt-password-hashing-in-wheels-4-1/).
+
+**One-line session auth.** `injector().enableSession()` in `config/services.cfm` wires the authenticator, the session strategy singleton, and idempotent strategy registration — and composes with a pre-mapped authenticator. [Deep dive](https://blog.wheels.dev/posts/one-line-session-auth-with-enablesession/).
+
+**Pretty routes.** `bindBy="slug"` on a resource binds its `:key` segment to a non-primary-key column via the parameterized finder — `/posts/wheels-4-1-0-released` instead of `/posts/42`. [Deep dive](https://blog.wheels.dev/posts/pretty-urls-with-route-bindby/).
+
+**DI factories.** `map("x").toFactory(function(ctx){...})` binds a name to a closure that receives the container and builds the instance — with full singleton/request-scoped/transient lifecycle support. [Deep dive](https://blog.wheels.dev/posts/dependency-injection-factories-with-tofactory/).
+
+**CLI workflow tools.** `wheels migrate diff` (preview or `--write` schema changes with rename hints), `generate --dry-run`, offline mode, plus fail-closed `wheels test` exit codes and new `wheels doctor` checks. [Deep dive](https://blog.wheels.dev/posts/cli-workflow-upgrades-migrate-diff-dry-run-offline/).
+
+## The performance work
+
+Model instantiation is **~2.5× faster than 4.0.3** on our benchmark rig — the result of a head-to-head 2.5-vs-4.x benchmark that confirmed a user's "4.x is much slower" report, followed by three hot-path changes: request-scoped caching of the mixin plan, compile-time inheritance of the model API, and direct construction. The full story, including the two unrelated bugs the benchmarking surfaced, is in the [write-up](https://blog.wheels.dev/posts/how-we-made-model-instantiation-2-5x-faster/).
+
+## The hardening pass
+
+4.1 ships a release-cycle security hardening pass: fail-closed policies and auth, controller/action retargeting protection, strict mass-assignment mode, zip-slip and path-escape fixes in the plugin system, view-helper encoding fixes, middleware copy semantics, and storage key validation. [What changed, area by area](https://blog.wheels.dev/posts/the-wheels-4-1-security-hardening-pass/).
+
+## And the rest
+
+- **Developer tooling:** a Code Complexity panel in the debug bar and the `wheels coverage` CRAP-ranking command — [write-up](https://blog.wheels.dev/posts/wheels-coverage-and-the-complexity-panel/).
+- **Engine compatibility:** the Adobe CF 2023/2025 matrix failures are fixed (debug bar, `"Null"` string binding, nested hasMany keys, pagination params) and the core suite runs clean on the JVM-free RustCFML engine.
+- **Deploy:** Kamal-compatible `boot` config (`limit`/`wait`) for `wheels deploy`.
+- **Deprecations:** `wheels.Test` (RocketUnit) now emits a one-time deprecation warning; removal is planned for Wheels 5.0. If you still run RocketUnit suites, this is your heads-up.
+
+## Upgrading
+
+```sh
+wheels upgrade check
+wheels upgrade apply
+```
+
+The upgrade is additive — the changes that alter behavior are opt-in (strict mass assignment, `sanitizeHref`, JWT `requireExpiry`) or bug fixes to documented defaults. The changelog's "changed" section is the complete list of the latter; it's a ten-minute read and worth it before you deploy.
+
+Thanks as always to everyone who filed the issues that shaped this release — especially the performance report that started the whole investigation.

--- a/web/content/blog/scheduled/wheels-coverage-and-the-complexity-panel.md
+++ b/web/content/blog/scheduled/wheels-coverage-and-the-complexity-panel.md
@@ -1,0 +1,63 @@
+---
+title: 'Find your riskiest code with wheels coverage and the complexity panel'
+slug: wheels-coverage-and-the-complexity-panel
+publishedAt: '2026-09-09T14:00:00.000Z'
+updatedAt: null
+author: Peter Amiri
+tags:
+  - wheels-4
+  - CLI
+  - testing
+categories:
+  - Releases
+excerpt: >-
+  4.1 adds two ways to see where your app's risk lives: a Code Complexity
+  panel in the debug bar that scores every file in app/ statically, and a
+  wheels coverage command that instruments the app, runs your test suite, and
+  reports a CRAP ranking of your most change-risky files.
+coverImage: null
+---
+
+Two numbers predict where your next bug will come from better than any code review checklist: **how complex a file is, and how little of it your tests touch.** Wheels 4.1 ships one tool for each, and they share a score.
+
+## The Code Complexity debug panel
+
+In development, the debug bar now has a *Code Complexity* panel. It walks `app/`, scores every file's cyclomatic complexity statically — one point per decision point (`if`, `loop`, `catch`, boolean operator) — and lists your worst offenders with their scores.
+
+Two design choices matter:
+
+- **It's static.** No instrumentation, no test run, no state. The scan runs once per reload and is cached for the application lifetime, so the panel costs you one scan, not one per request.
+- **It's always visible.** You don't have to remember to run anything — the panel is there every time you open the debug bar in dev, which means you *notice* the 40-decision-point controller you wrote last sprint instead of discovering it in review.
+
+## `wheels coverage` — the test half
+
+Complexity alone is half the story. A 30-point file with thorough tests is fine; a 10-point file with no tests is where regressions live. The command:
+
+```sh
+wheels coverage            # top 5 by default
+wheels coverage --top 10
+```
+
+What it does:
+
+1. Instruments `app/` with function-level coverage counters.
+2. Runs your app test suite against the running server.
+3. Reports a **CRAP ranking** — *Change Risk Analysis and Predictions*: cyclomatic complexity weighted by test coverage, the same metric Jenkins' Crap4J made famous. A file with high complexity and low coverage scores high; a well-tested file scores low.
+4. **Reverts the instrumentation automatically**, so there's nothing to clean up or accidentally commit.
+
+The pairing is deliberate: complexity is static and always visible; `wheels coverage` adds the coverage half on demand, when you want the number rather than the intuition.
+
+## The workflow
+
+The intended loop is simple:
+
+1. Debug bar shows you the complexity rankings while you work.
+2. Before a change, run `wheels coverage --top 10` — files near the top of *that* list are your change-risky set.
+3. Add tests for the risky paths, watch the ranking move.
+4. Enforce the floor in CI if you want to — the same complexity engine that powers the panel runs as a maintainer-side gate, so the numbers you see locally are the numbers CI would see.
+
+## Where it comes from
+
+The complexity engine is the same static analyzer the Wheels maintainers run against the framework itself — the 4.0 series added it as a CI gate on `vendor/wheels/`, and 4.1 exposes it to your app. Which means the tool has been chewing on the framework's own 10,000-file codebase for months before being pointed at yours. It's not a port of a generic linter; it's CFML-aware where it matters (comment stripping included).
+
+If your suite is slow, pair it with the batch finders from the 4.0 series — coverage runs the whole app suite, and `findEach`/`findInBatches` don't hurt to have around. But start with the command. The list it prints is the most honest risk assessment your codebase has ever had.


### PR DESCRIPTION
The approved 4.1.0 blog series, staged for daily publishing, plus the CI tool that publishes it.

## Posts (9, in `web/content/blog/scheduled/`)

Staggered `publishedAt` dates (UTC), one per day from 2026-09-02:

1. `bcrypt-password-hashing-in-wheels-4-1` — the pure-CFML bcrypt helpers, cost trade-offs, engine notes.
2. `one-line-session-auth-with-enablesession` — the enableSession() facade.
3. `pretty-urls-with-route-bindby` — route bindBy=.
4. `dependency-injection-factories-with-tofactory` — DI toFactory().
5. `cli-workflow-upgrades-migrate-diff-dry-run-offline` — CLI diff/dry-run/offline + honesty fixes.
6. `how-we-made-model-instantiation-2-5x-faster` — the #3213 performance memoir with real numbers.
7. `the-wheels-4-1-security-hardening-pass` — the hardening campaign, area by area.
8. `wheels-coverage-and-the-complexity-panel` — coverage command + complexity panel.
9. `wheels-4-1-0-released` — the umbrella release post (last).

All frontmatter validated against the Astro content schema (unique slugs, ISO dates, required fields).

## Daily publisher

- `.github/workflows/blog-publish-scheduled.yml` — runs at 06:00 UTC + `workflow_dispatch`; uses the wheels-bot app token so its push triggers the existing blog deploy.
- `.github/scripts/blog-publish-scheduled.sh` — moves due posts (`publishedAt` date <= today UTC) from `scheduled/` into `posts/`, commits as `wheels-bot[bot]`, pushes. Catch-up semantics (a missed day publishes on the next run); idempotent re-runs. Smoke-tested locally: correctly no-ops while all dates are future.
- `web/content/blog/scheduled/README.md` documents the flow for future authors.