### PR TITLE
Scaffold form layout: stacked fields, full-width inputs, red accessible validation errors

### DIFF
--- a/changelog.d/scaffold-red-validation-errors.added.md
+++ b/changelog.d/scaffold-red-validation-errors.added.md
@@ -1,0 +1,1 @@
+- Validation errors in scaffolded forms are now styled red with sufficient contrast and a non-color "Error:" text prefix (via `errorMessageOn` defaults and `wheels-forms.css`), so they read as errors at a glance without relying on color alone (#3550)

--- a/changelog.d/scaffold-stacked-form-layout.changed.md
+++ b/changelog.d/scaffold-stacked-form-layout.changed.md
@@ -1,0 +1,1 @@
+- New `wheels new` scaffolds render forms with the label on its own line above the field and string/text inputs spanning the full row width (a new `wheels-forms.css` + `labelPlacement="before"` field wrapper defaults), while each property's validation error is now nested inside its field block instead of only appearing in the summary list (#3549)

--- a/cli/lucli/templates/app/app/views/layout.cfm
+++ b/cli/lucli/templates/app/app/views/layout.cfm
@@ -20,6 +20,10 @@
 			      to bring your own CSS, or swap for a richer kit — e.g.
 			      `wheels packages add wheels-basecoat`. --->
 			<cfoutput>#styleSheetLinkTag(sources="simple")#</cfoutput>
+			<!--- Scaffold form layout: stacked label-above-field, full-width
+			      text inputs, and red accessible validation errors (#3549/#3550).
+			      Loaded after simple.css so it layers on top. --->
+			<cfoutput>#styleSheetLinkTag(sources="wheels-forms")#</cfoutput>
 		</head>
 
 		<body>

--- a/cli/lucli/templates/app/config/settings.cfm
+++ b/cli/lucli/templates/app/config/settings.cfm
@@ -34,5 +34,40 @@
 	*/
 	set(useUnderscoreReferenceColumns=true);
 
+	/*
+		Form helper defaults for scaffolded forms (issues #3549 / #3550):
+		stack the label above the field, let string/text inputs span the full
+		row width (via public/stylesheets/wheels-forms.css), and nest each
+		property's validation error inside the field block. These are defaults
+		for NEW scaffolds only — the framework's global `labelPlacement` stays
+		`around` so existing apps and exact-HTML expectations are unaffected.
+	*/
+	set(
+		functionName="textField,textFieldTag,emailField,emailFieldTag,urlField,urlFieldTag,numberField,numberFieldTag,telField,telFieldTag,searchField,searchFieldTag,passwordField,passwordFieldTag,textArea,textAreaTag,select,selectTag,fileField,fileFieldTag",
+		labelPlacement="before",
+		prependToLabel="<div class=""field"">",
+		append="</div>",
+		errorElement="div",
+		errorClass="field-with-errors",
+		encode="attributes"
+	);
+	// Boolean controls stay inline (label beside the checkbox/radio).
+	set(
+		functionName="checkBox,checkBoxTag,radioButton,radioButtonTag",
+		labelPlacement="aroundRight"
+	);
+	// Accessible validation errors: a "Error:" text prefix is a non-color cue
+	// (red styling lives in wheels-forms.css).
+	set(
+		functionName="errorMessageOn",
+		prependText="Error:",
+		wrapperElement="span",
+		class="error-message"
+	);
+	set(
+		functionName="errorMessagesFor",
+		class="error-messages"
+	);
+
 	// CLI-Appends-Here
 </cfscript>

--- a/cli/lucli/templates/app/public/stylesheets/wheels-forms.css
+++ b/cli/lucli/templates/app/public/stylesheets/wheels-forms.css
@@ -1,0 +1,82 @@
+/*
+ * wheels-forms.css — scaffolded form layout (issues #3549 / #3550)
+ *
+ * Loaded after simple.css in app/views/layout.cfm. Complements the classless
+ * simple.css with stacked, full-width form fields and red, accessible
+ * validation errors. Remove it (and the <link> in layout.cfm) to bring your
+ * own form styling.
+ */
+
+/* Field block: label on its own line, control below. */
+.field {
+    margin-bottom: 1rem;
+}
+.field label {
+    display: block;
+    margin-bottom: 0.25rem;
+    font-weight: 600;
+}
+
+/*
+ * Errored field block. The framework wraps the label + control in
+ * `.field-with-errors` when the property has validation errors and nests the
+ * per-property message inside it, so keep the message visually attached.
+ */
+.field-with-errors {
+    margin-bottom: 1rem;
+}
+.field-with-errors .field {
+    margin-bottom: 0.25rem;
+}
+
+/* String/text controls span the full row (checkbox/radio stay inline). */
+.field input[type="text"],
+.field input[type="password"],
+.field input[type="email"],
+.field input[type="url"],
+.field input[type="search"],
+.field input[type="number"],
+.field input[type="tel"],
+.field textarea,
+.field select {
+    width: 100%;
+    display: block;
+}
+
+/*
+ * Validation errors: red with strong contrast, plus a non-color cue (the
+ * "Error:" text prefix configured in config/settings.cfm) so they are not
+ * conveyed by color alone.
+ */
+.error-message,
+.error-messages {
+    color: #b91c1c; /* red-700: ~4.6:1 contrast on white */
+    font-weight: 600;
+}
+.error-message {
+    display: block;
+    margin-top: 0.25rem;
+    font-size: 0.9rem;
+}
+.error-messages {
+    list-style: none;
+    padding: 0.5rem 0.75rem;
+    margin: 0 0 1rem;
+    border-left: 3px solid #b91c1c;
+    background: #fef2f2;
+}
+.error-messages::before {
+    content: "Errors: ";
+    font-weight: 700;
+}
+
+@media (prefers-color-scheme: dark) {
+    .error-message,
+    .error-messages {
+        color: #f87171; /* red-400: readable on dark backgrounds */
+    }
+    .error-messages {
+        background: rgba(185, 28, 28, 0.15);
+        border-left-color: #f87171;
+    }
+}

--- a/cli/lucli/tests/specs/commands/NewCommandTemplateSpec.cfc
+++ b/cli/lucli/tests/specs/commands/NewCommandTemplateSpec.cfc
@@ -102,6 +102,33 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 				expect(fileExists(templateRoot & "tests/specs/models/.gitkeep")).toBeTrue();
 			});
 
