### PR TITLE
fix: $includeConfig shadowing + pin singleton re-map lifecycle (#3526, #3527)

### DIFF
--- a/vendor/wheels/Global.cfc
+++ b/vendor/wheels/Global.cfc
@@ -102,39 +102,43 @@ component output="false" {
 	public void function $includeConfig(required string template) {
 		try {
 			// cfformat-ignore-start
-			local.resolved = $resolveGlobalIncludeTemplate(arguments.template);
-			var configIncludeState = {done = false, output = ""};
-			var configCaptured = "";
+			// Every local is $-prefixed so it cannot shadow a same-named variable in
+			// the included config template (#3526): the include runs inside this
+			// function's scope, so a bare `resolved`/`configCaptured` here would
+			// otherwise win over the app's own variable.
+			local.$resolved = $resolveGlobalIncludeTemplate(arguments.template);
+			var $configIncludeState = {done = false, output = ""};
+			var $configCaptured = "";
 			try {
-				savecontent variable="configCaptured" {
-					include "#local.resolved#"
+				savecontent variable="$configCaptured" {
+					include "#local.$resolved#"
 				};
-				configIncludeState.output = configCaptured;
-				configIncludeState.done = true;
+				$configIncludeState.output = $configCaptured;
+				$configIncludeState.done = true;
 			} catch (any e) {
 				if (!$isMissingMappedInclude(e)) {
 					rethrow;
 				}
 			}
-			if (!configIncludeState.done) {
-				var configFallbacks = $mappedIncludeFallbacks(local.resolved);
-				var configFbCount = ArrayLen(configFallbacks);
-				for (var configFbIndex = 1; configFbIndex <= configFbCount; configFbIndex++) {
+			if (!$configIncludeState.done) {
+				var $configFallbacks = $mappedIncludeFallbacks(local.$resolved);
+				var $configFbCount = ArrayLen($configFallbacks);
+				for (var $configFbIndex = 1; $configFbIndex <= $configFbCount; $configFbIndex++) {
 					try {
-						savecontent variable="configCaptured" {
-							include "#configFallbacks[configFbIndex]#"
+						savecontent variable="$configCaptured" {
+							include "#$configFallbacks[$configFbIndex]#"
 						};
-						configIncludeState.output = configCaptured;
-						configIncludeState.done = true;
+						$configIncludeState.output = $configCaptured;
+						$configIncludeState.done = true;
 						break;
 					} catch (any e) {
-						if (configFbIndex == configFbCount || !$isMissingMappedInclude(e)) {
+						if ($configFbIndex == $configFbCount || !$isMissingMappedInclude(e)) {
 							rethrow;
 						}
 					}
 				}
 			}
-			local.$wheelsConfigOutput = configIncludeState.output;
+			local.$wheelsConfigOutput = $configIncludeState.output;
 			// cfformat-ignore-end
 		} catch (any e) {
 			// Fail closed: a compile-time or runtime failure in a config template is a

--- a/vendor/wheels/tests/specs/di/InjectorSpec.cfc
+++ b/vendor/wheels/tests/specs/di/InjectorSpec.cfc
@@ -123,6 +123,21 @@ component extends="wheels.WheelsTest" {
 					expect(structKeyExists(after, "hasDependency")).toBeTrue();
 				});
 
+				it("preserves the singleton lifecycle when re-bound to a different path WITHOUT re-flagging (##3516)", () => {
+					di.map("repointedSingleton").to("wheels.tests._assets.di.SimpleService").asSingleton();
+					di.getInstance("repointedSingleton");
+					// Re-point to a DIFFERENT component without re-applying .asSingleton().
+					// The lifecycle must survive the re-map (the test-double DI-swap
+					// pattern) — dropping the flag here degrades it to transient.
+					di.map("repointedSingleton").to("wheels.tests._assets.di.OptionalDependentService");
+
+					expect(di.isSingleton("repointedSingleton")).toBeTrue();
+					var first = di.getInstance("repointedSingleton");
+					var second = di.getInstance("repointedSingleton");
+					expect(first).toBe(second);
+					expect(structKeyExists(first, "hasDependency")).toBeTrue();
+				});
+
 				it("keeps the cached singleton when the alias is re-registered with the same path (dev-reload pattern)", () => {
 					di.map("stableSingleton").to("wheels.tests._assets.di.SimpleService").asSingleton();
 					var before = di.getInstance("stableSingleton");


### PR DESCRIPTION
## Summary

Two follow-up items from the v4.1 upgrade pass.

### #3526 — `$includeConfig` locals shadow config-template variables
Same shadowing class as #3518, but in `$includeConfig()` (which includes `/config/settings.cfm` and `/config/services.cfm` at `onApplicationStart`). `$`-prefixes every local (`$resolved`, `$configIncludeState`, `$configCaptured`, `$configFallbacks`, `$configFbCount`, `$configFbIndex`), matching `$includeAndReturnOutput`.

### #3527 — regression test for the #3516 singleton re-map
The two existing re-bind tests in `InjectorSpec.cfc` both re-applied `.asSingleton()`, so neither caught the flag-drop. Adds the exact regression: re-point a singleton to a **different** component **without** re-flagging, asserting it stays a singleton.

## Verification

- Full core suite (Lucee 7 + SQLite): **5,603 pass / 0 fail / 0 error**.
- DI specs: 53 pass (includes the new test).