### PR TITLE
feat(cli): Rails-style column size modifiers for generators

### DIFF
--- a/changelog.d/cli-column-size-modifiers.added.md
+++ b/changelog.d/cli-column-size-modifiers.added.md
@@ -1,0 +1,1 @@
+- CLI generators (`model`, `scaffold`, `api-resource`) accept Rails-style column size modifiers (`title:string{50}`, `price:decimal{10,2}`) and emit the custom `limit` / `precision` / `scale` in the generated migration

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -8316,31 +8316,85 @@ component extends="modules.BaseModule" {
 				var rels = listToArray(valueAfterEquals(arg));
 				result.hasOne.append(rels, true);
 			} else if (!arg.startsWith("--")) {
-				// Property: name, name:type, or name:enum:value1,value2,...
-				// Split on the FIRST two colons only — any additional colons
-				// (e.g. inside the comma-separated value list) belong in the
-				// values segment.
-				var parts = listToArray(arg, ":");
-				var prop = {
-					name: parts[1],
-					type: arrayLen(parts) > 1 ? parts[2] : "string"
-				};
-				if (lCase(prop.type) == "enum" && arrayLen(parts) > 2) {
-					// Re-join everything after the second colon so values
-					// like "draft,published,archived" land in a single
-					// segment. Most cases are arrayLen==3 (no embedded
-					// colons), so this is just parts[3] — defensive against
-					// pathological inputs.
-					var valueSegments = [];
-					for (var i = 3; i <= arrayLen(parts); i++) {
-						arrayAppend(valueSegments, parts[i]);
-					}
-					prop.values = arrayToList(valueSegments, ":");
-				}
-				arrayAppend(result.properties, prop);
+				// Property: name, name:type, name:type{N}, name:type{P,S},
+				// or name:enum:value1,value2,...
+				arrayAppend(result.properties, $parsePropertyArg(arg));
 			}
 		}
 
+		return result;
+	}
+
+	/**
+	 * Parse one generator property token into a name/type struct, plus
+	 * optional Rails-style brace modifiers (`string{50}`, `decimal{10,2}`)
+	 * and colon-delimited enum values (`status:enum:draft,published`).
+	 *
+	 * Brace modifiers attach to the type token only, so they never steal
+	 * the value list from `name:enum:a,b`.
+	 */
+	private struct function $parsePropertyArg(required string arg) {
+		// Split on the FIRST two colons only — any additional colons
+		// (e.g. inside the comma-separated value list) belong in the
+		// values segment.
+		var parts = listToArray(arguments.arg, ":");
+		var typeToken = arrayLen(parts) > 1 ? parts[2] : "string";
+		var modifiers = $parseTypeModifiers(typeToken);
+		var prop = {
+			name: parts[1],
+			type: modifiers.type
+		};
+		if (structKeyExists(modifiers, "limit")) {
+			prop.limit = modifiers.limit;
+		}
+		if (structKeyExists(modifiers, "precision")) {
+			prop.precision = modifiers.precision;
+		}
+		if (structKeyExists(modifiers, "scale")) {
+			prop.scale = modifiers.scale;
+		}
+		if (lCase(prop.type) == "enum" && arrayLen(parts) > 2) {
+			// Re-join everything after the second colon so values
+			// like "draft,published,archived" land in a single
+			// segment. Most cases are arrayLen==3 (no embedded
+			// colons), so this is just parts[3] — defensive against
+			// pathological inputs.
+			var valueSegments = [];
+			for (var i = 3; i <= arrayLen(parts); i++) {
+				arrayAppend(valueSegments, parts[i]);
+			}
+			prop.values = arrayToList(valueSegments, ":");
+		}
+		return prop;
+	}
+
+	/**
+	 * Strip a trailing `{N}` or `{P,S}` modifier from a type token.
+	 * Single number → limit. Two comma-separated numbers → precision, scale.
+	 * Malformed or empty braces leave the type unchanged and add no fields.
+	 */
+	private struct function $parseTypeModifiers(required string typeToken) {
+		var result = {type: arguments.typeToken};
+		var openBrace = find("{", arguments.typeToken);
+		if (openBrace < 2) {
+			return result;
+		}
+		if (right(arguments.typeToken, 1) != "}") {
+			return result;
+		}
+		var inner = mid(arguments.typeToken, openBrace + 1, len(arguments.typeToken) - openBrace - 1);
+		if (!len(trim(inner))) {
+			return result;
+		}
+		// openBrace is at least 2, so this Left() length is at least 1
+		result.type = left(arguments.typeToken, openBrace - 1);
+		var bits = listToArray(inner);
+		if (arrayLen(bits) >= 2 && isNumeric(trim(bits[1])) && isNumeric(trim(bits[2]))) {
+			result.precision = trim(bits[1]);
+			result.scale = trim(bits[2]);
+		} else if (arrayLen(bits) == 1 && isNumeric(trim(bits[1]))) {
+			result.limit = trim(bits[1]);
+		}
 		return result;
 	}
 

