### PR TITLE
fix(cli): fail wheels console on eval errors (tutorial e2e flake)

### DIFF
--- a/changelog.d/console-eval-exit-code.fixed.md
+++ b/changelog.d/console-eval-exit-code.fixed.md
@@ -1,0 +1,1 @@
+- `wheels console` now exits non-zero when a piped/EOF session had an evaluation error, a connection/ping failure, or a returned model with validation errors (previously always exited 0, which hid failed `create()` calls from scripts and the tutorial e2e)

--- a/changelog.d/tutorial-e2e-test-load.fixed.md
+++ b/changelog.d/tutorial-e2e-test-load.fixed.md
@@ -1,0 +1,1 @@
+- `wheels test` now prints runner `error` / `message` / `bundlesDiscovered` / mapping-path diagnostics when on-disk specs are not loaded, instead of only warning that they "failed to compile" (a populate failure or empty TestBox discovery produced the same WARN)

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -1840,27 +1840,33 @@ component extends="modules.BaseModule" {
 			password = detectReloadPassword();
 		}
 
-		// Verify connectivity with a ping
+		// Verify connectivity with a ping. Fail closed (##2229 / ##2941): a
+		// silent `return ""` here made `printf '...' | wheels console && ...`
+		// look successful when the eval endpoint was down or still restarting.
 		var evalUrl = "#$serverUrlBase(serverPort)#/wheels/console/eval";
 		try {
 			var pingResult = makeHttpPost(evalUrl, serializeJSON({expression: "__ping__", password: password}));
 			if (isJSON(pingResult)) {
 				var pingData = deserializeJSON(pingResult);
 				if (!pingData.success) {
-					out("Console connection failed: #pingData.error#", "red");
-					return "";
+					$consoleFail("Console connection failed: #pingData.error#");
 				}
 				var wheelsVersion = pingData.version ?: "unknown";
 				var wheelsEnv = pingData.environment ?: "unknown";
 			} else {
-				out("Server returned unexpected response. Is this a Wheels 3.x application?", "red");
-				return "";
+				$consoleFail("Server returned unexpected response. Is this a Wheels 3.x application?");
 			}
 		} catch (any e) {
+			if (e.type == "Wheels.ConsoleFailed") {
+				rethrow;
+			}
 			out("Cannot connect to console endpoint at #evalUrl#", "red");
 			out("Ensure your Wheels app is v3.1+ with console support.", "yellow");
 			out("Error: #e.message#", "yellow");
-			return "";
+			throw(
+				type = "Wheels.ConsoleFailed",
+				message = "Cannot connect to console endpoint at #evalUrl#: #e.message#"
+			);
 		}
 
 		// Banner
