### PR TITLE
ci(web): publish scheduled blog posts via PR; announce only after durable publish (C1+B)

### DIFF
--- a/.github/scripts/blog-announce-on-publish.sh
+++ b/.github/scripts/blog-announce-on-publish.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Announce newly-published blog posts to the GitHub Discussions board.
+#
+# Runs from blog-announce-on-publish.yml after a push to develop touches
+# web/content/blog/posts/** (the publish PR merged), or on workflow_dispatch.
+#
+# 1. Identify candidate posts:
+#    - push: files added/modified under web/content/blog/posts/ by this push.
+#    - workflow_dispatch (or a push with no resolvable base): every post whose
+#      `announcement:` block still lacks a `discussionUrl` (backfill).
+# 2. Run web/scripts/blog-announce-discussion.mjs over the candidates. The
+#    dedupe already lives in that script: before creating a discussion it
+#    searches existing Announcements by exact title and/or the post's blog URL,
+#    and on a hit writes that URL back instead of creating a duplicate.
+# 3. If the frontmatter gained a discussionUrl, commit it on
+#    docs/bot-blog-announce-<shortsha> and open a tiny PR to develop (same
+#    pattern as the publish workflow — never push to develop directly).
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+REPO="${REPO:-${GITHUB_REPOSITORY:-wheels-dev/wheels}}"
+EVENT_NAME="${EVENT_NAME:-${GITHUB_EVENT_NAME:-}}"
+POSTS_DIR="web/content/blog/posts"
+
+# --- 1. Collect candidate posts -------------------------------------------
+
+# A post still needs announcing when its frontmatter has an `announcement:`
+# block without a `discussionUrl:` line. Scoped to the frontmatter (between
+# the first and second `---` fences) so a `discussionUrl` mention in the body
+# prose doesn't suppress a real announcement.
+needs_announcement() {
+  awk '
+    /^---[ \t]*$/ { fences++; next }
+    fences == 1 {
+      if ($0 ~ /^announcement:[ \t]*$/) ann = 1
+      if ($0 ~ /discussionUrl:/) url = 1
+    }
+    END { exit (ann && !url ? 0 : 1) }
+  ' "$1"
+}
+
+candidates=()
+
+if [ "$EVENT_NAME" = "push" ]; then
+  before="${BEFORE_SHA:-}"
+  after="${HEAD_SHA:-$GITHUB_SHA}"
+  if [ -n "$before" ] && [ "$before" != "0000000000000000000000000000000000000000" ]; then
+    mapfile -t candidates < <(git diff --name-only --diff-filter=AM "$before" "$after" -- "$POSTS_DIR" || true)
+  fi
+fi
+
+if [ ${#candidates[@]} -eq 0 ]; then
+  # workflow_dispatch, or a push with no resolvable base: scan every post.
+  for f in "$POSTS_DIR"/*.md; do
+    [ -e "$f" ] || continue
+    if needs_announcement "$f"; then
+      candidates+=("$f")
+    fi
+  done
+fi
+
+if [ ${#candidates[@]} -eq 0 ]; then
+  echo "No posts need announcing. Done."
+  exit 0
+fi
+
+echo "Candidate posts (${#candidates[@]}):"
+printf '  %s\n' "${candidates[@]}"
+
+# --- 2. Announce (dedupe lives inside the .mjs) ---------------------------
+node web/scripts/blog-announce-discussion.mjs "${candidates[@]}"
+
+# --- 3. Commit any discussionUrl writeback and open a PR -------------------
+# The .mjs writes discussionUrl back into the post frontmatter when it posts
+# (or links an existing) discussion. If nothing changed, there is nothing to
+# commit — the writeback may already be on develop, or none of the candidates
+# carried an announcement block.
+if git diff --quiet -- "$POSTS_DIR" && git diff --cached --quiet -- "$POSTS_DIR"; then
+  echo "No discussionUrl writeback produced — nothing to commit."
+  exit 0
+fi
+
+git config user.name "wheels-bot[bot]"
+git config user.email "wheels-bot[bot]@users.noreply.github.com"
+
+shortsha="$(git rev-parse --short=7 HEAD)"
+branch="docs/bot-blog-announce-${shortsha}"
+
+# Idempotency: if this branch already exists on origin, the writeback for this
+# develop HEAD is already queued — do not recreate it.
+if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+  echo "Branch $branch already exists on origin — announce writeback is already queued. Nothing to do."
+  exit 0
+fi
+
+git checkout -b "$branch"
+
+git add "$POSTS_DIR"
+git commit -m "docs(blog): record discussion announcements" -m "Write back discussionUrl for newly-published posts.
+
+Opened by blog-announce-on-publish.yml after a publish PR merged to develop." || {
+  echo "Commit failed or nothing to commit — checking status."
+  git status --short
+  exit 1
+}
+
+git push -u origin HEAD
+
+# Open the PR. The docs/bot-* branch prefix makes the required
+# "Bot PR TDD Gate" a declared no-op (bot-tdd-gate.yml) for this
+# docs-content-only PR.
+pr_body_file="$(mktemp)"
+{
+  echo "## Summary"
+  echo ""
+  echo "Record the Discussion URLs created for newly-published blog posts by writing \`announcement.discussionUrl\` back into the post frontmatter (the idempotency marker that makes future announces a no-op)."
+  echo ""
+  echo "🤖 Opened automatically by \`.github/workflows/blog-announce-on-publish.yml\`."
+} > "$pr_body_file"
+
+pr_url="$(gh pr create \
+  --repo "$REPO" \
+  --base develop \
+  --head "$branch" \
+  --title "docs(blog): record discussion announcements" \
+  --body-file "$pr_body_file")"
+rm -f "$pr_body_file"
+
+echo "Opened $pr_url"

--- a/.github/scripts/blog-publish-scheduled.sh
+++ b/.github/scripts/blog-publish-scheduled.sh
@@ -2,18 +2,26 @@
 # Publish scheduled blog posts whose publishedAt date is today or earlier (UTC).
 #
 # Moves each web/content/blog/scheduled/*.md that is due into
-# web/content/blog/posts/, commits as wheels-bot[bot], and pushes. The push
-# triggers the blog deploy workflow (blog_content_changed).
+# web/content/blog/posts/, commits as wheels-bot[bot] on a
+# docs/bot-blog-publish-<YYYYMMDD> branch, and opens a PR against develop.
 #
-# Idempotent: after a successful run there is nothing left to move, so
-# re-running the same day is a no-op. Posts whose day was missed (failed or
-# skipped run) publish on the next successful run — catch-up, never stranded.
+# develop's branch protection rejects direct pushes (GH013), so the publish
+# lands through a PR. Merging that PR pushes the new posts to develop, which
+# triggers (a) the blog deploy (web-deploy.yml) and (b) the announcement
+# workflow (blog-announce-on-publish.yml). The announcement is intentionally
+# NOT done here — only after the publish is durable on develop.
+#
+# Idempotent: the branch is day-scoped, so a second run the same day is the
+# same publish. If the branch already exists on origin, the publish is already
+# queued and this run exits 0. Posts whose day was missed (failed or skipped
+# run) publish on the next successful run — catch-up, never stranded.
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
 SOURCE_DIR="web/content/blog/scheduled"
 TARGET_DIR="web/content/blog/posts"
+REPO="${GITHUB_REPOSITORY:-wheels-dev/wheels}"
 
 if [ ! -d "$SOURCE_DIR" ]; then
   echo "No scheduled directory at $SOURCE_DIR — nothing to do."
@@ -21,10 +29,17 @@ if [ ! -d "$SOURCE_DIR" ]; then
 fi
 
 TODAY="$(date -u +%Y-%m-%d)"
+BRANCH="docs/bot-blog-publish-$(date -u +%Y%m%d)"
 echo "Publishing scheduled posts due on or before $TODAY (UTC)..."
 
+# Idempotency: if this day's branch already exists on origin, its publish PR
+# is already open (or was closed) — do not recreate the branch or push again.
+if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+  echo "Branch $BRANCH already exists on origin — this day's publish is already queued. Nothing to do."
+  exit 0
+fi
+
 published=()
-moved_paths=()
 for file in "$SOURCE_DIR"/*.md; do
   # Skip the README (it has no publishedAt).
   [ -e "$file" ] || continue
@@ -47,7 +62,6 @@ for file in "$SOURCE_DIR"/*.md; do
   echo "  publishing: $(basename "$file") (due $due_date)"
   git mv "$file" "$TARGET_DIR/$(basename "$file")"
   published+=("$(basename "$file" .md)")
-  moved_paths+=("$TARGET_DIR/$(basename "$file")")
 done
 
 if [ ${#published[@]} -eq 0 ]; then
@@ -55,22 +69,10 @@ if [ ${#published[@]} -eq 0 ]; then
   exit 0
 fi
 
-# Post each newly-published post's `announcement` frontmatter to the GitHub
-# Discussions board. The script writes the discussion URL back into the post's
-# frontmatter (idempotency marker), and the commit below includes it.
-#
-# Best-effort: a discussion-announcement failure must NOT strand the post
-# publish. The announcement is additive — the post goes live regardless, and
-# the failure is surfaced in the run log (not by failing the run). Typical
-# cause is the wheels-bot GitHub App missing the "Discussions" permission.
-echo "Posting discussion announcements for ${#moved_paths[@]} post(s)..."
-if ! node web/scripts/blog-announce-discussion.mjs "${moved_paths[@]}"; then
-  echo "WARNING: discussion announcement failed — publishing the post(s) anyway." >&2
-  echo "  (Check that the wheels-bot GitHub App has the Discussions read/write permission.)" >&2
-fi
-
 git config user.name "wheels-bot[bot]"
 git config user.email "wheels-bot[bot]@users.noreply.github.com"
+
+git checkout -b "$BRANCH"
 
 count=${#published[@]}
 slug_list="$(printf ', %s' "${published[@]}")"
@@ -85,6 +87,30 @@ Slugs: $slug_list" || {
   exit 1
 }
 
-git push origin HEAD
+git push -u origin HEAD
 
-echo "Published $count post(s): $slug_list"
+# Open the PR. The docs/bot-* branch prefix makes the required
+# "Bot PR TDD Gate" a declared no-op (bot-tdd-gate.yml) for this
+# docs-content-only PR.
+pr_body_file="$(mktemp)"
+{
+  echo "## Summary"
+  echo ""
+  echo "Automated scheduled publish: moved $count due post(s) from \`web/content/blog/scheduled/\` into \`web/content/blog/posts/\`."
+  echo ""
+  echo "Merging this PR pushes the posts to develop, which triggers the blog deploy and the announcement workflow (\`blog-announce-on-publish.yml\`). No Discussions are created here."
+  echo ""
+  echo "Slugs: $slug_list"
+  echo ""
+  echo "🤖 Opened automatically by \`.github/workflows/blog-publish-scheduled.yml\`."
+} > "$pr_body_file"
+
+pr_url="$(gh pr create \
+  --repo "$REPO" \
+  --base develop \
+  --head "$BRANCH" \
+  --title "docs(blog): publish $count scheduled post(s)" \
+  --body-file "$pr_body_file")"
+rm -f "$pr_body_file"
+
+echo "Opened $pr_url for $count post(s): $slug_list"

--- a/.github/workflows/blog-announce-on-publish.yml
+++ b/.github/workflows/blog-announce-on-publish.yml
@@ -1,0 +1,69 @@
+name: Blog — Announce on Publish
+
+# After a publish PR merges to develop (or on manual dispatch), post each
+# newly-published post's `announcement` frontmatter to the GitHub Discussions
+# board. The `discussionUrl` writeback is committed on a
+# docs/bot-blog-announce-<shortsha> branch and opened as a tiny PR against
+# develop — never pushed to develop directly.
+#
+# Why this runs here and not in the publish workflow: the publisher used to
+# announce then push to develop. When the push failed (GH013 required checks),
+# the Discussion already existed but the publish never landed, so the next
+# day's run re-announced and duplicated the thread. Announcing only on
+# push-to-develop means a post is durable before any announcement is made,
+# and the dedupe in web/scripts/blog-announce-discussion.mjs (exact title /
+# blog-URL search before create) is a second line of defence.
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'web/content/blog/posts/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: blog-announce-on-publish
+  cancel-in-progress: false
+
+jobs:
+  announce:
+    name: Announce published posts
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WHEELS_BOT_APP_ID }}
+          private-key: ${{ secrets.WHEELS_BOT_PRIVATE_KEY }}
+
+      # Full history so the push path can diff event.before..event.after to
+      # identify exactly which posts this push added or modified.
+      - name: Checkout develop
+        uses: actions/checkout@v6
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      # Node for the discussion-announcement helper (web/scripts/...mjs).
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Announce and write back discussion URLs
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          chmod +x .github/scripts/blog-announce-on-publish.sh
+          bash .github/scripts/blog-announce-on-publish.sh

--- a/.github/workflows/blog-publish-scheduled.yml
+++ b/.github/workflows/blog-publish-scheduled.yml
@@ -2,10 +2,14 @@ name: Blog — Publish Scheduled Posts
 
 # Every morning (06:00 UTC), moves blog posts whose publishedAt date is
 # today or earlier from web/content/blog/scheduled/ into
-# web/content/blog/posts/, commits as wheels-bot[bot], and pushes. The push
-# triggers the blog deploy (web-deploy.yml detects web/content/blog/posts/
-# changes), so the posts go live without further intervention. Catch-up
-# semantics: a missed day publishes on the next successful run.
+# web/content/blog/posts/, commits as wheels-bot[bot] on a
+# docs/bot-blog-publish-<YYYYMMDD> branch, and opens a PR against develop.
+# develop's branch protection rejects direct pushes (GH013), so the publish
+# lands through a PR rather than a push to develop. Merging that PR triggers
+# the blog deploy (web-deploy.yml detects web/content/blog/posts/ changes) and
+# the announcement workflow (blog-announce-on-publish.yml), so the posts go
+# live and are announced once they are durable on develop.
+# Catch-up semantics: a missed day publishes on the next successful run.
 
 on:
   schedule:
@@ -14,6 +18,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: blog-publish-scheduled
@@ -33,18 +38,13 @@ jobs:
           private-key: ${{ secrets.WHEELS_BOT_PRIVATE_KEY }}
 
       # App-token pushes trigger downstream workflows (GITHUB_TOKEN pushes
-      # do not), which is what makes the blog deploy fire.
+      # do not), which is what makes the blog deploy and the announce
+      # workflow fire after the publish PR merges.
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
           token: ${{ steps.app-token.outputs.token }}
-
-      # Node for the discussion-announcement helper (web/scripts/...mjs).
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22
 
       - name: Publish due posts
         env:

--- a/web/content/blog/scheduled/README.md
+++ b/web/content/blog/scheduled/README.md
@@ -9,9 +9,14 @@ area for scheduled publishing.
 The [Blog — Publish Scheduled Posts](../../.github/workflows/blog-publish-scheduled.yml)
 workflow runs every morning at 06:00 UTC (and on `workflow_dispatch`). It
 moves every post here whose `publishedAt` date is **today or earlier** (UTC)
-into `web/content/blog/posts/`, commits as `wheels-bot[bot]`, and pushes.
-That push triggers the existing blog deploy, which builds and publishes the
-site.
+into `web/content/blog/posts/`, commits as `wheels-bot[bot]` on a
+`docs/bot-blog-publish-<YYYYMMDD>` branch, and opens a PR against develop.
+
+develop's branch protection rejects direct pushes, so the publish lands
+through a PR. Merging that PR triggers the existing blog deploy, which builds
+and publishes the site, and a separate [announcement workflow](../../.github/workflows/blog-announce-on-publish.yml)
+posts the post's `announcement` frontmatter to GitHub Discussions once the
+publish is durable on develop.
 
 Catch-up semantics are deliberate: if a run fails or is skipped, posts due
 in the past publish on the next successful run instead of being stranded.

--- a/web/sites/blog/src/content.config.ts
+++ b/web/sites/blog/src/content.config.ts
@@ -19,7 +19,8 @@ const posts = defineCollection({
 		legacyId: z.string().optional(),
 		// Discussion announcement posted to the repo's Discussions board when
 		// the post is published. `discussionUrl` is written back by the
-		// scheduler after the discussion is created (idempotency marker).
+		// announce-on-publish workflow after the discussion is created
+		// (idempotency marker).
 		announcement: z
 			.object({
 				title: z.string(),


### PR DESCRIPTION
## Summary

Implements C1 (PR-based publish) + B (announce only after durable publish) for the blog publisher, following up on the A/dedupe already on develop (#3531).

### C1 — publish via PR, never push develop
`.github/workflows/blog-publish-scheduled.yml` + `.github/scripts/blog-publish-scheduled.sh`:
- Moves due `web/content/blog/scheduled/*.md` → `posts/`, commits as `wheels-bot[bot]` on `docs/bot-blog-publish-YYYYMMDD`, pushes the branch, and opens a PR against develop.
- Removed the in-flow discussion-announcement call (and the now-unused Node setup step).
- Idempotent (day-scoped branch gate) — re-running opens ≤1 PR.

### B — announce only after the publish is durable
New `.github/workflows/blog-announce-on-publish.yml` + `.github/scripts/blog-announce-on-publish.sh`:
- on: push to develop `web/content/blog/posts/**`, plus `workflow_dispatch`.
- Identifies changed posts (push) or posts still missing `discussionUrl` (dispatch), runs the dedupe-aware `web/scripts/blog-announce-discussion.mjs`, and commits any `discussionUrl` writeback on `docs/bot-blog-announce-<shortsha>` as a tiny PR.

The original failure chain — announce → failed `git push` to develop (GH013) → posts stuck in scheduled/ → next day duplicated Announcements — is closed at both ends: the publish never pushes develop, and announcements only fire after the publish is durable on develop.

## Ship order note
The scheduled workflow stays **disabled** until a green `workflow_dispatch` dry run confirms the PR-based publish and CoS re-enables it. No Discussions are created until a publish PR merges; after merge, announce-on-publish creates at most one Announcement per post (dedupe in the `.mjs` + `discussionUrl` writeback).

## Non-goals honored
- No re-enable of the disabled scheduled workflow
- No C2 ruleset bypass
- No cleanup of existing duplicate Announcement threads
- No change to A/dedupe behavior beyond integration
- Not merged by the authoring agent

## Test plan
- [ ] `bash -n` on both scripts
- [ ] YAML parse of both workflows
- [ ] `node --test web/scripts/blog-announce-discussion.test.mjs` (16/16 already passing locally)
- [ ] After merge: `workflow_dispatch` dry run of publish (schedule stays disabled until CoS re-enables)