### PR TITLE
fix(cli): reject unknown scaffold property types instead of emitting VARCHAR

### DIFF
--- a/changelog.d/scaffold-unknown-property-type.fixed.md
+++ b/changelog.d/scaffold-unknown-property-type.fixed.md
@@ -1,0 +1,1 @@
+- `wheels generate scaffold` and `wheels generate api-resource` now reject unknown property types (e.g. `user:references`) with a clear error instead of silently emitting a plain `string`/VARCHAR column with no foreign key

--- a/cli/lucli/services/Scaffold.cfc
+++ b/cli/lucli/services/Scaffold.cfc
@@ -1227,7 +1227,16 @@ component {
 		var textual = $mapWheelsTextualType(t);
 		if (len(textual)) return textual;
 
-		return $mapWheelsOtherType(t);
+		var other = $mapWheelsOtherType(t);
+		if (len(other)) return other;
+
+		// Never silently map an unknown type to a VARCHAR — `references` and
+		// other unrecognised tokens must fail loudly instead of producing a
+		// plain string column with no foreign key.
+		throw(
+			type = "ScaffoldError",
+			message = "Unknown property type '#arguments.type#'. Valid types: string, text, integer, biginteger, float, decimal, boolean, date, datetime, time, binary, uuid, enum, email, url."
+		);
 	}
 
 	/**
@@ -1255,8 +1264,10 @@ component {
 	}
 
 	/**
-	 * Map boolean/temporal/binary/uuid property types (and the default) to
-	 * their Wheels migration column type.
+	 * Map boolean/temporal/binary/uuid property types to their Wheels
+	 * migration column type. `email`/`url`/`enum` are stored as VARCHAR
+	 * columns (the model layer adds format/enum behaviour); anything else
+	 * returns "" so mapToWheelsType() rejects it instead of guessing "string".
 	 */
 	private string function $mapWheelsOtherType(required string type) {
 		switch (arguments.type) {
@@ -1266,7 +1277,8 @@ component {
 			case "time": return "time";
 			case "binary": case "blob": return "binary";
 			case "uuid": return "uniqueidentifier";
-			default: return "string";
+			case "email": case "url": case "enum": return "string";
+			default: return "";
 		}
 	}
 

--- a/cli/lucli/tests/specs/services/ScaffoldSpec.cfc
+++ b/cli/lucli/tests/specs/services/ScaffoldSpec.cfc
@@ -673,6 +673,24 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 
 			});
 
+			describe("unknown property type rejection", () => {
+
+				it("rejects 'references' instead of silently emitting a VARCHAR", () => {
+					// `user:references` was previously mapped to `string`, producing
+					// a plain VARCHAR column with no FK and no warning. Unknown types
+					// must fail loudly rather than generate silently-wrong output.
+					var result = scaffold.generateScaffold(
+						name = "Assignment",
+						properties = [{name: "content", type: "text"}, {name: "user", type: "references"}],
+						force = true
+					);
+					expect(result.success).toBeFalse();
+					expect(arrayLen(result.errors)).toBeGTE(1);
+					expect(result.errors[1]).toInclude("references");
+				});
+
+			});
+
 		});
 
 	}


### PR DESCRIPTION
## Summary

`wheels generate scaffold Widget content:text user:references` silently
produced a plain `string`/VARCHAR `user` column with no foreign key and no
warning. `references` is not a recognised property type, so the type mapper
fell through to `string`.

**Repro**

```
wheels generate scaffold Widget content:text user:references
# generated migration contained: t.string(columnNames='user', ...)  (a plain VARCHAR, no FK)
```

`mapToWheelsType()` no longer falls through to `string`. Unknown property
types now raise a clear, actionable error (`Unknown property type
'references'. Valid types: string, text, integer, biginteger, float,
decimal, boolean, date, datetime, time, binary, uuid, enum, email, url.`)
instead of generating silently-wrong output. `email`/`url`/`enum` still map
to a `string` column (the model layer adds the format/enum behaviour).

This deliberately does NOT implement `references` as a first-class type —
that would duplicate the existing `--belongsTo=` flow and is a larger design
change. Rejecting the unknown token is the minimal correct fix for the
silently-wrong output.

## Related Issue

- #2781 — Migrator `t.references()` API quirks (closed; context only — this
  PR is about the scaffold's property-type mapper, not `t.references()`).

## Type of Change

- Bug fix

## Test Plan

- Spec: `cli/lucli/tests/specs/services/ScaffoldSpec.cfc`
  — `"rejects 'references' instead of silently emitting a VARCHAR"`.
- Run: `bash tools/test-cli-local.sh` (all CLI specs) via the LuCLI runner.

> Local note: I could not run the suite locally — the repo's CLI harness
> (`tools/test-cli-local.sh`) requires LuCLI 0.3.3+ on PATH and Java 21+,
> and the full-suite LuCLI server harness was not wired up in this
> environment. The spec change is correct and CI should exercise it.
