### PR TITLE
fix(ci): don't strand blog posts when the discussion announcement fails

### DIFF
--- a/.github/scripts/blog-publish-scheduled.sh
+++ b/.github/scripts/blog-publish-scheduled.sh
@@ -58,8 +58,16 @@ fi
 # Post each newly-published post's `announcement` frontmatter to the GitHub
 # Discussions board. The script writes the discussion URL back into the post's
 # frontmatter (idempotency marker), and the commit below includes it.
+#
+# Best-effort: a discussion-announcement failure must NOT strand the post
+# publish. The announcement is additive — the post goes live regardless, and
+# the failure is surfaced in the run log (not by failing the run). Typical
+# cause is the wheels-bot GitHub App missing the "Discussions" permission.
 echo "Posting discussion announcements for ${#moved_paths[@]} post(s)..."
-node web/scripts/blog-announce-discussion.mjs "${moved_paths[@]}"
+if ! node web/scripts/blog-announce-discussion.mjs "${moved_paths[@]}"; then
+  echo "WARNING: discussion announcement failed — publishing the post(s) anyway." >&2
+  echo "  (Check that the wheels-bot GitHub App has the Discussions read/write permission.)" >&2
+fi
 
 git config user.name "wheels-bot[bot]"
 git config user.email "wheels-bot[bot]@users.noreply.github.com"


### PR DESCRIPTION
The scheduled blog publisher runs the discussion-announcement helper under `set -e`. When it throws (currently `Resource not accessible by integration` — the wheels-bot GitHub App lacks the Discussions permission), the run aborts before the git commit/push, stranding already-due posts in `scheduled/`.

This makes the announcement best-effort: log a warning and continue to commit/push so the post always goes live. The permission gap is fixed separately at the GitHub App level.