### PR TITLE
fix(debugbar): reserve page space so the expanded bar does not cover content

### DIFF
--- a/changelog.d/debugbar-page-inset.fixed.md
+++ b/changelog.d/debugbar-page-inset.fixed.md
@@ -1,0 +1,1 @@
+- Debug bar: the expanded bar now reserves its height at the bottom of the page (`--wdb-inset` / `padding-bottom` on `html`) so content and controls are not covered and remain reachable by scrolling. Collapsing to the logo strip releases that space

--- a/vendor/wheels/public/assets/css/debugbar.css
+++ b/vendor/wheels/public/assets/css/debugbar.css
@@ -47,3 +47,5 @@
 #wheels-debugbar .wdb-env-dot{width:8px;height:8px;border-radius:50%;display:inline-block;}
 #wheels-debugbar .wdb-section{margin-bottom:16px;}
 #wheels-debugbar .wdb-section-title{font-size:11px;font-weight:700;color:#89b4fa;text-transform:uppercase;letter-spacing:.5px;margin-bottom:8px;padding-bottom:4px;border-bottom:1px solid #313244;}
+html:has(#wheels-debugbar),html.wdb-has-debugbar{--wdb-inset:36px;padding-bottom:var(--wdb-inset);scroll-padding-bottom:var(--wdb-inset);}
+html:has(#wheels-debugbar.wdb-collapsed),html.wdb-debugbar-collapsed{--wdb-inset:0px;}

--- a/vendor/wheels/public/assets/js/debugbar.js
+++ b/vendor/wheels/public/assets/js/debugbar.js
@@ -5,6 +5,23 @@
 		return document.getElementById('wheels-debugbar');
 	}
 
+	function syncPageInset() {
+		var root = debugRoot();
+		var html = document.documentElement;
+		if (!html) return;
+		var insetPx = '0px';
+		if (root && !root.classList.contains('wdb-collapsed')) {
+			var measured = root.offsetHeight;
+			insetPx = (measured > 0 ? measured : 36) + 'px';
+			html.classList.add('wdb-has-debugbar');
+			html.classList.remove('wdb-debugbar-collapsed');
+		} else if (root) {
+			html.classList.add('wdb-has-debugbar');
+			html.classList.add('wdb-debugbar-collapsed');
+		}
+		html.style.setProperty('--wdb-inset', insetPx);
+	}
+
 	function setCollapsed(collapsed, animate) {
 		var root = debugRoot();
 		if (!root) return;
@@ -24,6 +41,7 @@
 			root.offsetWidth;
 			root.classList.remove('wdb-no-transition');
 		}
+		syncPageInset();
 		try {
 			if (collapsed) {
 				sessionStorage.setItem('wdb-hidden', '1');
@@ -86,6 +104,10 @@
 		if (sessionStorage.getItem('wdb-hidden') === '1') {
 			wdbClosePanel();
 			setCollapsed(true, false);
+		} else {
+			syncPageInset();
 		}
-	} catch (e) {}
+	} catch (e) {
+		syncPageInset();
+	}
 })();

--- a/vendor/wheels/tests/specs/events/DebugBarPageInsetSpec.cfc
+++ b/vendor/wheels/tests/specs/events/DebugBarPageInsetSpec.cfc
@@ -1,0 +1,64 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+		describe("debug bar page inset (expanded vs collapsed)", () => {
+			// The bar is position:fixed at the bottom of the viewport. Without a
+			// compensating inset, expanded chrome overlays page controls and
+			// document scroll cannot reach that strip. These specs lock the
+			// CSS/JS contract: reserve --wdb-inset on html while expanded,
+			// collapse it to 0 when the logo strip is showing.
+
+			it("reserves page padding for the expanded bar and releases it when collapsed", () => {
+				var css = FileRead(ExpandPath("/wheels/public/assets/css/debugbar.css"));
+				var js = FileRead(ExpandPath("/wheels/public/assets/js/debugbar.js"));
+
+				expect(FindNoCase("--wdb-inset", css)).toBeGT(
+					0,
+					"debugbar.css must expose --wdb-inset so page content can sit above the bar"
+				);
+				expect(FindNoCase("padding-bottom:var(--wdb-inset)", css)).toBeGT(
+					0,
+					"debugbar.css must apply padding-bottom from --wdb-inset on the document"
+				);
+				expect(FindNoCase("scroll-padding-bottom:var(--wdb-inset)", css)).toBeGT(
+					0,
+					"debugbar.css must keep scroll-into-view above the reserved strip"
+				);
+				expect(FindNoCase(":has(##wheels-debugbar)", css)).toBeGT(
+					0,
+					"expanded inset must apply when ##wheels-debugbar is in the document"
+				);
+				expect(FindNoCase(":has(##wheels-debugbar.wdb-collapsed)", css)).toBeGT(
+					0,
+					"collapsed chrome must zero the inset via :has(.wdb-collapsed)"
+				);
+				expect(FindNoCase("--wdb-inset:0px", css)).toBeGT(
+					0,
+					"collapsed inset must be 0 so the logo strip does not leave a full-width dead zone"
+				);
+				expect(FindNoCase("wdb-has-debugbar", css)).toBeGT(
+					0,
+					"debugbar.css must keep a class fallback alongside :has() for the inset"
+				);
+				expect(FindNoCase("wdb-debugbar-collapsed", css)).toBeGT(
+					0,
+					"debugbar.css must zero the inset when html.wdb-debugbar-collapsed is set"
+				);
+
+				expect(FindNoCase("syncPageInset", js)).toBeGT(
+					0,
+					"debugbar.js must sync --wdb-inset when collapse state changes"
+				);
+				expect(FindNoCase("setProperty('--wdb-inset'", js)).toBeGT(
+					0,
+					"debugbar.js must write --wdb-inset on the document element"
+				);
+				expect(FindNoCase("wdb-debugbar-collapsed", js)).toBeGT(
+					0,
+					"debugbar.js must toggle html.wdb-debugbar-collapsed with the chrome class"
+				);
+			});
+		});
+	}
+
+}