+			it("ships scaffolded form layout defaults (label above field, full-width, nested errors)", () => {
+				// Issues #3549/#3550: new scaffolds stack the label above the
+				// field and nest the validation error in the field block via
+				// `set()` defaults in config/settings.cfm. The framework's
+				// global `labelPlacement` default is intentionally left as
+				// `around` so existing apps are unaffected.
+				var content = fileRead(templateRoot & "config/settings.cfm");
+				expect(content).toInclude('labelPlacement="before"');
+				expect(content).toInclude('functionName="textField,textFieldTag');
+				expect(content).toInclude('prependToLabel="<div class=""field"">"');
+				expect(content).toInclude('errorElement="div"');
+				expect(content).toInclude('prependText="Error:"');
+				expect(content).toInclude('functionName="errorMessageOn"');
+				// Boolean controls stay inline.
+				expect(content).toInclude('labelPlacement="aroundRight"');
+			});
+
+			it("ships wheels-forms.css and links it after simple.css in layout.cfm", () => {
+				// The companion stylesheet layers full-width inputs and red
+				// accessible error styling on top of the bundled simple.css.
+				expect(fileExists(templateRoot & "public/stylesheets/wheels-forms.css")).toBeTrue();
+				var layout = fileRead(templateRoot & "app/views/layout.cfm");
+				expect(layout).toInclude('sources="simple"');
+				expect(layout).toInclude('sources="wheels-forms"');
+				expect(find('sources="wheels-forms"', layout)).toBeGT(find('sources="simple"', layout));
+			});
+
 		});
 
 	}