@@ -1870,13 +1876,18 @@ component extends="modules.BaseModule" {
 		out("Type expressions to evaluate in your app context. /help for commands.", "");
 		out("", "");
 
-		// Interactive REPL loop
+		// Interactive REPL loop. Piped sessions (EOF after one or more
+		// expressions) throw at EOF if any eval failed so shell `&&` gates
+		// and the tutorial e2e do not treat a printed `Error:` as success.
+		// Interactive `/exit` still returns 0 so a typo does not fail the
+		// whole session.
 		var System = createObject("java", "java.lang.System");
 		var reader = createObject("java", "java.io.BufferedReader").init(
 			createObject("java", "java.io.InputStreamReader").init(System.in)
 		);
 
 		var running = true;
+		var hadError = false;
 		while (running) {
 			// Print prompt
 			System.out.print("wheels> ");
@@ -1885,10 +1896,16 @@ component extends="modules.BaseModule" {
 			// Read input
 			var line = reader.readLine();
 
-			// Handle EOF (Ctrl+D)
+			// Handle EOF (Ctrl+D or end of a pipe)
 			if (isNull(line)) {
 				out("");
 				out("Bye!", "cyan");
+				if (hadError) {
+					throw(
+						type = "Wheels.ConsoleFailed",
+						message = "One or more console expressions failed"
+					);
+				}
 				break;
 			}
 
@@ -1903,12 +1920,18 @@ component extends="modules.BaseModule" {
 				running = false;
 				continue;
 			}
+			if (verdict == "error") {
+				hadError = true;
+				continue;
+			}
 			if (verdict == "handled") {
 				continue;
 			}
 
 			// Evaluate expression
-			consoleExec(evalUrl, line, password);
+			if (!consoleExec(evalUrl, line, password)) {
+				hadError = true;
+			}
 		}
 
 		return "";
@@ -1916,8 +1939,8 @@ component extends="modules.BaseModule" {
 
 	/**
 	 * Handle one REPL command line. Returns "exit" to end the loop, "handled"
-	 * when the line was a slash command, or "" when it should be evaluated as
-	 * an expression by the caller.
+	 * when the line was a slash command, "error" when a slash command's eval
+	 * failed, or "" when it should be evaluated as an expression by the caller.
 	 */
 	private string function $consoleHandleCommand(required string line, required string evalUrl, required string password, required string serverPort, required any javaSystem) {
 		switch (lCase(arguments.line)) {
@@ -1933,7 +1956,9 @@ component extends="modules.BaseModule" {
 				return "handled";
 
 			case "/env":
-				consoleExec(arguments.evalUrl, "__env__", arguments.password);
+				if (!consoleExec(arguments.evalUrl, "__env__", arguments.password)) {
+					return "error";
+				}
 				return "handled";
 
 			case "/reload":
@@ -1963,29 +1988,40 @@ component extends="modules.BaseModule" {
 				return "handled";
 
 			case "/models":
-				consoleExec(arguments.evalUrl, "structKeyArray(application.wheels.models).sort('textnocase')", arguments.password);
+				if (!consoleExec(arguments.evalUrl, "structKeyArray(application.wheels.models).sort('textnocase')", arguments.password)) {
+					return "error";
+				}
 				return "handled";
 
 			case "/routes":
-				consoleExec(arguments.evalUrl, "application.wheels.routes.map(function(r){ return r.pattern & ' -> ' & r.controller & '##' & r.action; })", arguments.password);
+				if (!consoleExec(arguments.evalUrl, "application.wheels.routes.map(function(r){ return r.pattern & ' -> ' & r.controller & '##' & r.action; })", arguments.password)) {
+					return "error";
+				}
 				return "handled";
 
 			case "/version":
-				consoleExec(arguments.evalUrl, "application.wheels.version", arguments.password);
+				if (!consoleExec(arguments.evalUrl, "application.wheels.version", arguments.password)) {
+					return "error";
+				}
 				return "handled";
 
 			case "/ds":
 			case "/datasource":
-				consoleExec(arguments.evalUrl, "application.wheels.dataSourceName", arguments.password);
+				if (!consoleExec(arguments.evalUrl, "application.wheels.dataSourceName", arguments.password)) {
+					return "error";
+				}
 				return "handled";
 		}
 		return "";
 	}
 
 	/**
-	 * Execute a single expression and display the result
+	 * Execute a single expression and display the result. Returns false when
+	 * the HTTP call failed, the server reported success=false, or a model
+	 * result carries validation errors — the REPL records that and exits
+	 * non-zero on EOF so piped scripts cannot hide a failed create.
 	 */
-	private void function consoleExec(required string requestUrl, required string expression, string password = "") {
+	private boolean function consoleExec(required string requestUrl, required string expression, string password = "") {
 		try {
 			var body = serializeJSON({expression: expression, password: password});
 			var httpResult = makeHttpPost(requestUrl, body);
@@ -1993,7 +2029,7 @@ component extends="modules.BaseModule" {
 			if (!isJSON(httpResult)) {
 				out("Server returned non-JSON response.", "red");
 				verbose(httpResult);
-				return;
+				return false;
 			}
 
 			var result = deserializeJSON(httpResult);
@@ -2005,7 +2041,7 @@ component extends="modules.BaseModule" {
 
 			if (!result.success) {
 				out("Error: #result.error#", "red");
-				return;
+				return false;
 			}
 
 			// Display result based on type
@@ -2014,7 +2050,7 @@ component extends="modules.BaseModule" {
 
 			if (resultType == "void" && !len(resultValue)) {
 				// No return value and no output — nothing to display
-				return;
+				return true;
 			}
 
 			switch (resultType) {
@@ -2024,6 +2060,9 @@ component extends="modules.BaseModule" {
 
 				case "model":
 					displayModelResult(resultValue);
+					if ($consoleModelHasErrors(resultValue)) {
+						return false;
+					}
 					break;
 
 				case "struct":
@@ -2047,9 +2086,38 @@ component extends="modules.BaseModule" {
 					}
 			}
 
+			return true;
+
 		} catch (any e) {
 			out("Request failed: #e.message#", "red");
+			return false;
 		}
+	}
+
+	/**
+	 * Print-then-throw for console startup failures so LuCLI surfaces a
+	 * non-zero exit (same contract as reload / routes, GH ##2229 / ##2941).
+	 */
+	private void function $consoleFail(required string message) {
+		out(arguments.message, "red");
+		throw(type = "Wheels.ConsoleFailed", message = arguments.message);
+	}
+
+	/**
+	 * True when a serialized model result includes validation errors.
+	 * `.create()` that fails validation still evaluates successfully and
+	 * returns the unsaved object — without this, piped console sessions
+	 * exited 0 after a no-op persist.
+	 */
+	public boolean function $consoleModelHasErrors(required string jsonResult) {
+		if (!isJSON(arguments.jsonResult)) {
+			return false;
+		}
+		var props = deserializeJSON(arguments.jsonResult);
+		if (!isStruct(props) || !structKeyExists(props, "_hasErrors")) {
+			return false;
+		}
+		return isBoolean(props._hasErrors) && props._hasErrors;
 	}
 
 	/**
@@ -2137,6 +2205,14 @@ component extends="modules.BaseModule" {
 			}
 			if (structKeyExists(props, "_isNew")) {
 				out("    _isNew: #props._isNew#", "cyan");
+			}
+			if (structKeyExists(props, "_hasErrors") && isBoolean(props._hasErrors) && props._hasErrors) {
+				out("    Validation failed:", "red");
+				if (structKeyExists(props, "_errors") && isArray(props._errors)) {
+					for (var errMsg in props._errors) {
+						out("    #errMsg#", "red");
+					}
+				}
 			}
 			out("  }", "green");
 		} catch (any e) {

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -7021,7 +7021,9 @@ component extends="modules.BaseModule" {
 		var unloadedSpecPaths = $collectUnloadedSpecs(result, arguments.testDirectory, specsFailedToLoad);
 
 		if (specsFailedToLoad > 0) {
-			$printFailedToLoadWarning(specsFailedToLoad, unloadedSpecPaths);
+			$printFailedToLoadWarning(specsFailedToLoad, unloadedSpecPaths, result);
+		} else {
+			$printTestResultDiagnostics(result);
 		}
 
 		// Display bundle/suite/spec tree if verbose and bundles exist
@@ -7082,16 +7084,87 @@ component extends="modules.BaseModule" {
 	}
 
 	/**
-	 * Print the "specs failed to load" warning block (and the parse-error hint).
+	 * Print the "specs failed to load" warning block plus any runner-payload
+	 * diagnostics (populate / TestBox constructor / 0-bundle / parse error).
+	 * Disk-vs-bundleStats is only a proxy — the same WARN used to fire for a
+	 * non-TestBox JSON body (e.g. tests/populate.cfm failed) with no compile
+	 * error at all.
 	 */
-	private void function $printFailedToLoadWarning(required numeric specsFailedToLoad, required array unloadedSpecPaths) {
+	private void function $printFailedToLoadWarning(
+		required numeric specsFailedToLoad,
+		required array unloadedSpecPaths,
+		required any result
+	) {
 		out("");
-		out("WARN  #arguments.specsFailedToLoad# spec file(s) failed to compile and were silently skipped:", "yellow");
+		out("WARN  #arguments.specsFailedToLoad# spec file(s) were on disk but not loaded (compile error, empty discovery, or runner error):", "yellow");
 		for (var unloaded in arguments.unloadedSpecPaths) {
 			out("        #unloaded#", "yellow");
 		}
-		out("        Visit /wheels/app/tests in a browser for the parse-error details.", "yellow");
+		out("        Visit /wheels/app/tests?format=json for runner diagnostics.", "yellow");
+		$printTestResultDiagnostics(arguments.result);
 		out("");
+	}
+
+	/**
+	 * Human-readable lines from a runner JSON body that is missing bundleStats
+	 * or carries an explicit error (populate.cfm, TestBox constructor, 0-bundle
+	 * discovery). Public so CLI specs can lock the fields without a live server.
+	 */
+	public array function $testResultDiagnosticLines(required any result) {
+		var lines = [];
+		if (!isStruct(arguments.result)) {
+			return lines;
+		}
+		var interesting = false;
+		if (structKeyExists(arguments.result, "error") && isSimpleValue(arguments.result.error) && len(arguments.result.error)) {
+			arrayAppend(lines, "Runner error: #arguments.result.error#");
+			interesting = true;
+		}
+		if (structKeyExists(arguments.result, "message") && isSimpleValue(arguments.result.message) && len(arguments.result.message)) {
+			arrayAppend(lines, "Message: #arguments.result.message#");
+			interesting = true;
+		}
+		if (structKeyExists(arguments.result, "detail") && isSimpleValue(arguments.result.detail) && len(arguments.result.detail)) {
+			arrayAppend(lines, "Detail: #arguments.result.detail#");
+			interesting = true;
+		}
+		if (structKeyExists(arguments.result, "directoryRejected") && arguments.result.directoryRejected) {
+			arrayAppend(lines, "directoryRejected: true");
+			interesting = true;
+		}
+		if (structKeyExists(arguments.result, "bundlesDiscovered") && arguments.result.bundlesDiscovered == 0) {
+			arrayAppend(lines, "bundlesDiscovered: 0");
+			interesting = true;
+		}
+		if (structKeyExists(arguments.result, "testDirectoryExists") && !arguments.result.testDirectoryExists) {
+			arrayAppend(lines, "testDirectoryExists: false");
+			interesting = true;
+		}
+		if (structKeyExists(arguments.result, "warnings") && isArray(arguments.result.warnings) && arrayLen(arguments.result.warnings)) {
+			interesting = true;
+			for (var warning in arguments.result.warnings) {
+				if (isSimpleValue(warning) && len(warning)) {
+					arrayAppend(lines, "Warning: #warning#");
+				}
+			}
+		}
+		// Path / resolved-directory only when something above was wrong —
+		// a clean pass always carries bundlesDiscovered > 0 and must stay quiet.
+		if (interesting) {
+			if (structKeyExists(arguments.result, "directoryResolved") && isSimpleValue(arguments.result.directoryResolved) && len(arguments.result.directoryResolved)) {
+				arrayAppend(lines, "directoryResolved: #arguments.result.directoryResolved#");
+			}
+			if (structKeyExists(arguments.result, "testDirectoryPath") && isSimpleValue(arguments.result.testDirectoryPath) && len(arguments.result.testDirectoryPath)) {
+				arrayAppend(lines, "testDirectoryPath: #arguments.result.testDirectoryPath#");
+			}
+		}
+		return lines;
+	}
+
+	private void function $printTestResultDiagnostics(required any result) {
+		for (var line in $testResultDiagnosticLines(arguments.result)) {
+			out("        #line#", "yellow");
+		}
 	}
 
 	/**

--- a/cli/lucli/tests/specs/commands/ConsoleCommandSpec.cfc
+++ b/cli/lucli/tests/specs/commands/ConsoleCommandSpec.cfc
@@ -1,36 +1,94 @@
 /**
- * Regression for the `/models`, `/routes`, `/version`, `/datasource`
- * console commands. They route through `consoleExec`, which previously
- * declared a `required string url` parameter that the CFML URL scope
- * shadowed — `makeHttpPost(url, body)` then received the URL scope
- * struct and threw "Cannot cast Object type [url] to a value of type
- * [string]".
+ * Console command contracts.
  *
- * Regression cover is source-level: `consoleExec` is private and makes
- * a real HTTP call, so the cheapest accurate check is asserting the
- * parameter name no longer collides with the reserved scope. See
- * `ReloadCommandSpec.cfc` for the same source-inspection pattern.
+ * `consoleExec` is private and makes a real HTTP call, so reserved-scope
+ * cover stays source-level (see ReloadCommandSpec). Exit-code and model
+ * validation wiring is asserted both at source (print-then-throw, no
+ * silent `return ""` on ping failure) and by exercising the public
+ * `$consoleModelHasErrors` helper.
  */
 component extends="wheels.wheelstest.system.BaseSpec" {
+
+	function beforeAll() {
+		variables.testHelper = new cli.lucli.tests.TestHelper();
+		variables.tempRoot = testHelper.scaffoldTempProject(expandPath("/"));
+		directoryCreate(tempRoot & "/vendor/wheels", true, true);
+		variables.mod = new cli.lucli.Module(cwd = variables.tempRoot);
+		variables.moduleSource = fileRead(expandPath("/cli/lucli/Module.cfc"));
+	}
+
+	function afterAll() {
+		testHelper.cleanupTempProject(variables.tempRoot);
+	}
 
 	function run() {
 
 		describe("Module.cfc::consoleExec — reserved-scope shadowing", () => {
 
 			it("does not declare a bare `url` parameter that the URL scope would shadow", () => {
-				var moduleSource = fileRead(expandPath("/cli/lucli/Module.cfc"));
 				var pattern = "function consoleExec\(\s*required\s+string\s+url\b";
-				expect(reFind(pattern, moduleSource) > 0).toBeFalse(
+				expect(reFind(pattern, variables.moduleSource) > 0).toBeFalse(
 					"consoleExec must not use `url` as a parameter name — it collides with the CFML URL scope and breaks /models, /routes, /version, /datasource (issue ##2582)."
 				);
 			});
 
 			it("does not pass a bare `url` reference into makeHttpPost", () => {
-				var moduleSource = fileRead(expandPath("/cli/lucli/Module.cfc"));
-				expect(moduleSource).notToInclude(
+				expect(variables.moduleSource).notToInclude(
 					"makeHttpPost(url,",
 					"makeHttpPost must receive an unshadowed string argument; bare `url` resolves to the URL scope struct on a request."
 				);
+			});
+
+		});
+
+		describe("Module.cfc::console — non-zero exit on eval / connect failure", () => {
+
+			it("throws Wheels.ConsoleFailed from $consoleFail instead of returning empty on ping failure", () => {
+				expect(variables.moduleSource).toInclude("Wheels.ConsoleFailed");
+				expect(variables.moduleSource).toInclude("$consoleFail(");
+				expect(reFindNoCase("function\s+\$consoleFail\s*\(", variables.moduleSource)).toBeGT(0);
+			});
+
+			it("console() does not return empty string after a failed ping", () => {
+				var startIdx = reFindNoCase("(?m)^[ \t]*public\s+string\s+function\s+console\s*\(", variables.moduleSource);
+				expect(startIdx).toBeGT(0);
+				var nextFn = reFindNoCase("(?m)^[ \t]*(public|private)\s+\w+\s+function\s+", variables.moduleSource, startIdx + 1);
+				var bodyLen = nextFn > startIdx ? nextFn - startIdx : 2500;
+				var body = mid(variables.moduleSource, startIdx, bodyLen);
+				expect(body).toInclude("$consoleFail(");
+				expect(body).toInclude("One or more console expressions failed");
+				expect(find("return """";", body)).toBeGT(0, "successful sessions still return empty string");
+				// The pre-fix pattern: print "Console connection failed" then `return ""`.
+				expect(reFind("Console connection failed[\s\S]{0,200}return\s+"""";", body)).toBe(0);
+			});
+
+			it("consoleExec returns boolean so the REPL can record a failed expression", () => {
+				expect(reFindNoCase("private\s+boolean\s+function\s+consoleExec\s*\(", variables.moduleSource)).toBeGT(0);
+			});
+
+			it("throws on EOF when any expression failed", () => {
+				expect(variables.moduleSource).toInclude("if (hadError)");
+				expect(variables.moduleSource).toInclude("One or more console expressions failed");
+			});
+
+		});
+
+		describe("$consoleModelHasErrors — invalid create is a failed expression", () => {
+
+			it("is true when the model payload reports _hasErrors", () => {
+				expect(mod.$consoleModelHasErrors('{"title":"Console Post","_hasErrors":true,"_errors":["publishedAt: [empty]"]}')).toBeTrue();
+			});
+
+			it("is false when the model payload reports no errors", () => {
+				expect(mod.$consoleModelHasErrors('{"title":"Console Post","_hasErrors":false,"_key":1}')).toBeFalse();
+			});
+
+			it("is false when the payload has no _hasErrors key (new() / finders)", () => {
+				expect(mod.$consoleModelHasErrors('{"title":"Console Post","_isNew":true}')).toBeFalse();
+			});
+
+			it("is false for non-JSON", () => {
+				expect(mod.$consoleModelHasErrors("not-json")).toBeFalse();
 			});
 
 		});

--- a/cli/lucli/tests/specs/commands/TestExitFailClosedSpec.cfc
+++ b/cli/lucli/tests/specs/commands/TestExitFailClosedSpec.cfc
@@ -244,6 +244,53 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 
 		});
 
+		describe("$testResultDiagnosticLines — runner JSON that is not a TestBox pass", () => {
+
+			it("is empty for a clean TestBox pass (no populate/0-bundle noise)", () => {
+				expect(
+					arrayLen(
+						mod.$testResultDiagnosticLines({
+							totalPass: 12,
+							totalFail: 0,
+							totalError: 0,
+							bundlesDiscovered: 6,
+							directoryRejected: false,
+							warnings: []
+						})
+					)
+				).toBe(0);
+			});
+
+			it("surfaces populate/constructor errors that the compile-skip WARN used to hide", () => {
+				var lines = mod.$testResultDiagnosticLines({
+					success: false,
+					error: "tests/populate.cfm failed",
+					message: "Test-db migration did not complete cleanly",
+					detail: "Error migrating 003",
+					bundlesDiscovered: 0
+				});
+				var joined = arrayToList(lines, chr(10));
+				expect(joined).toInclude("tests/populate.cfm failed");
+				expect(joined).toInclude("Test-db migration did not complete cleanly");
+				expect(joined).toInclude("Error migrating 003");
+				expect(joined).toInclude("bundlesDiscovered: 0");
+			});
+
+			it("surfaces a missing test-directory mapping", () => {
+				var lines = mod.$testResultDiagnosticLines({
+					testDirectoryExists: false,
+					testDirectoryPath: "/tmp/app/public/tests/specs",
+					directoryResolved: "tests.specs",
+					warnings: ["Test directory mapping 'tests.specs' expanded to '/tmp/app/public/tests/specs' which does not exist."]
+				});
+				var joined = arrayToList(lines, chr(10));
+				expect(joined).toInclude("testDirectoryExists: false");
+				expect(joined).toInclude("/tmp/app/public/tests/specs");
+				expect(joined).toInclude("does not exist");
+			});
+
+		});
+
 	}
 
 }

--- a/cli/lucli/tests/test-server-required-exit-codes.sh
+++ b/cli/lucli/tests/test-server-required-exit-codes.sh
@@ -17,10 +17,10 @@
 #   wheels db status       — surfaced by audit (same pattern)
 #   wheels db version      — surfaced by audit (same pattern)
 #
-# `wheels console` is excluded — its success path reads from stdin, so driving
-# it from a non-interactive shell test without a server is already covered by
-# type-parity with the other throws. (Same rationale as the TemplateNotFound
-# case in test-new-exit-codes.sh.)
+# `wheels console` is excluded here — its success path reads from stdin.
+# Connection/eval failures now throw `Wheels.ConsoleFailed` (same print-then-
+# throw contract as reload). Covered by ConsoleCommandSpec source + helper
+# tests, not this no-server smoke.
 #
 # Prerequisites:
 #   - wheels binary on PATH

--- a/tools/test-tutorial-e2e.sh
+++ b/tools/test-tutorial-e2e.sh
@@ -151,12 +151,18 @@ else
 fi
 
 wait_for_server() {
+    # Any HTTP response (including 500 during applicationStop() / first
+    # compile after `wheels reload` purges cfclasses) used to count as
+    # "up". Require 200 so later beats do not race a half-started app.
+    local code=""
     for i in $(seq 1 120); do
-        if curl -s -o /dev/null --connect-timeout 2 --max-time 3 "http://localhost:$PORT/" 2>/dev/null; then
+        code="$(curl -s -o /dev/null --connect-timeout 2 --max-time 10 -w '%{http_code}' "http://localhost:$PORT/" 2>/dev/null || echo 000)"
+        if [ "$code" = "200" ]; then
             return 0
         fi
         sleep 2
     done
+    echo "  last HTTP status from /: ${code:-000}"
     return 1
 }
 if wait_for_server; then
@@ -342,11 +348,109 @@ run_cli migrate latest > "$TMPDIR/migrate3.log" 2>&1 \
     && pass "migrate (auth) exited 0" || { fail "migrate (auth) failed"; cat "$TMPDIR/migrate3.log"; }
 
 # ── Beat 6: test ──────────────────────────────────────────────────────────
-reload_app
+# `wheels test` hits the isolated `#3374` application (`<name>_wheelsTest`).
+# Reloading the *live* app immediately beforehand is unnecessary (the
+# isolated app cold-starts from current source) and harmful: `wheels reload`
+# wipes Lucee's cfclass cache, then the first TestBox directory scan can
+# return 0 bundles. The CLI then reports every on-disk *Spec.cfc as
+# "failed to compile" even when the runner JSON is a populate/constructor
+# error or an empty discovery — which is what CI showed after the console
+# flake was fixed (6 specs, 0 passed, ~2s).
 echo ""
 echo "==> test"
-run_cli test > "$TMPDIR/test.log" 2>&1 \
-    && pass "test exited 0" || { fail "test failed"; tail -40 "$TMPDIR/test.log"; }
+if wait_for_server; then
+    pass "server HTTP 200 before test"
+else
+    fail "server not HTTP 200 before test"
+fi
+
+wait_for_test_app() {
+    # Start the isolated test application on a cheap request so `wheels test`
+    # is not the first hit after a cfclass purge / live-app restart.
+    local i code=""
+    for i in $(seq 1 30); do
+        code="$(curl -s -o /dev/null --connect-timeout 2 --max-time 30 -w '%{http_code}' \
+            -H "X-Wheels-Test-Context: 1" \
+            "http://localhost:$PORT/" 2>/dev/null || echo 000)"
+        if [ "$code" = "200" ]; then
+            return 0
+        fi
+        sleep 2
+    done
+    echo "  isolated test app last HTTP status: ${code:-000}"
+    return 1
+}
+
+dump_test_runner_json() {
+    echo "  --- /wheels/app/tests?format=json ---"
+    local body
+    body="$(curl -s --connect-timeout 2 --max-time 90 \
+        "http://localhost:$PORT/wheels/app/tests?format=json&useTestDB=true" 2>/dev/null || true)"
+    if command -v python3 >/dev/null 2>&1 && [ -n "$body" ]; then
+        printf '%s' "$body" | python3 -c '
+import json, sys
+raw = sys.stdin.read()
+try:
+    d = json.loads(raw)
+except Exception:
+    print(raw[:4096])
+    sys.exit(0)
+keys = (
+    "success", "error", "message", "detail",
+    "bundlesDiscovered", "directoryRejected", "directoryResolved",
+    "testDirectoryPath", "testDirectoryExists", "warnings",
+    "totalPass", "totalFail", "totalError",
+)
+for k in keys:
+    if k in d:
+        print("  %s: %r" % (k, d[k]))
+snippet = d.get("RootCause") or d.get("rootCause")
+if snippet:
+    print("  RootCause: %r" % (snippet,))
+' || printf '%s\n' "${body:0:4096}"
+    else
+        printf '%s\n' "${body:0:4096}"
+    fi
+    echo "  --- end runner JSON ---"
+}
+
+run_wheels_test() {
+    local code=0
+    run_cli test > "$TMPDIR/test.log" 2>&1 || code=$?
+    if [ "$code" -ne 0 ]; then
+        return 1
+    fi
+    if grep -q 'failed to load' "$TMPDIR/test.log"; then
+        return 1
+    fi
+    if ! grep -qE '[1-9][0-9]* passed' "$TMPDIR/test.log"; then
+        return 1
+    fi
+    return 0
+}
+
+if wait_for_test_app; then
+    pass "isolated test app ready"
+else
+    echo "  WARN isolated test app not HTTP 200 yet; continuing to wheels test"
+fi
+
+if run_wheels_test; then
+    pass "test exited 0"
+else
+    echo "  first wheels test attempt failed; dumping runner JSON and retrying"
+    dump_test_runner_json
+    tail -40 "$TMPDIR/test.log" || true
+    wait_for_server || true
+    wait_for_test_app || true
+    if run_wheels_test; then
+        pass "test exited 0 (after retry)"
+    else
+        fail "test failed"
+        dump_test_runner_json
+        tail -40 "$TMPDIR/test.log" || true
+    fi
+fi
 grep -qE 'passed' "$TMPDIR/test.log" && pass "test reported results" || fail "test output missing pass count"
 
 # ── Report ────────────────────────────────────────────────────────────────

--- a/tools/test-tutorial-e2e.sh
+++ b/tools/test-tutorial-e2e.sh
@@ -203,19 +203,22 @@ reload_app() {
 wait_for_console() {
     local password=""
     if [ -f "$APP_DIR/.env" ]; then
-        password="$(grep -E '^(WHEELS_)?RELOAD_PASSWORD=' "$APP_DIR/.env" | head -1 | cut -d= -f2- | tr -d '[:space:]' | tr -d '"' | tr -d "'")"
+        # First matching RELOAD_PASSWORD assignment; strip quotes/CR.
+        password="$(grep -E '^(WHEELS_)?RELOAD_PASSWORD=' "$APP_DIR/.env" | head -1 | cut -d= -f2- | tr -d '\r\n\t "')"
     fi
     local i body
-    for i in $(seq 1 60); do
+    for i in $(seq 1 30); do
         body="$(curl -s --connect-timeout 2 --max-time 10 \
             -X POST -H "Content-Type: application/json" \
             -d "{\"expression\":\"__ping__\",\"password\":\"${password}\"}" \
             "http://localhost:$PORT/wheels/console/eval" 2>/dev/null || true)"
-        if printf '%s' "$body" | grep -q '"success"[[:space:]]*:[[:space:]]*true'; then
+        # serializeJSON key case varies by engine (success vs SUCCESS).
+        if printf '%s' "$body" | grep -qiE '"success"[[:space:]]*:[[:space:]]*true'; then
             return 0
         fi
         sleep 2
     done
+    echo "  last console ping body: ${body:0:300}"
     return 1
 }
 
@@ -224,8 +227,10 @@ wait_for_console() {
 # so a silent no-op create cannot look like success.
 run_console_expr() {
     local expr="$1" label="$2" expect_re="${3:-}"
-    printf '%s\n' "$expr" | run_cli console > "$TMPDIR/console.log" 2>&1
-    local code=$?
+    local code=0
+    # pipefail + set -e would abort the whole script on a non-zero
+    # console exit before we can dump the log — capture it instead.
+    printf '%s\n' "$expr" | run_cli console > "$TMPDIR/console.log" 2>&1 || code=$?
     if [ "$code" -ne 0 ]; then
         fail "$label — console exited $code"
         cat "$TMPDIR/console.log"
@@ -282,8 +287,8 @@ run_console_expr \
     "console create persisted" \
     '_isNew: (false|no)'
 run_console_expr \
-    'model("Post").count(where="title=''Console Post''")' \
-    "console count of Console Post is 1" \
+    'model("Post").count()' \
+    "console count of posts is 1" \
     '=> 1'
 
 echo "==> routes"

--- a/tools/test-tutorial-e2e.sh
+++ b/tools/test-tutorial-e2e.sh
@@ -189,8 +189,65 @@ else
 fi
 
 reload_app() {
+    # `wheels reload` applicationStop()s; the next request re-runs
+    # onApplicationStart. A fixed sleep raced the first-compile of a
+    # freshly scaffolded Post model on cold CI runners. Wait for `/`
+    # to answer again instead.
     run_cli reload > /dev/null 2>&1 || true
-    sleep 2
+    wait_for_server || true
+}
+
+# POST /wheels/console/eval __ping__ until the eval surface is actually
+# ready (password + JSON + success=true). `/` coming up is not enough:
+# after reload the first eval can still 500 while models compile.
+wait_for_console() {
+    local password=""
+    if [ -f "$APP_DIR/.env" ]; then
+        password="$(grep -E '^(WHEELS_)?RELOAD_PASSWORD=' "$APP_DIR/.env" | head -1 | cut -d= -f2- | tr -d '[:space:]' | tr -d '"' | tr -d "'")"
+    fi
+    local i body
+    for i in $(seq 1 60); do
+        body="$(curl -s --connect-timeout 2 --max-time 10 \
+            -X POST -H "Content-Type: application/json" \
+            -d "{\"expression\":\"__ping__\",\"password\":\"${password}\"}" \
+            "http://localhost:$PORT/wheels/console/eval" 2>/dev/null || true)"
+        if printf '%s' "$body" | grep -q '"success"[[:space:]]*:[[:space:]]*true'; then
+            return 0
+        fi
+        sleep 2
+    done
+    return 1
+}
+
+# Run one console expression. Fails the check (and dumps the log) when the
+# CLI exits non-zero, prints `Error:`, or reports a validation failure —
+# so a silent no-op create cannot look like success.
+run_console_expr() {
+    local expr="$1" label="$2" expect_re="${3:-}"
+    printf '%s\n' "$expr" | run_cli console > "$TMPDIR/console.log" 2>&1
+    local code=$?
+    if [ "$code" -ne 0 ]; then
+        fail "$label — console exited $code"
+        cat "$TMPDIR/console.log"
+        return 0
+    fi
+    if grep -q '^Error:' "$TMPDIR/console.log"; then
+        fail "$label — console printed Error:"
+        cat "$TMPDIR/console.log"
+        return 0
+    fi
+    if grep -q 'Validation failed' "$TMPDIR/console.log"; then
+        fail "$label — model validation failed"
+        cat "$TMPDIR/console.log"
+        return 0
+    fi
+    if [ -n "$expect_re" ] && ! grep -qiE "$expect_re" "$TMPDIR/console.log"; then
+        fail "$label — console output missing /$expect_re/"
+        cat "$TMPDIR/console.log"
+        return 0
+    fi
+    pass "$label"
+    return 0
 }
 
 # ── Beat 2: scaffold Post + migrate + routes ──────────────────────────────
@@ -210,11 +267,24 @@ run_cli migrate latest > "$TMPDIR/migrate.log" 2>&1 \
     && pass "migrate latest exited 0" || { fail "migrate latest failed"; cat "$TMPDIR/migrate.log"; }
 
 reload_app
+if wait_for_console; then
+    pass "console eval endpoint ready after reload"
+else
+    fail "console eval endpoint not ready after reload"
+fi
 echo "==> console: create a Post"
 # The scaffold adds validatesPresenceOf("title,body,publishedAt"), so pass all three.
-printf '%s\n' 'model("Post").create(title="Console Post", body="Created from the console", publishedAt=Now())' \
-    | run_cli console > "$TMPDIR/console.log" 2>&1 \
-    && pass "console create exited 0" || { fail "console create failed"; cat "$TMPDIR/console.log"; }
+# create() returns the model even when validation fails — the CLI now treats
+# `_hasErrors` as a failed expression (non-zero on EOF). Also assert the
+# row is actually queryable before we look at /posts.
+run_console_expr \
+    'model("Post").create(title="Console Post", body="Created from the console", publishedAt=Now())' \
+    "console create persisted" \
+    '_isNew: (false|no)'
+run_console_expr \
+    'model("Post").count(where="title=''Console Post''")' \
+    "console count of Console Post is 1" \
+    '=> 1'
 
 echo "==> routes"
 run_cli routes > "$TMPDIR/routes.log" 2>&1 \
@@ -236,10 +306,15 @@ echo ""
 echo "==> HTTP surface"
 assert_http "/posts" 200 "GET /posts"
 assert_http "/posts.json" 200 "GET /posts.json (format suffix)"
-if curl -s "http://localhost:$PORT/posts" | grep -q "Console Post"; then
+POSTS_BODY="$(curl -s --connect-timeout 2 --max-time 15 "http://localhost:$PORT/posts" 2>/dev/null || true)"
+if printf '%s' "$POSTS_BODY" | grep -q "Console Post"; then
     pass "console-created Post appears in /posts"
 else
     fail "console-created Post missing from /posts"
+    echo "  --- /posts body (first 2k) ---"
+    printf '%s' "$POSTS_BODY" | head -c 2048
+    echo ""
+    echo "  --- end /posts body ---"
 fi
 
 # ── Beat 7: api-resource + .json ──────────────────────────────────────────

--- a/vendor/wheels/public/views/consoleeval.cfm
+++ b/vendor/wheels/public/views/consoleeval.cfm
@@ -199,80 +199,95 @@ if (!StructKeyExists(variables, "$consoleEvalHandleBuiltInCommands")) {
 	};
 }
 
+if (!StructKeyExists(variables, "$consoleEvalFormatQuery")) {
+	variables.$consoleEvalFormatQuery = function(required evalResult, required response) {
+		local.response = arguments.response;
+		local.response.type = "query";
+		local.cols = listToArray(arguments.evalResult.columnList);
+		local.rows = [];
+		local.rowCount = 0;
+		for (local.row in arguments.evalResult) {
+			local.rowCount++;
+			// Limit to 100 rows to avoid huge responses
+			if (local.rowCount > 100) break;
+			local.r = {};
+			for (local.col in local.cols) {
+				local.r[local.col] = isNull(local.row[local.col]) ? "" : local.row[local.col];
+			}
+			arrayAppend(local.rows, local.r);
+		}
+		local.response.result = serializeJSON({
+			columns: local.cols,
+			recordCount: arguments.evalResult.recordCount,
+			data: local.rows
+		});
+	};
+}
+
+if (!StructKeyExists(variables, "$consoleEvalFormatModel")) {
+	variables.$consoleEvalFormatModel = function(required evalResult, required response) {
+		local.evalResult = arguments.evalResult;
+		local.response = arguments.response;
+		local.response.type = "model";
+		try {
+			local.props = local.evalResult.properties();
+			if (structKeyExists(local.evalResult, "key") && isCustomFunction(local.evalResult.key)) {
+				local.props["_key"] = local.evalResult.key();
+			}
+			if (structKeyExists(local.evalResult, "isNew") && isCustomFunction(local.evalResult.isNew)) {
+				local.props["_isNew"] = local.evalResult.isNew();
+			}
+			$consoleEvalAttachModelErrors(local.evalResult, local.props);
+			local.response.result = serializeJSON(local.props);
+		} catch (any e) {
+			local.response.result = getMetadata(local.evalResult).name ?: "Model";
+			local.response.type = "object";
+		}
+	};
+}
+
+if (!StructKeyExists(variables, "$consoleEvalAttachModelErrors")) {
+	variables.$consoleEvalAttachModelErrors = function(required evalResult, required props) {
+		// Validation state so the CLI can fail a piped session when
+		// `.create()` returned an unsaved invalid model.
+		local.errorMeta = {hasErrors = false, errors = []};
+		if (structKeyExists(arguments.evalResult, "hasErrors") && isCustomFunction(arguments.evalResult.hasErrors)) {
+			local.errorMeta.hasErrors = arguments.evalResult.hasErrors();
+		}
+		if (
+			local.errorMeta.hasErrors
+			&& structKeyExists(arguments.evalResult, "allErrors")
+			&& isCustomFunction(arguments.evalResult.allErrors)
+		) {
+			local.rawErrors = arguments.evalResult.allErrors();
+			for (local.err in local.rawErrors) {
+				local.propName = structKeyExists(local.err, "property") ? local.err.property : "";
+				local.msg = structKeyExists(local.err, "message") ? local.err.message : "";
+				arrayAppend(
+					local.errorMeta.errors,
+					len(local.propName) ? (local.propName & ": " & local.msg) : local.msg
+				);
+			}
+		}
+		arguments.props["_hasErrors"] = local.errorMeta.hasErrors;
+		arguments.props["_errors"] = local.errorMeta.errors;
+	};
+}
+
 if (!StructKeyExists(variables, "$consoleEvalFormatResult")) {
 	variables.$consoleEvalFormatResult = function(required evalResult, required response) {
 		local.evalResult = arguments.evalResult;
 		local.response = arguments.response;
 
 		if (!isNull(local.evalResult)) {
-			// Query objects (from findAll, etc.)
 			if (isQuery(local.evalResult)) {
-				local.response.type = "query";
-				local.cols = listToArray(local.evalResult.columnList);
-				local.rows = [];
-				local.rowCount = 0;
-				for (local.row in local.evalResult) {
-					local.rowCount++;
-					// Limit to 100 rows to avoid huge responses
-					if (local.rowCount > 100) break;
-					local.r = {};
-					for (local.col in local.cols) {
-						local.r[local.col] = isNull(local.row[local.col]) ? "" : local.row[local.col];
-					}
-					arrayAppend(local.rows, local.r);
-				}
-				local.response.result = serializeJSON({
-					columns: local.cols,
-					recordCount: local.evalResult.recordCount,
-					data: local.rows
-				});
-
-			// Wheels model objects (from findByKey, findOne, new)
+				$consoleEvalFormatQuery(local.evalResult, local.response);
 			} else if (
 				isObject(local.evalResult)
 				&& structKeyExists(local.evalResult, "properties")
 				&& isCustomFunction(local.evalResult.properties)
 			) {
-				local.response.type = "model";
-				try {
-					local.props = local.evalResult.properties();
-					// Add key if available
-					if (structKeyExists(local.evalResult, "key") && isCustomFunction(local.evalResult.key)) {
-						local.props["_key"] = local.evalResult.key();
-					}
-					if (structKeyExists(local.evalResult, "isNew") && isCustomFunction(local.evalResult.isNew)) {
-						local.props["_isNew"] = local.evalResult.isNew();
-					}
-					// Validation state so the CLI can fail a piped session
-					// when `.create()` returned an unsaved invalid model.
-					local.errorMeta = {hasErrors = false, errors = []};
-					if (structKeyExists(local.evalResult, "hasErrors") && isCustomFunction(local.evalResult.hasErrors)) {
-						local.errorMeta.hasErrors = local.evalResult.hasErrors();
-					}
-					if (
-						local.errorMeta.hasErrors
-						&& structKeyExists(local.evalResult, "allErrors")
-						&& isCustomFunction(local.evalResult.allErrors)
-					) {
-						local.rawErrors = local.evalResult.allErrors();
-						for (local.err in local.rawErrors) {
-							local.propName = structKeyExists(local.err, "property") ? local.err.property : "";
-							local.msg = structKeyExists(local.err, "message") ? local.err.message : "";
-							arrayAppend(
-								local.errorMeta.errors,
-								len(local.propName) ? (local.propName & ": " & local.msg) : local.msg
-							);
-						}
-					}
-					local.props["_hasErrors"] = local.errorMeta.hasErrors;
-					local.props["_errors"] = local.errorMeta.errors;
-					local.response.result = serializeJSON(local.props);
-				} catch (any e) {
-					local.response.result = getMetadata(local.evalResult).name ?: "Model";
-					local.response.type = "object";
-				}
-
-			// Simple values (strings, numbers, booleans)
+				$consoleEvalFormatModel(local.evalResult, local.response);
 			} else if (isSimpleValue(local.evalResult)) {
 				if (isNumeric(local.evalResult)) {
 					local.response.type = "number";
@@ -282,24 +297,16 @@ if (!StructKeyExists(variables, "$consoleEvalFormatResult")) {
 					local.response.type = "string";
 				}
 				local.response.result = toString(local.evalResult);
-
-			// Structs
 			} else if (isStruct(local.evalResult)) {
 				local.response.type = "struct";
 				local.response.result = serializeJSON(local.evalResult);
-
-			// Arrays
 			} else if (isArray(local.evalResult)) {
 				local.response.type = "array";
 				local.response.result = serializeJSON(local.evalResult);
-
-			// Other objects (services, components, etc.)
 			} else if (isObject(local.evalResult)) {
 				local.response.type = "object";
 				local.meta = getMetadata(local.evalResult);
 				local.response.result = local.meta.name ?: "Object";
-
-			// Fallback
 			} else {
 				local.response.type = "unknown";
 				try {

--- a/vendor/wheels/public/views/consoleeval.cfm
+++ b/vendor/wheels/public/views/consoleeval.cfm
@@ -243,6 +243,29 @@ if (!StructKeyExists(variables, "$consoleEvalFormatResult")) {
 					if (structKeyExists(local.evalResult, "isNew") && isCustomFunction(local.evalResult.isNew)) {
 						local.props["_isNew"] = local.evalResult.isNew();
 					}
+					// Validation state so the CLI can fail a piped session
+					// when `.create()` returned an unsaved invalid model.
+					local.errorMeta = {hasErrors = false, errors = []};
+					if (structKeyExists(local.evalResult, "hasErrors") && isCustomFunction(local.evalResult.hasErrors)) {
+						local.errorMeta.hasErrors = local.evalResult.hasErrors();
+					}
+					if (
+						local.errorMeta.hasErrors
+						&& structKeyExists(local.evalResult, "allErrors")
+						&& isCustomFunction(local.evalResult.allErrors)
+					) {
+						local.rawErrors = local.evalResult.allErrors();
+						for (local.err in local.rawErrors) {
+							local.propName = structKeyExists(local.err, "property") ? local.err.property : "";
+							local.msg = structKeyExists(local.err, "message") ? local.err.message : "";
+							arrayAppend(
+								local.errorMeta.errors,
+								len(local.propName) ? (local.propName & ": " & local.msg) : local.msg
+							);
+						}
+					}
+					local.props["_hasErrors"] = local.errorMeta.hasErrors;
+					local.props["_errors"] = local.errorMeta.errors;
 					local.response.result = serializeJSON(local.props);
 				} catch (any e) {
 					local.response.result = getMetadata(local.evalResult).name ?: "Model";

--- a/vendor/wheels/tests/app-runner.cfm
+++ b/vendor/wheels/tests/app-runner.cfm
@@ -117,6 +117,12 @@
                 }
             }
 
+            // Expand the TestBox mapping up front so constructor / run failures
+            // can report the filesystem path (a missing `/tests` mapping after
+            // applicationStop() looks exactly like "specs failed to compile").
+            local.testFsPath = ExpandPath("/" & Replace(local.testDirectory, ".", "/", "all"));
+            local.testDirectoryExists = DirectoryExists(local.testFsPath);
+
             try {
                 testBox = new wheels.wheelstest.system.TestBox(
                     directory = local.testDirectory,
@@ -128,7 +134,11 @@
                 writeOutput(SerializeJSON({
                     success: false,
                     error: "Failed to create TestBox instance",
-                    message: e.message
+                    message: e.message,
+                    detail: e.detail ?: "",
+                    directoryResolved: local.testDirectory,
+                    testDirectoryPath: local.testFsPath,
+                    testDirectoryExists: local.testDirectoryExists
                 }));
                 abort;
             }
@@ -145,6 +155,13 @@
                 scope = local.testScope,
                 bundlesDiscovered = local.bundlesDiscovered
             );
+            if (!local.testDirectoryExists) {
+                ArrayAppend(
+                    local.scopeWarnings,
+                    "Test directory mapping '" & local.testDirectory & "' expanded to '"
+                    & local.testFsPath & "' which does not exist."
+                );
+            }
 
             // Resolve the output format (reporter + content type + whether to
             // render an HTML report) through TestFormatResolver so the rule is
@@ -155,7 +172,24 @@
             local.output = local.fmtResolver.resolveFormat(url);
 
             if (local.output.recognized) {
-                result = testBox.run(reporter = local.output.reporter);
+                try {
+                    result = testBox.run(reporter = local.output.reporter);
+                } catch (any runErr) {
+                    cfheader(statuscode = 500);
+                    cfcontent(type = "application/json");
+                    writeOutput(SerializeJSON({
+                        success: false,
+                        error: "TestBox run failed",
+                        message: runErr.message,
+                        detail: runErr.detail ?: "",
+                        bundlesDiscovered: local.bundlesDiscovered,
+                        directoryResolved: local.testDirectory,
+                        testDirectoryPath: local.testFsPath,
+                        testDirectoryExists: local.testDirectoryExists,
+                        warnings: local.scopeWarnings
+                    }));
+                    abort;
+                }
 
                 if (local.output.rendersHtml) {
                     // Render the TestBox-style HTML report for the html / no-format

--- a/vendor/wheels/tests/specs/security/ConsoleEvalModelMetaSpec.cfc
+++ b/vendor/wheels/tests/specs/security/ConsoleEvalModelMetaSpec.cfc
@@ -1,0 +1,25 @@
+/**
+ * consoleeval model payloads must carry validation state so the CLI can
+ * fail a piped `wheels console` session when `.create()` returns an
+ * unsaved invalid model (the tutorial e2e flake: exit 0, then /posts
+ * missing the title).
+ */
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("consoleeval model result metadata", () => {
+
+			it("attaches _hasErrors and _errors on model results", () => {
+				var src = fileRead(expandPath("/wheels/public/views/consoleeval.cfm"));
+				expect(src).toInclude("_hasErrors");
+				expect(src).toInclude("_errors");
+				expect(src).toInclude("hasErrors");
+				expect(src).toInclude("allErrors");
+			});
+
+		});
+
+	}
+
+}

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/console-and-repl.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/console-and-repl.mdx
@@ -151,6 +151,23 @@ Any of these end the session:
 
 There is no `.exit` command. Typing `exit` or `quit` without the leading slash will be evaluated as a CFML expression and produce an error.
 
+### Scripting and exit codes
+
+Piped sessions (EOF after one or more expressions) exit non-zero when:
+
+- the console cannot connect or the `__ping__` handshake fails
+- an expression evaluates with `success: false` (the CLI prints `Error: …`)
+- the result is a model that has validation errors (`.create()` that did not persist)
+
+Interactive `/exit` still returns 0 so a typo does not fail the whole session. Connection and ping failures always exit non-zero, interactive or not.
+
+```bash title="illustrative — fail a script when create does not persist"
+printf '%s\n' 'model("Post").create(title="Console Post", body="Created from the console", publishedAt=Now())' \
+  | wheels console
+```
+
+`model().create()` returns the object even when validation fails. The console treats `_hasErrors` on that result as a failed expression, so the pipeline above is a safe gate — do not assert success from the CLI exit code alone without this contract.
+
 <Aside type="note" title="Expressions, not statements">
 Each line is evaluated as a CFML expression. Variable assignments work (`var x = 1`), but multi-line blocks, `if`/`else` control flow, and `cfscript` component declarations are not supported — wrap them in a `.cfm` script and execute that instead.
 </Aside>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the flaky Tutorial E2E check in `tools/test-tutorial-e2e.sh`. Two stacked failures showed up on CI:

1. **Original flake (fixed):** `console-created Post missing from /posts` — `wheels console` always exited 0, so a failed/skipped create looked like success.
2. **Follow-up on the latest push:** after create/count/`/posts` all passed, `wheels test` reported `0 passed, 6 failed to load` for the scaffold/auth/api-resource specs.

## Root cause

### Console exit code

`wheels console` returned `""` (exit 0) after ping/connect failure, after `consoleExec` printed `Error:`, and after `model().create()` returned an unsaved invalid model. Same class as GH #2229 / #2941.

### Specs “failed to compile”

CI job `34379772692` finished `wheels test` in ~2.5s (LuCLI startup dominates) with **no parse-error payload**. The CLI WARN is a disk-vs-`bundleStats` proxy: any JSON without loaded bundles is labeled “failed to compile,” including:

- `tests/populate.cfm` 500 JSON
- TestBox constructor failure
- **0-bundle discovery** after `wheels reload` wipes Lucee’s cfclass cache (`$purgeServerCfclasses`) and the next request races `applicationStop()` / first compile

This PR’s earlier `reload_app` change (replace `sleep 2` with “any HTTP response”) made that race more likely. Generated spec templates have no unescaped `#`; this is not six independent CFC syntax errors.

## What changed

**CLI (`console()`)** — ping/connect failure throws; piped EOF exits non-zero if any expression failed; model `_hasErrors` counts as failure.

**Eval endpoint** — model JSON includes `_hasErrors` / `_errors`. Format helpers stay under complexity 30.

**`wheels test` diagnostics** — when on-disk specs are not loaded, print runner `error` / `message` / `detail` / `bundlesDiscovered` / mapping-path warnings instead of only “failed to compile.”

**App runner** — TestBox constructor/run failures and a missing expanded `tests.specs` path are returned as JSON (so CI can dump them).

**Tutorial e2e**

- Wait for HTTP **200** on `/` (not any response).
- Do **not** live-reload immediately before `wheels test` (avoids a cfclass purge racing the isolated `#3374` app).
- Warm the isolated test app (`X-Wheels-Test-Context`) first.
- On failure: dump `/wheels/app/tests?format=json` keys, retry once.

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Feature Completeness Checklist

- [x] **DCO sign-off** -- `git commit -s`
- [x] **Tests** -- `ConsoleCommandSpec`; `ConsoleEvalModelMetaSpec`; `TestExitFailClosedSpec` diagnostics (21/21)
- [x] **Framework Docs** -- `console-and-repl.mdx` scripting / exit-code section
- [ ] **AI Reference Docs** -- not required
- [ ] **CLAUDE.md** -- not required
- [x] **Changelog fragment** -- `changelog.d/console-eval-exit-code.fixed.md`, `changelog.d/tutorial-e2e-test-load.fixed.md`
- [x] **Complexity gate** -- `consoleEvalFormatResult` 14

## Test Plan

- [x] `bash -n tools/test-tutorial-e2e.sh`
- [x] `TestExitFailClosedSpec` — 21 passed / 0 failed (including the new diagnostic lines)
- [x] `PORT=60107 bash tools/test-tutorial-e2e.sh` — **28/28 TUTORIAL E2E PASSED** (test beat green without retry)
- [x] Prior revision: `bash tools/test-local.sh security` — 303 passed; ConsoleCommandSpec 10/10

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-680d7091-c1d3-4095-af6e-eb5407fc061e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-680d7091-c1d3-4095-af6e-eb5407fc061e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