--- a/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/debug-panel.mdx
+++ b/web/sites/guides/src/content/docs/v4-0-0/digging-deeper/debug-panel.mdx
@@ -48,7 +48,7 @@ Do not put this override in `config/environment.cfm`. That file only selects the
 
 ## The debug bar
 
-When active, the bar appears as a slim strip pinned to the bottom of the browser window. Tabs are arranged from left to right: a Wheels logo (doubles as the Request tab toggle), then Request, Timing, Params, Environment, and optionally Tools. The right side shows the current git branch (when the web root — `public/` — contains a `.git` directory), the framework version, and a one-click reload link when no reload password is configured.
+When active, the bar appears as a slim strip pinned to the bottom of the browser window. While it is expanded, the page reserves the bar's height at the bottom (`--wdb-inset` on `html`, default 36px) so content and controls are not covered and remain reachable by scrolling. Collapsing the bar to the logo strip releases that reserved space — the corner logo stays fixed, but it does not leave a full-width dead zone. Tabs are arranged from left to right: a Wheels logo (doubles as the Request tab toggle), then Request, Timing, Params, Environment, and optionally Tools. The right side shows the current git branch (when the web root — `public/` — contains a `.git` directory), the framework version, and a one-click reload link when no reload password is configured.
 
 ![The Wheels debug bar pinned to the bottom of a browser window: Wheels logo, Posts.index controller.action, timing badge, Params, Development environment, and Tools tabs, with Wheels 4.0.0-SNAPSHOT version on the right](/v4-0-0/digging-deeper/debug-panel-screenshots/01-collapsed-bar.png)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The development debug bar is `position: fixed` at the bottom of the viewport. When **expanded**, it overlaid the last strip of the page: buttons and other controls under the bar could not be clicked, and document scrollbars could not bring that strip into view.

This change reserves the expanded bar's height on `html` (`--wdb-inset`, default 36px, plus `padding-bottom` / `scroll-padding-bottom`) so page content ends at the **top of the bar**. Collapsing to the stylized W logo strip sets the inset to `0` so the corner chrome stays accessible without leaving a full-width dead zone. The #3562 width slide / collapse animation is unchanged.

## Related Issue

No dedicated issue number — follow-up to the #3547 / #3562 collapse UX.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [x] Documentation update
- [ ] Refactoring

## Feature Completeness Checklist

- [x] **DCO sign-off** -- Every commit carries `Signed-off-by:`
- [x] **Tests** -- `DebugBarPageInsetSpec` locks the CSS/JS inset contract (same FileRead pattern as `DebugBarCollapseSpec`)
- [x] **Framework Docs** -- Guide note on `web/sites/guides/src/content/docs/v4-0-0/digging-deeper/debug-panel.mdx`
- [ ] **AI Reference Docs** -- N/A (no maintainer runbook change)
- [ ] **CLAUDE.md** -- N/A (no model/controller/view convention change)
- [x] **Changelog fragment** -- `changelog.d/debugbar-page-inset.fixed.md`
- [ ] **Test runner passes** -- Wheels CLI is not installed in this agent environment; inset contract was verified with a headless Chrome fixture using the real `debugbar.css` / `debugbar.js` (see Test Plan)

## Test Plan

### Automated (project norm)

`DebugBarPageInsetSpec` FileRead-checks the CSS/JS contract. Run with:

```bash
bash tools/test-local.sh wheels.tests.specs.events
```

(`events` is not a short alias in `tools/test-local.sh`; pass the dotted directory.)

### Headless Chrome fixture (this PR)

Loaded the real stylesheet + script against a 200vh page with a bottom `Save` button, scrolled to the end, then toggled collapse/restore.

| State | `--wdb-inset` | `padding-bottom` | Button vs bar |
|---|---|---|---|
| Expanded | `36px` | `36px` | Button sits above the bar (`btnBottom` 964 / `barTop` 977, no overlap) |
| Collapsed | `0px` | `0px` | Content uses the full viewport again; 40px logo strip stays in the corner (no full-width dead zone) |
| Restored | `36px` | `36px` | Same as expanded; slide-to-W classes still toggle |

### Manual

1. Open a development page with a control near the bottom (or a long page).
2. **Expanded:** scroll to the bottom — last content sits above the bar; bottom buttons are clickable.
3. Click X to collapse to the W logo — reserved space goes away; page uses the full viewport; logo remains bottom-left.
4. Click the logo to expand — inset returns; collapse animation still slides to the W.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f58f5c42-da85-431d-93a2-c3b63b48adff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f58f5c42-da85-431d-93a2-c3b63b48adff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

