### PR TITLE
docs(blog): postpone 4.1.0 release post to 2026-09-17

### DIFF
--- a/web/content/blog/scheduled/wheels-4-1-0-released.md
+++ b/web/content/blog/scheduled/wheels-4-1-0-released.md
@@ -1,7 +1,7 @@
 ---
 title: 'Wheels 4.1.0 is out — the release a bug report built'
 slug: wheels-4-1-0-released
-publishedAt: '2026-09-10T14:00:00.000Z'
+publishedAt: '2026-09-17T14:00:00.000Z'
 updatedAt: null
 author: Peter Amiri
 tags:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Postpone the scheduled Wheels 4.1.0 release blog by one week so today's catch-up publisher does not re-publish it.

The morning bot already opened then closed PR #3572 (publish move) without merging; the post remains in `web/content/blog/scheduled/`. Catch-up semantics would re-publish anything with `publishedAt` ≤ today unless this date is moved first.

Only frontmatter `publishedAt` changed: `2026-09-10T14:00:00.000Z` → `2026-09-17T14:00:00.000Z` (same 14:00 UTC). Body, title, slug, and announcement block are unchanged. The file stays in `scheduled/`.

## Related Issue

N/A — maintainer hold on today's publish.

## Type of Change

- [x] Documentation update

## Feature Completeness Checklist

- [x] **DCO sign-off** -- Every commit carries `Signed-off-by:` (use `git commit -s`); see [CONTRIBUTING.md](../blob/develop/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [ ] **Tests** -- N/A (frontmatter date only)
- [ ] **Framework Docs** -- N/A
- [ ] **AI Reference Docs** -- N/A
- [ ] **CLAUDE.md** -- N/A
- [ ] **Changelog fragment** -- N/A (blog schedule, not a framework user-facing change)
- [ ] **Test runner passes** -- N/A

## Test Plan

- Confirm the diff is a single-line `publishedAt` change
- Confirm the file remains under `web/content/blog/scheduled/`
- Confirm title, slug, body, and announcement block are unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0972de77-6ee2-4144-b58b-b034f61ea987?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0972de77-6ee2-4144-b58b-b034f61ea987&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

