### PR TITLE
ci(rustcfml): add a daily version-check-and-bump workflow

### DIFF
--- a/.github/workflows/rustcfml-version-check.yml
+++ b/.github/workflows/rustcfml-version-check.yml
@@ -1,0 +1,52 @@
+name: RustCFML — version check
+
+# Daily: check github.com/RustCFML/RustCFML for a newer release than the pinned
+# tools/rustcfml/ENGINE_VERSION. When one exists, run the full core suite
+# against it (compare mode vs the pinned baseline). If GREEN, bump the pin and
+# regenerate baseline.json via a PR; if the suite has new failures, the run
+# stays red and the pin is left unchanged for a human to investigate.
+
+on:
+  schedule:
+    - cron: '30 8 * * *'   # daily, 08:30 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check:
+    name: Check for newer RustCFML
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v6
+        with:
+          ref: develop
+          fetch-depth: 1
+
+      - name: Check for a newer release and run the suite
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash tools/rustcfml/check-version.sh
+
+      - name: Open bump PR
+        if: env.RUSTCFML_LATEST != ''
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: "auto-bump/rustcfml-${{ env.RUSTCFML_LATEST }}"
+          title: "chore(rustcfml): bump engine pin to ${{ env.RUSTCFML_LATEST }}"
+          body: |
+            Automated RustCFML engine bump (daily version check).
+
+            **Pinned** `${{ env.RUSTCFML_PINNED }}` → **`${{ env.RUSTCFML_LATEST }}`**.
+
+            The full core suite ran **green** against the new engine, so this PR
+            bumps `tools/rustcfml/ENGINE_VERSION` and regenerates
+            `tools/rustcfml/baseline.json` to the new engine's result set.
+
+            If the suite had shown new failures, the pin would have been left
+            unchanged and this PR would not exist.
+          commit-message: "chore(rustcfml): bump engine pin to ${{ env.RUSTCFML_LATEST }}"
+          delete-branch: true

--- a/tools/rustcfml/check-version.sh
+++ b/tools/rustcfml/check-version.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Detect a newer RustCFML release than the pinned tools/rustcfml/ENGINE_VERSION.
+#
+# When a newer release exists, run the full core suite against it (compare mode
+# against the current baseline.json). If the suite is GREEN (no new failures vs
+# the pinned baseline), bump ENGINE_VERSION and regenerate baseline.json, and
+# surface the old/new versions via GITHUB_ENV so a follow-up
+# create-pull-request step can open the bump PR. If the suite has NEW failures,
+# exit 1 and leave the pin unchanged — the daily run surfaces the regressions
+# rather than silently absorbing them.
+#
+# Exits 0 when already at the latest release, or when a green bump was applied.
+# Exits 1 when the candidate release is not usable (download/boot/new failures).
+#
+# Requires: gh on PATH, GH_TOKEN set (for release metadata + binary download).
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PINNED="$(tr -d '[:space:]' < "$DIR/ENGINE_VERSION")"
+
+# Keep the tag's `v` prefix — ENGINE_VERSION stores it verbatim (e.g.
+# `v0.637.0`), and run-suite.sh passes the value straight to
+# `gh release download`, which needs the real tag name.
+LATEST="$(gh api repos/RustCFML/RustCFML/releases/latest --jq .tag_name)"
+[ -n "$LATEST" ] || { echo "::error::Could not resolve the latest RustCFML release."; exit 1; }
+
+if [ "$LATEST" = "$PINNED" ]; then
+  echo "RustCFML already at latest ($PINNED). Nothing to do."
+  exit 0
+fi
+
+echo "Newer RustCFML release available: $LATEST (pinned $PINNED)."
+echo "Running the full core suite against $LATEST..."
+
+# Compare mode exits non-zero on NEW failures vs the pinned baseline.
+if RUSTCFML_VERSION="$LATEST" bash "$DIR/run-suite.sh"; then
+  echo "Suite green against $LATEST — bumping the pin and regenerating the baseline."
+  echo "$LATEST" > "$DIR/ENGINE_VERSION"
+  RUSTCFML_VERSION="$LATEST" bash "$DIR/run-suite.sh" --write-baseline
+  echo "Pinned version bumped to $LATEST and baseline.json regenerated."
+  if [ -n "${GITHUB_ENV:-}" ]; then
+    echo "RUSTCFML_LATEST=$LATEST" >> "$GITHUB_ENV"
+    echo "RUSTCFML_PINNED=$PINNED" >> "$GITHUB_ENV"
+  fi
+  exit 0
+else
+  echo "::error::Suite has NEW failures against $LATEST — leaving the pin at $PINNED."
+  exit 1
+fi

--- a/tools/rustcfml/run-suite.sh
+++ b/tools/rustcfml/run-suite.sh
@@ -23,7 +23,10 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$DIR/../.." && pwd)"
-VERSION="$(tr -d '[:space:]' < "$DIR/ENGINE_VERSION")"
+# RUSTCFML_VERSION overrides the pinned ENGINE_VERSION so the version-check
+# workflow can run the suite against a candidate release before committing a
+# bump (tools/rustcfml/check-version.sh).
+VERSION="${RUSTCFML_VERSION:-$(tr -d '[:space:]' < "$DIR/ENGINE_VERSION")}"
 BASELINE="$DIR/baseline.json"
 PORT="${RUSTCFML_PORT:-8513}"
 MODE="compare"


### PR DESCRIPTION
Adds the daily RustCFML version-check process requested — detect a newer release than the pinned `tools/rustcfml/ENGINE_VERSION`, run the full core suite against it, and on green bump the pin + regenerate `baseline.json` via a PR. On new failures the pin is left unchanged and the run stays red.

- `tools/rustcfml/check-version.sh` — check + run + bump logic (keeps the tag's `v` prefix, consistent with `ENGINE_VERSION`).
- `tools/rustcfml/run-suite.sh` — `RUSTCFML_VERSION` env override so the script can run against a candidate release before the bump is committed.
- `.github/workflows/rustcfml-version-check.yml` — cron (08:30 UTC daily) + `workflow_dispatch`, opens the bump PR via `peter-evans/create-pull-request`.