### PR TITLE
refactor(test): rename user-facing TestBox references to WheelsTest

### DIFF
--- a/cli/lucli/templates/app/CLAUDE.md
+++ b/cli/lucli/templates/app/CLAUDE.md
@@ -431,7 +431,7 @@ component extends="wheels.WheelsTest" {
 ### Running tests locally
 
 ```bash
-wheels test                      # run the app's tests/specs/ (TestBox)
+wheels test                      # run the app's tests/specs/ (WheelsTest)
 wheels test tests/specs/models   # a subdirectory of specs
 ```
 

--- a/cli/lucli/templates/app/tests/runner.cfm
+++ b/cli/lucli/templates/app/tests/runner.cfm
@@ -2,7 +2,7 @@
 	tests/runner.cfm — entry point for /wheels/app/tests in the browser
 	and `wheels test run` from the CLI. By default this defers to the
 	framework's built-in app-test runner, which scans `tests/specs/` via
-	TestBox and emits a structured result the CLI knows how to parse.
+	WheelsTest and emits a structured result the CLI knows how to parse.
 
 	Customise this file when you need pre-test setup the framework
 	runner doesn't cover — e.g. registering a custom reporter,

--- a/docs/consumer-ai/CLAUDE.md
+++ b/docs/consumer-ai/CLAUDE.md
@@ -493,7 +493,7 @@ component extends="wheels.WheelsTest" {
 ### Running tests locally
 
 ```bash
-wheels test                      # run the app's tests/specs/ (TestBox)
+wheels test                      # run the app's tests/specs/ (WheelsTest)
 wheels test tests/specs/models   # a subdirectory of specs
 ```
 

--- a/examples/starter-app/tests/routes.cfm
+++ b/examples/starter-app/tests/routes.cfm
@@ -1,4 +1,4 @@
 <cfscript>
-    // Write the routes for your Application's Testbox Tests here
+    // Write the routes for your application's tests here
 
 </cfscript>

--- a/examples/starter-app/tests/runner.cfm
+++ b/examples/starter-app/tests/runner.cfm
@@ -2,7 +2,7 @@
 <cfscript>
     testBox = new wheels.wheelstest.system.TestBox(directory="tests.specs")
 
-    setTestboxEnvironment()
+    setTestEnvironment()
 
     if (!structKeyExists(url, "format") || url.format eq "html") {
         result = testBox.run(
@@ -117,11 +117,11 @@
         include "/wheels/tests_testbox/html.cfm";
     }
 
-    private function setTestboxEnvironment() {
+    private function setTestEnvironment() {
         // creating backup for original environment
         application.$$$wheels = Duplicate(application.wheels)
 
-        // load testbox routes
+        // load test routes
         application.wo.$include(template = "/tests/routes.cfm")
         application.wo.$setNamedRoutePositions()
 

--- a/examples/tweet/tests/routes.cfm
+++ b/examples/tweet/tests/routes.cfm
@@ -1,4 +1,4 @@
 <cfscript>
-    // Write the routes for your Application's Testbox Tests here
+    // Write the routes for your application's tests here
 
 </cfscript>

--- a/examples/tweet/tests/runner.cfm
+++ b/examples/tweet/tests/runner.cfm
@@ -1,6 +1,6 @@
 <cfsetting requestTimeOut="1800">
 <cfscript>
-    // Parameter defaults - handle all TestBox CLI parameters
+    // Parameter defaults - handle all test CLI parameters
     param name="url.directory" default="tests.specs";
     param name="url.bundles" default="";
     param name="url.recurse" default="true" type="boolean";
@@ -21,7 +21,7 @@
     param name="url.coverageBlacklist" default="*Test.cfc,*Spec.cfc";
     param name="url.coverageBrowserOutputDir" default="/tests/results/coverage";
     
-    // Build TestBox options
+    // Build test options
     testBoxOptions = {};
     
     // Determine if using bundles or directory
@@ -94,7 +94,7 @@
         testBoxOptions.bail = true;
     }
     
-    // Initialize TestBox with options
+    // Initialize the test runner with options
     if (len(url.bundles)) {
         testBox = new wheels.wheelstest.system.TestBox(bundles=url.bundles);
     } else {
@@ -104,7 +104,7 @@
         );
     }
 
-    setTestboxEnvironment()
+    setTestEnvironment()
 
     if (!structKeyExists(url, "format") || url.format eq "html") {
         // Determine reporter for HTML format
@@ -257,11 +257,11 @@
         include "/wheels/tests_testbox/html.cfm";
     }
 
-    private function setTestboxEnvironment() {
+    private function setTestEnvironment() {
         // creating backup for original environment
         application.$$$wheels = Duplicate(application.wheels)
 
-        // load testbox routes
+        // load test routes
         application.wo.$include(template = "/tests/routes.cfm")
         application.wo.$setNamedRoutePositions()
 

--- a/tests/TestRunner.cfc
+++ b/tests/TestRunner.cfc
@@ -1,6 +1,6 @@
 component {
     // Setup the test environment
-    function setTestboxEnvironment() {
+    function setTestEnvironment() {
         // creating backup for original environment
         if (structKeyExists(server, "boxlang")) {
             application.$$$wheels = {}
@@ -13,7 +13,7 @@ component {
             application.$$$wheels = Duplicate(application.wheels)
         }
 
-        // load testbox routes
+        // load test routes
         application.wo.$include(template = "/tests/routes.cfm")
         application.wo.$setNamedRoutePositions()
 

--- a/tests/routes.cfm
+++ b/tests/routes.cfm
@@ -1,4 +1,4 @@
 <cfscript>
-    // Write the routes for your Application's Testbox Tests here
+    // Write the routes for your application's tests here
 
 </cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -1,6 +1,6 @@
 <cfsetting requestTimeOut="1800">
 <cfscript>
-    // Parameter defaults - handle all TestBox CLI parameters
+    // Parameter defaults - handle all test CLI parameters
     param name="url.directory" default="tests.specs";
     param name="url.bundles" default="";
     param name="url.recurse" default="true" type="boolean";
@@ -21,7 +21,7 @@
     param name="url.coverageBlacklist" default="*Test.cfc,*Spec.cfc";
     param name="url.coverageBrowserOutputDir" default="/tests/results/coverage";
     
-    // Build TestBox options
+    // Build test options
     testBoxOptions = {};
     
     // Determine if using bundles or directory
@@ -94,7 +94,7 @@
         testBoxOptions.bail = true;
     }
     
-    // Initialize TestBox with options
+    // Initialize the test runner with options
     if (len(url.bundles)) {
         testBox = new wheels.wheelstest.system.TestBox(bundles=url.bundles);
     } else {
@@ -106,7 +106,7 @@
 
     // Sets up the test environment
     local.testRunner = new tests.TestRunner();
-    local.testRunner.setTestboxEnvironment()
+    local.testRunner.setTestEnvironment()
 
     if (!structKeyExists(url, "format") || url.format eq "html") {
         // Determine reporter for HTML format

--- a/web/sites/guides/src/content/docs/v4-0-0/testing/fixtures-and-test-data.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/testing/fixtures-and-test-data.mdx
@@ -25,7 +25,7 @@ Every test type in Wheels — model, controller, view, integration, functional, 
 
 ## The populate lifecycle
 
-`tests/populate.cfm` runs **once per test run**, not once per spec. The runner includes it before TestBox boots, which means every `describe` and every `it` in the run starts with the same schema and the same seed rows. If your first spec writes a row and the tenth spec reads the table, the tenth spec sees the write.
+`tests/populate.cfm` runs **once per test run**, not once per spec. The runner includes it before the test suite boots, which means every `describe` and every `it` in the run starts with the same schema and the same seed rows. If your first spec writes a row and the tenth spec reads the table, the tenth spec sees the write.
 
 The trigger conditions live in `vendor/wheels/tests/runner.cfm`. The runner reads `url.populate` — defaulting to `true` when the param is missing — and also checks whether the core tables already exist. Populate runs when `url.populate` is truthy *or* when a sentinel table (`c_o_r_e_authors` in the framework's own suite) is missing from the database. In practice that means a fresh `wheels test` always populates; passing `?populate=false` in a URL invocation skips the drop-and-recreate but still runs if the schema is missing.
 


### PR DESCRIPTION
The built-in test framework has been WheelsTest since 4.0 (the Ortus TestBox fork is internal). This fixes the remaining user-facing drift where docs/comments still call the test mechanism "TestBox".

## Changes
- Shipped app-developer guides (`docs/consumer-ai/CLAUDE.md` + `cli/lucli/templates/app/CLAUDE.md`): `wheels test ... (TestBox)` → `(WheelsTest)`.
- `wheels new` test-runner template (`cli/lucli/templates/app/tests/runner.cfm`): comment "via TestBox" → "via WheelsTest".
- Demo (`tests/`) and example (`examples/starter-app`, `examples/tweet`) runners: comments + the private `setTestboxEnvironment()` helper renamed to `setTestEnvironment()`.
- `v4-0-0/testing/fixtures-and-test-data.mdx`: "before TestBox boots" → "before the test suite boots".

## Left alone on purpose
- The vendored fork internals (`vendor/wheels/wheelstest/**` — `TestBox.cfc`, reporters, MockBox, `TestBox.AssertionFailed`), which are the actual fork.
- The `wheels.Testbox` deprecated alias.
- The `tests_testbox` include path (functional, framework-internal).
- The v3-0-0 guides (where TestBox was historically accurate).