### PR TITLE
fix(debugbar): animate slide-to-logo collapse without floating button

### DIFF
--- a/changelog.d/3547-debugbar-slide-animation.fixed.md
+++ b/changelog.d/3547-debugbar-slide-animation.fixed.md
@@ -1,0 +1,1 @@
+- Debug bar: collapsing via the X now animates a stylesheet-driven width slide to a logo-only black strip (stylized red W). The root container no longer pins `width:100%` inline next to `all:initial`, which blocked the transition and left a hovering-button look (#3547)

--- a/vendor/wheels/events/onrequestend/debug.cfm
+++ b/vendor/wheels/events/onrequestend/debug.cfm
@@ -107,7 +107,7 @@
 <cfset local.codeComplexity = local.codeComplexityAnalyzer.load(ExpandPath("/app"))>
 <!--- cfformat-ignore-start --->
 <cfsavecontent variable="local.wdbHtml"><cfoutput>
-<div id="wheels-debugbar" style="all:initial;position:fixed;bottom:0;left:0;width:100%;overflow:hidden;z-index:99999;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,sans-serif;">
+<div id="wheels-debugbar" style="all:initial;display:block;position:fixed;bottom:0;left:0;overflow:hidden;z-index:99999;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,sans-serif;">
 <style><cfinclude template="/wheels/public/assets/css/debugbar.css"></style>
 
 <!--- ============ RELOAD-REFUSED NOTICE (issue 3311) ============

--- a/vendor/wheels/public/assets/css/debugbar.css
+++ b/vendor/wheels/public/assets/css/debugbar.css
@@ -1,11 +1,12 @@
 #wheels-debugbar *{box-sizing:border-box;margin:0;padding:0;}
-#wheels-debugbar{position:fixed;bottom:0;left:0;width:100%;overflow:hidden;z-index:99999;font-size:13px;line-height:1.4;transition:width .35s cubic-bezier(.4,0,.2,1) !important;}
+#wheels-debugbar{display:block !important;position:fixed;bottom:0;left:0;width:100% !important;min-width:0;overflow:hidden;z-index:99999;font-size:13px;line-height:1.4;background:#1e1e2e !important;transition:width .35s cubic-bezier(.4,0,.2,1) !important;}
 #wheels-debugbar.wdb-collapsed{width:40px !important;}
 #wheels-debugbar.wdb-no-transition{transition:none !important;}
 @media (prefers-reduced-motion:reduce){#wheels-debugbar{transition:none !important;}}
 #wheels-debugbar.wdb-collapsed>:not(.wdb-bar):not(style):not(script){display:none !important;}
+#wheels-debugbar.wdb-collapsed .wdb-bar>:not(.wdb-logo){display:none !important;}
 #wheels-debugbar .wdb-logo{flex-shrink:0;}
-#wheels-debugbar.wdb-collapsed .wdb-bar{padding:0;}
+#wheels-debugbar.wdb-collapsed .wdb-bar{padding:0;background:#1e1e2e;}
 #wheels-debugbar.wdb-collapsed .wdb-logo{width:40px;padding:0;justify-content:center;}
 #wheels-debugbar .wdb-bar{display:flex;align-items:center;background:#1e1e2e;color:#cdd6f4;height:36px;padding:0 8px;gap:2px;border-top:1px solid #45475a;user-select:none;overflow:hidden;flex-wrap:nowrap;}
 #wheels-debugbar .wdb-bar a,#wheels-debugbar .wdb-bar span{color:#cdd6f4;text-decoration:none;}

--- a/vendor/wheels/tests/specs/events/DebugBarCollapseSpec.cfc
+++ b/vendor/wheels/tests/specs/events/DebugBarCollapseSpec.cfc
@@ -6,7 +6,8 @@ component extends="wheels.WheelsTest" {
 			// sibling button labeled "Debug" (the ##3345 restore control). Collapse
 			// now keeps the container visible and shrinks it to the stylized W logo
 			// via a CSS width transition. These specs lock the chrome contract:
-			// logo first, X last, no floating Debug button, CSS/JS animation hooks.
+			// logo first, X last, no floating Debug button, no inline width fight,
+			// collapsed-chrome CSS hides non-logo bar children.
 
 			it("renders the stylized W logo first and the X close last, with no floating Debug button", () => {
 				var output = $renderDebugBar();
@@ -19,6 +20,18 @@ component extends="wheels.WheelsTest" {
 				);
 				expect(output contains "</svg>Debug</button>").toBeFalse(
 					"the collapsed chrome must not be a floating button labeled Debug"
+				);
+				expect(
+					FindNoCase('id="wheels-debugbar" style="all:initial;display:block;', output)
+				).toBeGT(
+					0,
+					"all:initial isolation must restore display:block so width can layout and transition"
+				);
+				expect(
+					FindNoCase('id="wheels-debugbar" style="all:initial;display:block;position:fixed;bottom:0;left:0;width:', output)
+				).toBe(
+					0,
+					"the root inline style must not pin width — stylesheet width has to animate"
 				);
 
 				var barStart = FindNoCase('id="wdb-bar"', output);
@@ -80,6 +93,14 @@ component extends="wheels.WheelsTest" {
 				expect(FindNoCase("width:40px", css)).toBeGT(
 					0,
 					"collapsed chrome must shrink to a logo-sized width"
+				);
+				expect(FindNoCase("width:100% !important", css)).toBeGT(
+					0,
+					"expanded width must be stylesheet-driven with !important so it beats all:initial and interpolates with the collapsed 40px rule"
+				);
+				expect(FindNoCase(".wdb-bar>:not(.wdb-logo)", css)).toBeGT(
+					0,
+					"collapsed chrome must hide non-logo children of .wdb-bar, not only clip them"
 				);
 				expect(FindNoCase("wdb-collapsed", js)).toBeGT(
 					0,

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/debug-panel.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/debug-panel.mdx
@@ -50,9 +50,9 @@ Do not put this override in `config/environment.cfm`. That file only selects the
 
 When active, the bar appears as a slim strip pinned to the bottom of the browser window. Tabs are arranged from left to right: a Wheels logo (doubles as the Request tab toggle), then Request, Timing, Params, Environment, and optionally Tools. The right side shows the current git branch (when the web root — `public/` — contains a `.git` directory), the framework version, and a one-click reload link when no reload password is configured.
 
-![The collapsed Wheels debug bar pinned to the bottom of a browser window: Wheels logo, Posts.index controller.action, timing badge, Params, Development environment, and Tools tabs, with Wheels 4.0.0-SNAPSHOT version on the right](/v4-0-0/digging-deeper/debug-panel-screenshots/01-collapsed-bar.png)
+![The Wheels debug bar pinned to the bottom of a browser window: Wheels logo, Posts.index controller.action, timing badge, Params, Development environment, and Tools tabs, with Wheels 4.0.0-SNAPSHOT version on the right](/v4-0-0/digging-deeper/debug-panel-screenshots/01-collapsed-bar.png)
 
-Clicking any tab opens a panel above the bar. Clicking the same tab again closes it. The minimize button (×) collapses the bar to a small "Debug" button in the corner, persisted via `sessionStorage` so it stays collapsed as you navigate.
+Clicking any tab opens a panel above the bar. Clicking the same tab again closes it. The close button (×) slides the bar left to a logo-sized black strip that shows only the stylized red W. Click the collapsed logo to expand the bar back across the bottom. The collapsed state is persisted via `sessionStorage` so it stays collapsed as you navigate.
 
 ## Request tab
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #3559 / #3547: the collapse class and width transition shipped, but the debug bar still snapped away into a hovering-button look instead of sliding to a logo-only strip.

The root cause is a cascade fight on `#wheels-debugbar`. The markup pinned `style="all:initial;...;width:100%;..."`. `all:initial` resets `display` to `inline` and `width` to `auto`; the inline `width:100%` then won over the stylesheet's non-important expanded width. Collapsing jumped from an inline width to `width:40px !important`, so browsers did not interpolate a visible slide. Combined with a transparent root box (also from `all:initial`) and overflow-only clipping of tabs, the collapsed chrome looked like a floating button.

This PR:

- Restores `display:block` next to `all:initial` and removes the inline width pin
- Drives both expanded (`width:100% !important`) and collapsed (`width:40px !important`) widths from the stylesheet so the existing width transition can interpolate
- Gives the root a dark `!important` background so the shrinking strip stays a black bar
- Hides `.wdb-bar > :not(.wdb-logo)` while collapsed (logo-only chrome, not clipped tabs)
- Updates the guides copy that still described a floating "Debug" button
- Strengthens `DebugBarCollapseSpec` to lock the no-inline-width contract and the collapsed-chrome hide rule

Confirmed no remaining `#wdb-minimized` / floating "Debug" restore-button code path.

## Related Issue

Fixes the remaining #3547 UX after #3559. #3547 is already closed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [x] Documentation update
- [ ] Refactoring

## Feature Completeness Checklist

- [x] **DCO sign-off** -- Every commit carries `Signed-off-by:`
- [x] **Tests** -- `DebugBarCollapseSpec` now asserts no root inline width, `display:block` after `all:initial`, stylesheet `width:100% !important`, and `.wdb-bar>:not(.wdb-logo)` hide rule
- [x] **Framework Docs** -- Updated `web/sites/guides/src/content/docs/v4-0-0/digging-deeper/debug-panel.mdx` (live v4 guide; there is no v4-0-0-snapshot copy of this page)
- [x] **AI Reference Docs** -- N/A (chrome-only; consumer-ai has no debug-bar collapse copy)
- [x] **CLAUDE.md** -- N/A
- [x] **Changelog fragment** -- `changelog.d/3547-debugbar-slide-animation.fixed.md`
- [x] **Test runner passes** -- `bash tools/test-local.sh wheels.tests.specs.events` → 100 passed (Lucee 7 + SQLite)

## Test Plan

- [x] Rendered debug bar HTML has `wdb-logo` first and `wdb-close` last
- [x] No `#wdb-minimized` / floating "Debug" button in source or rendered HTML
- [x] Root inline style has `all:initial;display:block` and does not pin `width`
- [x] CSS hides `.wdb-bar > :not(.wdb-logo)` when `.wdb-collapsed`
- [x] Core events specs via `bash tools/test-local.sh wheels.tests.specs.events` (100 passed)
- [x] Hand-checked on the live demo at `http://localhost:8080/`: X slides left to a flush 40px dark strip with only the red W; logo click expands back; no floating Debug button

## Screenshots / Output

[debugbar-slide-to-logo.mp4](https://cursor.com/agents/bc-d05f3079-1c9d-45c0-ad7d-130e434a4648/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdebugbar-slide-to-logo.mp4)

[Collapsed logo-only strip](https://cursor.com/agents/bc-d05f3079-1c9d-45c0-ad7d-130e434a4648/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdebugbar_collapsed_logo_strip.webp)
[Expanded full debug bar](https://cursor.com/agents/bc-d05f3079-1c9d-45c0-ad7d-130e434a4648/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdebugbar_expanded_full_bar.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d05f3079-1c9d-45c0-ad7d-130e434a4648?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d05f3079-1c9d-45c0-ad7d-130e434a4648&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

