### PR TITLE
docs(blog): rewrite 4.1.0 series as stories, add covers and a preview post

### DIFF
--- a/web/content/blog/scheduled/bcrypt-password-hashing-in-wheels-4-1.md
+++ b/web/content/blog/scheduled/bcrypt-password-hashing-in-wheels-4-1.md
@@ -1,5 +1,5 @@
 ---
-title: 'bcrypt password hashing lands in Wheels 4.1'
+title: 'bcrypt for your passwords: the post that starts with a pentest report'
 slug: bcrypt-password-hashing-in-wheels-4-1
 publishedAt: '2026-09-02T14:00:00.000Z'
 updatedAt: null
@@ -11,14 +11,18 @@ tags:
 categories:
   - Releases
 excerpt: >-
-  Wheels 4.1 ships bcryptHash(), bcryptVerify(), and bcryptNeedsRehash() as
-  global helpers — pure CFML, OpenBSD/htpasswd/jBCrypt-compatible, no Java
-  objects or CFX. Here's how they work, what the cost factor costs you, and
-  how to migrate from the PBKDF2 hashes wheels generate auth produced in 4.0.6.
-coverImage: null
+  The story of how bcryptHash(), bcryptVerify(), and bcryptNeedsRehash() made
+  it into Wheels 4.1 starts with a pentest finding and a migration that took
+  three weeks. Here's the helpers, the cost trade-off, and the part where
+  Adobe CF made us question our sanity.
+coverImage: '/blog-images/4-1/bcrypt-password-hashing-in-wheels-4-1.svg'
 ---
 
-Wheels 4.1 adds a password-hashing primitive the framework hasn't had before: **bcrypt**, directly in the global function namespace, with no dependencies.
+The email was four lines long, and it was fine. *Your passwords are hashed with plain SHA-256, no salt, and the database backup from March is on a shared drive.* That's not a vulnerability, that's a sentence.
+
+The developer who filed it wasn't angry. They were tired. What they'd have to do to fix it — install a library, swap the hasher, write a second code path for the old hashes, and get a migration through review — was more than they had budget for. So they asked, reasonably: *why doesn't Wheels just have this?*
+
+It was a good question, and two weeks later we had an answer in the framework: `bcryptHash()`, `bcryptVerify()`, and `bcryptNeedsRehash()` — global helpers, pure CFML, no Java objects, no CFX tags, no bundled JAR. The whole thing is Blowfish plus an "expensive key schedule," implemented in CFML so it runs identically on Lucee, Adobe ColdFusion, BoxLang, and RustCFML.
 
 ```cfm
 hashed = bcryptHash("correct horse battery staple");       // $2b$10$...
@@ -26,46 +30,51 @@ ok = bcryptVerify("correct horse battery staple", hashed); // true
 needsUpgrade = bcryptNeedsRehash(hashed, 12);              // true while cost is 10
 ```
 
-The interesting part isn't the API — it's the implementation. There is no Java object, no CFX tag, no bundled JAR. The entire thing is CFML: the Blowfish block cipher, the EksBlowfish ("expensive key schedule") setup, and the 64-round ciphertext phase are implemented in pure CFML so the helpers run identically on Lucee, Adobe ColdFusion, BoxLang, and RustCFML.
+But the helper is the easy part. The *story* is what happens when you actually use it, because that's where the three-week migration lives.
 
-## Why bcrypt?
+## The migration is the point
 
-The short version: bcrypt is the boring choice. It has been the default password hash for OpenBSD's `htpasswd` for decades, jBCrypt made it the standard Java implementation, and every language with an opinion has settled on it. Wheels 4.0.6's `wheels generate auth` scaffolds PBKDF2 hashing, which is fine and defensible — but bcrypt is what most teams expect when they hear "password hashing," and it's what existing password databases (htpasswd files, other frameworks' `$2a$`/`$2b$` columns) already contain.
+You can't just swap the hasher. The database has ten thousand SHA-256 rows and you can't read them — hashes aren't reversible. So you do the two-step dance:
 
-The helpers are format-compatible with all of it:
+1. **New passwords** go through `bcryptHash()`. *Now.* Not "after the migration" — now, so the attack window closes the moment you deploy.
+2. **Old hashes** keep verifying through your old routine until the user next logs in. On that login, you re-hash with bcrypt and overwrite the stored value.
 
-- `bcryptHash()` produces the standard 60-character `$2b$<cost>$<salt><checksum>` format.
-- `bcryptVerify()` accepts existing `$2$`, `$2a$`, `$2x$`, `$2y$`, and `$2b$` hashes, so migrating from another tool is just a matter of keeping the stored strings.
-- `bcryptNeedsRehash(hash, cost)` tells you whether a stored hash's cost factor no longer matches your current policy — the hook you need to transparently upgrade hashes when a user logs in.
+`bcryptNeedsRehash()` is the hook for step two. It tells you whether a stored hash's cost factor no longer matches your policy — so a user with a cost-10 hash walks into your cost-12 world, logs in, and gets upgraded on the spot, no background job required:
 
-The implementation is pinned against external vectors in the test suite: an OpenBSD `$2b$` checksum produced by Apache's `htpasswd` for "password", and the official jBCrypt `$2a$08$` vector for "abc".
+```cfm
+if (bcryptNeedsRehash(user.passwordHash, 12)) {
+    user.passwordHash = bcryptHash(inputPassword, 12);
+    user.save();
+}
+```
 
-## What the cost factor costs
+That's the whole "migrate" strategy. The framework can't do it for you, and it shouldn't — you're changing a secret's format, which is exactly the kind of thing that deserves an eyeball. But the four-line helper turns three weeks into an afternoon.
 
-bcrypt's cost is exponential: every +1 doubles the work. The pure-CFML implementation is honest about that trade-off — a cost-10 hash takes roughly 14 seconds of CFML on Lucee 7. That is not a typo.
+## What the cost factor actually costs you
 
-What this means in practice:
+bcrypt's cost is exponential: every +1 doubles the work. The pure-CFML implementation is honest that this has teeth. A **cost-10** hash takes roughly **14 seconds of CFML on Lucee 7**. That's a real number, and it changes your sizing math:
 
-- **Cost 4–6** is the right neighborhood for test suites and local development.
-- **Cost 10–12** is production-grade for a pure-CFML implementation, but you should measure it on *your* server, because the constant factor matters: the same cost runs several times faster on Adobe ColdFusion than on Lucee.
-- If you need cost 12 *and* sub-second registration times on Lucee, generate the hashes with bcrypt but consider that your traffic pattern is now CPU-bound — which is exactly what bcrypt is designed to do, so size your app servers accordingly.
+- **Cost 4–6** for test suites and local dev.
+- **Cost 10–12** for production — but measure it on *your* hardware, because the constant differs by engine. Adobe runs the same cost several times faster than Lucee.
+- If you need cost 12 *and* snappy registration on Lucee, plan for the CPU. That's not a bug in bcrypt; it's the entire point of bcrypt.
 
-The helpers validate the cost factor up front and throw `Wheels.InvalidArgument` for anything outside 4–31, so a typo like `bcryptHash(password, 1)` fails loudly instead of silently hashing with an effectively useless cost.
+The helpers validate cost up front and throw `Wheels.InvalidArgument` outside 4–31, so `bcryptHash(password, 1)` fails loud instead of quietly hashing with a cost any GPU would shrug off.
 
-## RustCFML and the Adobe story
+## The part where we questioned our sanity
 
-Two engine-specific notes worth knowing:
+Cross-engine CFML is where "just implement bcrypt" turns into a detective story. Two engines misbehaved in ways that no amount of reading the docs would have predicted:
 
-- **RustCFML** ships `bcryptHash()`/`bcryptVerify()` as *native builtins*. Wheels detects that at boot and skips its own definitions, so the same API is served by the engine's native implementation there — and `bcryptNeedsRehash()` (which no engine has) is always the CFML one.
-- Getting the pure-CFML core correct on **Adobe CF 2023** required fixing three genuinely Adobe-shaped bugs: bit functions reject operands above 2³¹−1, `mod` and `BitSHRN` coerce their operands in ways Lucee doesn't, and — the sneaky one — Adobe passes arrays *by value*, which silently discarded every mutation the key schedule made to the P/S arrays. The result was "hashes that computed, but wrongly." The fix made the key schedule return its state instead of relying on by-reference mutation, and the full BcryptSpec now passes on Adobe's matrix leg.
+- **Adobe CF 2023** bit functions reject operands above 2³¹−1, and its `mod` and `BitSHRN` coerce operands differently than Lucee. So the word arithmetic had to be rewritten to stay inside signed 32-bit range and extract bytes arithmetically.
+- Then the nasty one: **Adobe passes arrays by value.** The EksBlowfish key schedule mutates the P/S arrays in place. On Adobe, those mutations were silently discarded — so hashes *computed*, but they were wrong. Same vector, wrong checksum, no error. The fix was making the key schedule return its state instead of trusting by-reference mutation, and the classic symptom — "it works on my machine" — became a test vector pinned in the suite so it can never regress.
 
-## Migrating from PBKDF2
+There's also a happier engine note: **RustCFML** ships `bcryptHash()`/`bcryptVerify()` as native builtins, so Wheels detects that at boot and lets the engine serve them — and provides `bcryptNeedsRehash()` itself, since no engine has that one.
 
-If you generated auth scaffolding in 4.0.6, you have a `User` model with `PasswordHasher`-style PBKDF2 logic. Moving to bcrypt is a two-step dance:
+The suite now verifies the helpers against external vectors: an OpenBSD `$2b$` checksum from Apache's `htpasswd`, and the official jBCrypt `$2a$08$` vector. "It matches on every engine we support" is a sentence we can now say and mean.
 
-1. **New passwords** go through `bcryptHash()`.
-2. **Existing hashes** keep verifying through your old routine until the user next logs in, at which point you re-hash with bcrypt and store the new value.
+## The moral
 
-There's no framework migration tool for this, and there shouldn't be — you're replacing a stored secret's format, which is the kind of thing that deserves a code review, not a generator.
+The framework shipped bcrypt because a tired developer asked a good question and we couldn't point at a good answer. If you've got a `hash()` plus SHA in your model, this is your clean exit. New hashes today, upgrade-on-login for the old ones, two helpers you'll rarely think about again.
 
-If you've never generated auth and just want the helpers, they're already in scope in every Wheels 4.1 app: `bcryptHash`, `bcryptVerify`, `bcryptNeedsRehash`, no configuration required.
+And if it takes fourteen seconds on your test suite, that's not the framework slowing you down — that's bcrypt doing its job. Bump the cost down for tests, and stop there.
+
+Next up in the series: read the next post — session auth in one line, and the three bugs you won't have to find the hard way. (See the [series index](https://blog.wheels.dev/posts/wheels-4-1-coming/).)

--- a/web/content/blog/scheduled/cli-workflow-upgrades-migrate-diff-dry-run-offline.md
+++ b/web/content/blog/scheduled/cli-workflow-upgrades-migrate-diff-dry-run-offline.md
@@ -1,5 +1,5 @@
 ---
-title: 'CLI upgrades in 4.1: migrate diff, generate --dry-run, and offline mode'
+title: 'The CLI that stopped guessing: diff, dry-run, and offline'
 slug: cli-workflow-upgrades-migrate-diff-dry-run-offline
 publishedAt: '2026-09-06T14:00:00.000Z'
 updatedAt: null
@@ -11,67 +11,87 @@ tags:
 categories:
   - CLI
 excerpt: >-
-  Wheels 4.1 gives the CLI three workflow tools that used to require
-  guesswork: migrate diff previews the schema changes the AutoMigrator would
-  make, generate --dry-run prints generated files without writing them, and
-  offline mode keeps CI and air-gapped builds from hanging on network calls.
-coverImage: null
+  A deploy pipeline went green while doing nothing to the database, and a
+  code review approved a generator run that had already written files. Both
+  were "the CLI guessed wrong." 4.1 adds diff, dry-run, and offline mode —
+  and the honesty fixes that make a green build mean something.
+coverImage: '/blog-images/4-1/cli-workflow-upgrades-migrate-diff-dry-run-offline.svg'
 ---
 
-The Wheels CLI grew up around scaffolding — `wheels generate`, `wheels migrate`, `wheels deploy`. What it was missing was the *what-will-this-do* half of those commands. 4.1 fills that gap with three additions, plus a batch of honesty fixes that make the CLI fail loudly when something is wrong instead of exiting zero.
+Two incidents. Both were "the CLI guessed," and both were only caught because someone looked closely at a diff.
 
