### PR TITLE
feat(errors): Copy button on error page for clipboard JSON (#3552)

### DIFF
--- a/changelog.d/3552-error-page-copy.added.md
+++ b/changelog.d/3552-error-page-copy.added.md
@@ -1,0 +1,1 @@
+- Development error page now includes a Copy button that copies a JSON dump of the exception (type, message, suggested action, file and line, source snippet, and app/framework stack frames) to the clipboard for pasting into a coding agent (#3552)

--- a/docs/consumer-ai/CLAUDE.md
+++ b/docs/consumer-ai/CLAUDE.md
@@ -501,6 +501,14 @@ The CLI boots the app on an isolated port and runs the suite over HTTP,
 mirroring CI. Browser-driven specs need Playwright installed once:
 `wheels browser setup`.
 
+## Development Error Page
+
+When `showErrorInformation` is on (the development default), the framework
+error page includes a **Copy** button. One click copies a JSON payload
+(exception type and message, suggested action, file + line, source snippet,
+and stack frames tagged app vs framework) to the clipboard for pasting into
+a coding agent.
+
 ## Where to go deeper
 
 - Human guides: https://guides.wheels.dev (start-here, core-concepts, testing, deployment)

--- a/vendor/wheels/events/onerror/ErrorCopyPayload.cfc
+++ b/vendor/wheels/events/onerror/ErrorCopyPayload.cfc
@@ -1,0 +1,254 @@
+/**
+ * Builds a clipboard-ready JSON dump of a Wheels error-page exception.
+ *
+ * Used by `wheelserror.cfm` so a single Copy click can paste type, message,
+ * suggested action, location, source snippet, and classified stack frames
+ * into a coding agent. Standalone (not mixed in) so the template can
+ * `CreateObject` it from `application.wo` includes as well as EventMethods.
+ */
+component output="false" {
+
+	/**
+	 * Structured payload for the development error page clipboard.
+	 * The exception argument is untyped: Adobe's validator rejects a cfcatch
+	 * object passed to a struct-typed parameter (same reason cfmlerror.cfm
+	 * leaves its exception argument untyped).
+	 */
+	public struct function build(required any wheelsError) {
+		var exception = arguments.wheelsError;
+		var payload = {
+			source = "wheels-error-page",
+			exception = {
+				type = $structString(exception, "type"),
+				message = $structString(exception, "message"),
+				detail = $structString(exception, "detail")
+			},
+			suggestedAction = $structString(exception, "extendedInfo"),
+			location = {},
+			sourceSnippet = {},
+			stack = [],
+			request = $requestInfo()
+		};
+
+		var tagContext = [];
+		if (StructKeyExists(exception, "tagContext") && IsArray(exception.tagContext)) {
+			tagContext = exception.tagContext;
+		}
+		var frames = classifyFrames(tagContext = tagContext);
+		payload.stack = frames;
+
+		var locationFrame = $locationFrame(frames);
+		if (!StructIsEmpty(locationFrame)) {
+			payload.location = {
+				file = locationFrame.file,
+				line = locationFrame.line,
+				type = locationFrame.type,
+				template = locationFrame.template
+			};
+			payload.sourceSnippet = readSnippet(
+				templatePath = locationFrame.template,
+				lineNumber = locationFrame.line
+			);
+		}
+
+		if (IsDefined("application.wheels.version") && Len(application.wheels.version)) {
+			payload.wheelsVersion = application.wheels.version;
+		}
+
+		return payload;
+	}
+
+	public string function toJson(required any wheelsError) {
+		return SerializeJSON(build(wheelsError = arguments.wheelsError));
+	}
+
+	/**
+	 * Classify every tagContext entry the same way the error page does:
+	 * framework (`vendor/wheels`, public/index.cfm, public/Application.cfc),
+	 * library (other `vendor/`), plugin (`plugins/`), otherwise app.
+	 */
+	public array function classifyFrames(required any tagContext, string appRoot = "") {
+		var frames = [];
+		if (!IsArray(arguments.tagContext)) {
+			return frames;
+		}
+		var root = Len(arguments.appRoot) ? arguments.appRoot : $appRoot();
+		var count = ArrayLen(arguments.tagContext);
+		var i = 1;
+		for (i = 1; i <= count; i++) {
+			var entry = arguments.tagContext[i];
+			if (!IsStruct(entry) || !StructKeyExists(entry, "template")) {
+				continue;
+			}
+			var tpl = entry.template;
+			if (!IsSimpleValue(tpl) || !Len(tpl)) {
+				continue;
+			}
+			var frameLine = 0;
+			if (StructKeyExists(entry, "line") && IsNumeric(entry.line)) {
+				frameLine = Val(entry.line);
+			}
+			ArrayAppend(
+				frames,
+				{
+					index = ArrayLen(frames) + 1,
+					template = tpl,
+					file = Replace(tpl, root, ""),
+					line = frameLine,
+					type = $frameType(tpl)
+				}
+			);
+		}
+		return frames;
+	}
+
+	public struct function readSnippet(required string templatePath, required numeric lineNumber, numeric contextLines = 5) {
+		var snippet = {
+			startLine = 0,
+			endLine = 0,
+			errorLine = Val(arguments.lineNumber),
+			lines = []
+		};
+		if (!Len(arguments.templatePath) || !FileExists(arguments.templatePath)) {
+			return snippet;
+		}
+		var state = {ok = false, content = ""};
+		try {
+			state.content = FileRead(arguments.templatePath);
+			state.ok = true;
+		} catch (any e) {
+			state.ok = false;
+		}
+		if (!state.ok || !Len(state.content)) {
+			return snippet;
+		}
+		var normalized = Replace(state.content, Chr(13) & Chr(10), Chr(10), "all");
+		normalized = Replace(normalized, Chr(13), Chr(10), "all");
+		var allLines = ListToArray(normalized, Chr(10), true);
+		var total = ArrayLen(allLines);
+		if (!total) {
+			return snippet;
+		}
+		var errorLine = Val(arguments.lineNumber);
+		if (errorLine < 1) {
+			errorLine = 1;
+		}
+		if (errorLine > total) {
+			errorLine = total;
+		}
+		var radius = Val(arguments.contextLines);
+		if (radius < 0) {
+			radius = 0;
+		}
+		var startLine = Max(1, errorLine - radius);
+		var endLine = Min(total, errorLine + radius);
+		snippet.startLine = startLine;
+		snippet.endLine = endLine;
+		snippet.errorLine = errorLine;
+		var pos = startLine;
+		for (pos = startLine; pos <= endLine; pos++) {
+			var code = allLines[pos];
+			if (!IsSimpleValue(code)) {
+				code = "";
+			}
+			if (Len(code) > 500) {
+				code = Left(code, 500) & "...";
+			}
+			ArrayAppend(
+				snippet.lines,
+				{line = pos, code = code, highlight = (pos == errorLine)}
+			);
+		}
+		return snippet;
+	}
+
+	public string function $appRoot() {
+		var path = GetDirectoryFromPath(GetBaseTemplatePath());
+		if (FindNoCase("/public/", path) || FindNoCase("\public\", path)) {
+			return REReplaceNoCase(path, "[/\\]public[/\\]?$", "/");
+		}
+		return path;
+	}
+
+	public string function $frameType(required string templatePath) {
+		var tpl = arguments.templatePath;
+		if (FindNoCase("vendor/wheels/", tpl) || FindNoCase("vendor\wheels\", tpl)) {
+			return "framework";
+		}
+		if (FindNoCase("/vendor/", tpl) || FindNoCase("\vendor\", tpl)) {
+			return "library";
+		}
+		if (FindNoCase("/plugins/", tpl) || FindNoCase("\plugins\", tpl)) {
+			return "plugin";
+		}
+		var fileName = GetFileFromPath(tpl);
+		if (fileName == "index.cfm" && FindNoCase("public", tpl)) {
+			return "framework";
+		}
+		if (fileName == "Application.cfc" && FindNoCase("public", tpl)) {
+			return "framework";
+		}
+		return "app";
+	}
+
+	/**
+	 * Same location pick as wheelserror.cfm: ignore the first tagContext
+	 * entry (typically the framework throw site), prefer the first app
+	 * frame, otherwise the first remaining frame.
+	 */
+	public struct function $locationFrame(required array frames) {
+		var candidates = [];
+		var count = ArrayLen(arguments.frames);
+		var i = 1;
+		if (count > 1) {
+			for (i = 2; i <= count; i++) {
+				ArrayAppend(candidates, arguments.frames[i]);
+			}
+		} else if (count == 1) {
+			ArrayAppend(candidates, arguments.frames[1]);
+		}
+		var candidateCount = ArrayLen(candidates);
+		for (i = 1; i <= candidateCount; i++) {
+			if (candidates[i].type == "app") {
+				return candidates[i];
+			}
+		}
+		if (candidateCount) {
+			return candidates[1];
+		}
+		return {};
+	}
+
+	private string function $structString(required any data, required string key) {
+		if (!IsStruct(arguments.data) || !StructKeyExists(arguments.data, arguments.key)) {
+			return "";
+		}
+		var value = arguments.data[arguments.key];
+		if (!IsSimpleValue(value)) {
+			return "";
+		}
+		return value;
+	}
+
+	private struct function $requestInfo() {
+		var info = {method = "", path = "", queryString = ""};
+		if (IsDefined("cgi.request_method")) {
+			info.method = cgi.request_method;
+		}
+		if (IsDefined("request.cgi.path_info") && Len(request.cgi.path_info)) {
+			info.path = request.cgi.path_info;
+		} else if (IsDefined("cgi.path_info") && Len(cgi.path_info)) {
+			info.path = cgi.path_info;
+		} else if (IsDefined("cgi.script_name")) {
+			info.path = cgi.script_name;
+		}
+		if (IsDefined("cgi.query_string")) {
+			info.queryString = cgi.query_string;
+		}
+		if (IsDefined("request.wheels.requestId") && Len(request.wheels.requestId)) {
+			info.requestId = request.wheels.requestId;
+		}
+		return info;
+	}
+
+}

--- a/vendor/wheels/events/onerror/wheelserror.cfm
+++ b/vendor/wheels/events/onerror/wheelserror.cfm
@@ -1,10 +1,37 @@
 <cfoutput>
 	<!--- cfformat-ignore-start --->
+	<cfset local.copyJson = "">
+	<cfset local.copyReady = false>
+	<cftry>
+		<cfset local.copyBuilder = CreateObject("component", "wheels.events.onerror.ErrorCopyPayload")>
+		<cfset local.copyJson = local.copyBuilder.toJson(wheelsError = arguments.wheelsError)>
+		<cfset local.copyReady = Len(local.copyJson) GT 0>
+		<cfcatch>
+			<cftry>
+				<cfset local.copyFallback = {}>
+				<cfif StructKeyExists(arguments.wheelsError, "type")>
+					<cfset local.copyFallback["type"] = arguments.wheelsError.type>
+				</cfif>
+				<cfif StructKeyExists(arguments.wheelsError, "message")>
+					<cfset local.copyFallback["message"] = arguments.wheelsError.message>
+				</cfif>
+				<cfset local.copyJson = SerializeJSON(local.copyFallback)>
+				<cfset local.copyReady = Len(local.copyJson) GT 0>
+				<cfcatch></cfcatch>
+			</cftry>
+		</cfcatch>
+	</cftry>
 	<div class="ui container" style="padding-bottom:2em;">
-		<!--- Error Type Badge --->
-		<div style="margin-bottom:1.5em;">
+		<!--- Error Type Badge + Copy control --->
+		<div style="display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:1.5em;flex-wrap:wrap;">
 			<span style="display:inline-block;background:rgba(243,139,168,.15);color:##f38ba8;padding:4px 12px;border-radius:4px;font-size:12px;font-weight:600;letter-spacing:.5px;text-transform:uppercase;">#EncodeForHTML(arguments.wheelsError.type)#</span>
+			<cfif local.copyReady>
+				<button type="button" id="wheels-copy-error" data-label="Copy" onclick="wheelsCopyErrorPayload()" aria-label="Copy error details as JSON" style="font-size:11px;padding:4px 12px;border-radius:4px;border:1px solid ##89b4fa;background:rgba(137,180,250,.15);color:##89b4fa;cursor:pointer;font-weight:600;">Copy</button>
+			</cfif>
 		</div>
+		<cfif local.copyReady>
+			<script type="application/json" id="wheels-error-copy-payload">#EncodeForHTML(local.copyJson)#</script>
+		</cfif>
 
 		<!--- Error Message --->
 		<h1 style="font-size:1.8em;margin-bottom:.5em;line-height:1.3;">
@@ -187,6 +214,55 @@
 			wheelsFilterTrace('app');
 		}
 	})();
+
+	function wheelsCopyErrorPayload() {
+		var el = document.getElementById('wheels-error-copy-payload');
+		var text = el ? (el.textContent || el.innerText || '') : '';
+		var btn = document.getElementById('wheels-copy-error');
+		var done = function() {
+			if (!btn) return;
+			var orig = btn.getAttribute('data-label') || 'Copy';
+			btn.textContent = 'Copied';
+			btn.style.borderColor = '#a6e3a1';
+			btn.style.background = 'rgba(166,227,161,.15)';
+			btn.style.color = '#a6e3a1';
+			setTimeout(function() {
+				btn.textContent = orig;
+				btn.style.borderColor = '#89b4fa';
+				btn.style.background = 'rgba(137,180,250,.15)';
+				btn.style.color = '#89b4fa';
+			}, 1500);
+		};
+		var fail = function() {
+			if (!btn) return;
+			btn.textContent = 'Copy failed';
+		};
+		if (navigator.clipboard && navigator.clipboard.writeText) {
+			navigator.clipboard.writeText(text).then(done).catch(function() {
+				if (wheelsCopyErrorFallback(text)) { done(); } else { fail(); }
+			});
+		} else if (wheelsCopyErrorFallback(text)) {
+			done();
+		} else {
+			fail();
+		}
+	}
+
+	function wheelsCopyErrorFallback(text) {
+		var ta = document.createElement('textarea');
+		ta.value = text;
+		ta.setAttribute('readonly', '');
+		ta.style.position = 'fixed';
+		ta.style.left = '-9999px';
+		document.body.appendChild(ta);
+		ta.focus();
+		ta.select();
+		ta.setSelectionRange(0, text.length);
+		var ok = false;
+		try { ok = document.execCommand('copy'); } catch (err) { ok = false; }
+		document.body.removeChild(ta);
+		return ok;
+	}
 
 	function wheelsFilterTrace(filter) {
 		var frames = document.querySelectorAll('[data-frame-type]');

--- a/vendor/wheels/tests/specs/events/ErrorCopyPayloadSpec.cfc
+++ b/vendor/wheels/tests/specs/events/ErrorCopyPayloadSpec.cfc
@@ -1,0 +1,166 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		describe("ErrorCopyPayload builder", () => {
+
+			it("includes exception type, message, and suggested action", () => {
+				var builder = CreateObject("component", "wheels.events.onerror.ErrorCopyPayload");
+				var payload = builder.build({
+					type = "Wheels.ViewNotFound",
+					message = "Could not find the view `show`",
+					extendedInfo = "Create app/views/users/show.cfm",
+					tagContext = []
+				});
+				expect(payload.exception.type).toBe("Wheels.ViewNotFound");
+				expect(payload.exception.message).toInclude("show");
+				expect(payload.suggestedAction).toInclude("app/views/users/show.cfm");
+				expect(payload.source).toBe("wheels-error-page");
+			});
+
+			it("serializes to JSON that round-trips the exception fields", () => {
+				var builder = CreateObject("component", "wheels.events.onerror.ErrorCopyPayload");
+				var json = builder.toJson({
+					type = "Wheels.RouteNotFound",
+					message = "No route matched",
+					extendedInfo = "Check config/routes.cfm",
+					tagContext = []
+				});
+				expect(IsJSON(json)).toBeTrue();
+				var data = DeserializeJSON(json);
+				expect(data.exception.type).toBe("Wheels.RouteNotFound");
+				expect(data.exception.message).toBe("No route matched");
+				expect(data.suggestedAction).toBe("Check config/routes.cfm");
+			});
+
+			it("classifies app, framework, library, and plugin frames", () => {
+				var builder = CreateObject("component", "wheels.events.onerror.ErrorCopyPayload");
+				var frames = builder.classifyFrames([
+					{template = "/srv/app/models/User.cfc", line = 10},
+					{template = "/srv/vendor/wheels/Model.cfc", line = 20},
+					{template = "/srv/vendor/testbox/system/TestBox.cfc", line = 30},
+					{template = "/srv/plugins/sentry/Sentry.cfc", line = 40}
+				]);
+				expect(ArrayLen(frames)).toBe(4);
+				expect(frames[1].type).toBe("app");
+				expect(frames[2].type).toBe("framework");
+				expect(frames[3].type).toBe("library");
+				expect(frames[4].type).toBe("plugin");
+				expect(frames[2].line).toBe(20);
+			});
+
+			it("classifies Windows-style vendor wheels paths as framework", () => {
+				var builder = CreateObject("component", "wheels.events.onerror.ErrorCopyPayload");
+				var winPath = Replace("C:/sites/demo/vendor/wheels/Dispatch.cfc", "/", Chr(92), "all");
+				var frames = builder.classifyFrames([{template = winPath, line = 8}]);
+				expect(ArrayLen(frames)).toBe(1);
+				expect(frames[1].type).toBe("framework");
+			});
+
+			it("classifies public index.cfm and Application.cfc as framework", () => {
+				var builder = CreateObject("component", "wheels.events.onerror.ErrorCopyPayload");
+				var frames = builder.classifyFrames([
+					{template = "/srv/public/index.cfm", line = 1},
+					{template = "/srv/public/Application.cfc", line = 12}
+				]);
+				expect(frames[1].type).toBe("framework");
+				expect(frames[2].type).toBe("framework");
+			});
+
+			it("picks the first app frame after the innermost throw site as location", () => {
+				var builder = CreateObject("component", "wheels.events.onerror.ErrorCopyPayload");
+				var payload = builder.build({
+					type = "Wheels.TestError",
+					message = "location-pick",
+					tagContext = [
+						{template = "/srv/vendor/wheels/Global.cfc", line = 99},
+						{template = "/srv/app/controllers/Users.cfc", line = 3},
+						{template = "/srv/vendor/wheels/Dispatch.cfc", line = 40}
+					]
+				});
+				expect(payload.location.line).toBe(3);
+				expect(payload.location.type).toBe("app");
+				expect(payload.location.template).toInclude("Users.cfc");
+			});
+
+			it("reads a source snippet around the error line", () => {
+				var builder = CreateObject("component", "wheels.events.onerror.ErrorCopyPayload");
+				var specPath = GetCurrentTemplatePath();
+				var snippet = builder.readSnippet(templatePath = specPath, lineNumber = 1, contextLines = 2);
+				expect(snippet.errorLine).toBe(1);
+				expect(snippet.startLine).toBe(1);
+				expect(ArrayLen(snippet.lines)).toBeGT(0);
+				expect(snippet.lines[1].highlight).toBeTrue();
+				expect(snippet.lines[1].code).toInclude("component");
+			});
+
+			it("returns an empty snippet when the file cannot be read", () => {
+				var builder = CreateObject("component", "wheels.events.onerror.ErrorCopyPayload");
+				var snippet = builder.readSnippet(
+					templatePath = "/tmp/wheels-error-copy-missing-file.cfm",
+					lineNumber = 10
+				);
+				expect(ArrayLen(snippet.lines)).toBe(0);
+				expect(snippet.startLine).toBe(0);
+			});
+
+			it("survives a missing tagContext", () => {
+				var builder = CreateObject("component", "wheels.events.onerror.ErrorCopyPayload");
+				var payload = builder.build({
+					type = "Wheels.TestError",
+					message = "no-stack"
+				});
+				expect(payload.exception.type).toBe("Wheels.TestError");
+				expect(payload.stack).toBeArray();
+				expect(ArrayLen(payload.stack)).toBe(0);
+				expect(StructIsEmpty(payload.location)).toBeTrue();
+			});
+
+		});
+
+		describe("wheelserror.cfm Copy control", () => {
+
+			it("renders a Copy button and a JSON payload script", () => {
+				var specPath = GetCurrentTemplatePath();
+				var wheelsError = {
+					type = "Wheels.TestError",
+					message = "copy-button-marker-message",
+					extendedInfo = "copy-button-suggested-action",
+					tagContext = [
+						{template = specPath, line = 1},
+						{template = specPath, line = 2}
+					]
+				};
+				var actual = application.wo.$includeAndReturnOutput(
+					$template = "/wheels/events/onerror/wheelserror.cfm",
+					wheelsError = wheelsError
+				);
+				expect(actual).toInclude("wheels-copy-error");
+				expect(actual).toInclude("wheels-error-copy-payload");
+				expect(actual).toInclude("Copy");
+				expect(actual).toInclude("copy-button-marker-message");
+				expect(actual).toInclude("Wheels.TestError");
+				expect(actual).toInclude("copy-button-suggested-action");
+				expect(actual).toInclude("wheelsCopyErrorPayload");
+				expect(actual).toInclude("navigator.clipboard");
+				expect(actual).toInclude("wheels-error-page");
+			});
+
+			it("keeps the Copy control when tagContext is empty", () => {
+				var actual = application.wo.$includeAndReturnOutput(
+					$template = "/wheels/events/onerror/wheelserror.cfm",
+					wheelsError = {
+						type = "Wheels.EmptyStack",
+						message = "empty-stack-copy",
+						tagContext = []
+					}
+				);
+				expect(actual).toInclude("wheels-copy-error");
+				expect(actual).toInclude("empty-stack-copy");
+			});
+
+		});
+
+	}
+
+}

--- a/web/sites/guides/src/content/docs/v4-0-0/core-concepts/environments-and-configuration.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/core-concepts/environments-and-configuration.mdx
@@ -29,6 +29,8 @@ A fourth value, `maintenance`, is supported for planned downtime. Most apps neve
 
 These are the defaults the framework itself flips per environment. Operational concerns like log rotation and HTTPS enforcement are not framework settings — handle those in your web server, or use the `SecurityHeaders` middleware for transport-security headers.
 
+In development, the framework error page (`showErrorInformation=true`) includes a **Copy** button that puts a JSON dump of the exception — type, message, suggested action, file and line, a source snippet, and stack frames tagged as app vs framework — on the clipboard so you can paste it into a coding agent.
+
 ## Where settings live
 
 Configuration loads from a small set of files in `config/`. The framework reads them in order at application start and on every reload (`?reload=true&password=...`):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Copy** button to the development error page so a single click puts a complete, structured JSON dump of the exception on the clipboard — suitable for pasting into a coding agent.

Closes #3552

## Type of Change

- [x] New feature
- [x] Enhancement to existing feature
- [x] Documentation update

## Approach

- New standalone `wheels.events.onerror.ErrorCopyPayload` builder (not mixed in) so `wheelserror.cfm` can `CreateObject` it from both EventMethods and `application.wo` includes.
- Payload fields: exception type / message / detail, suggested action (`extendedInfo`), location (file + line + app/framework/library/plugin tag), source snippet (±5 lines), full classified stack, and a light request summary (method, path, query, request id).
- Error page badge row gets a Copy control styled like the existing stack-filter buttons.
- Clipboard API first (`navigator.clipboard.writeText`), `document.execCommand('copy')` fallback, with Copied / Copy failed feedback.
- Payload build is wrapped in try/catch so a clipboard failure can never take down the error page itself.

## Feature Completeness Checklist

- [x] **DCO sign-off** -- commit carries `Signed-off-by: Cursor Agent <cursoragent@cursor.com>`
- [x] **Tests** -- `ErrorCopyPayloadSpec.cfc` covers builder fields, JSON round-trip, frame classification (app/framework/library/plugin + Windows paths), location pick, source snippet, empty tagContext, and the rendered Copy control + JSON script
- [x] **Framework Docs** -- note added to `environments-and-configuration.mdx` (current v4-0-0 guide tree; there is no `v4-0-0-snapshot` folder)
- [ ] **AI Reference Docs** -- not a maintainer runbook change; skipped
- [x] **CLAUDE.md** -- consumer-ai copy documents the Copy button (the feature is aimed at coding agents)
- [x] **Changelog fragment** -- `changelog.d/3552-error-page-copy.added.md`
- [x] **Test runner passes** -- `directory=wheels.tests.specs.events` on Lucee 7 + SQLite: **99 passed, 0 failed, 0 errors** (11/11 new ErrorCopyPayload specs; EventsHardenerSpec and onerrorSpec still green)

## Test Plan

- [x] Core events suite: `http://localhost:8080/wheels/core/tests?db=sqlite&format=json&directory=wheels.tests.specs.events`
- [x] Live error page: `GET /definitely-not-a-controller/nope` returns HTTP 404 `Wheels.ViewNotFound` with `#wheels-copy-error`, `#wheels-error-copy-payload`, and valid JSON (type, message, suggested action, location, 11-line snippet, 7 classified stack frames, request method/path)
- Manual: click Copy in a modern browser and paste into an editor

## Screenshots / Output

The Copy control sits on the error-type badge row (same accent styling as the stack App/Framework filters). Clicking it copies JSON and briefly shows **Copied**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cce34213-0c4d-44b0-a966-d3c52085e822?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cce34213-0c4d-44b0-a966-d3c52085e822&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