--- a/cli/lucli/services/Scaffold.cfc
+++ b/cli/lucli/services/Scaffold.cfc
@@ -1163,12 +1163,7 @@ component {
 			// types `default=''` just rendered DEFAULT NULL anyway. Omitting the
 			// default yields NULL for nullable columns, which is the same thing.
 			params &= ", allowNull=" & (structKeyExists(prop, "required") && prop.required ? "false" : "true");
-
-			switch (cfType) {
-				case "string": params &= ", limit='255'"; break;
-				case "decimal": params &= ", precision='10', scale='2'"; break;
-				case "integer": params &= ", limit='11'"; break;
-			}
+			params &= $columnSizeParams(prop, cfType);
 
 			c &= t & t & t & t & "t.#cfType#(#params#);" & nl;
 		}
@@ -1209,6 +1204,40 @@ component {
 	}
 
 	/**
+	 * Emit limit / precision / scale for a generated column.
+	 * Brace modifiers from the CLI (`string{50}`, `decimal{10,2}`) override
+	 * the defaults; types that do not take a default size only emit a limit
+	 * when the caller supplied one.
+	 */
+	private string function $columnSizeParams(required struct prop, required string cfType) {
+		switch (arguments.cfType) {
+			case "string":
+				return ", limit='" & $propOrDefault(arguments.prop, "limit", "255") & "'";
+			case "decimal":
+				return ", precision='" & $propOrDefault(arguments.prop, "precision", "10")
+					& "', scale='" & $propOrDefault(arguments.prop, "scale", "2") & "'";
+			case "integer":
+				return ", limit='" & $propOrDefault(arguments.prop, "limit", "11") & "'";
+			case "text":
+			case "binary":
+				if (structKeyExists(arguments.prop, "limit")) {
+					return ", limit='" & arguments.prop.limit & "'";
+				}
+				return "";
+			default:
+				return "";
+		}
+	}
+
+	/**
+	 * Read a numeric column-size override from a parsed property, or the
+	 * generator default when the caller omitted a brace modifier.
+	 */
+	private string function $propOrDefault(required struct prop, required string key, required string fallback) {
+		return structKeyExists(arguments.prop, arguments.key) ? arguments.prop[arguments.key] : arguments.fallback;
+	}
+
+	/**
 	 * Map property type to Wheels migration column type
 	 */
 	private string function mapToWheelsType(required string type) {
@@ -1241,8 +1270,8 @@ component {
 	 */
 	private string function $mapWheelsTextualType(required string type) {
 		switch (arguments.type) {
-			case "string": return "string";
-			case "text": return "text";
+			case "string": case "varchar": return "string";
+			case "text": case "longtext": return "text";
 			default: return "";
 		}
 	}

--- a/cli/lucli/tests/_fixtures/commands/ModuleArgvProbe.cfc
+++ b/cli/lucli/tests/_fixtures/commands/ModuleArgvProbe.cfc
@@ -75,4 +75,8 @@ component extends="cli.lucli.Module" {
 		return parseTestArgs(arguments.coll);
 	}
 
+	public struct function $parseGeneratorArgs(required array args) {
+		return parseGeneratorArgs(arguments.args);
+	}
+
 }

--- a/cli/lucli/tests/specs/commands/ParseGeneratorArgsSpec.cfc
+++ b/cli/lucli/tests/specs/commands/ParseGeneratorArgsSpec.cfc
@@ -1,0 +1,98 @@
+/**
+ * Unit coverage for parseGeneratorArgs() column-size brace modifiers.
+ *
+ * Rails-style `name:type{N}` / `name:decimal{P,S}` tokens must land as
+ * structured prop fields without breaking colon-based enum values.
+ */
+component extends="wheels.wheelstest.system.BaseSpec" {
+
+	function beforeAll() {
+		variables.probe = new cli.lucli.tests._fixtures.commands.ModuleArgvProbe(
+			cwd = expandPath("/")
+		);
+	}
+
+	function run() {
+
+		describe("parseGeneratorArgs — property tokens", () => {
+
+			it("defaults a bare name to type string with no size override", () => {
+				var parsed = probe.$parseGeneratorArgs(["title"]);
+				expect(arrayLen(parsed.properties)).toBe(1);
+				expect(parsed.properties[1].name).toBe("title");
+				expect(parsed.properties[1].type).toBe("string");
+				expect(structKeyExists(parsed.properties[1], "limit")).toBeFalse();
+			});
+
+			it("parses name:type without braces", () => {
+				var parsed = probe.$parseGeneratorArgs(["title:string"]);
+				expect(parsed.properties[1].name).toBe("title");
+				expect(parsed.properties[1].type).toBe("string");
+				expect(structKeyExists(parsed.properties[1], "limit")).toBeFalse();
+			});
+
+			it("parses title:string{50} as type string with limit 50", () => {
+				var parsed = probe.$parseGeneratorArgs(["title:string{50}"]);
+				expect(parsed.properties[1].name).toBe("title");
+				expect(parsed.properties[1].type).toBe("string");
+				expect(parsed.properties[1].limit).toBe("50");
+			});
+
+			it("parses price:decimal{10,2} as precision 10 and scale 2", () => {
+				var parsed = probe.$parseGeneratorArgs(["price:decimal{10,2}"]);
+				expect(parsed.properties[1].name).toBe("price");
+				expect(parsed.properties[1].type).toBe("decimal");
+				expect(parsed.properties[1].precision).toBe("10");
+				expect(parsed.properties[1].scale).toBe("2");
+				expect(structKeyExists(parsed.properties[1], "limit")).toBeFalse();
+			});
+
+			it("applies a brace limit to integer / text / binary / varchar aliases", () => {
+				var parsed = probe.$parseGeneratorArgs([
+					"count:integer{8}",
+					"body:text{1000}",
+					"blob:binary{4096}",
+					"sku:varchar{80}"
+				]);
+				expect(parsed.properties[1].type).toBe("integer");
+				expect(parsed.properties[1].limit).toBe("8");
+				expect(parsed.properties[2].type).toBe("text");
+				expect(parsed.properties[2].limit).toBe("1000");
+				expect(parsed.properties[3].type).toBe("binary");
+				expect(parsed.properties[3].limit).toBe("4096");
+				expect(parsed.properties[4].type).toBe("varchar");
+				expect(parsed.properties[4].limit).toBe("80");
+			});
+
+			it("still parses status:enum:a,b values after the type token", () => {
+				var parsed = probe.$parseGeneratorArgs(["status:enum:draft,published"]);
+				expect(parsed.properties[1].name).toBe("status");
+				expect(parsed.properties[1].type).toBe("enum");
+				expect(parsed.properties[1].values).toBe("draft,published");
+				expect(structKeyExists(parsed.properties[1], "limit")).toBeFalse();
+			});
+
+			it("does not treat enum value lists as brace modifiers", () => {
+				var parsed = probe.$parseGeneratorArgs(["status:enum:a,b,c"]);
+				expect(parsed.properties[1].type).toBe("enum");
+				expect(parsed.properties[1].values).toBe("a,b,c");
+			});
+
+			it("still collects association flags alongside sized properties", () => {
+				var parsed = probe.$parseGeneratorArgs([
+					"title:string{50}",
+					"--belongsTo=user",
+					"price:decimal{12,4}"
+				]);
+				expect(arrayLen(parsed.properties)).toBe(2);
+				expect(parsed.belongsTo[1]).toBe("user");
+				expect(parsed.properties[1].limit).toBe("50");
+				expect(parsed.properties[2].precision).toBe("12");
+				expect(parsed.properties[2].scale).toBe("4");
+			});
+
+		});
+
+	}
+
+}

--- a/cli/lucli/tests/specs/services/ScaffoldSpec.cfc
+++ b/cli/lucli/tests/specs/services/ScaffoldSpec.cfc
@@ -266,6 +266,77 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					expect(content).toInclude("active");
 				});
 
