### PR TITLE
test(coverage): measure CLI suite too, fix instrumented-run failures, add MCP spec

### DIFF
--- a/tools/code-quality/README.md
+++ b/tools/code-quality/README.md
@@ -67,14 +67,17 @@ python3 tools/code-quality/cfml-coverage.py revert vendor/wheels
 ```
 
 Latest combined measurement (Lucee 7 + SQLite): **81.0% function coverage**
-(2,143/2,646 functions). Known caveats:
+(2,144/2,646 functions). Known caveats:
 
 - Coverage is per-leg: `databaseAdapters/*` paths for MySQL/Oracle/SQLServer/
   CockroachDB only execute on those matrix legs — a SQLite-only measurement
   structurally under-reports them.
 - `public/` dev-console views and the stdio `wheels mcp wheels` surface are
   exercised by the e2e flow (real CLI invocations), not the in-server suites —
-  a spec-suite-only measurement under-reports them.
+  a spec-suite-only measurement under-reports them. The dev-console command
+  handlers (`public/CliBridge.cfc`) ARE covered in-server by
+  `tests/specs/cli/CliBridgeSpec.cfc`; only its DB-/worker-backed branches
+  (`diff`, `dbSchema`, `dbReset`, `dbDump`, `dbSeed`, `jobs*`) remain DB-covered.
 - `Public.cfc` is intentionally **not** instrumented (its gated handlers must
   call `$blockInProduction()` as their first statement, a structural guard
   enforced by `PublicComponentProductionSpec`), so an instrumented run is green

--- a/tools/code-quality/README.md
+++ b/tools/code-quality/README.md
@@ -38,7 +38,7 @@ stub, so `--coverage` is currently a sensitivity input, not a measured value.
 
 ## `cfml-coverage.py` (function coverage measurement)
 
-Function-level coverage for the CORE suite is measured via source
+Function-level coverage for the CORE **and CLI** suites is measured via source
 instrumentation (the no-op `CoverageService.cfc` can't provide it):
 
 ```bash
@@ -48,34 +48,37 @@ python3 tools/code-quality/cfml-complexity.py vendor/wheels --json /tmp/complexi
 # 2. Instrument (backs up originals under vendor/.cfml-cov-backup/)
 python3 tools/code-quality/cfml-coverage.py instrument vendor/wheels
 
-# 3. RESTART the CF engine, then run the suite with ?coverage=true — the core
-#    runner (vendor/wheels/tests/runner.cfm) resets server.__wheels_cov at
-#    request start and dumps it to /tmp/wheels-core-coverage.json at the end.
+# 3. RESTART the CF engine, then run BOTH suites with ?coverage=true. Each
+#    runner resets server.__wheels_cov at request start and dumps it at the
+#    end: core -> /tmp/wheels-core-coverage.json, CLI -> /tmp/wheels-cli-coverage.json.
 #    The restart matters: engine-compiled mixins are cached per app instance,
 #    and a warm app would execute pre-instrumentation bytecode.
 curl -s "http://localhost:8080/wheels/core/tests?db=sqlite&format=json&coverage=true"
+curl -s "http://localhost:8080/wheels/cli/tests?format=json&coverage=true"
 
-# 4. Combine into a CRAP ranking (writes crap-report.json)
+# 4. Merge the two dumps, then combine into a CRAP ranking (writes crap-report.json)
+python3 tools/code-quality/cfml-coverage.py merge \
+  /tmp/wheels-core-coverage.json /tmp/wheels-cli-coverage.json -o /tmp/wheels-coverage.json
 python3 tools/code-quality/cfml-coverage.py combine vendor/wheels \
-  /tmp/wheels-core-coverage.json /tmp/complexity.json
+  /tmp/wheels-coverage.json /tmp/complexity.json
 
 # 5. Always revert — never commit instrumented sources
 python3 tools/code-quality/cfml-coverage.py revert vendor/wheels
 ```
 
-Baseline (Lucee 7 + SQLite, measured 2026-08): **83.2% function coverage**
-(2,175/2,614 functions — template pseudo-entries and migrator generator
-templates excluded from the denominator). Known caveats:
+Latest combined measurement (Lucee 7 + SQLite): **81.0% function coverage**
+(2,143/2,646 functions). Known caveats:
 
 - Coverage is per-leg: `databaseAdapters/*` paths for MySQL/Oracle/SQLServer/
   CockroachDB only execute on those matrix legs — a SQLite-only measurement
   structurally under-reports them.
-- `public/` dev-console views and `public/mcp/` are exercised by the CLI
-  suite, not the core suite.
-- Instrumentation perturbs structural source-guards: `PublicComponentProductionSpec`
-  asserts `$blockInProduction()` is the FIRST statement of every `Public.cfc`
-  handler, and injected counters precede it — expect those 31 failures during
-  an instrumented run; coverage capture is unaffected.
+- `public/` dev-console views and the stdio `wheels mcp wheels` surface are
+  exercised by the e2e flow (real CLI invocations), not the in-server suites —
+  a spec-suite-only measurement under-reports them.
+- `Public.cfc` is intentionally **not** instrumented (its gated handlers must
+  call `$blockInProduction()` as their first statement, a structural guard
+  enforced by `PublicComponentProductionSpec`), so an instrumented run is green
+  with no expected-failure carve-out.
 - `Test.cfc` (legacy RocketUnit) is deprecated and intentionally not
   coverage-targeted.
 

--- a/tools/code-quality/cfml-coverage.py
+++ b/tools/code-quality/cfml-coverage.py
@@ -29,6 +29,11 @@ CLOSURE_FN = re.compile(r'\bvariables\s*\.\s*\$?([A-Za-z_$][\w$]*)\s*=\s*functio
 # embedding it produced ids full of quotes, i.e. invalid CFML in the counter.
 TAG_FN = re.compile(r'<cffunction\b[^>]*?\bname\s*=\s*["\']?([A-Za-z_$][\w$]*)', re.I)
 EXCLUDE_DIRS = {'tests', 'rocketunit_tests'}
+# Public.cfc's gated handlers must call $blockInProduction() as their FIRST
+# statement (enforced by PublicComponentProductionSpec). Injecting a coverage
+# counter as the first statement would break that structural security assert,
+# so skip it — its ~30 thin dispatcher handlers are negligible coverage loss.
+EXCLUDE_FILES = {'Public.cfc'}
 
 
 def _mask(text):
@@ -194,6 +199,8 @@ def _files(root):
             dirnames[:] = []
             continue
         for fn in filenames:
+            if fn in EXCLUDE_FILES:
+                continue
             if fn.lower().endswith(('.cfc', '.cfm')):
                 yield os.path.join(dirpath, fn)
 
@@ -303,21 +310,46 @@ def combine(root, coverage_path, complexity_path):
     print('wrote crap-report.json')
 
 
+def merge(coverage_paths, out):
+    """Union multiple server.__wheels_cov dumps (core + CLI) into one map."""
+    merged = {}
+    for p in coverage_paths:
+        d = json.load(open(p))
+        if isinstance(d, dict):
+            merged.update(d)
+    json.dump(merged, open(out, 'w'))
+    print(f'merged {len(coverage_paths)} coverage dumps -> {len(merged)} covered functions -> {out}')
+    return merged
+
+
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument('cmd', choices=['instrument', 'revert', 'combine'])
-    ap.add_argument('root')
-    ap.add_argument('coverage_json', nargs='?', default=None)
-    ap.add_argument('complexity_json', nargs='?', default=None)
+    sub = ap.add_subparsers(dest='cmd', required=True)
+
+    p_instr = sub.add_parser('instrument')
+    p_instr.add_argument('root')
+
+    p_revert = sub.add_parser('revert')
+    p_revert.add_argument('root')
+
+    p_merge = sub.add_parser('merge')
+    p_merge.add_argument('coverage_jsons', nargs='+')
+    p_merge.add_argument('-o', '--out', default='/tmp/wheels-coverage.json')
+
+    p_combine = sub.add_parser('combine')
+    p_combine.add_argument('root')
+    p_combine.add_argument('coverage_json')
+    p_combine.add_argument('complexity_json')
+
     args = ap.parse_args()
 
     if args.cmd == 'instrument':
         instrument(args.root)
     elif args.cmd == 'revert':
         revert(args.root)
+    elif args.cmd == 'merge':
+        merge(args.coverage_jsons, args.out)
     elif args.cmd == 'combine':
-        if not args.coverage_json or not args.complexity_json:
-            ap.error('combine needs <coverage.json> <complexity.json>')
         combine(args.root, args.coverage_json, args.complexity_json)
 
 

--- a/vendor/wheels/public/views/clitests.cfm
+++ b/vendor/wheels/public/views/clitests.cfm
@@ -4,6 +4,13 @@ setting showDebugOutput="no";
 
 param name="request.wheels.params.format" default="json";
 
+// Coverage mode (tools/code-quality/cfml-coverage.py): reset the function-level
+// counter map so the end-of-request dump reflects only THIS run. Mirrors the
+// core runner (vendor/wheels/tests/runner.cfm).
+if (StructKeyExists(url, "coverage") && url.coverage) {
+	server.__wheels_cov = {};
+}
+
 // Set content type early so errors return JSON, not HTML
 if (request.wheels.params.format == "json") {
 	cfcontent(type = "application/json");
@@ -36,6 +43,16 @@ try {
 	}
 
 	writeOutput(result);
+
+	// Coverage mode: dump the function-level counter map to an absolute path the
+	// coverage tooling reads. Best-effort — a failed dump must never break the
+	// test response.
+	if (StructKeyExists(url, "coverage") && url.coverage) {
+		try {
+			FileWrite("/tmp/wheels-cli-coverage.json", SerializeJSON(server.__wheels_cov));
+		} catch (any e) {
+		}
+	}
 } catch (any e) {
 	cfheader(statuscode = 500);
 	writeOutput('{"success":false,"error":"' & replace(e.message, '"', '\"', 'all') & '","detail":"' & replace(e.detail ?: '', '"', '\"', 'all') & '"}');

--- a/vendor/wheels/tests/specs/cli/CliBridgeSpec.cfc
+++ b/vendor/wheels/tests/specs/cli/CliBridgeSpec.cfc
@@ -95,6 +95,485 @@ component extends="wheels.WheelsTest" {
 
 		});
 
+		describe("CliBridge migration handler branches (fake migrator)", () => {
+
+			beforeEach(() => {
+				bridge = new wheels.public.CliBridge();
+			});
+
+			it("createMigration forwards the migrationPrefix when supplied", () => {
+				var fakeMigrator = {
+					createMigration = function() { return StructCount(arguments); }
+				};
+				var rv = bridge.dispatch(
+					command = "createMigration",
+					context = {migrator = fakeMigrator},
+					params = {migrationName = "AddFoo", templateName = "create", migrationPrefix = "20260101000000"}
+				);
+				expect(rv.message).toBe(3);
+			});
+
+			it("createMigration omits the migrationPrefix when not supplied", () => {
+				var fakeMigrator = {
+					createMigration = function() { return StructCount(arguments); }
+				};
+				var rv = bridge.dispatch(
+					command = "createMigration",
+					context = {migrator = fakeMigrator},
+					params = {migrationName = "AddFoo", templateName = "create"}
+				);
+				expect(rv.message).toBe(2);
+			});
+
+			it("migrateTo forwards the requested version", () => {
+				var fakeMigrator = {migrateTo = (version) => "Migrated to " & version};
+				var rv = bridge.dispatch(
+					command = "migrateTo",
+					context = {migrator = fakeMigrator},
+					params = {version = "20260102000000"}
+				);
+				expect(rv.message).toBe("Migrated to 20260102000000");
+			});
+
+			it("migrateTo returns an empty result when no version is supplied", () => {
+				var fakeMigrator = {migrateTo = (version) => "Migrated to " & version};
+				var rv = bridge.dispatch(
+					command = "migrateTo",
+					context = {migrator = fakeMigrator},
+					params = {}
+				);
+				expect(StructKeyExists(rv, "message")).toBeFalse();
+			});
+
+			it("migrateUp migrates to the first pending version", () => {
+				var fakeMigrator = {migrateTo = (version) => "Migrated to " & version};
+				var rv = bridge.dispatch(
+					command = "migrateUp",
+					context = {
+						currentVersion = "20260101000000",
+						migrations = [
+							{version = "20260101000000", status = "migrated"},
+							{version = "20260102000000", status = "pending"}
+						],
+						migrator = fakeMigrator
+					},
+					params = {}
+				);
+				expect(rv.message).toBe("Migrated to 20260102000000");
+			});
+
+			it("migrateUp reports no pending migrations", () => {
+				var fakeMigrator = {migrateTo = (version) => "Migrated to " & version};
+				var rv = bridge.dispatch(
+					command = "migrateUp",
+					context = {
+						currentVersion = "20260101000000",
+						migrations = [
+							{version = "20260101000000", status = "migrated"}
+						],
+						migrator = fakeMigrator
+					},
+					params = {}
+				);
+				expect(rv.message).toInclude("No pending migrations");
+			});
+
+			it("migrateDown migrates to the version immediately below current", () => {
+				var fakeMigrator = {migrateTo = (version) => "Migrated to " & version};
+				var rv = bridge.dispatch(
+					command = "migrateDown",
+					context = {
+						currentVersion = "20260102000000",
+						migrations = [
+							{version = "20260101000000", status = "migrated"},
+							{version = "20260102000000", status = "migrated"}
+						],
+						migrator = fakeMigrator
+					},
+					params = {}
+				);
+				expect(rv.message).toBe("Migrated to 20260101000000");
+			});
+
+			it("migrateDown reports nothing to roll back at version 0", () => {
+				var fakeMigrator = {migrateTo = (version) => "Migrated to " & version};
+				var rv = bridge.dispatch(
+					command = "migrateDown",
+					context = {
+						currentVersion = "0",
+						migrations = [],
+						migrator = fakeMigrator
+					},
+					params = {}
+				);
+				expect(rv.message).toInclude("nothing to roll back");
+			});
+
+			it("renameSystemTables surfaces a skipped message", () => {
+				var fakeMigrator = {
+					renameSystemTables = function(dryRun) {
+						return {success = true, skipped = "No legacy tables", renamed = [], sql = []};
+					}
+				};
+				var rv = bridge.dispatch(
+					command = "renameSystemTables",
+					context = {migrator = fakeMigrator},
+					params = {}
+				);
+				expect(rv.success).toBeTrue();
+				expect(rv.message).toBe("No legacy tables");
+			});
+
+			it("renameSystemTables lists renamed tables", () => {
+				var fakeMigrator = {
+					renameSystemTables = function(dryRun) {
+						return {success = true, skipped = "", renamed = ["core_users", "core_posts"], sql = []};
+					}
+				};
+				var rv = bridge.dispatch(
+					command = "renameSystemTables",
+					context = {migrator = fakeMigrator},
+					params = {}
+				);
+				expect(rv.message).toInclude("Renamed:");
+				expect(rv.message).toInclude("core_users");
+			});
+
+			it("renameSystemTables dry-run lists the SQL that would execute", () => {
+				var fakeMigrator = {
+					renameSystemTables = function(dryRun) {
+						return {success = true, skipped = "", renamed = [], sql = ["ALTER TABLE core_users RENAME TO users"]};
+					}
+				};
+				var rv = bridge.dispatch(
+					command = "renameSystemTables",
+					context = {migrator = fakeMigrator},
+					params = {dryRun = "true"}
+				);
+				expect(rv.message).toInclude("Dry run");
+				expect(rv.message).toInclude("ALTER TABLE core_users");
+			});
+
+			it("redoMigration uses the requested version", () => {
+				var fakeMigrator = {redoMigration = (version) => "Redone " & version};
+				var rv = bridge.dispatch(
+					command = "redoMigration",
+					context = {lastVersion = "20260101000000", migrator = fakeMigrator},
+					params = {version = "20260102000000"}
+				);
+				expect(rv.message).toBe("Redone 20260102000000");
+			});
+
+			it("redoMigration falls back to lastVersion", () => {
+				var fakeMigrator = {redoMigration = (version) => "Redone " & version};
+				var rv = bridge.dispatch(
+					command = "redoMigration",
+					context = {lastVersion = "20260101000000", migrator = fakeMigrator},
+					params = {}
+				);
+				expect(rv.message).toBe("Redone 20260101000000");
+			});
+
+			it("info renders datasource, type, and migrator output", () => {
+				var fakeMigrator = {$buildInfoOutput = function() { return ["line1", "line2"]; }};
+				var rv = bridge.dispatch(
+					command = "info",
+					context = {datasource = "myds", databaseType = "SQLite", migrator = fakeMigrator},
+					params = {}
+				);
+				expect(rv.message).toInclude("Datasource: myds");
+				expect(rv.message).toInclude("Database type: SQLite");
+				expect(rv.message).toInclude("line1");
+				expect(rv.message).toInclude("line2");
+			});
+
+			it("doctor surfaces report details including orphans and pending", () => {
+				var fakeMigrator = {
+					doctor = function() {
+						return {
+							healthy = true,
+							currentVersion = "20260102000000",
+							orphans = ["20250101000000"],
+							orphansWithMeta = [{version = "20250101000000", name = "CreateUsers", appliedAt = "2025-01-01"}],
+							pending = ["20260103000000"],
+							summary = {total = 4, applied = 2, pending = 1, orphan = 1},
+							message = "Health check"
+						};
+					}
+				};
+				var rv = bridge.dispatch(
+					command = "doctor",
+					context = {datasource = "myds", databaseType = "SQLite", migrator = fakeMigrator},
+					params = {}
+				);
+				expect(rv.healthy).toBeTrue();
+				expect(rv.currentVersion).toBe("20260102000000");
+				expect(rv.message).toInclude("Datasource: myds");
+				expect(rv.message).toInclude("orphan:");
+				expect(rv.message).toInclude("CreateUsers");
+				expect(rv.message).toInclude("20260103000000");
+			});
+
+			it("doctor renders an empty report without orphan/pending sections", () => {
+				var fakeMigrator = {
+					doctor = function() {
+						return {
+							healthy = false,
+							currentVersion = "0",
+							orphans = [],
+							orphansWithMeta = [],
+							pending = [],
+							summary = {total = 0, applied = 0, pending = 0, orphan = 0},
+							message = "Nothing to report"
+						};
+					}
+				};
+				var rv = bridge.dispatch(
+					command = "doctor",
+					context = {datasource = "myds", databaseType = "SQLite", migrator = fakeMigrator},
+					params = {}
+				);
+				expect(rv.healthy).toBeFalse();
+				expect(rv.message).toInclude("Current version: 0");
+				expect(rv.message).toInclude("Total migrations: 0");
+			});
+
+			it("forgetVersion forwards a version to the migrator", () => {
+				var fakeMigrator = {
+					forgetVersion = function(version) {
+						return {success = true, removed = 1, message = "Forgot " & version};
+					}
+				};
+				var rv = bridge.dispatch(
+					command = "forgetVersion",
+					context = {migrator = fakeMigrator},
+					params = {version = "20250101000000"}
+				);
+				expect(rv.success).toBeTrue();
+				expect(rv.removed).toBe(1);
+				expect(rv.message).toBe("Forgot 20250101000000");
+			});
+
+			it("pretendVersion forwards a version to the migrator", () => {
+				var fakeMigrator = {
+					pretendVersion = function(version) {
+						return {success = true, recorded = 1, message = "Recorded " & version};
+					}
+				};
+				var rv = bridge.dispatch(
+					command = "pretendVersion",
+					context = {migrator = fakeMigrator},
+					params = {version = "20260103000000"}
+				);
+				expect(rv.success).toBeTrue();
+				expect(rv.recorded).toBe(1);
+				expect(rv.message).toBe("Recorded 20260103000000");
+			});
+
+		});
+
+		describe("CliBridge database handler branches (fakes)", () => {
+
+			beforeEach(() => {
+				bridge = new wheels.public.CliBridge();
+			});
+
+			it("dbStatus formats migration status through the host", () => {
+				var fakeHost = {
+					$cliFormatMigrationStatus = function(migrations) {
+						return {
+							migrations = migrations,
+							summary = {total = ArrayLen(migrations), applied = 0, pending = ArrayLen(migrations)}
+						};
+					}
+				};
+				var migrations = [
+					{version = "20260101000000", status = "migrated"},
+					{version = "20260102000000", status = "pending"}
+				];
+				var rv = bridge.dispatch(
+					command = "dbStatus",
+					context = {host = fakeHost, migrations = migrations},
+					params = {}
+				);
+				expect(rv.success).toBeTrue();
+				expect(rv.summary.total).toBe(2);
+			});
+
+			it("dbRollback rolls back a single step by default", () => {
+				var fakeMigrator = {migrateTo = (version) => "Migrated to " & version};
+				var rv = bridge.dispatch(
+					command = "dbRollback",
+					context = {
+						migrations = [
+							{version = "20260101000000", status = "migrated"},
+							{version = "20260102000000", status = "migrated"},
+							{version = "20260103000000", status = "migrated"}
+						],
+						migrator = fakeMigrator
+					},
+					params = {}
+				);
+				expect(rv.success).toBeTrue();
+				expect(rv.message).toBe("Migrated to 20260102000000");
+			});
+
+			it("dbRollback rolls back to version 0 when steps equal the applied count", () => {
+				var fakeMigrator = {migrateTo = (version) => "Migrated to " & version};
+				var rv = bridge.dispatch(
+					command = "dbRollback",
+					context = {
+						migrations = [
+							{version = "20260101000000", status = "migrated"},
+							{version = "20260102000000", status = "migrated"},
+							{version = "20260103000000", status = "migrated"}
+						],
+						migrator = fakeMigrator
+					},
+					params = {steps = 3}
+				);
+				expect(rv.success).toBeTrue();
+				expect(rv.message).toBe("Migrated to 0");
+			});
+
+			it("dbRollback reports no migrations to rollback", () => {
+				var fakeMigrator = {migrateTo = (version) => "Migrated to " & version};
+				var rv = bridge.dispatch(
+					command = "dbRollback",
+					context = {
+						migrations = [
+							{version = "20260101000000", status = "pending"}
+						],
+						migrator = fakeMigrator
+					},
+					params = {}
+				);
+				expect(rv.success).toBeFalse();
+				expect(rv.message).toInclude("No migrations to rollback");
+			});
+
+			it("dbCreate prints MySQL DDL guidance", () => {
+				var rv = bridge.dispatch(
+					command = "dbCreate",
+					context = {databaseType = "MySQL"},
+					params = {}
+				);
+				expect(rv.message).toInclude("CREATE DATABASE dbname CHARACTER SET utf8mb4");
+			});
+
+			it("dbCreate prints PostgreSQL DDL guidance", () => {
+				var rv = bridge.dispatch(
+					command = "dbCreate",
+					context = {databaseType = "PostgreSQL"},
+					params = {}
+				);
+				expect(rv.message).toInclude("PostgreSQL: CREATE DATABASE dbname");
+			});
+
+			it("dbDrop refuses to drop the database", () => {
+				var rv = bridge.dispatch(command = "dbDrop", context = {}, params = {});
+				expect(rv.success).toBeFalse();
+				expect(rv.message).toInclude("Database dropping must be done");
+			});
+
+			it("dbSetup migrates to latest when no seed is requested", () => {
+				var fakeMigrator = {migrateToLatest = function() { return "Migrated to latest."; }};
+				var rv = bridge.dispatch(
+					command = "dbSetup",
+					context = {migrator = fakeMigrator},
+					params = {}
+				);
+				expect(rv.success).toBeTrue();
+				expect(rv.message).toInclude("Migrations completed.");
+			});
+
+			it("dbRestore prints MySQL restore guidance", () => {
+				var rv = bridge.dispatch(
+					command = "dbRestore",
+					context = {databaseType = "MySQL"},
+					params = {}
+				);
+				expect(rv.success).toBeFalse();
+				expect(rv.message).toInclude("mysql -u");
+			});
+
+			it("dbRestore prints H2 RUNSCRIPT guidance", () => {
+				var rv = bridge.dispatch(
+					command = "dbRestore",
+					context = {databaseType = "H2"},
+					params = {}
+				);
+				expect(rv.message).toInclude("RUNSCRIPT");
+			});
+
+			it("dbShell prints MySQL shell guidance", () => {
+				var rv = bridge.dispatch(
+					command = "dbShell",
+					context = {databaseType = "MySQL"},
+					params = {}
+				);
+				expect(rv.message).toInclude("mysql -u");
+			});
+
+			it("routes returns the application route list", () => {
+				var rv = bridge.dispatch(command = "routes", context = {}, params = {});
+				expect(rv.success).toBeTrue();
+				expect(IsArray(rv.routes)).toBeTrue();
+			});
+
+			it("introspect builds column and association metadata for a model", () => {
+				var fakeHost = {
+					model = function(modelName) {
+						return {
+							$classData = function() {
+								return {
+									tableName = "authors",
+									keys = "id",
+									properties = {
+										id = {type = "integer"},
+										name = {type = "string", maxLength = 100},
+										authorId = {type = "integer"}
+									},
+									associations = {
+										posts = {type = "hasMany", modelName = "post"}
+									}
+								};
+							}
+						};
+					}
+				};
+				var rv = bridge.dispatch(
+					command = "introspect",
+					context = {host = fakeHost},
+					params = {model = "Author"}
+				);
+				expect(rv.success).toBeTrue();
+				expect(rv.tableName).toBe("authors");
+				expect(rv.primaryKey).toBe("id");
+				expect(ArrayLen(rv.columns)).toBe(3);
+				expect(ArrayLen(rv.associations)).toBe(1);
+
+				// Struct iteration order is not guaranteed cross-engine, so
+				// resolve columns by name rather than position.
+				var idColumn = {};
+				var nameColumn = {};
+				var authorColumn = {};
+				for (var col in rv.columns) {
+					if (col.name == "id") { idColumn = col; }
+					if (col.name == "name") { nameColumn = col; }
+					if (col.name == "authorId") { authorColumn = col; }
+				}
+				expect(idColumn.primaryKey).toBeTrue();
+				expect(nameColumn.maxLength).toBe(100);
+				expect(authorColumn.foreignKey).toBeTrue();
+				expect(authorColumn.referencedModel).toBe("Author");
+
+				expect(rv.associations[1].type).toBe("hasMany");
+				expect(rv.associations[1].modelName).toBe("Post");
+			});
+
+		});
+
 	}
 
 }

--- a/vendor/wheels/tests/specs/cli/McpServerSpec.cfc
+++ b/vendor/wheels/tests/specs/cli/McpServerSpec.cfc
@@ -1,0 +1,35 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("McpServer (HTTP MCP endpoint)", () => {
+
+			var mcp = new wheels.public.mcp.McpServer();
+
+			it("lists tools", () => {
+				var response = mcp.handleRequest({ jsonrpc = "2.0", id = 1, method = "tools/list", params = {} }, "test-session");
+				expect(response.jsonrpc).toBe("2.0");
+				expect(StructKeyExists(response.result, "tools")).toBeTrue();
+				expect(arrayLen(response.result.tools)).toBeGT(0);
+			});
+
+			it("lists prompts", () => {
+				var response = mcp.handleRequest({ jsonrpc = "2.0", id = 2, method = "prompts/list", params = {} }, "test-session");
+				expect(StructKeyExists(response.result, "prompts")).toBeTrue();
+			});
+
+			it("rejects a request missing jsonrpc", () => {
+				var response = mcp.handleRequest({ method = "tools/list", id = 3 }, "test-session");
+				expect(response.error.code).toBe(-32600);
+			});
+
+			it("rejects an unknown method", () => {
+				var response = mcp.handleRequest({ jsonrpc = "2.0", id = 4, method = "bogus/method", params = {} }, "test-session");
+				expect(response.error.code).toBe(-32601);
+			});
+
+		});
+
+	}
+
+}


### PR DESCRIPTION
## Summary

Function-coverage tooling improvements + a new MCP spec.

- **CLI suite coverage** — `clitests.cfm` now resets/dumps `server.__wheels_cov` under `?coverage=true` (mirroring the core runner), and `cfml-coverage.py` gains a `merge` subcommand to union core + CLI dumps. Combined coverage went 80.0% → 81.0% on the SQLite/Lucee leg.
- **Instrumented run is green** — `Public.cfc` is excluded from instrumentation (its `$blockInProduction()`-first-statement guard was perturbed by injected counters), eliminating the 31 expected `PublicComponentProductionSpec` failures. Core instrumented run: 5,562 pass / 0 fail.
- **New `McpServerSpec`** — exercises the HTTP MCP endpoint's `tools/list`, `prompts/list`, and the invalid-request / unknown-method error paths, covering several high-CRAP uncovered handlers.

## Remaining known gaps (documented in README)

- Non-SQLite `databaseAdapters/*` and non-Lucee `engineAdapters/*` only execute on their matrix legs.
- `public/` dev views + the stdio `wheels mcp wheels` surface are covered by the e2e flow (real CLI invocations), not the in-server suites.
