### PR TITLE
feat(cli): emit validatesLengthOf from string{n} column limits

### DIFF
--- a/changelog.d/cli-validates-length-from-brace.added.md
+++ b/changelog.d/cli-validates-length-from-brace.added.md
@@ -1,0 +1,1 @@
+- CLI generators emit `validatesLengthOf(property=..., maximum=N)` on the generated model when a string-like property (`string`, `varchar`, `text`, `binary`) uses a `{N}` size modifier

--- a/cli/lucli/services/CodeGen.cfc
+++ b/cli/lucli/services/CodeGen.cfc
@@ -66,30 +66,50 @@ component {
 	/**
 	 * Build validation code lines for a model's config() from typed properties.
 	 * Emits a single combined validatesPresenceOf("a,b,c") for all properties,
-	 * plus per-property validatesFormatOf for email and URL types.
+	 * plus per-property validatesFormatOf for email and URL types, and
+	 * validatesLengthOf when a string-like property carries a brace `{N}` limit.
 	 */
 	private string function buildModelValidations(required array properties) {
 		if (!arrayLen(arguments.properties)) return "";
 
 		var presenceProps = [];
-		var formatLines = [];
+		var extraLines = [];
 
 		for (var prop in arguments.properties) {
 			arrayAppend(presenceProps, prop.name);
 			var propType = structKeyExists(prop, "type") ? lCase(prop.type) : "string";
 			if (propType == "email") {
-				arrayAppend(formatLines, "validatesFormatOf(property=""#prop.name#"", type=""email"");");
+				arrayAppend(extraLines, "validatesFormatOf(property=""#prop.name#"", type=""email"");");
 			} else if (propType == "url") {
-				arrayAppend(formatLines, "validatesFormatOf(property=""#prop.name#"", type=""URL"");");
+				arrayAppend(extraLines, "validatesFormatOf(property=""#prop.name#"", type=""URL"");");
+			}
+			if (isStringLikeLengthLimit(prop, propType)) {
+				arrayAppend(extraLines, "validatesLengthOf(property=""#prop.name#"", maximum=#prop.limit#);");
 			}
 		}
 
 		var lines = ["validatesPresenceOf(""#arrayToList(presenceProps)#"");"];
-		lines.append(formatLines, true);
+		lines.append(extraLines, true);
 		// Join with newline + 2 tabs so subsequent lines align with the template's
 		// `\t\t{{validations}}` placeholder indent. The first line gets its indent
 		// from the placeholder's leading whitespace at fill time.
 		return arrayToList(lines, chr(10) & chr(9) & chr(9));
+	}
+
+	/**
+	 * True when the property is string-like and carries a numeric `{N}` limit
+	 * from the generator parser. Integer `{N}` is a column display width, not
+	 * a string length, so it is excluded. Decimal `{p,s}` uses precision/scale
+	 * and never sets limit.
+	 */
+	private boolean function isStringLikeLengthLimit(required struct prop, required string propType) {
+		if (listFindNoCase("string,varchar,text,binary", arguments.propType) == 0) {
+			return false;
+		}
+		if (!structKeyExists(arguments.prop, "limit")) {
+			return false;
+		}
+		return isNumeric(arguments.prop.limit) && val(arguments.prop.limit) > 0;
 	}
 
 	/**

--- a/cli/lucli/tests/specs/services/CodeGenSpec.cfc
+++ b/cli/lucli/tests/specs/services/CodeGenSpec.cfc
@@ -135,6 +135,77 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					var content = fileRead(tempRoot & "/app/models/Empty.cfc");
 					expect(content).notToInclude("validatesPresenceOf");
 					expect(content).notToInclude("validatesFormatOf");
+					expect(content).notToInclude("validatesLengthOf");
+				});
+
+				it("emits validatesLengthOf for a string property with a brace limit", () => {
+					codegen.generateModel(
+						name = "SizedTitle",
+						properties = [{name: "title", type: "string", limit: "50"}],
+						force = true
+					);
+					var content = fileRead(tempRoot & "/app/models/SizedTitle.cfc");
+					expect(content).toInclude('validatesPresenceOf("title")');
+					expect(content).toInclude('validatesLengthOf(property="title", maximum=50)');
+				});
+
+				it("does not invent a length validation for a bare string", () => {
+					codegen.generateModel(
+						name = "BareTitle",
+						properties = [{name: "title", type: "string"}],
+						force = true
+					);
+					var content = fileRead(tempRoot & "/app/models/BareTitle.cfc");
+					expect(content).toInclude('validatesPresenceOf("title")');
+					expect(content).notToInclude("validatesLengthOf");
+				});
+
+				it("emits length validation for varchar / text / binary limits", () => {
+					codegen.generateModel(
+						name = "SizedMisc",
+						properties = [
+							{name: "sku", type: "varchar", limit: "80"},
+							{name: "body", type: "text", limit: "1000"},
+							{name: "blob", type: "binary", limit: "4096"}
+						],
+						force = true
+					);
+					var content = fileRead(tempRoot & "/app/models/SizedMisc.cfc");
+					expect(content).toInclude('validatesPresenceOf("sku,body,blob")');
+					expect(content).toInclude('validatesLengthOf(property="sku", maximum=80)');
+					expect(content).toInclude('validatesLengthOf(property="body", maximum=1000)');
+					expect(content).toInclude('validatesLengthOf(property="blob", maximum=4096)');
+				});
+
+				it("skips length validation for integer limits and decimal precision", () => {
+					codegen.generateModel(
+						name = "NumericSized",
+						properties = [
+							{name: "count", type: "integer", limit: "8"},
+							{name: "price", type: "decimal", precision: "10", scale: "2"}
+						],
+						force = true
+					);
+					var content = fileRead(tempRoot & "/app/models/NumericSized.cfc");
+					expect(content).toInclude('validatesPresenceOf("count,price")');
+					expect(content).notToInclude("validatesLengthOf");
+				});
+
+				it("keeps email format validation alongside a sibling string limit", () => {
+					codegen.generateModel(
+						name = "MixedValidations",
+						properties = [
+							{name: "title", type: "string", limit: "50"},
+							{name: "email", type: "email"}
+						],
+						force = true
+					);
+					var content = fileRead(tempRoot & "/app/models/MixedValidations.cfc");
+					expect(content).toInclude('validatesPresenceOf("title,email")');
+					expect(content).toInclude('validatesFormatOf(property="email", type="email")');
+					expect(content).toInclude('validatesLengthOf(property="title", maximum=50)');
+					expect(content).toInclude(chr(9) & chr(9) & "validatesLengthOf");
+					expect(content).notToInclude(chr(10) & "validatesLengthOf");
 				});
 
 				it("emits enum() for enum-typed properties (##M2)", () => {

--- a/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-generation.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-generation.mdx
@@ -64,7 +64,7 @@ The other generators (`controller`, `view`, `migration`, `route`, `test`, `helpe
 |---|---|---|
 | `name` | `string` | Type defaults to `string` when `:type` is omitted. |
 | `title:string` | `string` | Also: `varchar`. Default `limit=255`. |
-| `title:string{50}` | `string` | Rails-style brace sets `limit=50`. Same `{N}` form works on `integer`, `text`, `binary`, and `varchar`. |
+| `title:string{50}` | `string` | Rails-style brace sets migration `limit=50` and `validatesLengthOf(property="title", maximum=50)` on the generated model. Same `{N}` form works on `integer`, `text`, `binary`, and `varchar` (length validation is string-like types only). |
 | `body:text` | `text` | Also: `longtext`. |
 | `count:integer` | `integer` | Also: `int`. Default `limit=11`. |
 | `views:biginteger` | `bigInteger` | Also: `bigint`. |
@@ -91,6 +91,8 @@ Brace modifiers are Rails-compatible (`title:string{50}`, `price:decimal{10,2}`)
 wheels generate scaffold Post 'title:string{50}' 'price:decimal{10,2}' body:text
 wheels generate model Product 'name:string{80}' 'amount:decimal{12,4}'
 ```
+
+A `{n}` limit on `string`, `varchar`, `text`, or `binary` also emits `validatesLengthOf(property="…", maximum=n)` in the generated model's `config()`. Bare types without braces do not invent a length validation (no implicit `maximum=255`). Integer `{n}` is a column display width only; decimal `{p,s}` stays precision/scale.
 </Aside>
 
 ### `wheels generate model`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #3560. When a generator property has a brace limit on a string-like type (`title:string{50}`), the generated model's `config()` now also emits a matching length validation:

```cfml
validatesLengthOf(property="title", maximum=50);
```

Uses singular `property=` to match `buildModelValidations`' existing `validatesFormatOf` lines and the v4 validation docs.

## Related Issue

Follow-up to #3560 (Rails-style column size modifiers). No standalone issue.

## Type of Change

- [x] New feature
- [x] Documentation update

## Behavior

| Input | Generated model validation |
|---|---|
| `title:string{50}` | `validatesLengthOf(property="title", maximum=50)` plus presence |
| `title:string` (no braces) | presence only — no invented `maximum=255` |
| `body:text{1000}` / `sku:varchar{80}` / `blob:binary{4096}` | matching `validatesLengthOf` |
| `count:integer{8}` | presence only (integer `{N}` is a column display width) |
| `price:decimal{10,2}` | presence only (precision/scale, not length) |

Existing `validatesPresenceOf` (combined list) and email/url `validatesFormatOf` are unchanged.

## Feature Completeness Checklist

- [x] **DCO sign-off** -- Every commit carries `Signed-off-by:`
- [x] **Tests** -- `CodeGenSpec` covers brace-limit length validation, bare-string skip, integer/decimal skip, and coexistence with format validations
- [x] **Framework Docs** -- Updated `web/sites/guides/src/content/docs/v4-0-0/command-line-tools/wheels-commands/code-generation.mdx`
- [ ] **AI Reference Docs** -- N/A (CLI generator output, not a new framework convention)
- [ ] **CLAUDE.md** -- N/A
- [x] **Changelog fragment** -- `changelog.d/cli-validates-length-from-brace.added.md`
- [x] **Test runner passes** -- Targeted `CodeGenSpec` 38/38 and `ParseGeneratorArgsSpec` 8/8. Full CLI suite: 1269 pass; 5 pre-existing env failures in `DbCommandSpec` / `ServerCommandsSpec` (server-running vs `ServerNotRunning` expectations), unrelated to this change

## Test Plan

- [x] Unit: `title:string{50}` → `validatesLengthOf(property="title", maximum=50)`
- [x] Unit: bare `title:string` does not emit `validatesLengthOf`
- [x] Unit: integer `{N}` and decimal `{p,s}` do not emit length validation
- [x] Unit: presence + email format still emit alongside a sibling string limit
- [x] Targeted TestBox run of `CodeGenSpec` (38 pass) + `ParseGeneratorArgsSpec` (8 pass)
- [x] Complexity gate: `python3 tools/code-quality/cfml-complexity.py cli/lucli --gate 30 --baseline tools/code-quality/baseline-cli.json` (local + CI green)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22b95168-8754-4f85-9380-4c93e119775d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22b95168-8754-4f85-9380-4c93e119775d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