+				it("emits default string limit 255 when no brace modifier is present", () => {
+					var path = scaffold.createMigrationWithProperties(
+						name = "Barestring",
+						properties = [{name: "title", type: "string"}]
+					);
+					var content = fileRead(path);
+					expect(content).toInclude("t.string(columnNames='title', allowNull=true, limit='255')");
+				});
+
+				it("emits custom string limit from title:string{50}", () => {
+					var path = scaffold.createMigrationWithProperties(
+						name = "Sizedstring",
+						properties = [{name: "title", type: "string", limit: "50"}]
+					);
+					var content = fileRead(path);
+					expect(content).toInclude("t.string(columnNames='title', allowNull=true, limit='50')");
+					expect(content).notToInclude("limit='255'");
+				});
+
+				it("emits default decimal precision 10 scale 2 without braces", () => {
+					var path = scaffold.createMigrationWithProperties(
+						name = "Baredecimal",
+						properties = [{name: "price", type: "decimal"}]
+					);
+					var content = fileRead(path);
+					expect(content).toInclude("t.decimal(columnNames='price', allowNull=true, precision='10', scale='2')");
+				});
+
+				it("emits custom decimal precision and scale from price:decimal{10,2}", () => {
+					var path = scaffold.createMigrationWithProperties(
+						name = "Sizeddecimal",
+						properties = [{name: "price", type: "decimal", precision: "10", scale: "2"}]
+					);
+					var content = fileRead(path);
+					expect(content).toInclude("t.decimal(columnNames='price', allowNull=true, precision='10', scale='2')");
+				});
+
+				it("emits custom decimal precision and scale from amount:decimal{12,4}", () => {
+					var path = scaffold.createMigrationWithProperties(
+						name = "Widedecimal",
+						properties = [{name: "amount", type: "decimal", precision: "12", scale: "4"}]
+					);
+					var content = fileRead(path);
+					expect(content).toInclude("t.decimal(columnNames='amount', allowNull=true, precision='12', scale='4')");
+					expect(content).notToInclude("precision='10'");
+				});
+
+				it("emits custom integer limit and optional text/binary limit", () => {
+					var path = scaffold.createMigrationWithProperties(
+						name = "Sizedmisc",
+						properties = [
+							{name: "count", type: "integer", limit: "8"},
+							{name: "body", type: "text", limit: "1000"},
+							{name: "payload", type: "binary", limit: "4096"}
+						]
+					);
+					var content = fileRead(path);
+					expect(content).toInclude("t.integer(columnNames='count', allowNull=true, limit='8')");
+					expect(content).toInclude("t.text(columnNames='body', allowNull=true, limit='1000')");
+					expect(content).toInclude("t.binary(columnNames='payload', allowNull=true, limit='4096')");
+				});
+
+				it("emits default integer limit 11 when no brace modifier is present", () => {
+					var path = scaffold.createMigrationWithProperties(
+						name = "Bareinteger",
+						properties = [{name: "count", type: "integer"}]
+					);
+					var content = fileRead(path);
+					expect(content).toInclude("t.integer(columnNames='count', allowNull=true, limit='11')");
+				});
+
 			});
 
 			describe("updateRoutes()", () => {

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-generation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-generation.mdx
@@ -63,11 +63,14 @@ The other generators (`controller`, `view`, `migration`, `route`, `test`, `helpe
 | You write | Column type | Notes |
 |---|---|---|
 | `name` | `string` | Type defaults to `string` when `:type` is omitted. |
-| `title:string` | `string` | Also: `varchar`. |
+| `title:string` | `string` | Also: `varchar`. Default `limit=255`. |
+| `title:string{50}` | `string` | Rails-style brace sets `limit=50`. Same `{N}` form works on `integer`, `text`, `binary`, and `varchar`. |
 | `body:text` | `text` | Also: `longtext`. |
-| `count:integer` | `integer` | Also: `int`. |
+| `count:integer` | `integer` | Also: `int`. Default `limit=11`. |
 | `views:biginteger` | `bigInteger` | Also: `bigint`. |
-| `price:decimal` | `decimal` | Also: `float`, `numeric`. |
+| `price:decimal` | `decimal` | Also: `float`, `numeric`. Default `precision=10`, `scale=2`. |
+| `price:decimal{10,2}` | `decimal` | Brace sets `precision=10`, `scale=2`. |
+| `status:enum:draft,published` | `enum` | Colon-separated values are unchanged — braces must not be used for the value list. |
 | `active:boolean` | `boolean` | Also: `bool`. |
 | `publishedAt:datetime` | `datetime` | Also: `timestamp`. |
 | `publishedOn:date` | `date` | |
@@ -79,6 +82,15 @@ The other generators (`controller`, `view`, `migration`, `route`, `test`, `helpe
 
 <Aside type="note" title="Type aliases land on the same column type">
 The mapper folds aliases together — `varchar` and `string` both emit `t.string(...)`, `int` and `integer` both emit `t.integer(...)`, and so on. Pick whichever reads best; the generated migration is identical.
+</Aside>
+
+<Aside type="tip" title="Quote braced sizes in the shell">
+Brace modifiers are Rails-compatible (`title:string{50}`, `price:decimal{10,2}`). Some shells treat `{…}` as a glob or brace expansion, so quote those arguments when needed:
+
+```bash
+wheels generate scaffold Post 'title:string{50}' 'price:decimal{10,2}' body:text
+wheels generate model Product 'name:string{80}' 'amount:decimal{12,4}'
+```
 </Aside>
 
 ### `wheels generate model`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CLI generators (`model`, `scaffold`, `api-resource`) now accept Rails-style column size modifiers on property tokens:

```bash
wheels generate scaffold Post 'title:string{50}' 'price:decimal{10,2}' body:text
wheels generate model Product 'name:string{80}' 'amount:decimal{12,4}'
```

Generated migrations emit the custom `limit` / `precision` / `scale` instead of the hardcoded defaults (string 255, integer 11, decimal 10/2).

## Related Issue

N/A — requested as a v1 generator enhancement.

## Type of Change

- [x] New feature
- [x] Documentation update

## Behavior

| Input | Generated column |
|---|---|
| `title:string{50}` | `t.string(..., limit='50')` |
| `price:decimal{10,2}` | `t.decimal(..., precision='10', scale='2')` |
| `title:string` (no braces) | `t.string(..., limit='255')` (unchanged default) |
| `status:enum:draft,published` | still parses `values` — braces do not steal the colon list |

The same `{N}` limit parsing applies to `integer`, `text`, `binary`, and `varchar` aliases when they map through the migration emitter.

**Not in this PR:** `:uniq` / `:index` suffixes, bang `!` for `null:false`, key-value brace options.

## Feature Completeness Checklist

- [x] **DCO sign-off** -- Every commit carries `Signed-off-by:`
- [x] **Tests** -- `ParseGeneratorArgsSpec` + `ScaffoldSpec` cover brace parse + migration emit, plus enum regression
- [x] **Framework Docs** -- Updated `web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-generation.mdx` (property type table + quoted-shell example)
- [ ] **AI Reference Docs** -- N/A (CLI generator syntax, not a framework convention)
- [ ] **CLAUDE.md** -- N/A (no model/controller/view convention change)
- [x] **Changelog fragment** -- `changelog.d/cli-column-size-modifiers.added.md`
- [x] **Test runner passes** -- Targeted CLI specs: 53 pass, 0 fail, 0 error (`ParseGeneratorArgsSpec` 8 + `ScaffoldSpec` 45)

## Test Plan

- [x] Unit: `title:string{50}` → `limit` 50
- [x] Unit: `price:decimal{10,2}` → precision 10, scale 2
- [x] Unit: bare `title:string` still 255
- [x] Unit: `status:enum:a,b` still parses values
- [x] Targeted TestBox run of `ParseGeneratorArgsSpec` + `ScaffoldSpec` (53 pass)
- [x] Complexity gate: `python3 tools/code-quality/cfml-complexity.py cli/lucli --gate 30 --baseline tools/code-quality/baseline-cli.json` passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c71444f8-560d-4579-a277-344d0b6a13b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c71444f8-560d-4579-a277-344d0b6a13b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

