### PR TITLE
fix(cli): migrate diff renders column names and normalizes SQLite types

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -5524,25 +5524,25 @@ component extends="modules.BaseModule" {
 			out("--- #heading# ---", "bold");
 
 			for (var col in (diff.addColumns ?: [])) {
-				out("  + add    #col#", "green");
+				out("  + add    #col.name# (#col.type#)", "green");
 				anyOutput = true;
 			}
 			for (var col in (diff.removeColumns ?: [])) {
-				out("  - remove #col#", "red");
-				out("      (if this is a rename, use --rename #col#:newName)", "yellow");
+				out("  - remove #col.name#", "red");
+				out("      (if this is a rename, use --rename #col.name#:newName)", "yellow");
 				anyOutput = true;
 			}
 			for (var col in (diff.changeColumns ?: [])) {
-				out("  ~ change #col#", "yellow");
+				out("  ~ change #col.name# (#col.from.type# -> #col.to.type#)", "yellow");
 				anyOutput = true;
 			}
 			for (var col in (diff.renameColumns ?: [])) {
-				out("  ~ rename #col#", "yellow");
+				out("  ~ rename #col.from# -> #col.to#", "yellow");
 				anyOutput = true;
 			}
 			for (var suggestion in (diff.suggestedRenames ?: [])) {
-				var sugOld = suggestion.oldName ?: "?";
-				var sugNew = suggestion.newName ?: "?";
+				var sugOld = suggestion.from ?: "?";
+				var sugNew = suggestion.to ?: "?";
 				var sugConf = suggestion.confidence ?: "";
 				out("  ? suggest #sugOld# -> #sugNew# (#sugConf#)", "cyan");
 				anyOutput = true;


### PR DESCRIPTION
## Summary

`wheels migrate diff` crashed with `Can't cast Complex Object Type [Struct] to String`, and on SQLite it reported spurious `text -> string` changes on every column. Two fixes:

### 1. CLI renderer (`cli/lucli/Module.cfc`)

The AutoMigrator diff bridge returns `addColumns`/`removeColumns`/`changeColumns`/`renameColumns` as arrays of **structs** (`{name, from, to, …}`), but `$renderDiffResult()` interpolated the whole struct into the output line. Now renders the fields:

- `+ add    <name> (<type>)`
- `- remove <name>`
- `~ change <name> (<from.type> -> <to.type>)`
- `~ rename <from> -> <to>`
- `? suggest <from> -> <to> (<confidence>)` (also fixes `suggestedRenames` reading `.oldName`/`.newName` — RenameDetector emits `.from`/`.to`)

### 2. AutoMigrator type normalization (`vendor/wheels/migrator/AutoMigrator.cfc`)

SQLite type affinity stores string/text/datetime all as TEXT, so the model introspection reports `cf_sql_varchar` (→ `string`) while the raw column type maps to `text`. The diff flagged every column as changed. On SQLite, string↔text is now treated as equivalent, so an in-sync scaffold reports "No differences found".

## Verification

- Full core suite (Lucee 7 + SQLite): **5,623 pass / 0 fail / 0 error**.
- Demo app: `wheels migrate diff` on a fresh scaffold now renders `No differences found — models and database are in sync.`
