### PR TITLE
feat(blog): post GitHub Discussions announcements on publish

### DIFF
--- a/.github/scripts/blog-publish-scheduled.sh
+++ b/.github/scripts/blog-publish-scheduled.sh
@@ -24,6 +24,7 @@ TODAY="$(date -u +%Y-%m-%d)"
 echo "Publishing scheduled posts due on or before $TODAY (UTC)..."
 
 published=()
+moved_paths=()
 for file in "$SOURCE_DIR"/*.md; do
   # Skip the README (it has no publishedAt).
   [ -e "$file" ] || continue
@@ -46,12 +47,19 @@ for file in "$SOURCE_DIR"/*.md; do
   echo "  publishing: $(basename "$file") (due $due_date)"
   git mv "$file" "$TARGET_DIR/$(basename "$file")"
   published+=("$(basename "$file" .md)")
+  moved_paths+=("$TARGET_DIR/$(basename "$file")")
 done
 
 if [ ${#published[@]} -eq 0 ]; then
   echo "Nothing due today. Done."
   exit 0
 fi
+
+# Post each newly-published post's `announcement` frontmatter to the GitHub
+# Discussions board. The script writes the discussion URL back into the post's
+# frontmatter (idempotency marker), and the commit below includes it.
+echo "Posting discussion announcements for ${#moved_paths[@]} post(s)..."
+node web/scripts/blog-announce-discussion.mjs "${moved_paths[@]}"
 
 git config user.name "wheels-bot[bot]"
 git config user.email "wheels-bot[bot]@users.noreply.github.com"

--- a/.github/workflows/blog-publish-scheduled.yml
+++ b/.github/workflows/blog-publish-scheduled.yml
@@ -40,6 +40,12 @@ jobs:
           fetch-depth: 1
           token: ${{ steps.app-token.outputs.token }}
 
+      # Node for the discussion-announcement helper (web/scripts/...mjs).
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
       - name: Publish due posts
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/web/content/blog/posts/wheels-4-1-coming.md
+++ b/web/content/blog/posts/wheels-4-1-coming.md
@@ -16,6 +16,15 @@ excerpt: >-
   be safe, and where the framework got meaningfully faster. Here's what's
   coming, and the story behind it.
 coverImage: '/blog-images/4-1/wheels-4-1-coming.png'
+announcement:
+  title: 'Wheels 4.1 is coming — the release series begins'
+  discussionUrl: 'https://github.com/wheels-dev/wheels/discussions/3475'
+  body: |
+    The first post in the **Wheels 4.1** release series is live:
+
+    👉 **[Wheels 4.1 is coming](https://blog.wheels.dev/blog/wheels-4-1-coming)**
+
+    Over the next ten days we're publishing a short series on what's landing in 4.1.0 — bcrypt password hashing, one-line session auth, pretty URLs with `bindBy=`, DI factories, CLI upgrades, a 2.5x model-instantiation speedup, the security-hardening pass, and the new coverage tooling. The full release lands September 10.
 ---
 
 Most release previews are a list. This one has a plot, so let me set the scene.

--- a/web/content/blog/scheduled/bcrypt-password-hashing-in-wheels-4-1.md
+++ b/web/content/blog/scheduled/bcrypt-password-hashing-in-wheels-4-1.md
@@ -16,6 +16,10 @@ excerpt: >-
   three weeks. Here's the helpers, the cost trade-off, and the part where
   Adobe CF made us question our sanity.
 coverImage: '/blog-images/4-1/bcrypt-password-hashing-in-wheels-4-1.png'
+announcement:
+  title: 'bcrypt is in Wheels 4.1'
+  body: |
+    New post: **[bcrypt for your passwords](https://blog.wheels.dev/blog/bcrypt-password-hashing-in-wheels-4-1)** — the story behind `bcryptHash()`, `bcryptVerify()`, and `bcryptNeedsRehash()`: pure CFML, no JARs, verified against OpenBSD and jBCrypt vectors.
 ---
 
 The email was four lines long, and it was fine. *Your passwords are hashed with plain SHA-256, no salt, and the database backup from March is on a shared drive.* That's not a vulnerability, that's a sentence.

--- a/web/content/blog/scheduled/cli-workflow-upgrades-migrate-diff-dry-run-offline.md
+++ b/web/content/blog/scheduled/cli-workflow-upgrades-migrate-diff-dry-run-offline.md
@@ -16,6 +16,10 @@ excerpt: >-
   were "the CLI guessed wrong." 4.1 adds diff, dry-run, and offline mode —
   and the honesty fixes that make a green build mean something.
 coverImage: '/blog-images/4-1/cli-workflow-upgrades-migrate-diff-dry-run-offline.png'
+announcement:
+  title: 'CLI upgrades: diff, dry-run, offline'
+  body: |
+    New post: **[CLI workflows that never guess](https://blog.wheels.dev/blog/cli-workflow-upgrades-migrate-diff-dry-run-offline)** — `wheels migrate diff`, `wheels generate --dry-run`, and offline mode.
 ---
 
 Two incidents. Both were "the CLI guessed," and both were only caught because someone looked closely at a diff.

--- a/web/content/blog/scheduled/dependency-injection-factories-with-tofactory.md
+++ b/web/content/blog/scheduled/dependency-injection-factories-with-tofactory.md
@@ -15,6 +15,10 @@ excerpt: >-
   caller. toFactory() gives a DI container a *how* — and it's the difference
   between one closed arrow and ten open switch statements.
 coverImage: '/blog-images/4-1/dependency-injection-factories-with-tofactory.png'
+announcement:
+  title: 'DI factories with toFactory()'
+  body: |
+    New post: **[Factories for your container](https://blog.wheels.dev/blog/dependency-injection-factories-with-tofactory)** — `Injector.toFactory()` binds a name to a closure that builds the instance.
 ---
 
 The routing was fine. The uploads were fine. Then the app went to production and every picture was gone, because locally they landed on a disk and in production they were supposed to land in S3 — and the storage service had a `useS3` flag that each of the ten call sites checked in its own way.

--- a/web/content/blog/scheduled/how-we-made-model-instantiation-2-5x-faster.md
+++ b/web/content/blog/scheduled/how-we-made-model-instantiation-2-5x-faster.md
@@ -17,6 +17,10 @@ excerpt: >-
   investigation, two unrelated bugs it surfaced, and the lesson about
   trusting micro-benchmarks.
 coverImage: '/blog-images/4-1/how-we-made-model-instantiation-2-5x-faster.png'
+announcement:
+  title: '2.5x faster model instantiation'
+  body: |
+    New post: **[2.5x faster, the long way](https://blog.wheels.dev/blog/how-we-made-model-instantiation-2-5x-faster)** — how model materialization got 2.5x faster, the long way.
 ---
 
 The issue was polite, which is usually how bad news arrives. [@chapmandu](https://github.com/chapmandu) had ported a real app from Wheels 2.5 to 4.0.3, and his RocketUnit suite went from **274 seconds to 1,599** — nearly six times slower. He asked whether we'd ever done a performance comparison.

--- a/web/content/blog/scheduled/one-line-session-auth-with-enablesession.md
+++ b/web/content/blog/scheduled/one-line-session-auth-with-enablesession.md
@@ -16,6 +16,10 @@ excerpt: >-
   the second deploy, or only on a reload, or only for a user who was already
   logged in. Here's what happens when the wiring goes right.
 coverImage: '/blog-images/4-1/one-line-session-auth-with-enablesession.png'
+announcement:
+  title: 'Session auth, one line'
+  body: |
+    New post: **[Session auth in one line](https://blog.wheels.dev/blog/one-line-session-auth-with-enablesession)** — `enableSession()` in `config/services.cfm` wires the whole session-auth subsystem.
 ---
 
 The invitation email was two sentences. *We need login on the admin panel by Thursday. You can use the auth layer, right?* Sure. You can. The auth layer has everything: an `Authenticator`, named strategies, a `SessionStrategy`, `authenticateWith`. You've never wired it by hand, but how hard can fifteen lines be?

--- a/web/content/blog/scheduled/pretty-urls-with-route-bindby.md
+++ b/web/content/blog/scheduled/pretty-urls-with-route-bindby.md
@@ -15,6 +15,10 @@ excerpt: >-
   resource URLs say something — and it comes with one mistake you can make
   that quietly breaks your site.
 coverImage: '/blog-images/4-1/pretty-urls-with-route-bindby.png'
+announcement:
+  title: 'Pretty URLs with bindBy'
+  body: |
+    New post: **[Pretty URLs with bindBy](https://blog.wheels.dev/blog/pretty-urls-with-route-bindby)** — bind a resource route's `:key` segment to any column, so URLs carry slugs instead of primary keys.
 ---
 
 The support conversation goes like this: *"the article about migrating to 4.1? sure — here's the link."* The customer opens it, and their browser shows `/posts/4821`.

--- a/web/content/blog/scheduled/the-wheels-4-1-security-hardening-pass.md
+++ b/web/content/blog/scheduled/the-wheels-4-1-security-hardening-pass.md
@@ -16,6 +16,10 @@ excerpt: >-
   closes them by failing closed. Here's the story area by area, and what you
   have to check on the way up.
 coverImage: '/blog-images/4-1/the-wheels-4-1-security-hardening-pass.png'
+announcement:
+  title: 'The 4.1 security hardening pass'
+  body: |
+    New post: **[Fail closed, everywhere](https://blog.wheels.dev/blog/the-wheels-4-1-security-hardening-pass)** — the hardening pass that makes Wheels fail closed by default.
 ---
 
 Every framework has a layer of things you assume are safe because *surely* nobody would write it that way. A policy that returns `"yes"` authorizes. A `_method` field that works on a GET. A plugin zip that unzips wherever it wants. A route that trusts a header the client set.

--- a/web/content/blog/scheduled/wheels-4-1-0-released.md
+++ b/web/content/blog/scheduled/wheels-4-1-0-released.md
@@ -17,6 +17,10 @@ excerpt: >-
   single issue filed by @chapmandu — and the release is better because it
   didn't start with a features list.
 coverImage: '/blog-images/4-1/wheels-4-1-0-released.png'
+announcement:
+  title: 'Wheels 4.1.0 is out'
+  body: |
+    **[Wheels 4.1.0 is released](https://blog.wheels.dev/blog/wheels-4-1-0-released)** — the full changelog and where to get it.
 ---
 
 Wheels 4.1.0 is out. If you've followed [the series](https://blog.wheels.dev/posts/wheels-4-1-coming/), you know this release has a plot, and it starts with [@chapmandu](https://github.com/chapmandu) asking, politely, whether we'd ever benchmarked Wheels 4 against 2.5.

--- a/web/content/blog/scheduled/wheels-coverage-and-the-complexity-panel.md
+++ b/web/content/blog/scheduled/wheels-coverage-and-the-complexity-panel.md
@@ -17,6 +17,10 @@ excerpt: >-
   said the test suite had never touched it. 4.1 ships the two tools that make
   that obvious before the September bug goes out.
 coverImage: '/blog-images/4-1/wheels-coverage-and-the-complexity-panel.png'
+announcement:
+  title: 'Find your riskiest code'
+  body: |
+    New post: **[Find your riskiest code](https://blog.wheels.dev/blog/wheels-coverage-and-the-complexity-panel)** — `wheels coverage` and the new code-complexity panel rank your change-riskiest files.
 ---
 
 The controller was nine hundred lines. It did billing, refunds, invoicing, a CSV export, and it was the only place in the app that reached into the payment provider. Nobody was comfortable with it, but it worked, and nobody had the time to be uncomfortable *and* finish a sprint.

--- a/web/scripts/blog-announce-discussion.mjs
+++ b/web/scripts/blog-announce-discussion.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+/**
+ * Post the `announcement` frontmatter of one or more blog posts to the repo's
+ * GitHub Discussions board, then write the resulting discussion URL back into
+ * the post's frontmatter so the next run is a no-op.
+ *
+ * Used by the scheduled blog publisher (blog-publish-scheduled.sh): after the
+ * publisher moves a post from scheduled/ into posts/, it calls this script with
+ * the moved file paths. A post without an `announcement` block, or one whose
+ * `announcement.discussionUrl` is already set, is skipped.
+ *
+ * Usage:
+ *   node web/scripts/blog-announce-discussion.mjs <post.md> [<post.md> ...]
+ *   node web/scripts/blog-announce-discussion.mjs --dry-run <post.md> ...
+ *
+ * Env: GH_TOKEN (or GITHUB_TOKEN) — a token with discussion write access.
+ *      Runs with Node's built-ins only (node:fs, node:child_process, fetch).
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const files = args.filter((a) => a !== '--dry-run');
+
+// ---------------------------------------------------------------------------
+// Frontmatter parsing — just the `announcement:` block. The rest of the
+// frontmatter is opaque to this script; it only reads and writes this one
+// nested object, so it never needs a full YAML parser.
+// ---------------------------------------------------------------------------
+
+function splitFrontmatter(content) {
+	const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+	if (!m) throw new Error('no frontmatter found');
+	return { fm: m[1], rest: content.slice(m[0].length) };
+}
+
+/**
+ * Extract { title, body, category, discussionUrl } from an `announcement:`
+ * block, or return null when the post has none.
+ *
+ * Expected shape (2-space nesting; body is a `|` literal block at 4-space
+ * content indent):
+ *
+ *   announcement:
+ *     title: '...'
+ *     body: |
+ *       line one
+ *       line two
+ *     discussionUrl: 'https://...'
+ */
+function extractAnnouncement(fm) {
+	const lines = fm.split('\n');
+	const start = lines.findIndex((l) => /^announcement:\s*$/.test(l));
+	if (start === -1) return null;
+
+	const out = {};
+	let i = start + 1;
+	while (i < lines.length) {
+		const line = lines[i];
+		if (/^\S/.test(line)) break; // a top-level key ends the block
+
+		const keyMatch = line.match(/^ {2}([A-Za-z0-9_]+):(.*)$/);
+		if (!keyMatch) {
+			i++;
+			continue;
+		}
+		const key = keyMatch[1];
+		const raw = keyMatch[2].trim();
+
+		if (key === 'body' && (raw === '|' || raw === '|-')) {
+			const bodyLines = [];
+			i++;
+			while (i < lines.length && (lines[i] === '' || /^ {3,}/.test(lines[i]))) {
+				bodyLines.push(lines[i].replace(/^ {4}/, ''));
+				i++;
+			}
+			while (bodyLines.length && bodyLines[bodyLines.length - 1] === '') bodyLines.pop();
+			out.body = bodyLines.join('\n');
+			continue;
+		}
+
+		if (raw !== '') {
+			out[key] = raw.replace(/^'(.*)'$/, '$1').replace(/^"(.*)"$/, '$1');
+		}
+		i++;
+	}
+
+	if (!out.title || out.body == null) return null;
+	return out;
+}
+
+function writeDiscussionUrl(content, url) {
+	const { fm, rest } = splitFrontmatter(content);
+	const next = fm.replace(/^announcement:\s*$/m, `announcement:\n  discussionUrl: '${url}'`);
+	return `---\n${next}\n---\n${rest}`;
+}
+
+// ---------------------------------------------------------------------------
+// GitHub Discussions GraphQL
+// ---------------------------------------------------------------------------
+
+function repoOwnerName() {
+	let url = '';
+	try {
+		url = execFileSync('git', ['config', '--get', 'remote.origin.url'], {
+			encoding: 'utf8',
+			stdio: ['ignore', 'pipe', 'ignore'],
+		}).trim();
+	} catch {
+		// fall through
+	}
+	const m = url.match(/github\.com[:/]([^/]+)\/([^/.]+?)(?:\.git)?$/);
+	if (!m) throw new Error(`could not derive owner/repo from git remote: ${url || '(none)'}`);
+	return { owner: m[1], name: m[2] };
+}
+
+async function gql(token, query, variables = {}) {
+	const res = await fetch('https://api.github.com/graphql', {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${token}`,
+			'Content-Type': 'application/json',
+			'User-Agent': 'wheels-blog-publisher',
+		},
+		body: JSON.stringify({ query, variables }),
+	});
+	const payload = await res.json();
+	if (payload.errors && payload.errors.length) {
+		throw new Error(`GraphQL error: ${payload.errors.map((e) => e.message).join('; ')}`);
+	}
+	return payload.data;
+}
+
+async function resolveRepoAndCategories(token) {
+	const { owner, name } = repoOwnerName();
+	const data = await gql(
+		token,
+		`query($owner: String!, $name: String!) {
+			repository(owner: $owner, name: $name) {
+				id
+				discussionCategories(first: 50) {
+					nodes { id name }
+				}
+			}
+		}`,
+		{ owner, name },
+	);
+	const categories = new Map(
+		data.repository.discussionCategories.nodes.map((c) => [c.name, c.id]),
+	);
+	return { repositoryId: data.repository.id, categories };
+}
+
+async function createDiscussion(token, repositoryId, categoryId, title, body) {
+	const data = await gql(
+		token,
+		`mutation($repositoryId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
+			createDiscussion(input: {
+				repositoryId: $repositoryId,
+				categoryId: $categoryId,
+				title: $title,
+				body: $body
+			}) {
+				discussion { url }
+			}
+		}`,
+		{ repositoryId, categoryId, title, body },
+	);
+	return data.createDiscussion.discussion.url;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+if (!token && !dryRun) {
+	console.error('GH_TOKEN (or GITHUB_TOKEN) is not set.');
+	process.exit(1);
+}
+
+let ctx = null;
+if (!dryRun) {
+	ctx = await resolveRepoAndCategories(token);
+}
+
+let posted = 0;
+for (const file of files) {
+	const content = readFileSync(file, 'utf8');
+	let fm;
+	try {
+		fm = splitFrontmatter(content).fm;
+	} catch {
+		console.log(`skip (no frontmatter): ${file}`);
+		continue;
+	}
+	const announcement = extractAnnouncement(fm);
+
+	if (!announcement) {
+		console.log(`skip (no announcement): ${file}`);
+		continue;
+	}
+	if (announcement.discussionUrl) {
+		console.log(`skip (already posted): ${file} -> ${announcement.discussionUrl}`);
+		continue;
+	}
+
+	const category = announcement.category || 'Announcements';
+	if (!ctx && !dryRun) throw new Error('discussion context missing');
+
+	if (dryRun) {
+		console.log(`[dry-run] would post to ${category}:\n  title: ${announcement.title}\n  body: ${announcement.body.split('\n').join('\n        ')}`);
+		continue;
+	}
+
+	const categoryId = ctx.categories.get(category);
+	if (!categoryId) {
+		throw new Error(
+			`discussion category "${category}" not found. Available: ${[...ctx.categories.keys()].join(', ')}`,
+		);
+	}
+
+	const url = await createDiscussion(
+		token,
+		ctx.repositoryId,
+		categoryId,
+		announcement.title,
+		announcement.body,
+	);
+	writeFileSync(file, writeDiscussionUrl(content, url), 'utf8');
+	console.log(`posted: ${file} -> ${url}`);
+	posted++;
+}
+
+console.log(`Done. Posted ${posted} announcement(s).`);

--- a/web/sites/blog/src/content.config.ts
+++ b/web/sites/blog/src/content.config.ts
@@ -17,6 +17,18 @@ const posts = defineCollection({
 		excerpt: z.string().default(''),
 		coverImage: z.string().nullable().optional(),
 		legacyId: z.string().optional(),
+		// Discussion announcement posted to the repo's Discussions board when
+		// the post is published. `discussionUrl` is written back by the
+		// scheduler after the discussion is created (idempotency marker).
+		announcement: z
+			.object({
+				title: z.string(),
+				body: z.string(),
+				category: z.string().default('Announcements'),
+				discussionUrl: z.string().nullable().optional(),
+			})
+			.nullable()
+			.optional(),
 	}),
 });
 


### PR DESCRIPTION
Builds GitHub Discussions announcements into the scheduled blog publish cycle.

- New `announcement` frontmatter block (title + body + optional category) on every post.
- New `web/scripts/blog-announce-discussion.mjs` parses the frontmatter, creates the discussion, and writes the URL back as an idempotency marker.
- The daily publisher (`blog-publish-scheduled.sh` + workflow) calls it for each newly-published post; a `--dry-run` flag supports local testing.
- The already-published "4.1 is coming" post is pre-marked with its existing discussion URL (#3475), so it will not double-post.