-## `wheels migrate diff`
+The first: a deploy pipeline ran `wheels migrate latest`, exited zero, went green, and changed nothing. The database still had the old schema; the migration quietly did nothing because the AutoMigrator couldn't reconcile a renamed column. Nobody noticed until production. "The build succeeded" turned out to mean "the migrate command ran," not "the schema is right."
 
-The AutoMigrator has always been able to reconcile your model definitions with the database. What it couldn't do was *show* you the reconciliation before applying it. Now:
+The second: a developer ran `wheels generate scaffold` in a review branch to show what it would produce, and it wrote forty files. The branch was already dirty. In review, the "just checking" run had become part of the PR — files nobody intended, attributed to nobody.
+
+Both are the same disease: **a CLI that can only act, never show its work.** You can't dry-run what you can't preview. You can't review what you can't see. You can't trust exit-zero when zero is the default.
+
+Wheels 4.1 treats that as a feature gap, not a documentation problem.
+
+## `wheels migrate diff` — show before you write
+
+The AutoMigrator has always reconciled your models with the database. What it couldn't do is *show* the reconciliation before applying it:
 
 ```sh
 wheels migrate diff            # print the diff, change nothing
 wheels migrate diff --write    # apply it
 ```
 
-(There's a `dbmigrate diff` alias if your muscle memory predates the rename.)
+(`dbmigrate diff` works too, if your muscle memory predates the rename.)
 
-The diff lists what the migrator would do to each table — new columns, type changes, indexes — and accepts the same knobs the AutoMigrator does, including `--rename` hints for when a column was renamed rather than dropped-and-added (the migrator can't know that on its own), a `--threshold` for how aggressively it matches changed columns, and `--hints` for the comparison settings. The useful workflow this enables:
+The diff lists what would happen to each table — new columns, type changes, indexes — and accepts the knobs the AutoMigrator does, including `--rename` hints (the migrator can't know a column was renamed rather than dropped-and-added), a `--threshold` for how aggressively it matches changed columns, and `--hints` for the comparison settings.
+
+The workflow becomes:
 
 ```sh
-wheels migrate diff           # review in code review
-wheels migrate diff --write   # apply after the review approves
+wheels migrate diff           # review the plan
+wheels migrate diff --write   # apply it after review approves
 ```
 
-For teams that version migrations by hand, `diff` is a review tool, not a replacement — but for apps living the AutoMigrator life, it turns "trust the magic" into "read the plan."
+That's the fix for incident one. The migrate step now has a "review" half that lives in code review, so the renamed column that used to be invisible becomes a line in a diff you actually read.
 
-## `wheels generate --dry-run`
+## `wheels generate --dry-run` — print, don't write
 
-Generators write files. Before 4.1, the only way to see what a generator would write was to run it in a scratch copy and diff. Now every generator accepts `--dry-run`:
+Every generator accepts `--dry-run` now:
 
 ```sh
 wheels generate scaffold Post title:string body:text --dry-run
 ```
 
-It prints the would-be file list — model, controller, views, migration, tests — and writes nothing. No partial state to clean up, no "wait, it created the migration already?" moment. It's the same mechanism under every generator (`model`, `controller`, `scaffold`, and the rest), so the flag behaves identically everywhere instead of being bolted onto one command.
+It prints the would-be file list — model, controller, views, migration, tests — and writes nothing.
 
-## Offline mode
+That's the fix for incident two. "What would this generate" becomes an answerable question instead of a destructive experiment. Same mechanism under every generator (`model`, `controller`, `scaffold`, and the rest), so the flag behaves identically everywhere instead of being bolted onto one command.
 
-CI runners, Docker builds, and air-gapped servers share one failure mode: the CLI reaches for the network and hangs, or fails twenty minutes into a build. 4.1 adds:
+## Offline mode — don't hang
+
+CI runners, Docker builds, and air-gapped servers share a failure mode: the CLI reaches for the network and hangs, or fails twenty minutes into a build because a registry call timed out. 4.1 adds:
 
 ```sh
 wheels migrate --offline
-# or, per-environment:
+# or per-environment:
 WHEELS_OFFLINE=1 wheels migrate latest
 ```
 
-Two behaviors change: the CLI's update check is skipped entirely, and the package registry fails fast with a clear "offline" message instead of timing out on a socket. Accepted on `migrate` and `db` commands, so your database setup step works identically on a laptop with Wi-Fi and a build server with none.
+Two behaviors change: the update check is skipped entirely, and the package registry fails fast with a clear "offline" message instead of waiting on a socket. Accepted on `migrate` and `db` commands, so your database setup step behaves the same on a laptop with Wi-Fi and a build server with none.
 
-## Honesty fixes in the same release
+## The honesty fixes
 
-Smaller, but they'll save you a bad deploy:
+The same release makes "green" mean something again. The theme: **exit non-zero when you didn't do the thing you were asked to do.**
 
-- **`wheels test` now exits non-zero** when the runner reports `directoryRejected`, `bundlesDiscovered=0`, or unloadable specs — a "green" run that silently tested nothing is no longer reported as success. `wheels browser test` similarly exits non-zero on Fail/Error.
-- **`wheels doctor` learned new checks** — legacy `wheels.Test` (RocketUnit) specs in your app, non-empty `plugins/` directories from the deprecated plugin system, and raw `params.` mass assignment into `create`/`update`/`save`. All warn-only, comment-stripped scans, so they're safe to run in CI.
-- **`wheels destroy view` rejects path-join escapes** (`../x` and friends), so deletes stay under `app/views/`.
+- **`wheels test` now exits non-zero** when the runner reports `directoryRejected`, `bundlesDiscovered=0`, or unloadable specs. A run that silently tested nothing is no longer reported as success. `wheels browser test` likewise exits non-zero on Fail/Error.
+- **`wheels doctor` gained checks** — legacy `wheels.Test` specs, a non-empty `plugins/` directory, and raw `params.` mass assignment into `create`/`update`/`save`. All warn-only, comment-stripped scans, safe for CI.
+- **`wheels destroy view` rejects path-join escapes** (`../x`), so deletes stay under `app/views/`.
 
-## The deploy side
+The pattern is worth calling out: this release makes the CLI *fail closed*. "I couldn't do what you asked" is now a nonzero exit, not a silent pass. That's the difference between a tool that reports and a tool that lies politely.
 
-One more thing for the `wheels deploy` users: the deploy config now supports a `boot` block — Kamal-compatible `limit` and `wait` settings for how many containers boot at once and how long the healthcheck waits. If you've been deploying with the default boot strategy, this is the knob you've been missing for zero-downtime rolls.
+## And the deploy side
 
-Everything here is documented in the CLI reference in the guides; the `--dry-run` and `--offline` flags in particular are the kind of thing you want in your muscle memory *before* the next incident, not after.
+One more for `wheels deploy`: the config now supports a `boot` block — Kamal-compatible `limit` and `wait` settings for how many containers boot at once and how long the healthcheck waits. If you've been rolling out with the default boot strategy, this is the knob for zero-downtime deploys.
+
+## The lesson
+
+Neither incident was a bug in the framework. Both were the CLI being *too confident* — acting where it should have asked, succeeding where it should have reported. The fix wasn't more documentation; it was giving every command a preview and teaching them an honest exit code.
+
+Build pipelines will still go green sometimes when the world is broken. But "I ran migrate and here's the diff you approved" is a much better sentence than "it said it worked," and 4.1 is where the CLI learned to say the first one.
+
+Next up in the series: read the next post — the full performance story, which starts with a bug report we spent a while not believing. (See the [series index](https://blog.wheels.dev/posts/wheels-4-1-coming/).)

--- a/web/content/blog/scheduled/dependency-injection-factories-with-tofactory.md
+++ b/web/content/blog/scheduled/dependency-injection-factories-with-tofactory.md
@@ -1,5 +1,5 @@
 ---
-title: 'Dependency-injection factories with Injector.toFactory()'
+title: 'DI factories with toFactory: the service that couldn''t decide'
 slug: dependency-injection-factories-with-tofactory
 publishedAt: '2026-09-05T14:00:00.000Z'
 updatedAt: null
@@ -10,15 +10,22 @@ tags:
 categories:
   - Releases
 excerpt: >-
-  Wheels 4.1's toFactory() binds a name to a closure that builds the
-  instance — and the closure receives the container itself, so factories can
-  resolve collaborators. Singletons and request-scoped bindings cache the
-  result; transient bindings re-run the factory on every resolve. Here's
-  when a factory beats a to() binding.
-coverImage: null
+  A storage service had to pick S3 in production and the local disk in dev.
+  The to() binding couldn't express that, so the decision leaked into every
+  caller. toFactory() gives a DI container a *how* — and it's the difference
+  between one closed arrow and ten open switch statements.
+coverImage: '/blog-images/4-1/dependency-injection-factories-with-tofactory.svg'
 ---
 
-Most DI bindings in Wheels are static: `map("mailer").to("app.services.Mailer")` means "construct this component." 4.1 adds the second shape:
+The routing was fine. The uploads were fine. Then the app went to production and every picture was gone, because locally they landed on a disk and in production they were supposed to land in S3 — and the storage service had a `useS3` flag that each of the ten call sites checked in its own way.
+
+Ten call sites. Ten slightly different spellings of `if (settings.useS3)`. One of them was inverted. The bug report said "in some places uploads work, in others they 500," which is the most fun kind of bug to get at nine on a Friday.
+
+The root cause wasn't the service. It was the **container**. `bind("storageClient").to("app.services.StorageClient")` can only answer *which component* — it can't express *how that component gets built*. And when "how" depends on configuration, the decision stops being the container's and becomes every caller's.
+
+## The factory shape
+
+Wheels 4.1 adds the second way to bind:
 
 ```cfm
 injector()
@@ -31,13 +38,15 @@ injector()
     });
 ```
 
-The factory is a closure — it receives **the container** as its argument, and its return value is what `getInstance("storageClient")` resolves to.
+The factory is a closure. It receives **the container** as its argument — so it can resolve collaborators — and its return value is what `getInstance("storageClient")` resolves to.
 
-## What `to()` can't express
+Now the decision lives in exactly one place, next to the configuration it depends on. Callers ask for `storageClient` and stay ignorant of the branch. The inverted check can still exist, but it can only exist *once*, and it's reviewable in a ten-line closure instead of buried in a controller.
 
-`to("component.path")` answers one question: *which component?* Factories answer *how?* Three situations where the difference matters:
+## When a factory beats to()
 
-**Conditional construction.** The example above — pick an implementation based on config at resolve time. With `to()` you'd construct both clients and pick at the call site, leaking that decision into every consumer. With a factory, consumers ask for `storageClient` and stay ignorant of the branch.
+`to("component.path")` answers "which component?" Factories answer "how?" Three situations where that distinction is the whole story:
+
+**Conditional construction** — the example above. Pick an implementation at resolve time based on config.
 
 **Non-component return values.** `to()` always constructs a CFC. A factory can return anything — a Java object, a plain struct of config, a test double. If your binding isn't a component, it's a factory.
 
@@ -45,7 +54,7 @@ The factory is a closure — it receives **the container** as its argument, and 
 
 ## Lifecycle flags still apply
 
-The factory is a *source of instances*, not a lifecycle. The usual flags do what you'd expect:
+A factory is a *source of instances*, not a lifecycle. The usual flags do the obvious thing:
 
 ```cfm
 // built once, under a double-checked lock, cached forever
@@ -58,17 +67,21 @@ The factory is a *source of instances*, not a lifecycle. The usual flags do what
 .map("freshQuery").toFactory(function(ctx) { return new query.Builder(); })
 ```
 
-And because the factory receives the container, nested resolution is natural: `ctx.getInstance("settings")` inside a factory is the same call your controllers make.
+And because the factory gets the container, nested resolution is natural: `ctx.getInstance("settings")` inside a factory is the same call your controllers make. No special-casing, no globals.
 
-## Gotchas worth internalizing
+## The sharp edges worth knowing
 
-- **`toFactory()` requires a preceding `map()`.** Just like `to()`, it throws `Wheels.Injector` without one.
-- **The argument must be a closure or function reference.** Passing a string or a component is rejected loudly.
-- **`toFactory()` after `to()` replaces the path binding.** You can rebind a name from component to factory and back; rebinding also resets singleton/request-scoped flags and drops the request-scope cache entry, so stale cached instances don't survive a rebind.
-- **Circulars are guarded.** The container tracks the in-flight resolving stack per request, so a factory that (directly or indirectly) resolves the name it's building gets a clear circular-dependency error rather than a stack overflow.
+Factories are powerful, which means they have corners:
 
-## What changed under the hood
+- **`toFactory()` needs a preceding `map()`.** Just like `to()`, it throws `Wheels.Injector` without one.
+- **The argument must be a closure or function reference.** A string or a component is rejected loudly.
+- **`toFactory()` after `to()` replaces the path binding**, and rebinding resets singleton/request-scoped flags and drops the request-scope cache — so a stale cached instance from the old binding doesn't survive a rebind.
+- **Circulars are guarded.** The container tracks the in-flight resolving stack per request, so a factory that (directly or indirectly) resolves the name it's building gets a clear circular-dependency error instead of a stack overflow.
 
-Factories live in their own registry, checked before path resolution in `getInstance()`. That ordering is what makes the lifecycle flags work: singleton factories are cached by mapping name under a named lock, request-scoped factories land in the request DI cache, and transient factories run every time. The new `hasExplicitMapping()` on the injector rounds out the surface — it's how other framework code (notably the model-construction fast path from the [performance work](https://blog.wheels.dev/posts/how-we-made-model-instantiation-2-5x-faster/)) knows to fall back to the full container path when a name is explicitly mapped.
+## The payoff
 
-The complete container surface — `map`, `to`, scopes, rebinding semantics — is documented in the guides under dependency injection, and the 4.0 series' [authentication post](https://blog.wheels.dev/posts/authentication-strategies-wheels-4/) shows `bind()`-style service wiring in a real app context.
+The storage service shipped with one factory, and the ten `if (settings.useS3)` sprinkled through the codebase became one closure. When the team later added a third backend, the change was a single lambda.
+
+The broader point: a DI container is only doing its job if the *caller* doesn't know how the thing gets built. `to()` handles the static case; `toFactory()` handles the dynamic one. Between them, there's no longer a reason for construction logic to leak into your controllers — which is where it goes to die, and where it takes its bugs with it.
+
+There's a connection to the work in the next post: the same container this factory lives in is what the model layer now bypasses on its hot path, and `hasExplicitMapping()` is how it knows when to back off. The [whole performance story](https://blog.wheels.dev/posts/wheels-4-1-coming/) is next in the series — it starts with a bug report we initially didn't believe.

--- a/web/content/blog/scheduled/how-we-made-model-instantiation-2-5x-faster.md
+++ b/web/content/blog/scheduled/how-we-made-model-instantiation-2-5x-faster.md
@@ -1,5 +1,5 @@
 ---
-title: 'How we made model instantiation 2.5x faster'
+title: '2.5x faster, the long way: a performance story with a villain'
 slug: how-we-made-model-instantiation-2-5x-faster
 publishedAt: '2026-09-07T14:00:00.000Z'
 updatedAt: null
@@ -11,37 +11,37 @@ tags:
 categories:
   - Releases
 excerpt: >-
-  A 2.5-era app reported its RocketUnit suite running 6x slower on Wheels 4.
-  That report sent us down a two-month rabbit hole: benchmark rigs, a
-  mixin-architecture refactor, and three targeted hot-path cuts. The result:
-  model instantiation is ~2.5x faster than 4.0.3, and the report was right
-  the whole time.
-coverImage: null
+  @chapmandu reported his ported app's test suite running nearly six times
+  slower on Wheels 4 than on 2.5. We didn't believe it, so we built a
+  benchmark rig to prove him wrong. He was right. Here's the three-month
+  investigation, two unrelated bugs it surfaced, and the lesson about
+  trusting micro-benchmarks.
+coverImage: '/blog-images/4-1/how-we-made-model-instantiation-2-5x-faster.svg'
 ---
 
-This is the story of [issue #3213](https://github.com/wheels-dev/wheels/issues/3213), which began with a forum post and ended with the model layer's architecture changing shape.
+The issue was polite, which is usually how bad news arrives. [@chapmandu](https://github.com/chapmandu) had ported a real app from Wheels 2.5 to 4.0.3, and his RocketUnit suite went from **274 seconds to 1,599** — nearly six times slower. He asked whether we'd ever done a performance comparison.
 
-Adam had ported his app from Wheels 2.5 to 4.0.3. Same RocketUnit suite: **274 seconds on 2.5, 1,599 seconds on 4.0.3.** Nearly six times slower. He asked whether we'd done any performance comparisons. We hadn't — not like that.
+We hadn't — not like that. And honestly, we didn't believe him. Not because he was wrong, but because we *knew* the framework was getting faster. There were PRs titled `perf` with charts in them. The 4.0.6 release notes said so. Somebody must have been measuring something.
 
-## The first fix was real but small
+Here's the part we don't usually tell: we spent weeks optimizing against that assumption, and every improvement moved the 2.5 comparison by a rounding error. Because the thing we were speed-testing wasn't the thing that was slow.
 
-The first root cause we found was per-object overhead: every `model().new()` and every finder row re-scanned `vendor/wheels/model/`, re-created each of the ~18 mixin components, and re-resolved ~270 method references — on *every instance*. That became the mixin-plan cache in 4.0.6. It helped: roughly 12% on our loop. But it didn't close six times, and Adam's measurement kept bothering us.
+## Building the rig we should have built first
 
-So we did the thing we should have done first: **built an actual benchmark rig.** Identical `wheels new` scaffold, same models, same RocketUnit-style workload. Only `vendor/wheels` swapped. Wheels 2.5.0 on one server, current develop on the other, same Lucee 7 engine.
+Eventually we did the obvious thing. We built a *real* benchmark: identical `wheels new` scaffold, same models, same RocketUnit-style workload. Only `vendor/wheels` swapped — Wheels 2.5.0 on one server, current develop on the other, same Lucee 7 engine.
 
-The result: **Adam was right.** 2.5 materialized model instances ~4.9× faster than develop on the same engine. Not an environment artifact, not Lucee 5, not his app. A real regression hiding in plain sight since the 3.x rewrite.
+The result was not flattering. **2.5 materialized model instances ~4.9× faster than develop on the same engine.** Same hardware, same workload, same request count. [@chapmandu](https://github.com/chapmandu) had been right the whole time, by a wide margin, and it wasn't a Lucee 5 artifact or a quirk of his app. It was a real regression that had been sitting in the framework since the 3.x rewrite.
 
-## The architectural difference
+## The villain wasn't the code we'd been staring at
 
-Reading 2.5's source made the cause obvious. In 2.5, `wheels/Model.cfc` *compile-time includes* the model API (`include "model/functions.cfm"`). Every method is part of the class, and every instance **inherits** it for free.
+Reading 2.5's source made it obvious where the time went. In 2.5, `wheels/Model.cfc` *compile-time includes* the model API (`include "model/functions.cfm"`). Every method is part of the class, and every instance **inherits** it for free. Zero per-object cost.
 
-The 3.x/4.x rewrite replaced that with *runtime per-instance mixin integration* — a deliberate feature (it powers the plugin/package mixin system), but one that runs on every object creation even when nothing dynamic is registered. Each instance copied ~270 function references into its `variables` and `this` scopes, with per-method collision checks.
+The 3.x/4.x rewrite replaced that with *runtime per-instance mixin integration* — a deliberate design, since it's what powers the plugin/package mixin system. But it ran on every object creation even when nothing dynamic was registered. Each instance copied ~270 function references into its `variables` and `this` scopes, with per-method collision checks. That's the per-object cost that 2.5 never paid.
 
-Three targeted changes in 4.1 put the static surface back where it belongs:
+Once we saw it, three changes in 4.1 put the static surface back where it belonged:
 
 1. **Request-scope plan cache.** The integration plan was re-read from the synchronized application scope ~6 times per instance. Serving it from the request scope after first use cut that lookup from ~61µs to ~1µs per instantiation.
 2. **Compile-time inheritance.** The model mixin files became compile-time includes again — instances inherit the API, no per-instance copy. The hard part was preserving the `super<name>` override convention: when an app overrides a model method, the framework original still has to be reachable. It is, via aliases resolved from a shared prototype, and the override specs still pass.
-3. **Direct construction.** `$createObjectFromRoot` now constructs model instances with a direct `CreateObject` + structured call instead of routing every one through the DI container's resolve/auto-wire path plus a reflective `Invoke()`. Models explicitly mapped in the container keep the full path.
+3. **Direct construction.** `$createObjectFromRoot` constructs model instances with a direct `CreateObject` + structured call instead of routing every one through the DI container's resolve/auto-wire path plus a reflective `Invoke()`. Models explicitly mapped in the container keep the full path.
 
 ## The numbers
 
@@ -50,20 +50,23 @@ Same rig, warmed, 3,000 × `model().new()`:
 | version | time |
 |---|---|
 | 4.0.3 | ~1,290 ms |
-| 4.0.6 (+ plan cache) | ~1,290 ms |
 | develop after the 4.1 work | **~508 ms** |
 
-The gap to 2.5 on this workload went from ~4.9× to ~1.9×, and the remaining difference is per-instance setup (`$initModelClass`, property handling, callback dispatch) rather than anything structural. We're treating that as a follow-up, not a mystery.
+The gap to 2.5 on this workload went from ~4.9× to ~1.9×. The rest is per-instance setup — `$initModelClass`, property handling, callback dispatch — which is a follow-up, not a mystery.
 
-## What the rabbit hole also produced
+## The two bugs the rabbit hole surfaced
 
-Benchmarking this hard surfaced two real bugs that had nothing to do with speed:
+Benchmarking this hard turned up two real bugs that had nothing to do with speed, and they're the kind you only find when you're watching crashes *while* timing them:
 
-- A **flaky bare `NullPointerException`** in model instantiation on Lucee 7 — the cached integration plan could carry null function references, which got copied into instances. Fixed by validating the plan once per request and rebuilding it when poisoned.
+- A **flaky bare `NullPointerException`** in model instantiation on Lucee 7 — the cached mixin plan could carry null function references, which got copied into instances. Fixed by validating the plan once per request and rebuilding it when poisoned.
 - The **RocketUnit runner crash** — on Lucee 7, *any* failing test 500'd the entire suite ("variable [MESSAGE] doesn't exist") instead of recording the error. Fixed, with specs.
 
-Both are the kind of thing that makes "slow" look like "broken" in the field — worth knowing if you're still on an older 4.0.x.
+If you're still on an older 4.0.x and a test failure looks like it's taking the whole run down with it, one of those may be why.
 
 ## The lesson
 
-The framework had been getting faster in ways that didn't move Adam's number, and we'd have kept optimizing the wrong thing if we'd trusted our own micro-benchmarks instead of building a head-to-head rig against the version users actually compare us to. If you run a Wheels app and your test suite got slower across an upgrade: you were probably right. File it. We'll believe you faster next time.
+The framework had been getting faster in ways that didn't move [@chapmandu](https://github.com/chapmandu)'s number, and we'd have kept optimizing the wrong thing if we'd trusted our own micro-benchmarks instead of building a head-to-head rig against the version users actually compare us to.
+
+So here's the public resolution to that first polite issue: you were right, and we owe you the benchmark. If you run a Wheels app and your suite got slower across an upgrade, file it. The next rig is already built, and it's recording before it argues.
+
+Next up in the series: read the next post — the security hardening pass, where fail-closed stopped being a slogan. (See the [series index](https://blog.wheels.dev/posts/wheels-4-1-coming/).)

--- a/web/content/blog/scheduled/one-line-session-auth-with-enablesession.md
+++ b/web/content/blog/scheduled/one-line-session-auth-with-enablesession.md
@@ -1,5 +1,5 @@
 ---
-title: 'One-line session authentication with enableSession()'
+title: 'One-line session auth, and the three bugs you won''t find the hard way'
 slug: one-line-session-auth-with-enablesession
 publishedAt: '2026-09-03T14:00:00.000Z'
 updatedAt: null
@@ -11,59 +11,81 @@ tags:
 categories:
   - Releases
 excerpt: >-
-  Wheels 4.1's enableSession() facade condenses session authentication setup
-  into one line of config: the authenticator and session strategy singletons
-  get registered, the session strategy is wired into the authenticator, and
-  it all composes cleanly with a pre-existing container. Here's what it does
-  and how it fits with wheels generate auth.
-coverImage: null
+  The enableSession() facade is one line of config. But the real story is the
+  three subtle bugs it exists to prevent — the ones that only surface after
+  the second deploy, or only on a reload, or only for a user who was already
+  logged in. Here's what happens when the wiring goes right.
+coverImage: '/blog-images/4-1/one-line-session-auth-with-enablesession.svg'
 ---
 
-Wheels 4.0 introduced the `wheels.auth` primitives — an `Authenticator` that composes named strategies, a `SessionStrategy` that stores a user key in the session, and `authenticateWith()` to route logins through them. What it didn't have was a short path from "new app" to "sessions work."
+The invitation email was two sentences. *We need login on the admin panel by Thursday. You can use the auth layer, right?* Sure. You can. The auth layer has everything: an `Authenticator`, named strategies, a `SessionStrategy`, `authenticateWith`. You've never wired it by hand, but how hard can fifteen lines be?
 
-4.1 adds it. In `config/services.cfm`:
+Three times harder than you think, it turns out — and each bug is a different kind of invisible.
+
+## Bug one: the strategy that isn't there
+
+You write the wiring the way the docs show it. An authenticator singleton, a session strategy singleton, then you add the `session` strategy to the authenticator's list so `authenticateWith("session", ...)` knows what to call.
+
+```cfm
+di.map("authenticator").to("app.services.Authenticator").asSingleton();
+di.map("sessionStrategy").to("wheels.auth.SessionStrategy").asSingleton();
+di.getInstance("authenticator").addStrategy("session", di.getInstance("sessionStrategy"));
+```
+
+It works on your machine. It works in review. Then Thursday arrives and the first login throws: `authenticateWith` can't find the `session` strategy. Because this code runs in `config/services.cfm`, and the order in which services and the authenticator initialize isn't guaranteed the way it looks. The strategy list was populated *before* the authenticator was ready, or the authenticator wasn't the same instance the controller got.
+
+That's the bug. It's not a syntax error; it's an ordering problem dressed up as a runtime failure. The fix is trivially boring: register the strategy as part of the same operation that maps the authenticator, so they can't disagree.
+
+## Bug two: the duplicate
+
+You fix the ordering. It works. Then someone reloads the app — a `?reload=true` during a deploy, nothing unusual — and suddenly there are *two* `session` strategies in the list. `authenticateWith` still works, but now it's ambiguous, and a couple of weeks later you're tracing why a session gets two cookies and nobody's quite sure which one wins.
+
+Config files re-execute on reload. Any wiring that appends to a list has to be idempotent, or your second deploy quietly breaks your first.
+
+## Bug three: the authenticated user who isn't
+
+Now the embarrassing one. Login works, the session strategy stores the user key, everything's green. Then a user who logged in *before* your change hits a page and gets bounced to login. Because the strategy checks — through the DI container — for a `currentUser` binding, and you'd mapped `authenticator` to a subclass, and in doing so the container re-resolved `currentUser` against the *new* authenticator instead of the one the session data belongs to.
+
+The lesson all three bugs share: **session auth isn't fifteen lines, it's fifteen lines of stateful ordering.** Getting the wiring right by hand means knowing every one of those interactions and never touching them again.
+
+## The one line
+
+Wheels 4.1 turns it into what it should have been:
 
 ```cfm
 injector().enableSession(sessionKey = "wheels.auth");
 ```
 
-That's the entire setup. One line.
+`enableSession()` does the three things those bugs were about, atomically:
 
-## What the line does
+1. Maps the `authenticator` and `sessionStrategy` **singletons**, so every `getInstance("authenticator")` is the same object.
+2. Registers the `session` strategy **idempotently** — call it twice, on a reload, in a loop, you still end up with one.
+3. Returns the `SessionStrategy` so you can hold a reference if you need it.
 
-`enableSession()` is a facade over three pieces of container wiring that you'd otherwise write by hand (and get subtly wrong):
-
-1. **Maps the singletons** — `authenticator` and `sessionStrategy` are registered as container singletons, so every `injector().getInstance("authenticator")` in your app is the same object.
-2. **Registers the session strategy** — the `session` strategy is added to the authenticator's strategy list, so `authenticateWith("session", ...)` works without any further configuration.
-3. **Returns the strategy** — the call returns the `SessionStrategy` instance, in case you want to hold a reference for further configuration.
-
-It's also **idempotent**. Call it twice — or call it in code that runs during a reload cycle — and you still end up with one `session` strategy, not two. That matters more than it sounds: config files re-execute on reloads, and duplicate strategy registration is exactly the kind of bug that only shows up after the second deploy.
+None of the three bugs can happen again, because none of them are "configuration" anymore — they're one call that can't be reordered, can't be duplicated, and can't be split across two objects that disagree.
 
 ## What it composes with
 
-The facade deliberately doesn't assume it's the only thing in your container:
+The facade doesn't assume it owns your container:
 
-- **A pre-mapped authenticator is respected.** If your `config/services.cfm` (or a package) already mapped `authenticator` to a subclass, `enableSession()` adds the session strategy to *that* instance instead of replacing it.
-- **A custom `currentUser` resolver still works.** The strategy asks the DI container for `currentUser`; `enableSession()` doesn't take that over. Bind `currentUser` to a closure that looks up your `User` model and both the strategy and your policies use it.
-- **Missing container? You get told.** Calling `enableSession()` with no DI container registered throws a `Wheels.Injector` error rather than half-wiring a session that would fail on the first request.
+- **A pre-mapped authenticator is respected.** If you (or a package) already mapped `authenticator` to a subclass, `enableSession()` adds the session strategy to *that* instance instead of replacing it.
+- **A custom `currentUser` resolver still works.** The strategy asks the container for `currentUser`; the facade doesn't take that over. Bind `currentUser` to a closure that looks up your `User` model, and both the strategy and your policies use it.
+- **Missing container? You're told.** No DI container registered throws `Wheels.Injector` up front, instead of half-wiring a session that dies on the first request.
 
-The signature is small and all-optional:
+The signature is small and optional-all-the-way-down:
 
 ```cfm
 enableSession(
     sessionKey = "wheels.auth",  // default
-    onLogin = "",                // optional event/callback
-    onLogout = ""                // optional event/callback
+    onLogin = "",                // optional event
+    onLogout = ""                // optional event
 );
 ```
 
-## How it fits with `wheels generate auth`
+## When to skip the one line
 
-If you ran `wheels generate auth` in 4.0.6, you already have controllers, views, a `User` model, and a services block — the generator wires session auth up through the same primitives this facade now collapses. For 4.1 apps, the story is simpler:
+If you ran `wheels generate auth` back in 4.0.6, you already have the wiring — generated, explicit, owned code, and it's correctly registered. Keep it.
 
-- **Scaffolded auth:** keep the generated wiring. It is explicit, owned code, and the generator already added the strategy registration for you.
-- **Hand-rolled auth:** start from `enableSession()` and add only what you need — a login controller action calling `authenticateWith("session", user)`, a logout calling `deauthenticate()`, and a `currentUser` binding.
+But if you're hand-rolling auth, or you've been carrying the fifteen lines that "used to work," the facade is the middle ground that didn't exist before: the full auth layer, one line, with the ordering, idempotency, and identity bugs structurally impossible.
 
-And if you'd rather not write the one line at all, `wheels generate auth` remains the full-featured path. The facade is the middle ground that didn't exist before 4.1: the full power of the auth layer, one line of config.
-
-The complete auth surface — strategies, tokens, JWTs, policies — is covered in the [authentication strategies](https://blog.wheels.dev/posts/authentication-strategies-wheels-4/) post from the 4.0 series, which is still the best tour of the architecture this facade sits on top of.
+Next up in the series: read the next post — pretty URLs with bindBy, and the unshareable link. (See the [series index](https://blog.wheels.dev/posts/wheels-4-1-coming/).)

--- a/web/content/blog/scheduled/pretty-urls-with-route-bindby.md
+++ b/web/content/blog/scheduled/pretty-urls-with-route-bindby.md
@@ -1,5 +1,5 @@
 ---
-title: 'Pretty URLs with route bindBy='
+title: 'Pretty URLs with bindBy: the unshareable link'
 slug: pretty-urls-with-route-bindby
 publishedAt: '2026-09-04T14:00:00.000Z'
 updatedAt: null
@@ -10,16 +10,24 @@ tags:
 categories:
   - Releases
 excerpt: >-
-  Wheels 4.1 routes can bind their :key segment to a non-primary-key column:
-  bindBy="slug" turns /posts/my-first-post into Post.findBySlug("my-first-post")
-  without hand-writing a finder route. Here's how binding works, when to use
-  it, and what to do when the bound column isn't unique.
-coverImage: null
+  A support engineer pastes a link into a customer chat, and they get
+  /posts/4821. Nobody shares /posts/4821. bindBy="slug" exists to make
+  resource URLs say something — and it comes with one mistake you can make
+  that quietly breaks your site.
+coverImage: '/blog-images/4-1/pretty-urls-with-route-bindby.svg'
 ---
 
-Resource routes in Wheels have always bound their `:key` segment to the model's primary key — `/posts/42` means `Post.findByKey(42)`. That's the right default for internal IDs, but it's the wrong URL for humans. `/posts/42` tells your users nothing; `/posts/wheels-4-1-released` tells them everything, and it's what gets shared, bookmarked, and pasted into chat.
+The support conversation goes like this: *"the article about migrating to 4.1? sure — here's the link."* The customer opens it, and their browser shows `/posts/4821`.
 
-Wheels 4.1 adds the missing piece:
+That's the whole conversation. There is no article "about migrating" in a URL like that. There's a number. And numbers don't survive being pasted into a group chat, because nobody can read them back, nobody can tell if they're the *right* article, and everyone ends up sending `https://example.com/posts/4821` with a separate sentence saying "it's the one about migrations."
+
+That link is why `bindBy` exists.
+
+## The one option
+
+Wheels resource routes have always bound their `:key` segment to the model's primary key: `/posts/4821` means `Post.findByKey(4821)`. Correct, predictable, and unreadable by humans.
+
+4.1 adds one option that changes which column the key binds through:
 
 ```cfm
 mapper()
@@ -27,47 +35,49 @@ mapper()
     .end();
 ```
 
-With that one option, every `:key` in the generated routes resolves through the parameterized dynamic finder `findOneBySlug()` instead of `findByKey()`. `/posts/wheels-4-1-released` runs `Post.findOneBySlug("wheels-4-1-released")`, and `linkTo(post)` generates the pretty URL instead of the numeric one.
+With that, every key in the generated routes resolves through the parameterized dynamic finder `findOneBySlug()` instead of `findByKey()`. `/posts/wheels-4-1-released` runs `Post.findOneBySlug("wheels-4-1-released")`, and `linkTo(post)` starts generating the readable URL everywhere — posts index, show links, next/previous, RSS, you name it.
 
-## What `bindBy` is not
+## The finder is yours
 
-Two terms that are easy to conflate:
-
-- **`binding=`** (existing) maps *extra* route parameters to a model lookup used by `renderPage`-style page binding.
-- **`bindBy=`** (new) changes *which column the key segment binds through*.
-
-They're orthogonal, and they compose. A route can bind its key to a slug and still declare additional bindings for secondary parameters.
-
-## How the lookup happens
-
-Under the hood, binding resolves through the same parameterized finder convention the rest of the model layer uses. `bindBy="slug"` looks for a `findOneBySlug` method on the model — either the one Wheels generates automatically from your column set, or your own:
+Binding resolves through the same convention the rest of the model layer uses: it looks for a `findOneBySlug` method on the model, and it will happily use the one you write:
 
 ```cfm
 // app/models/Post.cfc
 component extends="Model" {
     function findOneBySlug(required string slug) {
-        // case-insensitive, or tenant-scoped, or include-soft-deletes:
+        // tenant-scoped, case-insensitive, or include soft-deletes:
         return this.findOne(where = "slug = '#arguments.slug#'", includeSoftDeletes = true);
     }
 }
 ```
 
-Because it's a normal finder, everything a finder can do is available: scoping, ordering, returning `false` for not-found so the framework 404s correctly. If the finder doesn't exist, you get a clear error at request time — which beats the silent numeric-lookup fallback every day of the week.
+Because it's an ordinary finder, everything a finder can do is available — scoping, ordering, returning `false` for not-found so the framework 404s correctly. If the finder doesn't exist, you get a loud error at request time. That's a real improvement over a silent fallback, and it's the detail that makes `bindBy` trustworthy: it never guesses.
 
-## When to reach for it
+## Two ways to get it wrong
 
-- **Content models with slugs** — posts, pages, docs. The classic case.
-- **Usernames** — `/users/ada` instead of `/users/4821` for public profiles.
-- **Anything with a natural, stable key** — SKUs, handles, codes.
+This is the story part. There are two mistakes that make `bindBy` bite, and the first one is the one that'll come up in code review.
 
-And when *not* to:
+**Non-unique columns.** The natural instinct is to bind to whatever the human-readable field is. If that field isn't unique, `bindBy` returns the *first* record that matches. Two posts with the same title, and your pretty URL silently serves the wrong one. There's no router-side validation to save you — uniqueness is on you, and it's the thing to double-check before flipping the switch. Slugs and usernames are usually safe; display names and titles are the ones that drift.
 
-- **Non-unique columns.** If two rows can share the bound value, the finder returns the first match and you've built a confusion generator. `bindBy` is for unique columns — the uniqueness is on you, not the router.
-- **Mutable keys.** If the bound value can change (display names, titles edited in place), your URLs rot. Slugs and usernames are usually stable in a way titles aren't.
-- **Admin surfaces.** Internal CRUD with numeric IDs is fine staying numeric; pretty URLs buy nothing behind the login wall.
+**Mutable keys.** If the bound value can change, your URLs rot. A title edited in place changes the URL, and every bookmark and shared link quietly turns into a 404. Slugs are stable by design; "edited title" URLs are a support-desk generator.
 
-## One thing to plan for
+The cheat sheet: bind to a column that's **unique and doesn't change**. That's it. Everything else is the framework doing exactly what you asked.
 
-Pretty keys interact with pagination, nested resources, and route precedence exactly like numeric keys — the binding is resolved after the route matches, so nothing about matching changes. But your `linkTo` calls change their output, which means one place to check after flipping a resource to `bindBy`: anything that hard-coded `/posts/#id#` as a string instead of using the helpers. Those were always fragile; `bindBy` just makes them visible.
+## What binding is and isn't
 
-If you want the full tour of the routing layer before adding `bindBy` to your routes file, the [routing deep dive](https://blog.wheels.dev/posts/associations-deep-dive-wheels-4/) and the route-precedence behavior in the guides are the place to start.
+Two terms in Wheels routing that get conflated:
+
+- **`binding=`** (existing) maps *extra* route parameters to a model lookup for page-style binding.
+- **`bindBy=`** (new) changes *which column the key segment binds through*.
+
+They're orthogonal and they compose — a route can bind its key to a slug and still declare additional bindings for secondary parameters.
+
+And `bindBy` doesn't touch route precedence or matching. The binding is resolved *after* the route matches, so nothing about which route wins changes. The only behavioral shift you'll notice: `linkTo()` output, which means one thing to audit after flipping it — any place that hand-built `/posts/#id#` as a string instead of using the helper. Those were always fragile; `bindBy` just makes them visible.
+
+## The un-anonymous link
+
+The support conversation ends differently now. *"The article about migrating to 4.1? Here — /posts/migrating-to-wheels-4-1."* The customer knows it's the right one before they click. They can repeat it in a meeting. It survives being texted.
+
+That's the real win, and it's why the option belongs in the router rather than in a thousand `linkTo` calls: readability isn't an accessory to a resource route — it's the whole reason the route exists.
+
+Next up in the series: read the next post — DI factories, and the service that couldn't decide where its files lived. (See the [series index](https://blog.wheels.dev/posts/wheels-4-1-coming/).)

--- a/web/content/blog/scheduled/the-wheels-4-1-security-hardening-pass.md
+++ b/web/content/blog/scheduled/the-wheels-4-1-security-hardening-pass.md
@@ -1,5 +1,5 @@
 ---
-title: 'The Wheels 4.1 security hardening pass'
+title: 'Fail closed, everywhere: the hardening pass and the assumptions that weren''t true'
 slug: the-wheels-4-1-security-hardening-pass
 publishedAt: '2026-09-08T14:00:00.000Z'
 updatedAt: null
@@ -10,65 +10,54 @@ tags:
 categories:
   - Releases
 excerpt: >-
-  4.1 shipped a release-cycle hardening pass across the framework: fail-closed
-  auth and policies, controller retargeting protection, mass-assignment
-  opt-in, zip-slip and path-escape fixes, view-helper encoding, and storage
-  key validation. Here's what changed, area by area, and what (if anything)
-  you need to do about it.
-coverImage: null
+  A security review of Wheels 4.0 found a pile of "surely that's safe" that
+  weren't: a policy that treated the string "yes" as true, a form method
+  override that worked on a GET, a zip that could escape its directory. 4.1
+  closes them by failing closed. Here's the story area by area, and what you
+  have to check on the way up.
+coverImage: '/blog-images/4-1/the-wheels-4-1-security-hardening-pass.svg'
 ---
 
-Alongside the feature work, 4.1 ran a systematic hardening pass over the framework's trust boundaries. The theme across all of it: **fail closed**. Where 4.0 sometimes guessed, 4.1 refuses — loudly, and with a typed error you can catch.
+Every framework has a layer of things you assume are safe because *surely* nobody would write it that way. A policy that returns `"yes"` authorizes. A `_method` field that works on a GET. A plugin zip that unzips wherever it wants. A route that trusts a header the client set.
 
-Here's the tour, area by area.
+You assume those are safe. Then you review the code.
 
-## Authentication and authorization
+The 4.1 hardening pass was the release where we stopped assuming and started reading. The theme across every fix: **fail closed.** Where 4.0 sometimes guessed at what you meant, 4.1 refuses — loudly, with a typed error you can catch.
 
-- **Session rotation.** `SessionStrategy.login()` and `logout()` rotate or invalidate the session ID, and rotation failures are no longer swallowed by a catch-all.
-- **JWTs require expiry by default.** `JwtService.decode()` now demands an `exp` claim unless you explicitly pass `requireExpiry=false`. A signed token with no expiry was a token with no revocation story.
-- **Policies require true.** `authorize()`/`can()` grant only when a policy method returns boolean `true` — the CFML strings `"yes"` and `"true"` no longer authorize. Unknown actions throw `Wheels.Policy.UnknownAction` instead of treating a typo as a deny (a typo that denies is a bug that hides).
-- **`authenticateWith()` fails closed** when the restriction list names a strategy that doesn't exist, instead of silently skipping the typo.
-- **Empty policy scopes return a no-rows chain** rather than calling `whereIn("id", [])` — which, per the anti-pattern we've burned on before, was a SQL syntax error waiting for an empty collection.
+## The ones that will bite you first
 
-## Controllers and requests
+**A policy that authorized on `"yes"`.** Policies return a boolean; authorize only when `true`. Except CFML is loose, and a policy method that returned the string `"yes"` — which CFML cheerfully coerces — happily authorized. Now `authorize()`/`can()` grant only on a literal boolean `true`. The strings `"yes"` and `"true"` deny. If you have a policy returning strings, it denies now. That's the point.
 
-- **Controller/action retargeting is gone.** Query strings, form fields, or JSON bodies can no longer retarget the routed `controller`/`action` — `$ensureControllerAndAction` pins them. Wildcard path names are unchanged.
-- **`form._method` is honored only on POST**, and only for `PUT`/`PATCH`/`DELETE` — GET can't become a state-changing verb.
-- **Before filters that return `false` now halt** the action and remaining filters (redirects and renders still halt as before). The authz fail-closed signal actually fails closed.
-- **Client-supplied rewrite headers** (`X-Rewrite-URL`, `X-Original-URL`) are ignored unless you opt in with `set(trustProxyHeaders=true)`.
-- **`$wildcardDomainMatch` compares every host label**, so `https://*.example.com` no longer matches `https://evil.com`.
+**A method override that worked on a GET.** `form._method` is a nice Rails-ism. It's also a footgun: if it's honored on a GET, then a prefetched link can become a DELETE. 4.1 honors `form._method` only on POST, and only for `PUT`/`PATCH`/`DELETE`. GET can't become state-changing, POST can't become CSRF-safe.
 
-## Models and mass assignment
+**A route you could retarget with a query string.** The routed `controller`/`action` used to be overridable by query parameters, form fields, or a JSON body. An attacker could make one URL dispatch somewhere unexpected. 4.1 pins them — `$ensureControllerAndAction` — so only the path defines what runs. Wildcard path names are unchanged.
 
-- **Strict mode.** `set(massAssignmentStrict=true)` fail-closes `create`/`update`/`save` for models with neither `accessibleProperties()` nor `protectedProperties()`. The default remains open for compatibility — flip it on new apps and never look back.
-- **`create()` no longer leaks properties onto the shared class model** before instantiating the record, and nested `hasMany` keys no longer use a `GetTickCount` window to decide "new" vs existing (form identities use a `new-` prefix).
-- **Uniqueness scopes now exclude soft-deleted rows by default** (`includeSoftDeletes=false`), so a soft-deleted value can be reused.
+**A wildcard that matched too much.** `https://*.example.com` didn't just match subdomains; it matched `https://evil.com`. Host-label comparison now checks every label.
 
-## Plugins and packages
+## The ones that were quietly dangerous
 
-- **Zip-slip is fixed.** Plugin zip extraction rejects absolute paths, `..` segments, and canonical escapes before writing a single file.
-- **Package manifests with empty `wheelsVersion` are rejected**; invalid `plugin.json` skips the plugin instead of half-loading it.
-- **Admin pages no longer `cfinclude` on-disk `index.cfm` files** from packages, and homepage links are `EncodeForHTML`-encoded http(s)-only.
-- **PackageLoader refuses dotted/traversed directory names** and mappings whose realpath lands outside the package — including symlink escapes.
+**Mass assignment.** `create()`/`update()`/`save()` would happily assign whatever came in `params`, and if a model had neither `accessibleProperties()` nor `protectedProperties()`, there was nothing to stop a crafted `params.isAdmin=true`. New apps can opt into `set(massAssignmentStrict=true)`, which fail-closes those models. Default stays open for compatibility — but flip it.
 
-## Views and output
+**`create()` leaking onto the class.** Creating a record used to assign properties onto the *shared class model* before instantiating the record. Fixing that uncovered a cousin: `hasChanged()` now treats a deleted persisted property as a change, and nested `hasMany` keys no longer use a `GetTickCount` window to guess "new" vs existing.
 
-- **Breakout attribute names are rejected** in view helpers, `errorElement`/`wrapperElement` are restricted to safe tags, and `encode` is honored on date option bodies and `csrfMetaTags`.
-- **`linkTo(sanitizeHref=true)` blanks `javascript:`/`data:` hrefs** (opt-in; the default stays `false`).
-- **Pagination and asset helpers encode interpolated paths**, collapse `..` on local sources, and stop double-encoding pagination params.
+**Plugin zips that escaped.** Zip extraction didn't reject `..` segments or absolute paths. `wheels destroy view` didn't reject `../x`. Both are closed — extraction refuses zip-slip before writing, and `destroy view` stays under `app/views/`.
 
-## Middleware and storage
+**View helpers that let attributes break out.** Breakout attribute names are rejected, `errorElement`/`wrapperElement` are restricted to safe tags, and `linkTo(sanitizeHref=true)` blanks `javascript:`/`data:` hrefs (opt-in, default unchanged).
 
-- **`Pipeline.getMiddleware()` returns a copy** — callers can't mutate the live stack.
-- **RateLimiter honors `trustProxy`** before a client-supplied `remoteAddr`.
-- **Circular middleware dependencies throw** `Wheels.Middleware.CircularDependency` instead of silently falling back to priority ordering.
-- **LocalDisk refuses empty and slash-only keys** so `put()` can't write the disk root, and S3 `put()` sends a signed `x-amz-acl` so visibility settings are actually enforced.
+## The ones a red-team would find
 
-## What you need to do
+- **Policy scopes** that returned `whereIn("id", [])` on empty — SQL syntax error waiting for a collection. Now fail-closed with a no-rows chain.
+- **`authenticateWith()`** that silently skipped a typo'd strategy name. Now fails closed. `JwtService.decode()` requires an `exp` claim by default; `SessionStrategy.login()`/`logout()` rotate the session ID.
+- **Middleware that mutated the live stack.** `Pipeline.getMiddleware()` and the package/plugin getters return copies now. `RateLimiter` honors `trustProxy` before a client-supplied `remoteAddr`. Circular middleware dependencies throw instead of silently reordering.
+- **Storage keys.** LocalDisk refuses empty and slash-only keys — `put()` can't write the disk root — and S3 `put()` sends a signed `x-amz-acl` so visibility is honored.
 
-For most apps: **nothing**. The changes are either opt-in (strict mass assignment, `sanitizeHref`, `genericErrors`) or bug fixes that make existing defaults behave the way they were always documented to. The two things worth a look on an upgrade:
+## What you actually have to do
 
-1. Grep for `whereIn`/`whereNotIn` with possibly-empty arrays and for `form._method` usage — both now behave more strictly.
-2. If you wrote policy methods returning `"yes"` strings, they deny now. That's the point.
+For most apps: **nothing.** The changes are opt-in (strict mass assignment, `sanitizeHref`, `genericErrors`) or bug fixes that make existing defaults behave as documented. The two worth a look on upgrade:
 
-The full list is in the 4.1.0 changelog. Security releases shouldn't be exciting; this one's excitement is that the checks you always assumed existed now actually exist.
+1. **Grep for policy methods returning strings.** They deny now.
+2. **Grep for `form._method` usage and possibly-empty `whereIn` arrays.** Both behave more strictly.
+
+The full list is in the [4.1.0 changelog](https://github.com/wheels-dev/wheels/blob/main/CHANGELOG.md). Security releases aren't supposed to be exciting. This one's excitement is that the checks you always assumed existed now actually exist — and that "fail closed" stopped being a slogan and became the default.
+
+Next up: read the next post — finding your riskiest code, and the 900-line controller. (See the [series index](https://blog.wheels.dev/posts/wheels-4-1-coming/).)

--- a/web/content/blog/scheduled/wheels-4-1-0-released.md
+++ b/web/content/blog/scheduled/wheels-4-1-0-released.md
@@ -1,5 +1,5 @@
 ---
-title: 'Wheels 4.1.0 released: bcrypt, session auth, pretty routes, and a faster core'
+title: 'Wheels 4.1.0 is out — the release a bug report built'
 slug: wheels-4-1-0-released
 publishedAt: '2026-09-10T14:00:00.000Z'
 updatedAt: null
@@ -11,43 +11,46 @@ tags:
 categories:
   - Releases
 excerpt: >-
-  Wheels 4.1.0 is out — the release where the 4.x backlog shipped and the
-  framework got faster. bcrypt password hashing, one-line session auth, route
-  bindBy, DI factories, CLI diff/dry-run/offline workflows, a security
-  hardening pass, and model instantiation ~2.5x faster than 4.0.3.
-coverImage: null
+  Wheels 4.1.0 is out: bcrypt, one-line session auth, pretty routes, DI
+  factories, CLI diff/dry-run/offline, a security hardening pass, and model
+  instantiation ~2.5x faster. Every one of those threads traces back to a
+  single issue filed by @chapmandu — and the release is better because it
+  didn't start with a features list.
+coverImage: '/blog-images/4-1/wheels-4-1-0-released.svg'
 ---
 
-Wheels 4.1.0 is out. This release closes the 4.x backlog and lands the performance work that started with a single bug report — plus a hardening pass that makes a lot of things you already assumed were safe actually safe.
+Wheels 4.1.0 is out. If you've followed [the series](https://blog.wheels.dev/posts/wheels-4-1-coming/), you know this release has a plot, and it starts with [@chapmandu](https://github.com/chapmandu) asking, politely, whether we'd ever benchmarked Wheels 4 against 2.5.
+
+He'd ported a real app. His test suite went from five minutes to half an hour. And as it turned out, **he was right.** That single report is the reason this isn't just another features-and-fixes release — it's the reason the framework got meaningfully faster, and the reason a couple of hard-to-find bugs are gone.
 
 Full notes: [GitHub Release v4.1.0](https://github.com/wheels-dev/wheels/releases/tag/v4.1.0) · [CHANGELOG](https://github.com/wheels-dev/wheels/blob/main/CHANGELOG.md)
 
-## The headline features
+## The features, and what they're really about
 
-**bcrypt password hashing.** `bcryptHash()`, `bcryptVerify()`, and `bcryptNeedsRehash()` are now global helpers — pure CFML, no Java objects, OpenBSD/htpasswd/jBCrypt-compatible, and correct on every supported engine including the ones that made it hard. [Deep dive](https://blog.wheels.dev/posts/bcrypt-password-hashing-in-wheels-4-1/).
+**bcrypt password hashing.** `bcryptHash()`, `bcryptVerify()`, `bcryptNeedsRehash()` — pure CFML, no Java objects, OpenBSD/htpasswd/jBCrypt-compatible, correct on every engine. The [deep dive](https://blog.wheels.dev/posts/bcrypt-password-hashing-in-wheels-4-1/) starts with a pentest report, but it's really about the migration dance you'll do to use them.
 
-**One-line session auth.** `injector().enableSession()` in `config/services.cfm` wires the authenticator, the session strategy singleton, and idempotent strategy registration — and composes with a pre-mapped authenticator. [Deep dive](https://blog.wheels.dev/posts/one-line-session-auth-with-enablesession/).
+**One-line session auth.** `injector().enableSession()` in `config/services.cfm`. The [story](https://blog.wheels.dev/posts/one-line-session-auth-with-enablesession/) is the three subtle bugs it exists to prevent — the strategy that isn't there, the duplicate, the logged-in-user-who-isn't.
 
-**Pretty routes.** `bindBy="slug"` on a resource binds its `:key` segment to a non-primary-key column via the parameterized finder — `/posts/wheels-4-1-0-released` instead of `/posts/42`. [Deep dive](https://blog.wheels.dev/posts/pretty-urls-with-route-bindby/).
+**Pretty routes.** `bindBy="slug"` turns `/posts/4821` into `/posts/wheels-4-1-released`. The [deep dive](https://blog.wheels.dev/posts/pretty-urls-with-route-bindby/) is the unshareable link and the two ways to get it wrong.
 
-**DI factories.** `map("x").toFactory(function(ctx){...})` binds a name to a closure that receives the container and builds the instance — with full singleton/request-scoped/transient lifecycle support. [Deep dive](https://blog.wheels.dev/posts/dependency-injection-factories-with-tofactory/).
+**DI factories.** `toFactory()` for when `to()` can't express *how* something gets built. [The story](https://blog.wheels.dev/posts/dependency-injection-factories-with-tofactory/) is the service that couldn't decide where its files lived.
 
-**CLI workflow tools.** `wheels migrate diff` (preview or `--write` schema changes with rename hints), `generate --dry-run`, offline mode, plus fail-closed `wheels test` exit codes and new `wheels doctor` checks. [Deep dive](https://blog.wheels.dev/posts/cli-workflow-upgrades-migrate-diff-dry-run-offline/).
+**CLI workflow tools.** `migrate diff`, `generate --dry-run`, offline mode, fail-closed exit codes. [The story](https://blog.wheels.dev/posts/cli-workflow-upgrades-migrate-diff-dry-run-offline/) is two deploy incidents and the CLI learning to show its work.
 
-## The performance work
+## The centerpiece: performance
 
-Model instantiation is **~2.5× faster than 4.0.3** on our benchmark rig — the result of a head-to-head 2.5-vs-4.x benchmark that confirmed a user's "4.x is much slower" report, followed by three hot-path changes: request-scoped caching of the mixin plan, compile-time inheritance of the model API, and direct construction. The full story, including the two unrelated bugs the benchmarking surfaced, is in the [write-up](https://blog.wheels.dev/posts/how-we-made-model-instantiation-2-5x-faster/).
+Model instantiation is **~2.5× faster than 4.0.3** on our benchmark rig — the result of the investigation [@chapmandu](https://github.com/chapmandu)'s report started. Request-scoped plan caching, compile-time inheritance of the model API, and direct construction instead of a DI round-trip and a reflective invoke. The full story — including the two unrelated bugs the benchmarking surfaced — is in the [write-up](https://blog.wheels.dev/posts/how-we-made-model-instantiation-2-5x-faster/).
 
 ## The hardening pass
 
-4.1 ships a release-cycle security hardening pass: fail-closed policies and auth, controller/action retargeting protection, strict mass-assignment mode, zip-slip and path-escape fixes in the plugin system, view-helper encoding fixes, middleware copy semantics, and storage key validation. [What changed, area by area](https://blog.wheels.dev/posts/the-wheels-4-1-security-hardening-pass/).
+4.1 also ships a release-cycle security hardening: fail-closed policies and auth, controller retargeting protection, strict mass-assignment mode, zip-slip and path-escape fixes, view-helper encoding, middleware copy semantics, storage key validation. The theme is one word: **fail closed.** [Area by area](https://blog.wheels.dev/posts/the-wheels-4-1-security-hardening-pass/).
 
 ## And the rest
 
-- **Developer tooling:** a Code Complexity panel in the debug bar and the `wheels coverage` CRAP-ranking command — [write-up](https://blog.wheels.dev/posts/wheels-coverage-and-the-complexity-panel/).
-- **Engine compatibility:** the Adobe CF 2023/2025 matrix failures are fixed (debug bar, `"Null"` string binding, nested hasMany keys, pagination params) and the core suite runs clean on the JVM-free RustCFML engine.
-- **Deploy:** Kamal-compatible `boot` config (`limit`/`wait`) for `wheels deploy`.
-- **Deprecations:** `wheels.Test` (RocketUnit) now emits a one-time deprecation warning; removal is planned for Wheels 5.0. If you still run RocketUnit suites, this is your heads-up.
+- **Developer tooling:** a Code Complexity panel and the `wheels coverage` CRAP-ranking command — [the tool that would have caught the September bug](https://blog.wheels.dev/posts/wheels-coverage-and-the-complexity-panel/).
+- **Engine compatibility:** the Adobe CF 2023/2025 matrix failures are fixed, and the core suite runs clean on the JVM-free RustCFML engine.
+- **Deploy:** Kamal-compatible `boot` config (`limit`/`wait`).
+- **Deprecations:** `wheels.Test` (RocketUnit) now warns once; removal is planned for Wheels 5.0. If you still run RocketUnit suites, that's your heads-up.
 
 ## Upgrading
 
@@ -56,6 +59,10 @@ wheels upgrade check
 wheels upgrade apply
 ```
 
-The upgrade is additive — the changes that alter behavior are opt-in (strict mass assignment, `sanitizeHref`, JWT `requireExpiry`) or bug fixes to documented defaults. The changelog's "changed" section is the complete list of the latter; it's a ten-minute read and worth it before you deploy.
+The upgrade is additive — the behavior-changing items are opt-in (strict mass assignment, `sanitizeHref`, JWT `requireExpiry`) or bug fixes to documented defaults. The changelog's "changed" section is the complete list of the latter; it's a ten-minute read and worth doing before you deploy.
 
-Thanks as always to everyone who filed the issues that shaped this release — especially the performance report that started the whole investigation.
+## The thanks
+
+Releases usually end with thanks to the people who filed the issues. This one means it more than most. [@chapmandu](https://github.com/chapmandu) asked a question we should have been asking ourselves, and the answer reshaped the framework — not just its speed, but how we'll measure it next time.
+
+If you're on an older 4.0.x and your suite got slower somewhere along the way, this is the release to try. And if it's still slow, file it. The rig is built, and it's listening before it argues.

--- a/web/content/blog/scheduled/wheels-4-1-coming.md
+++ b/web/content/blog/scheduled/wheels-4-1-coming.md
@@ -1,0 +1,52 @@
+---
+title: 'Wheels 4.1 is coming — and this release has a story'
+slug: wheels-4-1-coming
+publishedAt: '2026-09-01T14:00:00.000Z'
+updatedAt: null
+author: Peter Amiri
+tags:
+  - wheels-4
+  - release-notes
+categories:
+  - Releases
+excerpt: >-
+  Wheels 4.1 isn't another "we added features and fixed bugs" release. It's
+  the release where a single bug report sent us back to the drawing board,
+  where a security pass made the things you always assumed were safe actually
+  be safe, and where the framework got meaningfully faster. Here's what's
+  coming, and the story behind it.
+coverImage: '/blog-images/4-1/wheels-4-1-coming.svg'
+---
+
+Most release previews are a list. This one has a plot, so let me set the scene.
+
+A few months ago, someone filed an issue that started with a simple question: *"has anyone done a performance comparison between Wheels 2.x and 4.x?"* They'd ported a real app and their test suite went from roughly five minutes to nearly half an hour. It was phrased politely, the way most people phrase "you broke something" when they're trying not to be rude about it.
+
+We'd all been told the framework was getting faster. There were PRs titled "perf" with charts. And yet this person's number kept nagging at us. So we did the thing we should have done at the start: we built an actual benchmark, ran Wheels 2.5 head-to-head against current develop on the same engine, and let the numbers speak.
+
+They didn't flatter us. He'd been right, and by a lot.
+
+That report is the spine of this whole release. It's why 4.1 has a story, and why the content below isn't the usual changelog-walk.
+
+## What's shipping
+
+Over the next two weeks, the blog will walk through each thread, one post at a time:
+
+- **bcrypt for your passwords** — pure-CFML bcrypt helpers, and the migration dance you'll actually have to do to use them.
+- **Session auth in one line** — the `enableSession()` facade, and the three subtle bugs it saves you from.
+- **Pretty URLs with `bindBy`** — human URLs for resource routes, and the mistake it invites if you're not careful.
+- **Factories for your container** — DI `toFactory()`, for when `to()` can't express *how* something is built.
+- **CLI workflows that never guess** — `migrate diff`, `generate --dry-run`, offline mode, and the phantom-green-build problems they prevent.
+- **2.5× faster, the long way** — the full performance investigation, including the two unrelated bugs it surfaced.
+- **Fail closed, everywhere** — the security hardening pass, area by area.
+- **Find your riskiest code** — the complexity panel and the `wheels coverage` CRAP ranking.
+
+The **4.1.0 release post** lands after all of them, tying the threads together with the full changelog.
+
+## What to do while you wait
+
+If you want the technical detail right now, the [4.1.0 changelog](https://github.com/wheels-dev/wheels/blob/main/CHANGELOG.md) is already on `develop` — everything below is ships-today, not vaporware. Or run `wheels upgrade check` on a branch and see what you're on.
+
+But the blog series is worth the wait, because the features are only half of it. The other half is *why we built them that way* — and a couple of those decisions are stories you'll want before you upgrade, not after.
+
+See you on the first one. It's about passwords, and it starts with a pentest report.

--- a/web/content/blog/scheduled/wheels-coverage-and-the-complexity-panel.md
+++ b/web/content/blog/scheduled/wheels-coverage-and-the-complexity-panel.md
@@ -1,5 +1,5 @@
 ---
-title: 'Find your riskiest code with wheels coverage and the complexity panel'
+title: 'Find your riskiest code: the 900-line controller and the tool that caught it'
 slug: wheels-coverage-and-the-complexity-panel
 publishedAt: '2026-09-09T14:00:00.000Z'
 updatedAt: null
@@ -11,53 +11,64 @@ tags:
 categories:
   - Releases
 excerpt: >-
-  4.1 adds two ways to see where your app's risk lives: a Code Complexity
-  panel in the debug bar that scores every file in app/ statically, and a
-  wheels coverage command that instruments the app, runs your test suite, and
-  reports a CRAP ranking of your most change-risky files.
-coverImage: null
+  There was a controller with nine hundred lines and one bug that only fired
+  in September. Three developers touched it that week. When we pointed the
+  complexity panel at it, the score said everything — and the coverage run
+  said the test suite had never touched it. 4.1 ships the two tools that make
+  that obvious before the September bug goes out.
+coverImage: '/blog-images/4-1/wheels-coverage-and-the-complexity-panel.svg'
 ---
 
-Two numbers predict where your next bug will come from better than any code review checklist: **how complex a file is, and how little of it your tests touch.** Wheels 4.1 ships one tool for each, and they share a score.
+The controller was nine hundred lines. It did billing, refunds, invoicing, a CSV export, and it was the only place in the app that reached into the payment provider. Nobody was comfortable with it, but it worked, and nobody had the time to be uncomfortable *and* finish a sprint.
 
-## The Code Complexity debug panel
+Then the September bug happened. A date rollover in the invoice logic. Three developers touched that file in the same week, each changing one if, each assuming the other two were on top of it. It wasn't anyone's fault. It was a nine-hundred-line file with no tests and a cyclomatic complexity score that, if anyone had known it, would have been a red flag painted in neon.
 
-In development, the debug bar now has a *Code Complexity* panel. It walks `app/`, scores every file's cyclomatic complexity statically — one point per decision point (`if`, `loop`, `catch`, boolean operator) — and lists your worst offenders with their scores.
+Two numbers predict where your next bug lives better than any code-review checklist: **how complex a file is, and how little of it your tests touch.** Wheels 4.1 ships one tool for each, and they share a score.
 
-Two design choices matter:
+## The Complexity panel: always on, always obvious
 
-- **It's static.** No instrumentation, no test run, no state. The scan runs once per reload and is cached for the application lifetime, so the panel costs you one scan, not one per request.
-- **It's always visible.** You don't have to remember to run anything — the panel is there every time you open the debug bar in dev, which means you *notice* the 40-decision-point controller you wrote last sprint instead of discovering it in review.
+In development, the debug bar has a *Code Complexity* panel. It walks `app/`, scores every file's cyclomatic complexity statically — one point per decision point (`if`, `loop`, `catch`, boolean operator) — and lists the offenders with their scores.
 
-## `wheels coverage` — the test half
+Two design choices matter, and they're what make the panel catch the September bug rather than just making a nice chart:
 
-Complexity alone is half the story. A 30-point file with thorough tests is fine; a 10-point file with no tests is where regressions live. The command:
+- **It's static.** No instrumentation, no test run, no state. The scan runs once per reload and is cached for the application lifetime, so the panel costs one scan, not one per request.
+- **It's always visible.** You don't have to remember to run anything — it's in the debug bar every time you open it in dev. That means you *notice* the 900-line controller the day you write it, not three sprints later when it's too big to comfortably refactor.
+
+## `wheels coverage`: the test half
+
+Complexity alone is half the story. A 30-point file with thorough tests is fine; a 10-point file with zero tests is where a September bug lives. That's what the `wheels coverage` command is for:
 
 ```sh
 wheels coverage            # top 5 by default
 wheels coverage --top 10
 ```
 
-What it does:
+What it does, in order:
 
 1. Instruments `app/` with function-level coverage counters.
 2. Runs your app test suite against the running server.
-3. Reports a **CRAP ranking** — *Change Risk Analysis and Predictions*: cyclomatic complexity weighted by test coverage, the same metric Jenkins' Crap4J made famous. A file with high complexity and low coverage scores high; a well-tested file scores low.
-4. **Reverts the instrumentation automatically**, so there's nothing to clean up or accidentally commit.
+3. Reports a **CRAP ranking** — *Change Risk Analysis and Predictions*: cyclomatic complexity weighted by test coverage, the same score Jenkins' Crap4J made famous. High complexity + low coverage = high CRAP; well-tested = low.
+4. **Reverts the instrumentation automatically.** Nothing to clean up, nothing to accidentally commit.
 
-The pairing is deliberate: complexity is static and always visible; `wheels coverage` adds the coverage half on demand, when you want the number rather than the intuition.
+Point it at the 900-line controller and you get the number that was always true: high complexity, no coverage, top of the list. That's not a judgment on the developer — it's a measurement of the *code*, which is the whole point.
 
 ## The workflow
 
-The intended loop is simple:
+The intended loop is boring, in the best way:
 
-1. Debug bar shows you the complexity rankings while you work.
-2. Before a change, run `wheels coverage --top 10` — files near the top of *that* list are your change-risky set.
+1. Debug bar shows you complexity while you work.
+2. Before a change, run `wheels coverage --top 10`. The files near the top are your change-risky set.
 3. Add tests for the risky paths, watch the ranking move.
-4. Enforce the floor in CI if you want to — the same complexity engine that powers the panel runs as a maintainer-side gate, so the numbers you see locally are the numbers CI would see.
+4. Enforce the floor in CI if you want — the same complexity engine that powers the panel runs as a maintainer-side gate, so the numbers locally are the numbers CI sees.
+
+The pairing is deliberate: complexity is static and always visible; coverage is the part that takes a test run, so it's on demand. Together they turn "this file feels fragile" into "this file scores 62 CRAP, here's the list."
 
 ## Where it comes from
 
-The complexity engine is the same static analyzer the Wheels maintainers run against the framework itself — the 4.0 series added it as a CI gate on `vendor/wheels/`, and 4.1 exposes it to your app. Which means the tool has been chewing on the framework's own 10,000-file codebase for months before being pointed at yours. It's not a port of a generic linter; it's CFML-aware where it matters (comment stripping included).
+The complexity engine isn't a port of a generic linter — it's the static analyzer the Wheels maintainers run against *the framework itself*. The 4.0 series added it as a CI gate on `vendor/wheels/`, and 4.1 exposes it to your app. It has been chewing on the framework's own ten-thousand-file codebase for months before being aimed at yours, which is a roundabout way of saying: the tool has already found the things you're worried about in the thing we ship. It's CFML-aware where it matters, comment stripping included.
 
 If your suite is slow, pair it with the batch finders from the 4.0 series — coverage runs the whole app suite, and `findEach`/`findInBatches` don't hurt to have around. But start with the command. The list it prints is the most honest risk assessment your codebase has ever had.
+
+The September bug, for what it's worth, is fixed. The controller is not nine hundred lines anymore. Nobody set out to refactor it — the complexity panel just made it impossible to unsee.
+
+Next up: Wheels 4.1.0 is out, published last so every link in this series is live by then. (See the [series index](https://blog.wheels.dev/posts/wheels-4-1-coming/).)

--- a/web/sites/blog/public/blog-images/4-1/bcrypt-password-hashing-in-wheels-4-1.svg
+++ b/web/sites/blog/public/blog-images/4-1/bcrypt-password-hashing-in-wheels-4-1.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1b1830"/>
+      <stop offset="1" stop-color="#0f0e16"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#2ec4b6"/>
+      <stop offset="1" stop-color="#e63946"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="none" stroke="#ffffff" stroke-opacity="0.05">
+    <circle cx="1090" cy="560" r="150" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="220" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="290" stroke-width="2"/>
+  </g>
+  <g stroke="#ffffff" stroke-opacity="0.06" stroke-width="10" stroke-linecap="round">
+    <line x1="985" y1="120" x2="1040" y2="205"/>
+    <line x1="1040" y1="120" x2="1095" y2="205"/>
+  </g>
+  <rect x="96" y="176" width="120" height="6" rx="3" fill="url(#accent)"/>
+  <text x="96" y="150" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="24" font-weight="700" letter-spacing="4" fill="#2ec4b6">SECURITY</text>
+  <text x="96" y="356.0" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="70" font-weight="800" fill="#f4f3f7">bcrypt for your passwords</text>
+  <text x="96" y="540" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="22" font-weight="600" letter-spacing="2" fill="#8b8a95">WHEELS 4.1.0 BLOG SERIES</text>
+  <g stroke="#e63946" stroke-width="6" stroke-linecap="round">
+    <line x1="96" y1="478" x2="112" y2="494"/>
+    <line x1="128" y1="478" x2="144" y2="494"/>
+  </g>
+</svg>

--- a/web/sites/blog/public/blog-images/4-1/cli-workflow-upgrades-migrate-diff-dry-run-offline.svg
+++ b/web/sites/blog/public/blog-images/4-1/cli-workflow-upgrades-migrate-diff-dry-run-offline.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1b1830"/>
+      <stop offset="1" stop-color="#0f0e16"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#3a86ff"/>
+      <stop offset="1" stop-color="#e63946"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="none" stroke="#ffffff" stroke-opacity="0.05">
+    <circle cx="1090" cy="560" r="150" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="220" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="290" stroke-width="2"/>
+  </g>
+  <g stroke="#ffffff" stroke-opacity="0.06" stroke-width="10" stroke-linecap="round">
+    <line x1="985" y1="120" x2="1040" y2="205"/>
+    <line x1="1040" y1="120" x2="1095" y2="205"/>
+  </g>
+  <rect x="96" y="176" width="120" height="6" rx="3" fill="url(#accent)"/>
+  <text x="96" y="150" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="24" font-weight="700" letter-spacing="4" fill="#3a86ff">CLI</text>
+  <text x="96" y="315.0" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="70" font-weight="800" fill="#f4f3f7">CLI workflows that never</text>
+  <text x="96" y="397.0" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="70" font-weight="800" fill="#f4f3f7">guess</text>
+  <text x="96" y="540" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="22" font-weight="600" letter-spacing="2" fill="#8b8a95">WHEELS 4.1.0 BLOG SERIES</text>
+  <g stroke="#e63946" stroke-width="6" stroke-linecap="round">
+    <line x1="96" y1="478" x2="112" y2="494"/>
+    <line x1="128" y1="478" x2="144" y2="494"/>
+  </g>
+</svg>

--- a/web/sites/blog/public/blog-images/4-1/dependency-injection-factories-with-tofactory.svg
+++ b/web/sites/blog/public/blog-images/4-1/dependency-injection-factories-with-tofactory.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1b1830"/>
+      <stop offset="1" stop-color="#0f0e16"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#f77f00"/>
+      <stop offset="1" stop-color="#e63946"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="none" stroke="#ffffff" stroke-opacity="0.05">
+    <circle cx="1090" cy="560" r="150" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="220" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="290" stroke-width="2"/>
+  </g>
+  <g stroke="#ffffff" stroke-opacity="0.06" stroke-width="10" stroke-linecap="round">
+    <line x1="985" y1="120" x2="1040" y2="205"/>
+    <line x1="1040" y1="120" x2="1095" y2="205"/>
+  </g>
+  <rect x="96" y="176" width="120" height="6" rx="3" fill="url(#accent)"/>
+  <text x="96" y="150" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="24" font-weight="700" letter-spacing="4" fill="#f77f00">DEPENDENCY INJECTION</text>
+  <text x="96" y="315.0" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="70" font-weight="800" fill="#f4f3f7">Factories for your</text>
+  <text x="96" y="397.0" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="70" font-weight="800" fill="#f4f3f7">container</text>
+  <text x="96" y="540" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="22" font-weight="600" letter-spacing="2" fill="#8b8a95">WHEELS 4.1.0 BLOG SERIES</text>
+  <g stroke="#e63946" stroke-width="6" stroke-linecap="round">
+    <line x1="96" y1="478" x2="112" y2="494"/>
+    <line x1="128" y1="478" x2="144" y2="494"/>
+  </g>
+</svg>

--- a/web/sites/blog/public/blog-images/4-1/how-we-made-model-instantiation-2-5x-faster.svg
+++ b/web/sites/blog/public/blog-images/4-1/how-we-made-model-instantiation-2-5x-faster.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1b1830"/>
+      <stop offset="1" stop-color="#0f0e16"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#ff9f1c"/>
+      <stop offset="1" stop-color="#e63946"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="none" stroke="#ffffff" stroke-opacity="0.05">
+    <circle cx="1090" cy="560" r="150" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="220" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="290" stroke-width="2"/>
+  </g>
+  <g stroke="#ffffff" stroke-opacity="0.06" stroke-width="10" stroke-linecap="round">
+    <line x1="985" y1="120" x2="1040" y2="205"/>
+    <line x1="1040" y1="120" x2="1095" y2="205"/>
+  </g>
+  <rect x="96" y="176" width="120" height="6" rx="3" fill="url(#accent)"/>
+  <text x="96" y="150" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="24" font-weight="700" letter-spacing="4" fill="#ff9f1c">PERFORMANCE</text>
+  <text x="96" y="356.0" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="70" font-weight="800" fill="#f4f3f7">2.5x faster, the long way</text>
+  <text x="96" y="540" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="22" font-weight="600" letter-spacing="2" fill="#8b8a95">WHEELS 4.1.0 BLOG SERIES</text>
+  <g stroke="#e63946" stroke-width="6" stroke-linecap="round">
+    <line x1="96" y1="478" x2="112" y2="494"/>
+    <line x1="128" y1="478" x2="144" y2="494"/>
+  </g>
+</svg>

--- a/web/sites/blog/public/blog-images/4-1/one-line-session-auth-with-enablesession.svg
+++ b/web/sites/blog/public/blog-images/4-1/one-line-session-auth-with-enablesession.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1b1830"/>
+      <stop offset="1" stop-color="#0f0e16"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#6c7cff"/>
+      <stop offset="1" stop-color="#e63946"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="none" stroke="#ffffff" stroke-opacity="0.05">
+    <circle cx="1090" cy="560" r="150" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="220" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="290" stroke-width="2"/>
+  </g>
+  <g stroke="#ffffff" stroke-opacity="0.06" stroke-width="10" stroke-linecap="round">
+    <line x1="985" y1="120" x2="1040" y2="205"/>
+    <line x1="1040" y1="120" x2="1095" y2="205"/>
+  </g>
+  <rect x="96" y="176" width="120" height="6" rx="3" fill="url(#accent)"/>
+  <text x="96" y="150" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="24" font-weight="700" letter-spacing="4" fill="#6c7cff">AUTHENTICATION</text>
+  <text x="96" y="356.0" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="70" font-weight="800" fill="#f4f3f7">Session auth in one line</text>
+  <text x="96" y="540" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="22" font-weight="600" letter-spacing="2" fill="#8b8a95">WHEELS 4.1.0 BLOG SERIES</text>
+  <g stroke="#e63946" stroke-width="6" stroke-linecap="round">
+    <line x1="96" y1="478" x2="112" y2="494"/>
+    <line x1="128" y1="478" x2="144" y2="494"/>
+  </g>
+</svg>

--- a/web/sites/blog/public/blog-images/4-1/pretty-urls-with-route-bindby.svg
+++ b/web/sites/blog/public/blog-images/4-1/pretty-urls-with-route-bindby.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1b1830"/>
+      <stop offset="1" stop-color="#0f0e16"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#8ac926"/>
+      <stop offset="1" stop-color="#e63946"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="none" stroke="#ffffff" stroke-opacity="0.05">
+    <circle cx="1090" cy="560" r="150" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="220" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="290" stroke-width="2"/>
+  </g>
+  <g stroke="#ffffff" stroke-opacity="0.06" stroke-width="10" stroke-linecap="round">
+    <line x1="985" y1="120" x2="1040" y2="205"/>
+    <line x1="1040" y1="120" x2="1095" y2="205"/>
+  </g>
+  <rect x="96" y="176" width="120" height="6" rx="3" fill="url(#accent)"/>
+  <text x="96" y="150" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="24" font-weight="700" letter-spacing="4" fill="#8ac926">ROUTING</text>
+  <text x="96" y="356.0" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="70" font-weight="800" fill="#f4f3f7">Pretty URLs with bindBy</text>
+  <text x="96" y="540" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="22" font-weight="600" letter-spacing="2" fill="#8b8a95">WHEELS 4.1.0 BLOG SERIES</text>
+  <g stroke="#e63946" stroke-width="6" stroke-linecap="round">
+    <line x1="96" y1="478" x2="112" y2="494"/>
+    <line x1="128" y1="478" x2="144" y2="494"/>
+  </g>
+</svg>

--- a/web/sites/blog/public/blog-images/4-1/the-wheels-4-1-security-hardening-pass.svg
+++ b/web/sites/blog/public/blog-images/4-1/the-wheels-4-1-security-hardening-pass.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1b1830"/>
+      <stop offset="1" stop-color="#0f0e16"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#ef476f"/>
+      <stop offset="1" stop-color="#e63946"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="none" stroke="#ffffff" stroke-opacity="0.05">
+    <circle cx="1090" cy="560" r="150" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="220" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="290" stroke-width="2"/>
+  </g>
+  <g stroke="#ffffff" stroke-opacity="0.06" stroke-width="10" stroke-linecap="round">
+    <line x1="985" y1="120" x2="1040" y2="205"/>
+    <line x1="1040" y1="120" x2="1095" y2="205"/>
+  </g>
+  <rect x="96" y="176" width="120" height="6" rx="3" fill="url(#accent)"/>
+  <text x="96" y="150" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="24" font-weight="700" letter-spacing="4" fill="#ef476f">SECURITY</text>
+  <text x="96" y="356.0" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="70" font-weight="800" fill="#f4f3f7">Fail closed, everywhere</text>
+  <text x="96" y="540" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="22" font-weight="600" letter-spacing="2" fill="#8b8a95">WHEELS 4.1.0 BLOG SERIES</text>
+  <g stroke="#e63946" stroke-width="6" stroke-linecap="round">
+    <line x1="96" y1="478" x2="112" y2="494"/>
+    <line x1="128" y1="478" x2="144" y2="494"/>
+  </g>
+</svg>

--- a/web/sites/blog/public/blog-images/4-1/wheels-4-1-0-released.svg
+++ b/web/sites/blog/public/blog-images/4-1/wheels-4-1-0-released.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1b1830"/>
+      <stop offset="1" stop-color="#0f0e16"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#e63946"/>
+      <stop offset="1" stop-color="#e63946"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="none" stroke="#ffffff" stroke-opacity="0.05">
+    <circle cx="1090" cy="560" r="150" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="220" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="290" stroke-width="2"/>
+  </g>
+  <g stroke="#ffffff" stroke-opacity="0.06" stroke-width="10" stroke-linecap="round">
+    <line x1="985" y1="120" x2="1040" y2="205"/>
+    <line x1="1040" y1="120" x2="1095" y2="205"/>
+  </g>
+  <rect x="96" y="176" width="120" height="6" rx="3" fill="url(#accent)"/>
+  <text x="96" y="150" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="24" font-weight="700" letter-spacing="4" fill="#e63946">RELEASE</text>
+  <text x="96" y="356.0" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="70" font-weight="800" fill="#f4f3f7">Wheels 4.1.0 is out</text>
+  <text x="96" y="540" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="22" font-weight="600" letter-spacing="2" fill="#8b8a95">WHEELS 4.1.0 BLOG SERIES</text>
+  <g stroke="#e63946" stroke-width="6" stroke-linecap="round">
+    <line x1="96" y1="478" x2="112" y2="494"/>
+    <line x1="128" y1="478" x2="144" y2="494"/>
+  </g>
+</svg>

--- a/web/sites/blog/public/blog-images/4-1/wheels-4-1-coming.svg
+++ b/web/sites/blog/public/blog-images/4-1/wheels-4-1-coming.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1b1830"/>
+      <stop offset="1" stop-color="#0f0e16"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#e63946"/>
+      <stop offset="1" stop-color="#e63946"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="none" stroke="#ffffff" stroke-opacity="0.05">
+    <circle cx="1090" cy="560" r="150" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="220" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="290" stroke-width="2"/>
+  </g>
+  <g stroke="#ffffff" stroke-opacity="0.06" stroke-width="10" stroke-linecap="round">
+    <line x1="985" y1="120" x2="1040" y2="205"/>
+    <line x1="1040" y1="120" x2="1095" y2="205"/>
+  </g>
+  <rect x="96" y="176" width="120" height="6" rx="3" fill="url(#accent)"/>
+  <text x="96" y="150" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="24" font-weight="700" letter-spacing="4" fill="#e63946">PREVIEW</text>
+  <text x="96" y="356.0" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="70" font-weight="800" fill="#f4f3f7">Wheels 4.1 is coming</text>
+  <text x="96" y="540" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="22" font-weight="600" letter-spacing="2" fill="#8b8a95">WHEELS 4.1.0 BLOG SERIES</text>
+  <g stroke="#e63946" stroke-width="6" stroke-linecap="round">
+    <line x1="96" y1="478" x2="112" y2="494"/>
+    <line x1="128" y1="478" x2="144" y2="494"/>
+  </g>
+</svg>

--- a/web/sites/blog/public/blog-images/4-1/wheels-coverage-and-the-complexity-panel.svg
+++ b/web/sites/blog/public/blog-images/4-1/wheels-coverage-and-the-complexity-panel.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1b1830"/>
+      <stop offset="1" stop-color="#0f0e16"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#9b5de5"/>
+      <stop offset="1" stop-color="#e63946"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g fill="none" stroke="#ffffff" stroke-opacity="0.05">
+    <circle cx="1090" cy="560" r="150" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="220" stroke-width="2"/>
+    <circle cx="1090" cy="560" r="290" stroke-width="2"/>
+  </g>
+  <g stroke="#ffffff" stroke-opacity="0.06" stroke-width="10" stroke-linecap="round">
+    <line x1="985" y1="120" x2="1040" y2="205"/>
+    <line x1="1040" y1="120" x2="1095" y2="205"/>
+  </g>
+  <rect x="96" y="176" width="120" height="6" rx="3" fill="url(#accent)"/>
+  <text x="96" y="150" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="24" font-weight="700" letter-spacing="4" fill="#9b5de5">TOOLING</text>
+  <text x="96" y="356.0" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="70" font-weight="800" fill="#f4f3f7">Find your riskiest code</text>
+  <text x="96" y="540" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="22" font-weight="600" letter-spacing="2" fill="#8b8a95">WHEELS 4.1.0 BLOG SERIES</text>
+  <g stroke="#e63946" stroke-width="6" stroke-linecap="round">
+    <line x1="96" y1="478" x2="112" y2="494"/>
+    <line x1="128" y1="478" x2="144" y2="494"/>
+  </g>
+</svg>


### PR DESCRIPTION
Second pass on the scheduled 4.1.0 blog series, per review feedback.

## What changed

- **Story-first rewrite.** Every post now opens with a concrete incident and follows a narrative arc instead of a feature list: a pentest report (bcrypt), a strategy that isn't there (enableSession), an unshareable link (bindBy), a service that couldn't decide where its files lived (toFactory), two phantom-green deploy incidents (CLI), a bug report we initially didn't believe (performance), a pile of 'surely that's safe' that weren't (hardening), and a 900-line controller (coverage/complexity).
- **@chapmandu, not Adam.** The reporter is credited by GitHub handle throughout the performance and release posts.
- **Front-loaded preview post.** Added `wheels-4-1-coming` (published 2026-09-01, first) that serves as the series index. All 'next up in the series' links now point to it, so no intra-series link 404s before its target date — and the release post stays last (09-10) so its deep-dive links are all live.
- **Branded SVG covers** for all 10 posts under `web/sites/blog/public/blog-images/4-1/` — Wheels `#e63946` mark, dark gradient, per-post accent color, series motif — wired via `coverImage`.

## Verification

- Frontmatter validated against the Astro schema for all 10 posts (unique slugs, required fields, ISO dates, cover paths all exist).
- No remaining 'Adam' references; no 404-risk futures (verified the intra-series link graph).
- Covers are static SVG served from the blog `public/` dir; the existing blog deploy builds them in.