### PR TITLE
fix(web): skip duplicate blog announcement Discussions

### DIFF
--- a/changelog.d/blog-announce-dedupe.fixed.md
+++ b/changelog.d/blog-announce-dedupe.fixed.md
@@ -1,0 +1,1 @@
+- Blog announcement publisher no longer creates a second GitHub Discussion when one already exists for the same title or post URL

--- a/web/scripts/blog-announce-discussion.mjs
+++ b/web/scripts/blog-announce-discussion.mjs
@@ -9,6 +9,11 @@
  * the moved file paths. A post without an `announcement` block, or one whose
  * `announcement.discussionUrl` is already set, is skipped.
  *
+ * Before creating a discussion the script GraphQL-searches the repo's
+ * Announcements (or `announcement.category`) for an exact title match and/or
+ * a body that already contains the post's blog URL. A hit is treated as a
+ * prior announce: the existing URL is written back and create is skipped.
+ *
  * Usage:
  *   node web/scripts/blog-announce-discussion.mjs <post.md> [<post.md> ...]
  *   node web/scripts/blog-announce-discussion.mjs --dry-run <post.md> ...
@@ -17,11 +22,12 @@
  *      Runs with Node's built-ins only (node:fs, node:child_process, fetch).
  */
 import { readFileSync, writeFileSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { execFileSync } from 'node:child_process';
 
-const args = process.argv.slice(2);
-const dryRun = args.includes('--dry-run');
-const files = args.filter((a) => a !== '--dry-run');
+const BLOG_ORIGIN = 'https://blog.wheels.dev';
+const BLOG_URL_RE = /https:\/\/blog\.wheels\.dev\/(?:blog|posts)\/[A-Za-z0-9._-]+/g;
 
 // ---------------------------------------------------------------------------
 // Frontmatter parsing — just the `announcement:` block. The rest of the
@@ -29,7 +35,7 @@ const files = args.filter((a) => a !== '--dry-run');
 // nested object, so it never needs a full YAML parser.
 // ---------------------------------------------------------------------------
 
-function splitFrontmatter(content) {
+export function splitFrontmatter(content) {
 	const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
 	if (!m) throw new Error('no frontmatter found');
 	return { fm: m[1], rest: content.slice(m[0].length) };
@@ -49,7 +55,7 @@ function splitFrontmatter(content) {
  *       line two
  *     discussionUrl: 'https://...'
  */
-function extractAnnouncement(fm) {
+export function extractAnnouncement(fm) {
 	const lines = fm.split('\n');
 	const start = lines.findIndex((l) => /^announcement:\s*$/.test(l));
 	if (start === -1) return null;
@@ -90,7 +96,27 @@ function extractAnnouncement(fm) {
 	return out;
 }
 
-function writeDiscussionUrl(content, url) {
+export function extractSlug(fm) {
+	const m = fm.match(/^slug:\s*(?:'([^']*)'|"([^"]*)"|(\S+))\s*$/m);
+	if (!m) return '';
+	return m[1] || m[2] || m[3] || '';
+}
+
+/**
+ * Blog URLs used for Discussion-body dedupe. Prefer URLs already written in
+ * the announcement body; always include the canonical /blog/<slug> URL when
+ * a slug is known (frontmatter or filename).
+ */
+export function extractBlogUrls({ body = '', slug = '', file = '' } = {}) {
+	const urls = new Set();
+	const matches = String(body).match(BLOG_URL_RE) || [];
+	for (const url of matches) urls.add(url);
+	const resolvedSlug = slug || (file ? basename(file).replace(/\.mdx?$/i, '') : '');
+	if (resolvedSlug) urls.add(`${BLOG_ORIGIN}/blog/${resolvedSlug}`);
+	return [...urls];
+}
+
+export function writeDiscussionUrl(content, url) {
 	const { fm, rest } = splitFrontmatter(content);
 	const next = fm.replace(/^announcement:\s*$/m, `announcement:\n  discussionUrl: '${url}'`);
 	return `---\n${next}\n---\n${rest}`;
@@ -100,7 +126,49 @@ function writeDiscussionUrl(content, url) {
 // GitHub Discussions GraphQL
 // ---------------------------------------------------------------------------
 
-function repoOwnerName() {
+export function quoteSearchTerm(value) {
+	return `"${String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * GitHub search syntax for Discussions in one category. Title and URL clauses
+ * are OR'd so a single GraphQL `search` covers both signals; callers still
+ * exact-match client-side because `in:title` is substring, not equality.
+ */
+export function buildDiscussionSearchQuery({ owner, name, category, title, urls = [] } = {}) {
+	if (!owner || !name || !category) {
+		throw new Error('owner, name, and category are required to search discussions');
+	}
+	const clauses = [];
+	if (title) clauses.push(`in:title ${quoteSearchTerm(title)}`);
+	for (const url of urls) {
+		if (url) clauses.push(`in:body ${quoteSearchTerm(url)}`);
+	}
+	if (!clauses.length) return '';
+	const inner = clauses.length === 1 ? clauses[0] : `(${clauses.join(' OR ')})`;
+	return `repo:${owner}/${name} category:${quoteSearchTerm(category)} ${inner}`;
+}
+
+/**
+ * Pick a prior announcement from GraphQL search nodes. Requires an exact
+ * title match and/or a body that contains one of the post's blog URLs, and
+ * ignores hits from a different category when the node reports one.
+ */
+export function pickExistingDiscussion(nodes, { title, urls = [], category } = {}) {
+	const wantedUrls = new Set((urls || []).filter(Boolean));
+	for (const node of nodes || []) {
+		if (!node || !node.url) continue;
+		if (category && node.category?.name && node.category.name !== category) continue;
+		if (title && node.title === title) return node;
+		const body = node.body || '';
+		for (const url of wantedUrls) {
+			if (body.includes(url)) return node;
+		}
+	}
+	return null;
+}
+
+export function repoOwnerName() {
 	let url = '';
 	try {
 		url = execFileSync('git', ['config', '--get', 'remote.origin.url'], {
@@ -115,7 +183,7 @@ function repoOwnerName() {
 	return { owner: m[1], name: m[2] };
 }
 
-async function gql(token, query, variables = {}) {
+export async function gql(token, query, variables = {}) {
 	const res = await fetch('https://api.github.com/graphql', {
 		method: 'POST',
 		headers: {
@@ -132,9 +200,9 @@ async function gql(token, query, variables = {}) {
 	return payload.data;
 }
 
-async function resolveRepoAndCategories(token) {
+export async function resolveRepoAndCategories(token, gqlFn = gql) {
 	const { owner, name } = repoOwnerName();
-	const data = await gql(
+	const data = await gqlFn(
 		token,
 		`query($owner: String!, $name: String!) {
 			repository(owner: $owner, name: $name) {
@@ -149,11 +217,42 @@ async function resolveRepoAndCategories(token) {
 	const categories = new Map(
 		data.repository.discussionCategories.nodes.map((c) => [c.name, c.id]),
 	);
-	return { repositoryId: data.repository.id, categories };
+	return { repositoryId: data.repository.id, categories, owner, name };
 }
 
-async function createDiscussion(token, repositoryId, categoryId, title, body) {
-	const data = await gql(
+export async function searchDiscussions(token, query, gqlFn = gql) {
+	if (!query) return [];
+	const data = await gqlFn(
+		token,
+		`query($query: String!) {
+			search(query: $query, type: DISCUSSION, first: 20) {
+				nodes {
+					... on Discussion {
+						title
+						url
+						body
+						category { name }
+					}
+				}
+			}
+		}`,
+		{ query },
+	);
+	return (data.search?.nodes || []).filter(Boolean);
+}
+
+export async function findExistingDiscussion(
+	token,
+	{ owner, name, category, title, urls },
+	gqlFn = gql,
+) {
+	const query = buildDiscussionSearchQuery({ owner, name, category, title, urls });
+	const nodes = await searchDiscussions(token, query, gqlFn);
+	return pickExistingDiscussion(nodes, { title, urls, category });
+}
+
+export async function createDiscussion(token, repositoryId, categoryId, title, body, gqlFn = gql) {
+	const data = await gqlFn(
 		token,
 		`mutation($repositoryId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
 			createDiscussion(input: {
@@ -174,63 +273,109 @@ async function createDiscussion(token, repositoryId, categoryId, title, body) {
 // Main
 // ---------------------------------------------------------------------------
 
-const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
-if (!token && !dryRun) {
-	console.error('GH_TOKEN (or GITHUB_TOKEN) is not set.');
-	process.exit(1);
-}
-
-let ctx = null;
-if (!dryRun) {
-	ctx = await resolveRepoAndCategories(token);
-}
-
-let posted = 0;
-for (const file of files) {
-	const content = readFileSync(file, 'utf8');
-	let fm;
-	try {
-		fm = splitFrontmatter(content).fm;
-	} catch {
-		console.log(`skip (no frontmatter): ${file}`);
-		continue;
-	}
-	const announcement = extractAnnouncement(fm);
-
-	if (!announcement) {
-		console.log(`skip (no announcement): ${file}`);
-		continue;
-	}
-	if (announcement.discussionUrl) {
-		console.log(`skip (already posted): ${file} -> ${announcement.discussionUrl}`);
-		continue;
+export async function announceFiles(files, { dryRun = false, token, gqlFn = gql } = {}) {
+	let ctx = null;
+	if (!dryRun) {
+		ctx = await resolveRepoAndCategories(token, gqlFn);
 	}
 
-	const category = announcement.category || 'Announcements';
-	if (!ctx && !dryRun) throw new Error('discussion context missing');
+	let posted = 0;
+	for (const file of files) {
+		const content = readFileSync(file, 'utf8');
+		let fm;
+		try {
+			fm = splitFrontmatter(content).fm;
+		} catch {
+			console.log(`skip (no frontmatter): ${file}`);
+			continue;
+		}
+		const announcement = extractAnnouncement(fm);
 
-	if (dryRun) {
-		console.log(`[dry-run] would post to ${category}:\n  title: ${announcement.title}\n  body: ${announcement.body.split('\n').join('\n        ')}`);
-		continue;
-	}
+		if (!announcement) {
+			console.log(`skip (no announcement): ${file}`);
+			continue;
+		}
+		if (announcement.discussionUrl) {
+			console.log(`skip (already posted): ${file} -> ${announcement.discussionUrl}`);
+			continue;
+		}
 
-	const categoryId = ctx.categories.get(category);
-	if (!categoryId) {
-		throw new Error(
-			`discussion category "${category}" not found. Available: ${[...ctx.categories.keys()].join(', ')}`,
+		const category = announcement.category || 'Announcements';
+		const slug = extractSlug(fm);
+		const urls = extractBlogUrls({ body: announcement.body, slug, file });
+
+		if (dryRun) {
+			const searchQuery = buildDiscussionSearchQuery({
+				owner: 'OWNER',
+				name: 'REPO',
+				category,
+				title: announcement.title,
+				urls,
+			}).replace('repo:OWNER/REPO ', '');
+			console.log(
+				`[dry-run] would search ${category} then post if no match:\n  search: ${searchQuery}\n  title: ${announcement.title}\n  body: ${announcement.body.split('\n').join('\n        ')}`,
+			);
+			continue;
+		}
+
+		if (!ctx) throw new Error('discussion context missing');
+
+		const existing = await findExistingDiscussion(
+			token,
+			{
+				owner: ctx.owner,
+				name: ctx.name,
+				category,
+				title: announcement.title,
+				urls,
+			},
+			gqlFn,
 		);
+		if (existing) {
+			writeFileSync(file, writeDiscussionUrl(content, existing.url), 'utf8');
+			console.log(`skip (existing discussion): ${file} -> ${existing.url}`);
+			continue;
+		}
+
+		const categoryId = ctx.categories.get(category);
+		if (!categoryId) {
+			throw new Error(
+				`discussion category "${category}" not found. Available: ${[...ctx.categories.keys()].join(', ')}`,
+			);
+		}
+
+		const url = await createDiscussion(
+			token,
+			ctx.repositoryId,
+			categoryId,
+			announcement.title,
+			announcement.body,
+			gqlFn,
+		);
+		writeFileSync(file, writeDiscussionUrl(content, url), 'utf8');
+		console.log(`posted: ${file} -> ${url}`);
+		posted++;
 	}
 
-	const url = await createDiscussion(
-		token,
-		ctx.repositoryId,
-		categoryId,
-		announcement.title,
-		announcement.body,
-	);
-	writeFileSync(file, writeDiscussionUrl(content, url), 'utf8');
-	console.log(`posted: ${file} -> ${url}`);
-	posted++;
+	console.log(`Done. Posted ${posted} announcement(s).`);
+	return posted;
 }
 
-console.log(`Done. Posted ${posted} announcement(s).`);
+export async function main(argv = process.argv.slice(2), env = process.env) {
+	const dryRun = argv.includes('--dry-run');
+	const files = argv.filter((a) => a !== '--dry-run');
+	const token = env.GH_TOKEN || env.GITHUB_TOKEN;
+	if (!token && !dryRun) {
+		console.error('GH_TOKEN (or GITHUB_TOKEN) is not set.');
+		process.exitCode = 1;
+		return;
+	}
+	await announceFiles(files, { dryRun, token });
+}
+
+const isDirectRun =
+	Boolean(process.argv[1]) && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+
+if (isDirectRun) {
+	await main();
+}

--- a/web/scripts/blog-announce-discussion.test.mjs
+++ b/web/scripts/blog-announce-discussion.test.mjs
@@ -1,0 +1,340 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+	buildDiscussionSearchQuery,
+	extractAnnouncement,
+	extractBlogUrls,
+	extractSlug,
+	findExistingDiscussion,
+	pickExistingDiscussion,
+	quoteSearchTerm,
+	splitFrontmatter,
+	writeDiscussionUrl,
+	announceFiles,
+} from './blog-announce-discussion.mjs';
+
+const SAMPLE_FM = `title: 'Pretty URLs with bindBy: the unshareable link'
+slug: pretty-urls-with-route-bindby
+announcement:
+  title: 'Pretty URLs with bindBy'
+  body: |
+    New post: **[Pretty URLs with bindBy](https://blog.wheels.dev/blog/pretty-urls-with-route-bindby)** — bind a resource.
+`;
+
+const SAMPLE_POST = `---
+${SAMPLE_FM}---
+The support conversation goes like this.
+`;
+
+test('extractAnnouncement reads title, body, and discussionUrl', () => {
+	const announcement = extractAnnouncement(`${SAMPLE_FM}  discussionUrl: 'https://example.test/d/1'\n`);
+	assert.equal(announcement.title, 'Pretty URLs with bindBy');
+	assert.match(announcement.body, /blog\.wheels\.dev\/blog\/pretty-urls-with-route-bindby/);
+	assert.equal(announcement.discussionUrl, 'https://example.test/d/1');
+});
+
+test('extractAnnouncement returns null when the block is missing', () => {
+	assert.equal(extractAnnouncement('title: hello\n'), null);
+});
+
+test('extractSlug reads an unquoted slug', () => {
+	assert.equal(extractSlug(SAMPLE_FM), 'pretty-urls-with-route-bindby');
+});
+
+test('extractBlogUrls prefers body links and always adds /blog/<slug>', () => {
+	const urls = extractBlogUrls({
+		body: 'See https://blog.wheels.dev/posts/legacy-slug and https://blog.wheels.dev/blog/pretty-urls-with-route-bindby',
+		slug: 'pretty-urls-with-route-bindby',
+	});
+	assert.deepEqual(
+		[...urls].sort(),
+		[
+			'https://blog.wheels.dev/blog/pretty-urls-with-route-bindby',
+			'https://blog.wheels.dev/posts/legacy-slug',
+		],
+	);
+});
+
+test('extractBlogUrls falls back to the filename slug', () => {
+	const urls = extractBlogUrls({
+		body: 'no links here',
+		file: '/tmp/cli-workflow-upgrades-migrate-diff-dry-run-offline.md',
+	});
+	assert.deepEqual(urls, [
+		'https://blog.wheels.dev/blog/cli-workflow-upgrades-migrate-diff-dry-run-offline',
+	]);
+});
+
+test('quoteSearchTerm escapes quotes and backslashes', () => {
+	assert.equal(quoteSearchTerm('say "hi"'), '"say \\"hi\\""');
+	assert.equal(quoteSearchTerm('a\\b'), '"a\\\\b"');
+});
+
+test('buildDiscussionSearchQuery ORs exact title and blog URL clauses', () => {
+	const query = buildDiscussionSearchQuery({
+		owner: 'wheels-dev',
+		name: 'wheels',
+		category: 'Announcements',
+		title: 'Pretty URLs with bindBy',
+		urls: ['https://blog.wheels.dev/blog/pretty-urls-with-route-bindby'],
+	});
+	assert.equal(
+		query,
+		'repo:wheels-dev/wheels category:"Announcements" (in:title "Pretty URLs with bindBy" OR in:body "https://blog.wheels.dev/blog/pretty-urls-with-route-bindby")',
+	);
+});
+
+test('pickExistingDiscussion matches an exact title in the category', () => {
+	const hit = pickExistingDiscussion(
+		[
+			{
+				title: 'Pretty URLs with bindBy',
+				url: 'https://github.com/wheels-dev/wheels/discussions/1',
+				body: 'unrelated',
+				category: { name: 'Announcements' },
+			},
+		],
+		{
+			title: 'Pretty URLs with bindBy',
+			urls: ['https://blog.wheels.dev/blog/pretty-urls-with-route-bindby'],
+			category: 'Announcements',
+		},
+	);
+	assert.equal(hit.url, 'https://github.com/wheels-dev/wheels/discussions/1');
+});
+
+test('pickExistingDiscussion matches a body that contains the blog URL', () => {
+	const hit = pickExistingDiscussion(
+		[
+			{
+				title: 'A slightly different title',
+				url: 'https://github.com/wheels-dev/wheels/discussions/2',
+				body: 'New post: https://blog.wheels.dev/blog/pretty-urls-with-route-bindby',
+				category: { name: 'Announcements' },
+			},
+		],
+		{
+			title: 'Pretty URLs with bindBy',
+			urls: ['https://blog.wheels.dev/blog/pretty-urls-with-route-bindby'],
+			category: 'Announcements',
+		},
+	);
+	assert.equal(hit.url, 'https://github.com/wheels-dev/wheels/discussions/2');
+});
+
+test('pickExistingDiscussion ignores a substring title hit', () => {
+	const hit = pickExistingDiscussion(
+		[
+			{
+				title: 'Pretty URLs with bindBy and more',
+				url: 'https://github.com/wheels-dev/wheels/discussions/3',
+				body: 'no blog url',
+				category: { name: 'Announcements' },
+			},
+		],
+		{
+			title: 'Pretty URLs with bindBy',
+			urls: ['https://blog.wheels.dev/blog/pretty-urls-with-route-bindby'],
+			category: 'Announcements',
+		},
+	);
+	assert.equal(hit, null);
+});
+
+test('pickExistingDiscussion ignores a hit from another category', () => {
+	const hit = pickExistingDiscussion(
+		[
+			{
+				title: 'Pretty URLs with bindBy',
+				url: 'https://github.com/wheels-dev/wheels/discussions/4',
+				body: 'https://blog.wheels.dev/blog/pretty-urls-with-route-bindby',
+				category: { name: 'Ideas' },
+			},
+		],
+		{
+			title: 'Pretty URLs with bindBy',
+			urls: ['https://blog.wheels.dev/blog/pretty-urls-with-route-bindby'],
+			category: 'Announcements',
+		},
+	);
+	assert.equal(hit, null);
+});
+
+test('writeDiscussionUrl inserts discussionUrl under announcement', () => {
+	const next = writeDiscussionUrl(SAMPLE_POST, 'https://github.com/wheels-dev/wheels/discussions/9');
+	const { fm } = splitFrontmatter(next);
+	assert.match(fm, /^announcement:\n  discussionUrl: 'https:\/\/github.com\/wheels-dev\/wheels\/discussions\/9'/m);
+	assert.equal(extractAnnouncement(fm).discussionUrl, 'https://github.com/wheels-dev/wheels/discussions/9');
+});
+
+test('findExistingDiscussion issues a DISCUSSION search and exact-filters', async () => {
+	const calls = [];
+	const gqlFn = async (_token, query, variables) => {
+		calls.push({ query, variables });
+		return {
+			search: {
+				nodes: [
+					{
+						title: 'Pretty URLs with bindBy',
+						url: 'https://github.com/wheels-dev/wheels/discussions/1',
+						body: 'https://blog.wheels.dev/blog/pretty-urls-with-route-bindby',
+						category: { name: 'Announcements' },
+					},
+				],
+			},
+		};
+	};
+
+	const found = await findExistingDiscussion(
+		'token',
+		{
+			owner: 'wheels-dev',
+			name: 'wheels',
+			category: 'Announcements',
+			title: 'Pretty URLs with bindBy',
+			urls: ['https://blog.wheels.dev/blog/pretty-urls-with-route-bindby'],
+		},
+		gqlFn,
+	);
+
+	assert.equal(found.url, 'https://github.com/wheels-dev/wheels/discussions/1');
+	assert.equal(calls.length, 1);
+	assert.match(calls[0].query, /type: DISCUSSION/);
+	assert.equal(
+		calls[0].variables.query,
+		'repo:wheels-dev/wheels category:"Announcements" (in:title "Pretty URLs with bindBy" OR in:body "https://blog.wheels.dev/blog/pretty-urls-with-route-bindby")',
+	);
+});
+
+test('announceFiles skips when discussionUrl is already set and does not search', async () => {
+	const dir = await mkdtemp(join(tmpdir(), 'blog-announce-'));
+	const file = join(dir, 'already.md');
+	await writeFile(
+		file,
+		`---
+slug: already
+announcement:
+  discussionUrl: 'https://github.com/wheels-dev/wheels/discussions/99'
+  title: 'Already posted'
+  body: |
+    https://blog.wheels.dev/blog/already
+---
+body
+`,
+		'utf8',
+	);
+
+	const calls = [];
+	const gqlFn = async () => {
+		calls.push('gql');
+		throw new Error('should not be called');
+	};
+
+	try {
+		const posted = await announceFiles([file], { dryRun: true, token: 'x', gqlFn });
+		assert.equal(posted, 0);
+		assert.equal(calls.length, 0);
+		const kept = await readFile(file, 'utf8');
+		assert.match(kept, /discussionUrl: 'https:\/\/github.com\/wheels-dev\/wheels\/discussions\/99'/);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test('announceFiles writes the existing discussion URL and does not create', async () => {
+	const dir = await mkdtemp(join(tmpdir(), 'blog-announce-'));
+	const file = join(dir, 'pretty-urls-with-route-bindby.md');
+	await writeFile(file, SAMPLE_POST, 'utf8');
+
+	const gqlFn = async (_token, query) => {
+		if (query.includes('discussionCategories')) {
+			return {
+				repository: {
+					id: 'repo1',
+					discussionCategories: { nodes: [{ id: 'cat1', name: 'Announcements' }] },
+				},
+			};
+		}
+		if (query.includes('type: DISCUSSION')) {
+			return {
+				search: {
+					nodes: [
+						{
+							title: 'Pretty URLs with bindBy',
+							url: 'https://github.com/wheels-dev/wheels/discussions/3475',
+							body: 'https://blog.wheels.dev/blog/pretty-urls-with-route-bindby',
+							category: { name: 'Announcements' },
+						},
+					],
+				},
+			};
+		}
+		if (query.includes('createDiscussion')) {
+			throw new Error('createDiscussion must not run when a match exists');
+		}
+		throw new Error(`unexpected query: ${query}`);
+	};
+
+	try {
+		const posted = await announceFiles([file], { token: 'x', gqlFn });
+		assert.equal(posted, 0);
+		const updated = extractAnnouncement(splitFrontmatter(await readFile(file, 'utf8')).fm);
+		assert.equal(updated.discussionUrl, 'https://github.com/wheels-dev/wheels/discussions/3475');
+
+		const gqlFnSecond = async (_token, query) => {
+			if (query.includes('createDiscussion') || query.includes('type: DISCUSSION')) {
+				throw new Error('second announce must be a no-op after discussionUrl is written');
+			}
+			return {
+				repository: {
+					id: 'repo1',
+					discussionCategories: { nodes: [{ id: 'cat1', name: 'Announcements' }] },
+				},
+			};
+		};
+		const postedAgain = await announceFiles([file], { token: 'x', gqlFn: gqlFnSecond });
+		assert.equal(postedAgain, 0);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+test('announceFiles creates only when search finds no match', async () => {
+	const dir = await mkdtemp(join(tmpdir(), 'blog-announce-'));
+	const file = join(dir, 'pretty-urls-with-route-bindby.md');
+	await writeFile(file, SAMPLE_POST, 'utf8');
+	const calls = [];
+
+	const gqlFn = async (_token, query) => {
+		if (query.includes('discussionCategories')) {
+			return {
+				repository: {
+					id: 'repo1',
+					discussionCategories: { nodes: [{ id: 'cat1', name: 'Announcements' }] },
+				},
+			};
+		}
+		if (query.includes('type: DISCUSSION')) {
+			calls.push('search');
+			return { search: { nodes: [] } };
+		}
+		if (query.includes('createDiscussion')) {
+			calls.push('create');
+			return { createDiscussion: { discussion: { url: 'https://github.com/wheels-dev/wheels/discussions/new' } } };
+		}
+		throw new Error(`unexpected query: ${query}`);
+	};
+
+	try {
+		const posted = await announceFiles([file], { token: 'x', gqlFn });
+		assert.equal(posted, 1);
+		assert.deepEqual(calls, ['search', 'create']);
+		const updated = extractAnnouncement(splitFrontmatter(await readFile(file, 'utf8')).fm);
+		assert.equal(updated.discussionUrl, 'https://github.com/wheels-dev/wheels/discussions/new');
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Part **A only** of the blog Announcement dedupe fix. The scheduled publisher can create a GitHub Discussion, then fail the subsequent `git push` to `develop`, leaving the post in `scheduled/` without `announcement.discussionUrl`. The next run created another Announcement for the same post.

This PR makes a second announce of the same title or blog URL a no-op. CoS has already disabled **Blog — Publish Scheduled Posts**. This is safe to merge while that workflow stays paused.

C1 (announce-on-publish after a successful push) and B (workflow hardening) are **out of scope** and will land in a later PR.

## What changed

`web/scripts/blog-announce-discussion.mjs`:

1. Keep the existing skip when `announcement.discussionUrl` is already set.
2. Before `createDiscussion`, GraphQL-`search` repo Discussions (`type: DISCUSSION`) in the Announcements category for:
   - exact `title` match (search is substring; we exact-filter client-side), and/or
   - body containing the post’s blog URL (from the announcement body, frontmatter `slug`, or filename).
3. If found → skip create, write `discussionUrl` to the existing URL so the next run is the cheap skip.
4. Only then `createDiscussion`.

`--dry-run` now prints the search it would run, still without calling GitHub.

## Non-goals

- Do **not** change `.github/workflows/blog-publish-scheduled.yml` or `.github/scripts/blog-publish-scheduled.sh`
- Do **not** add a blog-announce-on-publish workflow
- Do **not** re-enable the disabled scheduled workflow
- Do **not** clean up existing duplicate Discussions
- Do **not** change branch protection / rulesets

## Related Issue

Follow-up to the paused scheduled publisher (duplicate Announcements). No issue number assigned.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Documentation update
- [ ] Refactoring

## Feature Completeness Checklist

- [x] **DCO sign-off** -- Every commit carries `Signed-off-by:`
- [x] **Tests** -- Colocated `node:test` suite (`web/scripts/blog-announce-discussion.test.mjs`). There is no existing Node test home under `web/scripts/`; this matches the `node:test` pattern used by `web/sites/guides/scripts/verify-docs/`.
- [ ] **Framework Docs** -- N/A (publisher script, not a framework API)
- [ ] **AI Reference Docs** -- N/A
- [ ] **CLAUDE.md** -- N/A
- [x] **Changelog fragment** -- `changelog.d/blog-announce-dedupe.fixed.md`
- [ ] **Test runner passes** -- N/A (Node script; not `/wheels/tests/core`)

## Test Plan

```bash
node --test web/scripts/blog-announce-discussion.test.mjs
```

16 tests, all passing. Coverage includes:

- existing `discussionUrl` skip (no GraphQL)
- GraphQL `search` + exact title match
- body contains blog URL
- substring title is **not** a match
- other categories ignored
- create only when search returns no match
- second announce of the same post is a no-op after `discussionUrl` is written

### Dry-run / fixture checklist

```bash
# scheduled post with no discussionUrl — prints the search, does not create
node web/scripts/blog-announce-discussion.mjs --dry-run \
  web/content/blog/scheduled/pretty-urls-with-route-bindby.md

# already-announced post — skip (already posted)
node web/scripts/blog-announce-discussion.mjs --dry-run \
  web/content/blog/posts/wheels-4-1-coming.md
```

Verified locally:

```
[dry-run] would search Announcements then post if no match:
  search: category:"Announcements" (in:title "Pretty URLs with bindBy" OR in:body "https://blog.wheels.dev/blog/pretty-urls-with-route-bindby")
skip (already posted): web/content/blog/posts/wheels-4-1-coming.md -> https://github.com/wheels-dev/wheels/discussions/3475
```

## Hypothesis

GitHub GraphQL has no dedicated “find discussion by title” field. `search(type: DISCUSSION)` with `repo:`, `category:`, `in:title`, and `in:body` is the supported path. Results are then exact-filtered so a similar title cannot steal the skip.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cbd4084-aba9-41a4-b362-998ec13add50?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cbd4084-aba9-41a4-b362-998ec13add50&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