--- a/vendor/wheels/tests/specs/view/errorsSpec.cfc
+++ b/vendor/wheels/tests/specs/view/errorsSpec.cfc
@@ -48,6 +48,27 @@ component extends="wheels.WheelsTest" {
 
 		})
 
+		describe("field helpers nest the per-property error in the field block", () => {
+
+			it("appends errorMessageOn inside the errorElement wrapper (##3549/##3550)", () => {
+				_controller = application.wo.controller(name = "ControllerWithModelErrors")
+				result = _controller.textField(objectName = "user", property = "firstname")
+				// The errorElement wrapper still marks the field...
+				expect(result).toInclude('class="field-with-errors"')
+				// ...and the inline message is now rendered with the control, after
+				// the field's input element.
+				expect(result).toInclude('<span class="error-message">firstname error1</span>')
+				expect(find('<span class="error-message">', result)).toBeGT(find("<input", result))
+			})
+
+			it("renders no inline message when the property has no errors", () => {
+				_controller = application.wo.controller(name = "ControllerWithModelErrors")
+				result = _controller.textField(objectName = "user", property = "username")
+				expect(result).notToInclude("error-message")
+			})
+
+		})
+
 		describe("Tests that errorMessagesFor", () => {
 
 			beforeEach(() => {

--- a/vendor/wheels/view/forms.cfc
+++ b/vendor/wheels/view/forms.cfc
@@ -540,6 +540,12 @@ component {
 		}
 		if ($formHasError(argumentCollection = arguments) && Len(arguments.errorElement)) {
 			arguments.errorElement = $sanitizeHtmlTagName(arguments.errorElement);
+			// Nest the property's validation error inside the field block, with
+			// the control (#3549 / #3550). errorMessageOn resolves the same
+			// object + property via $getObject, so this renders only when the
+			// field actually has errors and honors the app's errorMessageOn
+			// defaults (prependText, wrapperElement, class, encode).
+			local.rv &= errorMessageOn(objectName = arguments.objectName, property = arguments.property);
 			// the input has an error and is wrapped in a tag so we need to close that wrapper tag
 			local.rv &= "</" & arguments.errorElement & ">";
 		}


### PR DESCRIPTION
## Summary

Implements #3549 and #3550: new `wheels new` scaffolds render forms with the label on its own line above the field, string/text inputs spanning the full row width, and each property's validation error nested inside its field block and styled red with a non-color "Error:" prefix.

## Approach

- **Framework** (`vendor/wheels/view/forms.cfc`): `$formAfterElement` now appends `errorMessageOn()` for the same object/property before closing the `errorElement` wrapper, so an errored control renders its message inline. Tag-based and association helpers are unaffected (they bind a struct `objectName` that never reports errors), so existing apps without field errors see identical output.
- **Scaffold defaults** (`cli/lucli/templates/app/config/settings.cfm`): `labelPlacement="before"` + a `<div class="field">` wrapper + `errorElement="div"` for text/email/url/number/tel/search/password/textArea/select/file (and Tag variants); checkbox/radio stay inline (`aroundRight`); `errorMessageOn` gets `prependText="Error:"`.
- **Companion CSS** (`public/stylesheets/wheels-forms.css`, linked after `simple.css` in `layout.cfm`): full-width text-like controls, and red `.error-message`/`.error-messages` with sufficient contrast + dark-mode variants.
- The framework's global `labelPlacement` default is intentionally left as `around` so existing apps and exact-HTML specs are unchanged.

## Files changed

- `vendor/wheels/view/forms.cfc`
- `cli/lucli/templates/app/config/settings.cfm`
- `cli/lucli/templates/app/app/views/layout.cfm`
- `cli/lucli/templates/app/public/stylesheets/wheels-forms.css` (new)
- `vendor/wheels/tests/specs/view/errorsSpec.cfc`
- `cli/lucli/tests/specs/commands/NewCommandTemplateSpec.cfc`
- `changelog.d/scaffold-stacked-form-layout.changed.md` (new)
- `changelog.d/scaffold-red-validation-errors.added.md` (new)

Fixes #3549
Fixes #3550