### PR TITLE
docs(guides): document the 4.0.6/4.1 feature wave

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/basics/migrations.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/basics/migrations.mdx
@@ -258,6 +258,24 @@ component extends="wheels.migrator.Migration" hint="Seed admin role" {
 
 Quote string values inline; wrap each statement in `execute()` individually. For anything structural — building a compound object, branching on current rows — consider writing a one-off script under `app/lib/` and calling it from your deploy pipeline instead.
 
+For plain row updates and deletes, `updateRecord()` and `removeRecord()` save you the raw SQL — and fail closed on a full-table write. Both throw `Wheels.Migrator.MissingWhere` when `where` is empty unless you pass `all=true`:
+
+```cfm {test:compile}
+component extends="wheels.migrator.Migration" hint="Backfill and prune" {
+    function up() {
+        updateRecord(table="posts", where="status = 'legacy'", archived=true);
+        removeRecord(table="posts", where="deletedAt < CURRENT_TIMESTAMP");
+    }
+
+    function down() {
+        // An intentional full-table write still needs the explicit opt-in:
+        updateRecord(table="posts", all=true, archived=false);
+    }
+}
+```
+
+`updateRecord(table, where, ...columns)` sets the extra named arguments as column values (auto-typed: booleans, numbers, dates, and strings); `removeRecord(table, where)` deletes the matching rows. The `all=true` opt-in is the tripwire that keeps an accidentally-empty `where` from mutating every row.
+
 ## Reversible vs irreversible
 
 Every `up()` should have a matching `down()` so `wheels migrate down` can walk the history back. Most changes are trivially reversible: `createTable` pairs with `dropTable`, `addColumn` with `removeColumn`, `addIndex` with `removeIndex`.

--- a/web/sites/guides/src/content/docs/v4-0-0/basics/views-layouts-partials.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/basics/views-layouts-partials.mdx
@@ -140,7 +140,7 @@ Wheels 4.0 form helpers escape their input by default (see [Forms and Form Helpe
 
 The helpers you'll reach for most often in view code:
 
-- `linkTo(route=..., key=..., text=..., class=...)` — renders an `<a>` tag with the URL filled in from a named route. `class`, `id`, and other HTML attributes pass straight through onto the anchor.
+- `linkTo(route=..., key=..., text=..., class=...)` — renders an `<a>` tag with the URL filled in from a named route. `class`, `id`, and other HTML attributes pass straight through onto the anchor. When the `href` comes from user input, pass `sanitizeHref=true` to blank `javascript:` and `data:` URLs (the default is `false`, so external `href`s keep working unchanged).
 - `buttonTo(route=..., key=..., text=..., method="delete")` — renders a `<form>` wrapping a single submit button. Reach for it when an action must POST/PUT/PATCH/DELETE rather than GET (e.g. a "Delete" button). Because the button lives *inside* a form, attributes for the **button itself** are prefixed with `input` — use `inputClass`, `inputId`, `inputRel`, **not** `class`/`id`, e.g. `buttonTo(text="Delete", route="post", key=post.id, method="delete", inputClass="btn btn-danger")`. Unprefixed `class`/`id` land on the wrapping `<form>`. (`buttonTo` is the only link helper with this split — siblings like `linkTo` take `class`/`id` directly.)
 - `urlFor(route=..., key=...)` — returns just the URL string. Use when you need the URL outside an anchor (JavaScript, form action, `Location:` header).
 - `imageTag("logo.png", alt="Logo")` — renders `<img>` with the path resolved against `public/images/`.

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/index.mdx
@@ -45,6 +45,19 @@ You don't install them separately, and you don't switch contexts between them. E
   />
 </CardGrid>
 
+## Global flags
+
+A few flags apply to every command, anywhere on the command line:
+
+| Flag | Env var | Effect |
+|---|---|---|
+| `--offline` | `WHEELS_OFFLINE=1` | Skips the CLI update check and fails fast on any registry network call, instead of waiting on a timeout. Useful for CI and air-gapped machines. |
+
+```bash title="example"
+wheels generate model User --offline
+WHEELS_OFFLINE=1 wheels migrate latest
+```
+
 ## Wheels commands
 
 Framework-specific commands contributed by the Wheels Module. These are what you reach for daily.

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-generation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-generation.mdx
@@ -27,6 +27,14 @@ The `g` alias is supported for every form (`wheels g model User`). `wheels creat
 
 Running `wheels generate` with no arguments prints the list of supported types and one-line examples. Unknown types print `Unknown generator type: <type>` and exit without writing anything.
 
+Every generator accepts `--dry-run`, which prints the would-be file paths and generated content but writes nothing:
+
+```bash title="example"
+wheels generate model Post title:string --dry-run
+```
+
+Previewing is the safe way to see exactly what a generator will create — files, injected config blocks, and all — before it touches the project.
+
 ### Supported types
 
 | Type | Alias | Writes |

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-quality.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-quality.mdx
@@ -150,9 +150,11 @@ wheels coverage [--top=N] [--no-test-db]
 
 #### Example
 
-```bash {test:cli cmd="wheels coverage"}
+```bash
 wheels coverage
 ```
+
+`wheels coverage` needs a running server (it instruments `app/`, then runs the suite against it) — start one with `wheels start` first.
 
 Pairs with the debug bar's **Code Complexity** panel: complexity is static and always visible; `wheels coverage` adds the test-coverage half of the CRAP score on demand. Files at the top of the ranking are the ones to touch with tests in hand.
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-quality.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-quality.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Code Quality"
-description: wheels analyze and wheels validate — read-only diagnostics that surface anti-patterns, complex functions, code smells, and validation errors across models, controllers, views, and routes.
+description: wheels analyze, wheels validate, and wheels coverage — read-only diagnostics plus a change-risk ranking (complexity × test coverage) for the files most likely to break.
 type: reference
 sidebar:
   order: 7
@@ -8,7 +8,7 @@ sidebar:
 
 import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-Two commands cluster here, both read-only and both backed by the same `analysis` service. `wheels analyze` produces a long-form report with metrics, anti-patterns, and complexity hotspots. `wheels validate` runs a tighter, error-focused pass over models, controllers, routes, and views and reports pass/fail.
+Two read-only diagnostics cluster here — `wheels analyze` (a long-form report with metrics, anti-patterns, and complexity hotspots) and `wheels validate` (a tighter, error-focused pass over models, controllers, routes, and views) — plus `wheels coverage`, which instruments the app, runs the suite, and ranks files by change risk.
 
 **You'll use this for:**
 
@@ -130,6 +130,31 @@ Validation found 2 issue(s):
 <Aside type="note" title="analyze vs validate">
 Both commands read the same files through the same service, but they answer different questions. `wheels analyze` is **observational** — here's what your code looks like, here are metrics, here are hotspots. `wheels validate` is **pass/fail** — either there are no errors (exit green) or there are errors you need to fix. Reach for `analyze` during development or a refactor; reach for `validate` right before committing or deploying.
 </Aside>
+
+### `wheels coverage`
+
+Ranks your app's files by change risk — the CRAP score (cyclomatic complexity × test coverage) — so you can see which files are hardest to change safely. Unlike `analyze`'s static complexity, coverage adds the *tested* half: it instruments `app/` with function-level counters, runs the app test suite against a running server, and reports a ranked list. The instrumentation is reverted automatically afterward.
+
+#### Synopsis
+
+``` title="synopsis"
+wheels coverage [--top=N] [--no-test-db]
+```
+
+#### Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--top=N` | `15` | How many files to list in the ranking. |
+| `--no-test-db` | off | Run against the main database instead of the isolated test database. |
+
+#### Example
+
+```bash {test:cli cmd="wheels coverage"}
+wheels coverage
+```
+
+Pairs with the debug bar's **Code Complexity** panel: complexity is static and always visible; `wheels coverage` adds the test-coverage half of the CRAP score on demand. Files at the top of the ranking are the ones to touch with tests in hand.
 
 ## Common workflows
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/database.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/database.mdx
@@ -28,7 +28,7 @@ Apply or roll back migration files in `app/migrator/migrations/`.
 #### Synopsis
 
 ``` title="synopsis"
-wheels migrate [latest|up|down|info|doctor|forget|pretend|rename-system-tables]
+wheels migrate [latest|up|down|info|doctor|forget|pretend|rename-system-tables|diff]
 ```
 
 Running `wheels migrate` with no subcommand defaults to `latest`. Unknown subcommands print `Unknown migration action: <name>` and exit without touching the schema.
@@ -66,6 +66,25 @@ Records a version as applied without running its `up()`: `wheels migrate pretend
 ##### `rename-system-tables`
 
 Migrates legacy framework bookkeeping tables to their current `wheels_`-prefixed names. Run once when upgrading a project whose system tables predate the current naming.
+
+##### `diff`
+
+Diffs your models against the live schema via `AutoMigrator` and prints the would-be changes without writing anything. Add `--write` to emit migration files instead. This is the read-only way to answer "what would migrations say if I generated them now?" — it never mutates the database.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--model=<Name>` | all models | Diff a single model instead of every model. |
+| `--rename=<OLD:NEW>` | — | Repeatable rename hint; use `Model.OLD:NEW` when diffing all models. |
+| `--hints=<json>` | — | Rename hints as JSON: `{"renames":{"old":"new"}}`. |
+| `--threshold=<n>` | — | Heuristic rename-detection threshold between `0` and `1`. |
+| `--name=<Name>` | — | Migration name when writing a single-model diff with `--write`. |
+| `--write` | off | Write migration file(s) instead of previewing. |
+
+```bash title="example"
+wheels migrate diff --rename=Post.slug:Post.permalink
+```
+
+The `dbmigrate diff` alias is equivalent to `wheels migrate diff`.
 
 #### Example
 

--- a/web/sites/guides/src/content/docs/v4-0-0/core-concepts/middleware-pipeline.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/core-concepts/middleware-pipeline.mdx
@@ -38,12 +38,14 @@ set(middleware = [
 
 ## Built-in middleware
 
-Four components ship in `wheels.middleware`:
+Six components ship in `wheels.middleware`:
 
 - **`RequestId`** — stamps a unique correlation ID on every request. Sets `request.wheels.requestId` for downstream code and returns an `X-Request-Id` response header for log correlation.
 - **`SecurityHeaders`** — applies OWASP response headers: `X-Frame-Options`, `X-Content-Type-Options`, `X-XSS-Protection`, `Referrer-Policy`, and optionally `Content-Security-Policy`, `Strict-Transport-Security`, and `Permissions-Policy`. HSTS auto-enables in production when left unset.
 - **`Cors`** — handles the `OPTIONS` preflight and sets `Access-Control-*` response headers. Requires an explicit `allowOrigins` — the default is empty so a missing configuration fails closed rather than opens the app to every origin.
 - **`RateLimiter`** — throttles requests per client using fixed-window, sliding-window, or token-bucket strategies. Backed by in-memory counters by default; swap to `storage="database"` for shared state across nodes.
+- **`AuthMiddleware`** — authenticates a request and attaches the result. Accepts `genericErrors=true` to emit a generic `Unauthorized` JSON body on 401; the default 401 still includes `authResult.error` (more detail, at the cost of revealing why auth failed).
+- **`TenantResolver`** — resolves the active tenant per request. Accepts `failClosed=true` to 403 unmatched tenants; without it, unmatched requests proceed on the default datasource.
 
 ## Route-scoped middleware
 

--- a/web/sites/guides/src/content/docs/v4-0-0/deployment/security-hardening.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/deployment/security-hardening.mdx
@@ -150,6 +150,18 @@ component extends="Controller" {
 
 For an entire JSON API under `/api`, inherit from a controller that calls `protectsFromForgery(with="ignore")` instead of the default exception-throwing base.
 
+## Mass assignment
+
+`params.user` flows straight into `new()` and `update()` on a scaffolded form, which means a request that adds an `isAdmin=1` field can set columns you didn't intend. The default is open for backward compatibility; opt in to fail-closed with:
+
+```cfm {test:compile} title="config/settings.cfm"
+<cfscript>
+set(massAssignmentStrict=true);
+</cfscript>
+```
+
+With it on, any model that defines neither `accessibleProperties()` nor `protectedProperties()` fails closed on mass assignment instead of accepting every posted property. Define one of those two lists per model to state the intended surface explicitly — see [Models and the ORM](/v4-0-0/basics/models-and-the-orm/) for the property-list API.
+
 ## Reload password
 
 `reloadPassword` gates `?reload=true` and environment switches via URL (`?reload=production`). If it's empty, **both are disabled**: the reload gate in `public/Application.cfc` fails closed and requires a non-empty configured password plus a matching `password` parameter before it will restart anything, mirroring the environment-switch leg in `vendor/wheels/events/onapplicationstart.cfc`. The security warning Wheels logs on boot when the password is blank states exactly that. (Before [#3062](https://github.com/wheels-dev/wheels/issues/3062) a blank password left plain `?reload=true` open to any anonymous client — an internet-reachable restart-DoS — so still set a real password anywhere reload should work.)

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/authentication-patterns.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/authentication-patterns.mdx
@@ -12,8 +12,8 @@ This page shows you how to wire authentication into a Wheels app using the built
 
 **You'll learn:**
 
-- How to register `wheels.auth.SessionStrategy` for classic cookie-based login
-- How to hash passwords today, given the current bcrypt gap
+- How to register `wheels.auth.SessionStrategy` for classic cookie-based login — or skip the wiring with `enableSession()`
+- How to hash passwords with the built-in `bcryptHash()` / `bcryptVerify()` / `bcryptNeedsRehash()` helpers
 - How to add `wheels.auth.JwtStrategy` and `wheels.auth.TokenStrategy` for API auth
 - How to combine strategies so session auth protects HTML routes and token auth protects `/api/*`
 
@@ -101,6 +101,16 @@ if (StructKeyExists(application, "wheelsdi") && application.wheelsdi.containsIns
   The short `service("authenticator")` form and the long `application.wo.service("authenticator")` form resolve to the same instance. Use the short one in controllers, views, and other files that are already running inside the framework; the long form is only needed at app-init time when the global helper isn't in scope yet.
 </Aside>
 
+### The one-line shortcut: `enableSession()`
+
+Hand-wiring the session strategy spans two files — the singleton registration in `config/services.cfm` plus the `registerStrategy()` call in an app-init hook. `enableSession()` collapses both into one idempotent call made from `config/services.cfm`:
+
+```cfm {test:compile} title="config/services.cfm"
+enableSession(sessionKey = "wheels.auth");
+```
+
+It registers `wheels.auth.SessionStrategy` under `sessionKey` (default `"wheels.auth"`) and wires it into the authenticator, so the `registerStrategy()` block above is unnecessary. Optional `onLogin` / `onLogout` callbacks receive the principal struct. The helper belongs in `services.cfm` on purpose — the DI container is available there (it is **not** available in `config/app.cfm`, which loads before the container is built). Manual wiring keeps working; `enableSession()` is the convenience path.
+
 ### Log in, log out, protect actions
 
 After verifying the password in your `Sessions` controller, call `sessionStrategy.login(principal)` to stash the identity. `logout()` tears it down:
@@ -164,11 +174,11 @@ The filter must be `private`. A `public` filter becomes a routable action — Wh
 
 Model-level hashing stays the same regardless of which strategy you use — the strategy doesn't touch passwords, it just round-trips a principal struct after you've already verified credentials.
 
-<Aside type="caution">
-  **Bcrypt is not shipped with Wheels 4.0.** `hash(pw, "BCRYPT")` throws "bcrypt MessageDigest not available" in the bundled Lucee. Until that lands, the examples below use salted SHA-256, which is educational but **not production-grade** — SHA-256 is fast, which makes brute-force attacks cheap. For a real deployment, add a Java bcrypt library to `box.json`, use a CFX tag, or wait for the forthcoming `wheels-security` package. The mechanism (generate salt, hash `password + salt`, compare) stays the same — only the hash function changes. Bundling a stronger password hash is on the framework's radar — watch the [releases page](https://github.com/wheels-dev/wheels/releases) for `wheels-security`.
+<Aside type="tip">
+  **Bcrypt ships with Wheels 4.1.** `bcryptHash()`, `bcryptVerify()`, and `bcryptNeedsRehash()` are global helpers — pure-CFML bcrypt with no Java objects, CFX tags, or external libraries, byte-compatible with OpenBSD `$2b$` / jBCrypt hashes and verified against `$2$`, `$2a$`, `$2x$`, and `$2y$` inputs. Use them directly; there's no reason to hand-roll a salted hash anymore.
 </Aside>
 
-The stopgap pattern is a `beforeValidation` callback that hashes plaintext and clears it, plus an `authenticate(password)` instance method. The hash callback registers `beforeValidation` rather than `beforeSave` so the NOT NULL `passwordHash` and `passwordSalt` columns are populated by the time Wheels' automatic `validatesPresenceOf` rules check them — registering on `beforeSave` causes every signup to fail with `Passwordhash can't be empty`:
+The pattern is a `beforeValidation` callback that hashes plaintext and clears it, plus an `authenticate(password)` instance method that verifies against the stored hash:
 
 ```cfm {test:compile} title="app/models/User.cfc"
 component extends="Model" {
@@ -187,25 +197,32 @@ component extends="Model" {
 
     private function hashPassword() {
         if (StructKeyExists(this, "password") && Len(this.password)) {
-            if (!StructKeyExists(this, "passwordSalt") || !Len(this.passwordSalt ?: "")) {
-                this.passwordSalt = generateSecretKey("AES");
-            }
-            this.passwordHash = Hash(this.password & this.passwordSalt, "SHA-256");
+            this.passwordHash = bcryptHash(this.password);
             StructDelete(this, "password");
         }
     }
 
     public boolean function authenticate(required string password) {
-        if (!Len(this.passwordHash ?: "") || !Len(this.passwordSalt ?: "")) {
+        if (!Len(this.passwordHash ?: "")) {
             return false;
         }
-        var candidate = Hash(arguments.password & this.passwordSalt, "SHA-256");
-        return (candidate == this.passwordHash);
+        return bcryptVerify(arguments.password, this.passwordHash);
     }
 }
 ```
 
-`normalizeEmail` runs before validation so uniqueness sees a canonical address. `hashPassword` only fires when `this.password` is set (the caller just assigned a new one), generates a per-user salt on first write, and scrubs the plaintext before the save hits the database. When bcrypt ships, swap `Hash(... "SHA-256")` for the bcrypt equivalent — nothing else changes.
+`normalizeEmail` runs before validation so uniqueness sees a canonical address. `hashPassword` only fires when `this.password` is set (the caller just assigned a new one) and scrubs the plaintext before the save hits the database. One `passwordHash` column is all you need — the salt and cost are embedded in the bcrypt hash string, so there's no separate `passwordSalt` column to migrate.
+
+When you later raise the cost factor, `bcryptNeedsRehash()` flags stored hashes that predate it so you can rehash on login:
+
+```cfm {test:compile} title="transparent work-factor upgrade"
+if (bcryptNeedsRehash(user.passwordHash)) {
+    user.passwordHash = bcryptHash(params.password);
+    user.save();
+}
+```
+
+`bcryptHash(password, cost)` takes an optional cost (default `10`); `bcryptNeedsRehash(hash, cost)` compares the stored hash's cost against your target. `bcryptVerify()` compares in constant time, so the `authenticate()` above is safe as written. The `wheels generate auth` scaffold does all of this for you — this section is the hand-rolled equivalent.
 
 ## Token auth with `TokenStrategy`
 
@@ -388,7 +405,7 @@ You don't have to. `Authenticator`, `SessionStrategy`, `TokenStrategy`, and `Jwt
 ## Security pitfalls
 
 - **Session fixation.** `SessionStrategy.login()` calls `sessionRotate()` automatically on engines that support it (Lucee). If you're on an engine without session rotation, issue a new session ID manually before storing the principal.
-- **Timing-safe comparison.** The stopgap `authenticate()` uses `==` to compare hashes, which is not timing-safe. Under load an attacker can measure response times to recover the hash byte-by-byte. Swap for a constant-time comparator (`Compare()` in CFML is not guaranteed constant-time either — use a dedicated Java helper) when you ship bcrypt.
+- **Timing-safe comparison.** `bcryptVerify()` compares in constant time, so the `authenticate()` example above is safe as written. If you compare hashes yourself anywhere else, don't use `==` — under load an attacker can measure response times to recover the hash byte-by-byte.
 - **Secret rotation.** `JwtService` takes a single `secretKey`. Rotating it invalidates every outstanding token. For gradual rotation, validate against a list of current + previous secrets during the cutover window; the shipped `JwtService` doesn't do this natively, so you'll need to wrap it.
 - **JWT revocation.** JWTs are stateless by design — you cannot revoke an issued token before it expires unless you maintain a server-side deny-list and check it on every request. Keep token expiry short (minutes, not days) and use a refresh-token flow if you need long sessions.
 - **Token leakage in URLs.** Query-string tokens are disabled by default on both `TokenStrategy` and `JwtStrategy` (`queryParam=""`). Query strings show up in access logs, referer headers, and browser history — prefer the `Authorization` header, and only set `queryParam` if you must support URL-based keys.

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/dependency-injection-usage.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/dependency-injection-usage.mdx
@@ -109,37 +109,29 @@ Same instance inside filters, actions, views, and any service called during the 
 
 ## Factory registration
 
-The Wheels injector's public API is `map(name).to(componentPath).asSingleton() | .asRequestScoped()`. There is no `toFactory()` — `.to()` takes a dotted component path, not a callback. When construction needs logic (reading env vars, composing from other services, branching on environment), wrap it in a plain CFC whose `init()` returns the real instance.
+When construction needs logic — reading env vars, composing from other services, branching on environment — use `toFactory()`. It binds a name to a closure that builds the instance, receives the container, and honors the lifecycle flag you chain:
 
-```cfm {test:compile} title="app/lib/JwtStrategyFactory.cfc"
-component {
-    public any function init() {
-        variables.instance = new wheels.auth.JwtStrategy(
-            jwtService=new wheels.auth.JwtService(
-                secretKey=application.wo.get("jwtSecret"),
-                issuer="my-app"
-            )
-        );
-        return this;
-    }
-
-    public any function build() {
-        return variables.instance;
-    }
-}
-```
-
-Register the factory as a singleton, then have callers ask it for the built instance:
-
-```cfm {test:compile} title="config/services.cfm — factory pattern"
+```cfm {test:compile} title="config/services.cfm — toFactory()"
 local.di = injector();
-local.di.map("jwtStrategyFactory").to("app.lib.JwtStrategyFactory").asSingleton();
-
-// consumers do:
-// var jwt = service("jwtStrategyFactory").build();
+local.di.map("jwtStrategy").toFactory(function(container) {
+    return new wheels.auth.JwtStrategy(
+        jwtService = new wheels.auth.JwtService(
+            secretKey = env("JWT_SECRET"),
+            issuer = "my-app"
+        )
+    );
+});
 ```
 
-If you need the factory output to *itself* be registered under a name (so consumers call `service("jwtStrategy")` directly), register the strategy at app-init time after the factory has built it — the authenticator-wiring pattern in [Authentication Patterns](/v4-0-0/digging-deeper/authentication-patterns/) does exactly this.
+Consumers resolve the result directly — the factory's return value *is* the binding, so there's no `.build()` indirection:
+
+```cfm {test:compile}
+var jwt = service("jwtStrategy");
+```
+
+Chain a lifecycle as usual: `.asSingleton()` builds once and caches the result, `.asRequestScoped()` rebuilds once per request, and the default is transient (a fresh instance per `service()` call). The closure receives the `Injector` as its argument, so you can resolve other registered names with `container.getInstance("name")` while composing. Calling `to()` after `toFactory()` replaces the factory binding entirely, and vice versa.
+
+If you prefer an explicit CFC over a closure, the older wrapper pattern still works — a singleton CFC whose `build()` method returns the real instance. `toFactory()` removes that indirection for the common case.
 
 ## Auto-wiring `init()` parameters
 

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/index.mdx
@@ -52,6 +52,11 @@ The Digging Deeper section covers Wheels' advanced features — the ones you rea
     description="Multipart uploads, storage backends, validation, and serving downloads safely."
   />
   <LinkCard
+    title="Storage"
+    href="/v4-0-0/digging-deeper/storage/"
+    description="Local and S3 storage behind one interface — named disks, drivers, and signed URLs."
+  />
+  <LinkCard
     title="Server-Sent Events"
     href="/v4-0-0/digging-deeper/server-sent-events/"
     description="Stream updates to the browser over plain HTTP — one-shot responses and long-lived streams."

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/route-model-binding.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/route-model-binding.mdx
@@ -15,6 +15,7 @@ This page shows you how to stop writing `findByKey(params.key)` at the top of ev
 - How per-resource `binding=true` auto-loads records into `params.<singular>`
 - How `set(routeModelBinding=true)` makes it the default for every resource
 - How `binding="ModelName"` overrides the convention-derived class name
+- How `bindBy="slug"` binds the segment to a non-primary-key column
 - How scope-level binding cascades to every nested resource
 - What happens when the record doesn't exist — `Wheels.RecordNotFound` and the 404
 - The dev-mode hint the framework writes to the Wheels log when binding is off but the route looks like a binding candidate
@@ -107,6 +108,34 @@ mapper()
 <Aside type="tip">
   The silent skip applies only to **conventional** binding (`binding=true`): when the convention-derived model class doesn't exist (for example, the resource is routing to a controller that doesn't have a backing model), the dispatcher skips binding instead of throwing. This keeps non-model resources — health checks, static pages, API gateways — working without extra configuration. An **explicit** name is different: if `binding="BlogPost"` names a model class that can't be resolved, the dispatcher rethrows the failure as a configuration error — you asked for that class by name, so a typo should surface, not vanish.
 </Aside>
+
+## Binding on a non-primary-key column
+
+By default binding resolves `params.key` with `findByKey()` — the URL segment is expected to be a primary key. When your URLs carry something friendlier — a slug, a username, a permalink — pass `bindBy=` to resolve the segment against that column through the parameterized dynamic finder instead:
+
+```cfm {test:compile} title="config/routes.cfm"
+<cfscript>
+mapper()
+    .resources(name="posts", binding=true, bindBy="slug")
+    .wildcard()
+.end();
+</cfscript>
+```
+
+With `bindBy="slug"`, a request to `/posts/hello-world` runs `model("Post").findOneBySlug(value="hello-world")` and stores the result in `params.post` — exactly as if you'd written the lookup yourself. The segment value is bound as the finder argument, never interpolated into a `where=` string.
+
+`bindBy` composes with an explicit model class, so you can bind a segment to a column on a non-conventional model:
+
+```cfm {test:compile} title="config/routes.cfm"
+<cfscript>
+mapper()
+    .resources(name="authors", binding="User", bindBy="username")
+    .wildcard()
+.end();
+</cfscript>
+```
+
+The 404 behavior is unchanged: if the dynamic finder returns no record, the dispatcher raises `Wheels.RecordNotFound` before your action runs. `bindBy` only has an effect when binding is enabled — set without `binding=true` (or the global default), it's ignored.
 
 ## Scope-level binding
 

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/storage.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/storage.mdx
@@ -1,0 +1,187 @@
+---
+title: Storage
+description: Local filesystem and S3 storage behind one interface — named disks, two drivers, and signed URLs.
+type: howto
+sidebar:
+  order: 6
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+This page shows you how to read and write files through the `wheels.storage` abstraction instead of reaching for `FileWrite` / `cfhttp` directly. You configure one or more named *disks* — a local directory, an S3 bucket, or both — and resolve them through `StorageManager` for a single `put` / `get` / `exists` / `delete` / `url` / `signedUrl` surface that swaps backends with a config change.
+
+**You'll learn:**
+
+- How to declare disks in `config/settings.cfm` and resolve them by name
+- How `LocalDisk` stores objects on the filesystem and serves them through a URL prefix
+- How `S3Disk` talks to S3 over plain `cfhttp` with from-scratch SigV4 signing — no AWS SDK, no JARs
+- How signed (presigned) URLs work on both drivers
+- What the failure contract is (`Wheels.Storage.*` errors)
+
+<Aside type="note">
+  You should already know the DI container basics (see [The Dependency Injection Container](/v4-0-0/core-concepts/dependency-injection/)) and have multipart uploads working (see [File Uploads & Downloads](/v4-0-0/digging-deeper/file-uploads-and-downloads/)). This page covers where the uploaded bytes go.
+</Aside>
+
+## The model
+
+Storage mirrors the disk abstraction you already know from Laravel's Filesystem or Rails' ActiveStorage. Configuration *names* each disk and assigns it a `driver` — `"local"` or `"s3"`. Application code asks `StorageManager` for a disk by name and receives a `wheels.interfaces.StorageDiskInterface` back, regardless of which driver is behind it.
+
+```cfm {test:compile} title="config/settings.cfm"
+<cfscript>
+set(storage = {
+    default = "local",
+    disks = {
+        local = {
+            driver = "local",
+            root = ExpandPath("../storage/uploads"),
+            urlPrefix = "/uploads"
+        },
+        s3 = {
+            driver = "s3",
+            bucket = "my-bucket",
+            region = "us-east-1",
+            accessKeyId = env("S3_ACCESS_KEY_ID"),
+            secretAccessKey = env("S3_SECRET_ACCESS_KEY"),
+            visibility = "private"
+        }
+    }
+});
+</cfscript>
+```
+
+Register the manager as a singleton in `config/services.cfm`. Because its `init()` takes the storage config struct — which isn't a registered service — wrap construction in `toFactory()`:
+
+```cfm {test:compile} title="config/services.cfm"
+<cfscript>
+local.di = injector();
+local.di.map("storage").toFactory(function() {
+    return new wheels.storage.StorageManager(config = get("storage"));
+});
+</cfscript>
+```
+
+`StorageManager.disk()` returns the default disk when you pass no name, and throws `Wheels.Storage.UnknownDisk` for a name you didn't configure:
+
+```cfm {test:compile} title="resolving a disk"
+local.uploads = service("storage").disk();          // "local" (the default)
+local.assets  = service("storage").disk("s3");      // "s3"
+```
+
+If you aren't using the container, instantiate the manager directly — `new wheels.storage.StorageManager(config = get("storage"))` — and keep it in a scope you control.
+
+## Storing and reading objects
+
+Every disk exposes the same six methods. Keys are forward-slash-delimited path strings; `put()` creates intermediate directories for you.
+
+```cfm {test:compile} title="basic put/get/exists/delete"
+local.disk = service("storage").disk();
+
+local.disk.put("avatars/42.png", local.binary, contentType = "image/png", visibility = "public");
+// -> "avatars/42.png"
+
+local.content = local.disk.get("avatars/42.png");   // binary
+local.has     = local.disk.exists("avatars/42.png"); // true
+local.disk.delete("avatars/42.png");                // true
+```
+
+| Method | Returns | Notes |
+|---|---|---|
+| `put(key, content, contentType, visibility)` | the key | Binary or string content; `visibility` is `"public"` or `"private"`. |
+| `get(key)` | binary | Throws `Wheels.Storage.NotFound` when absent. |
+| `exists(key)` | boolean | `LocalDisk` checks the filesystem; `S3Disk` issues a `HEAD`. |
+| `delete(key)` | boolean | `false` when the object was already gone. |
+| `url(key)` | string | Public URL (local prefix, or the S3 object URL). |
+| `signedUrl(key, expiresIn, contentDisposition)` | string | Expiring URL; see below. |
+
+`get()` and `put()` round-trip bytes exactly — `LocalDisk.put()` writes binary, never a string, so a PNG comes back identical to what went in.
+
+## LocalDisk
+
+The local driver stores objects under a configured `root` and exposes them through `urlPrefix`, which is whatever path your app already serves statically. Its config:
+
+| Key | Required | Default | Meaning |
+|---|---|---|---|
+| `root` | yes | — | Directory objects are written under. |
+| `urlPrefix` | no | `""` | Public URL path the app serves the files from. |
+| `signingKey` | no | `""` | HMAC secret for `signedUrl()`; required only if you call it. |
+
+```cfm {test:compile} title="config/settings.cfm — local disk"
+<cfscript>
+set(storage = {
+    default = "local",
+    disks = {
+        local = {
+            driver = "local",
+            root = ExpandPath("../storage/uploads"),
+            urlPrefix = "/uploads",
+            signingKey = env("STORAGE_SIGNING_KEY")
+        }
+    }
+});
+</cfscript>
+```
+
+`url("avatars/42.png")` produces `/uploads/avatars/42.png`. Because the filesystem has no native presigning, `signedUrl()` appends an HMAC `expires` / `signature` query string over the key and expiry — your download route is expected to verify it with `verifySignature()` before streaming. This is the same tradeoff Rails' `DiskController` and Laravel's `serve` make.
+
+## S3Disk
+
+The S3 driver speaks to S3 (and S3-compatible endpoints) over plain `cfhttp`, signing each request with a from-scratch SigV4 implementation in `wheels.storage.S3Signer` — no AWS SDK, no bundled JARs. Its config:
+
+| Key | Required | Default | Meaning |
+|---|---|---|---|
+| `bucket` | yes | — | Bucket name. |
+| `region` | yes | — | AWS region, e.g. `us-east-1`. |
+| `accessKeyId` | yes | — | AWS access key. |
+| `secretAccessKey` | yes | — | AWS secret key. |
+| `visibility` | no | `"private"` | Default ACL for `put()` (`public` → `public-read`). |
+| `endpoint` | no | `""` | S3-compatible endpoint (MinIO, R2, etc.). |
+| `usePathStyle` | no | `false` | Force path-style addressing for non-AWS endpoints. |
+| `timeout` | no | `60` | HTTP timeout in seconds. |
+
+```cfm {test:compile} title="putting an object to S3"
+service("storage").disk("s3").put(
+    key = "reports/q3.pdf",
+    content = local.pdfBytes,
+    contentType = "application/pdf",
+    visibility = "private"
+);
+```
+
+`url()` returns the object's public URL; `signedUrl()` returns a presigned, expiring GET URL computed locally by `S3Signer` — no round-trip to AWS required:
+
+```cfm {test:compile} title="presigned download URL"
+local.url = service("storage").disk("s3").signedUrl(
+    key = "reports/q3.pdf",
+    expiresIn = 900,
+    contentDisposition = "attachment; filename=q3.pdf"
+);
+```
+
+## Signed URLs on both drivers
+
+Both `signedUrl()` signatures match: `signedUrl(key, expiresIn = 300, contentDisposition = "")`. `expiresIn` must be within `1..604800` (one second to seven days) or the call throws `Wheels.Storage.InvalidExpiresIn`. On S3 the URL is a real AWS presigned GET; on local it's a URL with an HMAC token your app verifies. Object keys are RFC3986-encoded on both drivers, so spaces and reserved characters behave identically.
+
+## Failure contract
+
+Storage errors are typed so you can rescue them precisely:
+
+| Error | Raised when |
+|---|---|
+| `Wheels.Storage.UnknownDisk` | `disk("nope")` names a disk that isn't configured. |
+| `Wheels.Storage.UnknownDriver` | A disk's `driver` is neither `local` nor `s3`. |
+| `Wheels.Storage.InvalidConfiguration` | A disk omits a required config key (e.g. `root`, `bucket`). |
+| `Wheels.Storage.NotFound` | `get()` on a missing key. |
+| `Wheels.Storage.InvalidKey` | An empty or slash-only key on `LocalDisk`. |
+| `Wheels.Storage.InvalidExpiresIn` | `expiresIn` outside `1..604800`. |
+| `Wheels.Storage.MissingSigningKey` | `signedUrl()` on a local disk with no `signingKey`. |
+| `Wheels.Storage.RequestFailed` | An S3 request fails in a way that isn't "the object is absent". |
+
+`exists()` and `delete()` deliberately distinguish "object absent" (`false`) from "the backend didn't answer" (a thrown error) — a connection failure must not read as "no file here."
+
+## Related guides
+
+<CardGrid>
+  <LinkCard title="File Uploads & Downloads" href="/v4-0-0/digging-deeper/file-uploads-and-downloads/" description="Multipart uploads, validation, and serving downloads safely." />
+  <LinkCard title="The Dependency Injection Container" href="/v4-0-0/core-concepts/dependency-injection/" description="Why services.cfm, and how toFactory() fits construction with config." />
+  <LinkCard title="Deployment: Secrets" href="/v4-0-0/deployment/secrets/" description="Keep accessKeyId / secretAccessKey out of source." />
+</CardGrid>

--- a/web/sites/guides/src/content/docs/v4-0-0/upgrading/whats-new-in-4.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/upgrading/whats-new-in-4.mdx
@@ -32,6 +32,19 @@ You know Wheels. You have a 3.x app in production. This page is the ten-minute a
 
 Smaller but daily-life: composable pagination (`paginationNav()` with Bootstrap/Tailwind presets), idempotent seeding (`seedOnce()`), migration reconciliation for shared dev databases (`migrate doctor`/`forget`/`pretend`), HTML5 form helpers, and a rebuilt debug bar.
 
+## New since 4.0 — the 4.0.6 and 4.1 wave
+
+The 4.0.x line kept shipping. The highlights you'll actually reach for:
+
+- **Storage.** Local and S3 file storage behind one interface — named disks, `put`/`get`/`exists`/`delete`/`url`/`signedUrl`, and from-scratch SigV4 signing with no AWS SDK. → [Storage](/v4-0-0/digging-deeper/storage/)
+- **Password hashing, solved.** `wheels.auth.PasswordHasher` (PBKDF2, 600k iterations) plus pure-CFML bcrypt via `bcryptHash()` / `bcryptVerify()` / `bcryptNeedsRehash()` — no more hand-rolled salted SHA-256. → [Authentication Patterns](/v4-0-0/digging-deeper/authentication-patterns/)
+- **Authorization policies.** `wheels.Policy` with `authorize()` / `can()` / `policyScope()` and a `wheels generate policy` generator. → [Authorization Policies](/v4-0-0/digging-deeper/authorization-policies/)
+- **`enableSession()`.** One-line session-auth wiring in `config/services.cfm`. → [Authentication Patterns](/v4-0-0/digging-deeper/authentication-patterns/)
+- **Route binding on any column.** `bindBy="slug"` resolves a resource's `:key` segment through the dynamic finder. → [Route Model Binding](/v4-0-0/digging-deeper/route-model-binding/)
+- **`toFactory()`.** Register a DI binding with a closure that builds the instance. → [Dependency Injection Usage](/v4-0-0/digging-deeper/dependency-injection-usage/)
+- **A sharper CLI.** `wheels migrate diff`, `wheels generate --dry-run`, a global `--offline` flag, and `wheels coverage` for CRAP-ranked change risk. → [Database](/v4-0-0/command-line-tools/wheels-commands/database/), [Code Quality](/v4-0-0/command-line-tools/wheels-commands/code-quality/)
+- **Fail-closed mass assignment.** `set(massAssignmentStrict=true)` rejects posted properties a model didn't explicitly allow. → [Security Hardening](/v4-0-0/deployment/security-hardening/)
+
 ## The tooling story, honestly
 
 4.0 ships a first-party CLI — `wheels new`, generators, `migrate`, `test`, `console`, `deploy` — built on the LuCLI runtime and installed via Homebrew, Scoop, or apt/yum. Three sentences for the teams watching this warily:


### PR DESCRIPTION
Documents the 4.0.6/4.1 feature wave in the guides:

- New Storage guide (LocalDisk/S3Disk/StorageManager, signed URLs)
- bcrypt helpers + enableSession() in Authentication Patterns (replaces the stale 'bcrypt not shipped' warning)
- bindBy= route binding, toFactory() DI registration (replaces the stale 'no toFactory' note)
- wheels migrate diff, generate --dry-run, --offline, wheels coverage
- massAssignmentStrict, linkTo sanitizeHref, AuthMiddleware/TenantResolver options, updateRecord/removeRecord all=true
- what's-new-in-4 section for the 4.0.6/4.1 wave
