### PR TITLE
fix(cli): scaffold belongsTo FK honors useUnderscoreReferenceColumns

### DIFF
--- a/changelog.d/scaffold-belongs-to-underscore-fk.fixed.md
+++ b/changelog.d/scaffold-belongs-to-underscore-fk.fixed.md
@@ -1,0 +1,1 @@
+- `wheels generate scaffold` and `wheels generate api-resource` now honour `useUnderscoreReferenceColumns` when adding the `belongsTo` foreign-key column: with the flag set (the `wheels new` default) the generated migration emits `<name>_id` (e.g. `user_id`) instead of a hard-coded camelCase `userId`, matching what `t.references()` produces (#3337)

--- a/cli/lucli/services/Scaffold.cfc
+++ b/cli/lucli/services/Scaffold.cfc
@@ -204,7 +204,7 @@ component {
 		var props = duplicate(arguments.properties);
 		if (len(arguments.belongsTo)) {
 			for (var parent in listToArray(arguments.belongsTo)) {
-				var fkName = lCase(parent) & "Id";
+				var fkName = $foreignKeyName(parent);
 				var hasFK = false;
 				for (var p in props) {
 					if (p.name == fkName) { hasFK = true; break; }
@@ -215,6 +215,45 @@ component {
 			}
 		}
 		return props;
+	}
+
+	/**
+	 * Foreign-key column name for a belongsTo parent, honoring the
+	 * `useUnderscoreReferenceColumns` setting (framework default false, but
+	 * `wheels new` apps opt in): `user_id` when true, `userId` when false.
+	 * Mirrors the suffix `t.references()` emits (TableDefinition.cfc) so the
+	 * scaffold's FK column matches a hand-written migration's column.
+	 */
+	private string function $foreignKeyName(required string parent) {
+		return lCase(arguments.parent) & ($usesUnderscoreReferenceColumns() ? "_id" : "Id");
+	}
+
+	/**
+	 * Whether config/settings.cfm opts into `<name>_id` reference columns.
+	 * The framework reads the flag via `$get()` at migration time; the CLI
+	 * service reads the source file directly, comment-stripped first
+	 * (Anti-Pattern #14) so a commented-out
+	 * `// set(useUnderscoreReferenceColumns=true);` doesn't satisfy the check.
+	 */
+	private boolean function $usesUnderscoreReferenceColumns() {
+		var settingsPath = variables.projectRoot & "/config/settings.cfm";
+		if (!fileExists(settingsPath)) return false;
+		return reFindNoCase(
+			"useUnderscoreReferenceColumns\s*=\s*true",
+			$stripCfmlComments(fileRead(settingsPath))
+		) > 0;
+	}
+
+	/**
+	 * Strip tag / block / line comments so source-grep checks can't be fooled
+	 * by commented-out code (Anti-Pattern #14). Mirrors Analysis.cfc.
+	 */
+	private string function $stripCfmlComments(required string source) {
+		var result = arguments.source;
+		result = reReplace(result, "<!---[\s\S]*?--->", "", "all");
+		result = reReplace(result, "/\*[\s\S]*?\*/", "", "all");
+		result = reReplace(result, "//[^\r\n]*", "", "all");
+		return result;
 	}
 
 	/**
@@ -428,7 +467,7 @@ component {
 			var props = duplicate(arguments.properties);
 			if (len(arguments.belongsTo)) {
 				for (var parent in listToArray(arguments.belongsTo)) {
-					var fkName = lCase(parent) & "Id";
+					var fkName = $foreignKeyName(parent);
 					var hasFK = false;
 					for (var p in props) {
 						if (p.name == fkName) { hasFK = true; break; }

--- a/cli/lucli/tests/specs/services/ScaffoldSpec.cfc
+++ b/cli/lucli/tests/specs/services/ScaffoldSpec.cfc
@@ -618,6 +618,33 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					expect(content).notToInclude('findByKey(params.key, include=');
 				});
 
+				it("emits <name>_id FK column when useUnderscoreReferenceColumns=true", () => {
+					// `wheels new` apps opt into underscore reference columns; the
+					// scaffold's belongsTo FK column must match what t.references()
+					// would produce rather than hard-coding camelCase `userId`.
+					var settingsPath = tempRoot & "/config/settings.cfm";
+					var originalSettings = fileRead(settingsPath);
+					fileWrite(
+						settingsPath,
+						replace(originalSettings, "// CLI-Appends-Here", "set(useUnderscoreReferenceColumns=true);" & chr(10) & "// CLI-Appends-Here")
+					);
+
+					scaffold.generateScaffold(
+						name = "Membership",
+						properties = [{name: "level", type: "string"}],
+						belongsTo = "User",
+						force = true
+					);
+
+					var files = directoryList(tempRoot & "/app/migrator/migrations", false, "name", "*memberships*");
+					expect(arrayLen(files)).toBeGTE(1);
+					var migration = fileRead(tempRoot & "/app/migrator/migrations/" & files[1]);
+					expect(migration).toInclude("t.integer(columnNames='user_id'");
+					expect(migration).notToInclude("columnNames='userId'");
+
+					fileWrite(settingsPath, originalSettings);
+				});
+
 			});
 
 			describe("generateApiTest() (CLI-D3)", () => {

--- a/cli/lucli/tests/specs/services/ScaffoldSpec.cfc
+++ b/cli/lucli/tests/specs/services/ScaffoldSpec.cfc
@@ -624,10 +624,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					// would produce rather than hard-coding camelCase `userId`.
 					var settingsPath = tempRoot & "/config/settings.cfm";
 					var originalSettings = fileRead(settingsPath);
-					fileWrite(
-						settingsPath,
-						replace(originalSettings, "// CLI-Appends-Here", "set(useUnderscoreReferenceColumns=true);" & chr(10) & "// CLI-Appends-Here")
-					);
+					fileWrite(settingsPath, originalSettings & chr(10) & "set(useUnderscoreReferenceColumns=true);");
 
 					scaffold.generateScaffold(
 						name = "Membership",


### PR DESCRIPTION
## Summary

`wheels generate scaffold Post title:string --belongsTo=User` hard-coded the
foreign-key column as camelCase `userId`, even when the app opts into
`useUnderscoreReferenceColumns=true` (the `wheels new` default). A fresh app
sets that flag in `config/settings.cfm`, which makes `t.references()` emit
`<name>_id` — so the scaffold's migration produced `userId` while a
hand-written migration (and the model layer's FK-default resolution) expects
`user_id`.

**Repro**

```
wheels new myapp && cd myapp          # sets useUnderscoreReferenceColumns=true
wheels generate scaffold Post title:string --belongsTo=User
# generated migration contains: t.integer(columnNames='userId', ...)
# expected:                     t.integer(columnNames='user_id', ...)
```

`$addForeignKeyColumns()` (and the inline loop in `generateApiResource()`) now
read `config/settings.cfm` (comment-stripped) and emit `<name>_id` when the
flag is true, `<name>Id` when false, matching `t.references()`.

## Related Issue

- #3337 — `useUnderscoreReferenceColumns=true` produces columns the
  belongsTo/hasMany foreignKey default never matches (closed; this PR fixes
  the CLI codegen half of that gap).

## Type of Change

- Bug fix

## Test Plan

- Spec: `cli/lucli/tests/specs/services/ScaffoldSpec.cfc`
  — `"emits <name>_id FK column when useUnderscoreReferenceColumns=true"`.
- Run: `bash tools/test-cli-local.sh` (all CLI specs) via the LuCLI runner.

> Local note: I could not run the suite locally — the repo's CLI harness
> (`tools/test-cli-local.sh`) requires LuCLI 0.3.3+ on PATH and Java 21+,
> and the full-suite LuCLI server harness was not wired up in this
> environment. The spec change is correct and CI should exercise it.
