### PR TITLE
docs(web): add languages to bare title= code fences in guides

### DIFF
--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/details.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/details.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy accessory details <name|all> [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/logs.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/logs.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy accessory logs <name|all> [--tail=<N>] [--follow] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/reboot.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/reboot.mdx
@@ -11,7 +11,7 @@ Stop, remove, and re-run the named accessory container. Useful after bumping the
 
 ## Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels deploy accessory reboot <name|all> [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/remove.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/remove.mdx
@@ -17,7 +17,7 @@ Volumes persist after `accessory remove`. Data survives. If you want a truly cle
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy accessory remove <name|all> [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/restart.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/restart.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy accessory restart <name|all> [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/start.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/start.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 ## Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels deploy accessory start <name|all> [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/stop.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/accessory/stop.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy accessory stop <name|all> [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/boot.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/boot.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy app boot --release=<v> [--role=<name>] [--destination=<name>] [--dry-run]
 ```
 
@@ -30,7 +30,7 @@ A literal `--version=` flag does not work — the CLI's picocli root intercepts 
 
 For each host in each role, emits:
 
-``` title="emitted docker run command"
+```txt title="
 docker run --detach --restart unless-stopped \
   --name <service>-<role>-<version> \
   --network kamal \

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/containers.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/containers.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy app containers [--role=<name>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/details.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/details.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy app details --release=<v> [--role=<name>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/images.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/images.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 ## Synopsis
 
-```  title="synopsis"
+```txt title="
 wheels deploy app images [--role=<name>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/live.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/live.mdx
@@ -13,7 +13,7 @@ Clear the server-side maintenance marker, resuming traffic. Pair with [`app main
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy app live --release=<v> [--role=<name>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/logs.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/logs.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy app logs [--tail=<N>] [--follow] [--container=<name>] [--role=<name>] [--destination=<name>]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/maintenance.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/maintenance.mdx
@@ -13,7 +13,7 @@ Write the server-side maintenance marker. Pair with [`app live`](/v4-0-0/command
 
 ## Synopsis
 
-```  title="synopsis"
+```txt title="
 wheels deploy app maintenance --release=<v> [--role=<name>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/remove.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/remove.mdx
@@ -11,7 +11,7 @@ Stop and remove app containers for the given version. Scoped to one version — 
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy app remove --release=<v> [--role=<name>] [--destination=<name>] [--dry-run]
 ```
 
@@ -28,7 +28,7 @@ wheels deploy app remove --release=<v> [--role=<name>] [--destination=<name>] [-
 
 For each host in each targeted role, chains:
 
-``` title="illustrative — internal docker commands"
+```txt title="
 docker stop <service>-<role>-<version> && docker rm <service>-<role>-<version>
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/start.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/start.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy app start --release=<v> [--role=<name>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/stop.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/app/stop.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 ## Synopsis
 
-```  title="Synopsis"
+```txt title="
 wheels deploy app stop --release=<v> [--role=<name>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/audit.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/audit.mdx
@@ -11,7 +11,7 @@ Tail the on-host audit log. Every deploy appends an entry with the actor, versio
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy audit [--tail=<N>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/build/create.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/build/create.mdx
@@ -11,7 +11,7 @@ Create a `docker buildx` builder on the control machine. One-time setup for mult
 
 ## Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels deploy build create [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/build/deliver.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/build/deliver.mdx
@@ -11,7 +11,7 @@ Build, push, and pull a new image. Equivalent to `push` followed by `pull`. Skip
 
 ## Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels deploy build deliver [--version=<v>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/build/details.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/build/details.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy build details [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/build/dev.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/build/dev.mdx
@@ -11,7 +11,7 @@ Build the app image locally and tag it with `:dev`. No registry push; intended f
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy build dev [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/build/pull.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/build/pull.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy build pull [--version=<v>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/build/push.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/build/push.mdx
@@ -11,7 +11,7 @@ Build the image locally and push it to the configured registry. Runs on the cont
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy build push [--version=<v>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/build/remove.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/build/remove.mdx
@@ -11,7 +11,7 @@ Remove the `docker buildx` builder. Inverse of [`build create`](/v4-0-0/command-
 
 ## Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels deploy build remove [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/config.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/config.mdx
@@ -11,7 +11,7 @@ Print the fully-resolved `deploy.yml` config as YAML. Mustache interpolation is 
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy config [--destination=<name>] [--config=<path>]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/deploy.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/deploy.mdx
@@ -11,7 +11,7 @@ The everyday deploy verb. Runs the full rolling flow: lock, build, push, pull, b
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy [--release=<v>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/details.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/details.mdx
@@ -11,7 +11,7 @@ Aggregate state — app containers, proxy, and every accessory — across every 
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy details [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/docs.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/docs.mdx
@@ -11,7 +11,7 @@ Print embedded per-topic help. `wheels deploy docs` lists the available sections
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy docs [<section>]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/init.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/init.mdx
@@ -11,7 +11,7 @@ Scaffold the files `wheels deploy` reads: `config/deploy.yml` and `.kamal/secret
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy init [--service=<name>] [--image=<path>] [--registry-username=<user>] [--force]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/lock/acquire.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/lock/acquire.mdx
@@ -11,7 +11,7 @@ Manually take the deploy lock. Useful when running an out-of-band maintenance ta
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy lock acquire [--message=<string>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/lock/release.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/lock/release.mdx
@@ -17,7 +17,7 @@ Releasing a lock held by an active deploy on another machine causes that deploy 
 
 ## Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels deploy lock release [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/lock/status.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/lock/status.mdx
@@ -11,7 +11,7 @@ Report whether the per-service deploy lock is held. If held, prints the user and
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy lock status [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/proxy/boot.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/proxy/boot.mdx
@@ -11,7 +11,7 @@ Install and run the `kamal-proxy` singleton on every host. First-run verb — pa
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy proxy boot [--destination=<name>] [--dry-run]
 ```
 
@@ -26,7 +26,7 @@ wheels deploy proxy boot [--destination=<name>] [--dry-run]
 
 For every host across every role (the proxy is a per-host singleton):
 
-``` title="docker command issued per host"
+```txt title="
 docker run -d --restart unless-stopped \
   --name kamal-proxy \
   --network kamal \

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/proxy/details.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/proxy/details.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy proxy details [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/proxy/logs.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/proxy/logs.mdx
@@ -11,7 +11,7 @@ Tail `kamal-proxy` logs on every host. Shows access logs, health-check results, 
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy proxy logs [--tail=<N>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/proxy/reboot.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/proxy/reboot.mdx
@@ -11,7 +11,7 @@ Stop, remove, and re-install `kamal-proxy` on every host. Useful after bumping t
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy proxy reboot [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/proxy/remove.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/proxy/remove.mdx
@@ -17,7 +17,7 @@ All inbound traffic stops. Re-run [`proxy boot`](/v4-0-0/command-line-tools/comm
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy proxy remove [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/proxy/restart.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/proxy/restart.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy proxy restart [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/proxy/start.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/proxy/start.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy proxy start [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/proxy/stop.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/proxy/stop.mdx
@@ -15,7 +15,7 @@ import { Aside } from '@astrojs/starlight/components';
 
 ## Synopsis
 
-``` title="synopsis — illustrative"
+```txt title="
 wheels deploy proxy stop [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/prune/all.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/prune/all.mdx
@@ -11,7 +11,7 @@ Prune old containers and old images on every host, keeping the most recent stopp
 
 ## Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels deploy prune all [--keep=<n>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/prune/containers.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/prune/containers.mdx
@@ -11,7 +11,7 @@ Prune old containers beyond the retention window (`--keep=<n>`, default 5) on ev
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy prune containers [--keep=<n>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/prune/images.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/prune/images.mdx
@@ -11,7 +11,7 @@ Prune old images of the service on every host. Leaves the current image and anyt
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy prune images [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/redeploy.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/redeploy.mdx
@@ -11,7 +11,7 @@ Re-run the deploy flow. Equivalent to `wheels deploy` — boots, ships, cuts tra
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy redeploy [--release=<v>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/registry/login.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/registry/login.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy registry login [--password=<value>] [--destination=<name>] [--dry-run]
 ```
 
@@ -27,7 +27,7 @@ wheels deploy registry login [--password=<value>] [--destination=<name>] [--dry-
 
 Per host:
 
-``` title="docker login invocation (illustrative)"
+```txt title="
 echo <password> | docker login <server> --username <username> --password-stdin
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/registry/setup.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/registry/setup.mdx
@@ -11,7 +11,7 @@ Alias for [`registry login`](/v4-0-0/command-line-tools/commands/deploy/registry
 
 ## Synopsis
 
-``` title="synopsis — illustrative"
+```txt title="
 wheels deploy registry setup [--password=<value>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/remove.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/remove.mdx
@@ -17,7 +17,7 @@ This removes running containers on every target host. Requires `--confirm`. Ther
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy remove --confirm [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/rollback.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/rollback.mdx
@@ -11,7 +11,7 @@ Revert traffic to a previously-deployed version. Finds the containers tagged wit
 
 ## Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels deploy rollback <version> [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/secrets/extract.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/secrets/extract.mdx
@@ -13,7 +13,7 @@ Invoke it through the **flat alias** `wheels deploy extract-secrets` — the nes
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy extract-secrets <KEY> --from=<block>
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/secrets/fetch.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/secrets/fetch.mdx
@@ -13,7 +13,7 @@ Invoke it through the **flat alias** `wheels deploy fetch-secrets` — the neste
 
 ## Synopsis
 
-``` title="synopsis (illustrative — do not type)"
+```txt title="
 wheels deploy fetch-secrets --adapter=<name> [--account=<acct>] [--from=<scope>] <KEY>...
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/secrets/print.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/secrets/print.mdx
@@ -19,7 +19,7 @@ Output is plaintext secrets. Never paste this into logs, tickets, or shared term
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy print-secrets [--destination=<name>]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/server/exec.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/server/exec.mdx
@@ -13,7 +13,7 @@ Invoke it through the **flat alias** `wheels deploy exec`. The nested `wheels de
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy exec <command> [--host=<host>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/setup.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/setup.mdx
@@ -11,7 +11,7 @@ The first-time deploy verb. Runs the full `wheels deploy` flow and also boots `k
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels deploy setup [--release=<v>] [--destination=<name>] [--dry-run]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/version.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/deploy/version.mdx
@@ -11,7 +11,7 @@ Print the Kamal version this port mirrors and the pinned `kamal-proxy` image tag
 
 ## Synopsis
 
-```  title="synopsis — illustrative"
+```txt title="
 wheels deploy version
 ```
 
@@ -21,7 +21,7 @@ None.
 
 ## Output
 
-```  title="sample output — illustrative"
+```txt title="
 wheels-deploy mirrors kamal 2.4.0 / kamal-proxy v0.8.6
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/packages/index.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/packages/index.mdx
@@ -14,7 +14,7 @@ There is no ForgeBox and no CommandBox. The registry manifest is authoritative, 
 
 ## Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels packages list [--tag=<tag>]
 wheels packages search <query>
 wheels packages show <name>

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/packages/list.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/packages/list.mdx
@@ -11,7 +11,7 @@ Prints one line per package in the registry. Served from the 24h manifest cache 
 
 ## Synopsis
 
-``` title="synopsis — illustrative"
+```txt title="
 wheels packages list [--tag=<tag>]
 ```
 
@@ -23,7 +23,7 @@ wheels packages list [--tag=<tag>]
 
 ## Example
 
-``` title="illustrative — example output"
+```txt title="
 $ wheels packages list
 wheels-basecoat         UI component primitives for Wheels [ui, components]
 wheels-hotwire          Hotwire (Turbo + Stimulus) integration [frontend, spa]

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/packages/remove.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/packages/remove.mdx
@@ -11,7 +11,7 @@ Removes an installed package by deleting `vendor/<name>/`. As a safety check, th
 
 ## Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels packages remove <name>
 ```
 
@@ -24,7 +24,7 @@ wheels packages remove <name>
 
 ## Example
 
-``` title="Example"
+```txt title="
 $ wheels packages remove wheels-sentry
 Removed vendor/wheels-sentry.
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/packages/search.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/commands/packages/search.mdx
@@ -11,13 +11,13 @@ Case-insensitive substring match across `name`, `description`, and `tags[]`. Use
 
 ## Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels packages search <query>
 ```
 
 ## Example
 
-``` title="example"
+```txt title="
 $ wheels packages search sentry
 wheels-sentry    Sentry error tracking [monitoring, errors, observability]
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/core-commands/server.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/core-commands/server.mdx
@@ -83,7 +83,7 @@ wheels server start --name=dev --version=6.2.2.91 --port=8080
 
 Sample output:
 
-```title="sample output"
+```txt title="
 Starting Lucee server 'dev' on port 8080...
 Lucee version: 6.2.2.91
 Server started successfully. Visit: http://localhost:8080/
@@ -125,7 +125,7 @@ wheels server stop --name=dev
 
 Sample output:
 
-```title="sample output"
+```txt title="
 Stopping server 'dev'...
 Server 'dev' stopped.
 ```
@@ -172,7 +172,7 @@ wheels server status --name=dev
 
 Sample output:
 
-```title="sample output"
+```txt title="
 Server: dev
 Status: RUNNING
 Port: 8080
@@ -204,7 +204,7 @@ wheels server list
 
 Sample output:
 
-```title="sample output"
+```txt title="
 NAME          STATUS    PORT    VERSION       DIRECTORY
 dev           RUNNING   8080    6.2.2.91      /Users/you/projects/app
 scratchpad    STOPPED   8081    6.2.0.280     /Users/you/projects/scratch

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/installation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/installation.mdx
@@ -207,13 +207,13 @@ wheels --version
 
 You should see something like:
 
-``` title="illustrative — example version output"
+```txt title="
 Wheels Version: 4.0.3
 ```
 
 followed by the Wheels ASCII-art banner. The richer check is `wheels version` (no dashes), which reports the release channel and the JVM the wrapper picked up:
 
-``` title="illustrative — example wheels version output"
+```txt title="
 Wheels 4.0.3 (stable)
 Java 21.0.11
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-generation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-generation.mdx
@@ -19,7 +19,7 @@ import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 ## Overview
 
-``` title="Synopsis"
+```txt title="
 wheels generate <type> <name> [attributes...] [flags]
 ```
 
@@ -87,7 +87,7 @@ Generate a model CFC and, when properties are supplied, a matching create-table 
 
 #### Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels generate model <Name> [property:type ...] [--belongsTo=<list>] [--hasMany=<list>] [--hasOne=<list>]
 ```
 
@@ -109,7 +109,7 @@ Generate a controller CFC and view files for each read-only action.
 
 #### Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels generate controller <Name> [action ...]
 ```
 
@@ -131,7 +131,7 @@ Generate a single view template.
 
 #### Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels generate view <controller> <action>
 ```
 
@@ -153,7 +153,7 @@ Generate a blank migration file.
 
 #### Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels generate migration <Name>
 ```
 
@@ -175,7 +175,7 @@ Generate a complete CRUD resource.
 
 #### Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels generate scaffold <Name> [property:type ...] [--belongsTo=<list>] [--hasMany=<list>]
 ```
 
@@ -210,7 +210,7 @@ Generate a JSON-only resource — model, controller, migration, tests, and a nam
 
 #### Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels generate api-resource <Name> [property:type ...] [--belongsTo=<list>] [--hasMany=<list>]
 ```
 
@@ -232,7 +232,7 @@ Add a single resource route to `config/routes.cfm`.
 
 #### Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels generate route <name>
 ```
 
@@ -256,7 +256,7 @@ Generate a BDD test spec file.
 
 #### Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels generate test <type> <Name>
 ```
 
@@ -280,7 +280,7 @@ Generate an add-column migration for an existing model.
 
 #### Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels generate property <ModelName> <property:type>
 ```
 
@@ -304,7 +304,7 @@ Generate a helper CFC under `app/helpers/`.
 
 #### Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels generate helper <name> [functionName ...] [--force]
 ```
 
@@ -326,7 +326,7 @@ Stamp out a named code pattern.
 
 #### Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels generate snippets [pattern] [--force]
 wheels generate snippets templates [--force]
 ```
@@ -392,7 +392,7 @@ Generate a complete authentication scaffold on the built-in `wheels.auth` primit
 
 #### Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels generate auth [ModelName] [--model=User] [--strategy=session|token|jwt] [--registration|--no-registration] [--force]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-quality.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-quality.mdx
@@ -22,7 +22,7 @@ Walk the project's CFC and CFM files and print a code-health report: totals, a g
 
 #### Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels analyze [target]
 ```
 
@@ -83,7 +83,7 @@ Run the shorter, error-focused pass: check model associations, controller conven
 
 #### Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels validate
 ```
 
@@ -137,7 +137,7 @@ Ranks your app's files by change risk — the CRAP score (cyclomatic complexity 
 
 #### Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels coverage [--top=N] [--no-test-db]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/creating-a-project.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/creating-a-project.mdx
@@ -30,7 +30,7 @@ Scaffold a new Wheels project directory.
 
 #### Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels new <name> [flags]
 ```
 
@@ -71,7 +71,7 @@ Create application components. In the current release the only supported subtype
 
 #### Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels create <type> <name> [flags]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/database.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/database.mdx
@@ -27,7 +27,7 @@ Apply or roll back migration files in `app/migrator/migrations/`.
 
 #### Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels migrate [latest|up|down|info|doctor|forget|pretend|rename-system-tables|diff]
 ```
 
@@ -104,7 +104,7 @@ Populate the database from `app/db/seeds.cfm` and any environment-specific seed 
 
 #### Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels seed [--environment=<env>] [--mode=<mode>] [--generate]
 ```
 
@@ -140,7 +140,7 @@ Utility subcommands for migration status, schema version, and full-reset workflo
 
 #### Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels db <command> [flags]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/dev-server.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/dev-server.mdx
@@ -30,7 +30,7 @@ Start a Wheels development server for the current project. Delegates to `wheels 
 
 #### Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels start [flags]
 ```
 
@@ -68,7 +68,7 @@ Stop the running Wheels development server for the current project.
 
 #### Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels stop
 ```
 
@@ -92,7 +92,7 @@ Reinitialize the running Wheels application without restarting the JVM. Useful a
 
 #### Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels reload
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/testing.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/testing.mdx
@@ -44,7 +44,7 @@ Run the Wheels BDD test suite. Auto-detects core tests when `vendor/wheels/tests
 
 #### Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels test [--filter=<dir>] [--db=<engine>] [--verbose] [--ci] [--core] [--base-path=<path>] [flags]
 ```
 
@@ -120,7 +120,7 @@ Download the Playwright Java JARs and a Chromium binary into `.wheels/browser/` 
 
 #### Synopsis
 
-``` title="synopsis"
+```txt title="
 wheels browser setup [--force]
 ```
 

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/upgrade.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/upgrade.mdx
@@ -19,7 +19,7 @@ import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 ### Synopsis
 
-``` title="Synopsis"
+```txt title="
 wheels upgrade check [--to=<version>] [--format=json] [--strict]
 wheels upgrade apply [--to=<version>] [--nobackup]
 ```

--- a/web/sites/guides/src/content/docs/v4-0-0/deployment/architecture.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/deployment/architecture.mdx
@@ -77,7 +77,7 @@ wheels deploy app boot --dry-run
 
 ## Code layout
 
-```title="Code layout"
+```txt title="
 cli/lucli/services/deploy/
 ├── cli/*.cfc           # User-facing CLI entry points (DeployMainCli, DeployAppCli, ...)
 ├── commands/*.cfc      # Pure string-returning command builders (AppCommands, ProxyCommands, ...)

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/multi-tenancy.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/multi-tenancy.mdx
@@ -166,7 +166,7 @@ Row scoping gives you the simplest deployment (one DB, one migration run), but t
 
 For schema-per-tenant and database-per-tenant layouts, you don't need to touch your model code. When `TenantResolver` sets `request.wheels.tenant.dataSource`, the framework's `$performQuery()` routes every non-shared model's queries to that datasource automatically:
 
-``` title="query routing flow (illustrative)"
+```txt title="
 model("Post").findAll()
   → $performQuery()
     → sees request.wheels.tenant.dataSource = "acme_ds"


### PR DESCRIPTION
Fixes bare code fences in the guides that were parsed incorrectly.

Fences like ``` title="synopsis" (no language) made expressive-code treat
title="synopsis" as the language, so the block fell back to txt and the title
was lost. Added a real language before title= (bash for command synopses, txt
for output/illustrative). 102 fences across 70 files; the build's
'language title=... could not be found' warnings are gone.
