### PR TITLE
docs: align Mid-Michigan CFUG materials with 4.1 rehearsal

### DIFF
--- a/docs/presentations/cfug-2026-09-15/deck.md
+++ b/docs/presentations/cfug-2026-09-15/deck.md
@@ -6,6 +6,10 @@ A ~60-minute talk in five parts. Speaker notes are the `> Notes:`
 blockquotes. The live build (Part 2) follows [`demo.md`](demo.md) beat-for-beat;
 everything else is slides with a few terminal snippets.
 
+This deck matches a rehearsal on **Wheels 4.1.0-snapshot / upcoming 4.1**.
+4.1 is what we're shipping — the cut is being held to absorb polish, and the
+release blog is postponed to ~September 17. Treat this build as 4.1.
+
 **Timing:** Part 1 ≈ 10 · Part 2 ≈ 25 · Part 3 ≈ 15 · Part 4 ≈ 8 · Part 5 ≈ 3,
 leaving ~30 min for announcements and Q&A in a 1.5-hour meeting.
 
@@ -21,28 +25,32 @@ leaving ~30 min for announcements and Q&A in a 1.5-hour meeting.
 Peter Amiri · Mid-Michigan CFUG · September 15, 2026
 
 > Notes: Thank Rick. One sentence of framing: "half of this is typing, half is
-> the story of why CFML needed this."
+> the story of why CFML needed this." This is a 4.1 talk on a 4.1.0-snapshot
+> build — the release is shipping imminently.
 
 ## Slide 2 — The one-liner
 
 **Wheels is the convention-over-configuration MVC framework for CFML.**
 
 - The project you knew as **CFWheels** — rebranded at v3.0.
-- **4.1.0 shipped September 10** — five days ago.
+- **4.1 is what we're shipping** — this build *is* 4.1; the cut is held
+  deliberately so polish lands with it.
 - Models, migrations, routes, controllers, views — wired by *naming*, not XML.
 
-> Notes: The thesis. Say it slowly. This is the "oh" moment for anyone who
-> fought CFML config in the 2000s.
+> Notes: The thesis. Say it slowly. Do not claim "4.1.0 shipped September 10"
+> — Peter held the release to absorb polish bugs; the blog post is postponed
+> to ~September 17. "This is 4.1" is the true sentence.
 
 ## Slide 3 — The Rails DNA
 
 - Convention over configuration, the DHH way.
-- `Post` → `posts` → `PostsController` → `/posts`.
+- `Post` → `posts` → `Posts.cfc` → `/posts`.
 - Associations, validations, migrations read like Rails.
 - If you've written Rails, **you already know the shape of Wheels**.
 
 > Notes: Aim this at Rick and the RoR folks. It's the bridge that makes the
-> rest of the talk land.
+> rest of the talk land. Controllers are `Posts.cfc` / `Comments.cfc` — not
+> `PostsController.cfc`.
 
 ## Slide 4 — A short history
 
@@ -71,10 +79,10 @@ configuration** — and it generates real files you own.
 ## Slide 6 — What we're building
 
 1. `wheels new` — a running app, in seconds.
-2. **Scaffold + migrate** — full CRUD.
+2. **Scaffold + migrate + seed** — full CRUD, content on screen.
 3. **Associations + validation** — comments on posts.
-4. **Route model binding** — no `findByKey`, 404s for free.
-5. **One-command auth** — bcrypt, generated.
+4. **Route model binding** — `params.post`, 404s for free.
+5. **One-command auth** — PBKDF2, generated.
 6. The CLI + debug bar.
 
 > Notes: "No more slideware after this." Everything here is reproducible from
@@ -87,21 +95,29 @@ $ wheels new blog
 $ cd blog && wheels start
 ```
 
-A running app with a status line: **version · engine · database · environment**.
+A running app. The welcome page is a **prose sentence**:
 
-> Notes: Beat 1. Zero config to a running app. Gesture at the status line.
+> Your Wheels … application is running on Lucee with blog (development).
 
-## Slide 8 — Scaffold + migrate
+> Notes: Beat 1. Zero config to a running app. Gesture at that sentence —
+> version, engine, datasource, environment, in English. If `wheels start`
+> complains about a leftover server name, `--force`.
+
+## Slide 8 — Scaffold + migrate + seed
 
 ```
 $ wheels generate scaffold Post title:string body:text
 $ wheels migrate latest
+$ wheels seed
 ```
 
-Model, migration, controller, views, tests, route — one command. Then CRUD live.
+Model, migration, controller, views, tests, route — one command. Then two
+posts on `/posts` without typing through the form.
 
-> Notes: Beat 2, the "blog in 15 minutes" moment. Open a generated file and
-> point at it: this is code you own.
+> Notes: Beat 2, the "blog in 15 minutes" moment. Drop
+> `demo-app/seeds.cfm` into `app/db/seeds.cfm` (LuCLI has no
+> `wheels generate seed`). Open `app/controllers/Posts.cfc` — real code
+> you own.
 
 ## Slide 9 — Associations + validation
 
@@ -121,13 +137,19 @@ validatesPresenceOf("author,body");
 ## Slide 10 — Route model binding
 
 ```cfm
-.resources(name="posts", binding=true)   // delete the findByKey in show()
+.resources(name="posts", binding=true)
+
+function show() {
+    post = params.post;   // was findByKey(params.key)
+}
 ```
 
-The dispatcher loads `params.post` before the action; missing `:key` → 404.
-`bindBy="slug"` swaps the segment to any column for pretty URLs.
+The dispatcher loads `params.post` before the action; a missing `:key` is a
+404. Scaffolded `show()` is only `findByKey` — replace it. `bindBy="slug"`
+swaps the segment to any column for pretty URLs.
 
-> Notes: Beat 4. The "wow" — the boilerplate literally disappears.
+> Notes: Beat 4. The "wow" — the boilerplate literally disappears. There is
+> no IsObject / not-found guard to delete.
 
 ## Slide 11 — One-command auth
 
@@ -136,22 +158,22 @@ $ wheels generate auth
 $ wheels migrate latest
 ```
 
-Registration + login + logout, generated. **bcrypt** hashing, per-user salt in
-the hash, constant-time verify.
+Registration + login + logout, generated. Column is **`passwordDigest`**.
+Hashing is **PBKDF2-HMAC-SHA256** via the `passwordHasher` service.
 
-> Notes: Beat 5. Point at the `passwordHash` column. "No JARs, no CFX — pure
-> CFML bcrypt, byte-identical to OpenBSD."
+> Notes: Beat 5. Point at `passwordDigest`. Do not say bcrypt here —
+> `bcryptHash()` / `bcryptVerify()` are a separate 4.1 helper set (Part 4).
 
 ## Slide 12 — The CLI + debug bar
 
 ```
-$ wheels migrate diff       # what would migrations say?
 $ wheels coverage --top=5   # change-risk ranking
 ```
 
 Plus the dev debug bar: request timing, params, queries, the complexity panel.
 
-> Notes: Beat 6. Pick two. This is the "tooling is first-class now" point.
+> Notes: Beat 6. This is the reliable wow. `migrate diff` is 4.1 polish —
+> do not promise a live crash-free demo of it.
 
 ---
 
@@ -234,13 +256,14 @@ Playwright, and `wheels coverage` for change-risk.
 
 ## Slide 18 — The CLI
 
-`wheels new · generate · migrate · test · console · deploy · doctor · coverage`
+`wheels new · generate · migrate · seed · test · console · deploy · doctor · coverage`
 
 A first-party CLI built on the LuCLI runtime — Homebrew/Scoop/apt. CommandBox
 still works; the CLI is an accelerator, not a gate.
 
-> Notes: Name the verbs. The deploy verb (Kamal-style) is worth one sentence if
-> time allows.
+> Notes: Name the verbs. They already saw `new`, `generate`, `migrate`,
+> `seed`, and `coverage`. The deploy verb (Kamal-style) is worth one
+> sentence if time allows.
 
 ---
 
@@ -248,14 +271,19 @@ still works; the CLI is an accelerator, not a gate.
 
 ## Slide 19 — What's in 4.1
 
-- **bcrypt** password hashing — pure CFML, OpenBSD/jBCrypt-compatible.
+- **`generate auth`** — session/token/JWT scaffolds; **PBKDF2-HMAC-SHA256**
+  into `passwordDigest`.
+- **`bcryptHash()` / `bcryptVerify()`** — a *separate* 4.1 helper set
+  (OpenBSD/jBCrypt-compatible). Not what `generate auth` uses.
 - **`enableSession()`** — one-line auth wiring.
 - **`bindBy=`** and **`toFactory()`** — routing and DI ergonomics.
-- **CLI:** `migrate diff`, `generate --dry-run`, `--offline`, `coverage`.
+- **CLI:** `coverage`, `generate --dry-run`, `--offline` — plus `migrate
+  diff` as shipping polish.
 - **The security-hardening pass** and a **2.5x** model-instantiation speedup.
 
-> Notes: This is the release post from the blog, condensed. Tie each bullet to
-> something they saw in the live build.
+> Notes: Keep bcrypt and `generate auth` in different sentences. Tie each
+> other bullet to something they saw in the live build. The release is
+> shipping imminently — this snapshot *is* the 4.1 surface.
 
 ## Slide 20 — The hardening pass
 
@@ -290,7 +318,7 @@ it's conventions plus real files.
 ## Slide 23 — Where to go, and Q&A
 
 - **guides.wheels.dev** — the docs
-- **blog.wheels.dev** — the 4.1 release series
+- **blog.wheels.dev** — the 4.1 series (release post ~September 17)
 - **github.com/wheels-dev/wheels** — issues, PRs, stars
 
 > Notes: "Come build something with it — and file the bug when it breaks."

--- a/docs/presentations/cfug-2026-09-15/demo-app/Comment.cfc
+++ b/docs/presentations/cfug-2026-09-15/demo-app/Comment.cfc
@@ -1,0 +1,11 @@
+/**
+ * Hand-typed target for Act 3 — belongsTo + presence validation.
+ * Diff against the live app with:
+ *   diff app/models/Comment.cfc docs/presentations/cfug-2026-09-15/demo-app/Comment.cfc
+ */
+component extends="Model" {
+	function config() {
+		belongsTo(name="post");
+		validatesPresenceOf("author,body");
+	}
+}

--- a/docs/presentations/cfug-2026-09-15/demo-app/Post.cfc
+++ b/docs/presentations/cfug-2026-09-15/demo-app/Post.cfc
@@ -1,0 +1,10 @@
+/**
+ * Hand-typed target for Act 3 — the association you add after the Comment scaffold.
+ * Diff against the live app with:
+ *   diff app/models/Post.cfc docs/presentations/cfug-2026-09-15/demo-app/Post.cfc
+ */
+component extends="Model" {
+	function config() {
+		hasMany(name="comments", dependent="delete");
+	}
+}

--- a/docs/presentations/cfug-2026-09-15/demo-app/README.md
+++ b/docs/presentations/cfug-2026-09-15/demo-app/README.md
@@ -9,8 +9,29 @@ Use it to diff your rehearsal build against the finished shape:
 
 ```bash
 diff app/models/Post.cfc docs/presentations/cfug-2026-09-15/demo-app/Post.cfc
+diff app/models/Comment.cfc docs/presentations/cfug-2026-09-15/demo-app/Comment.cfc
 ```
 
-`seeds.cfm` is optional — it pre-populates a couple of posts if you'd rather
-start the demo with content on screen (`wheels seed`) instead of creating the
-first post live.
+## Seed (in the live-build script)
+
+[`seeds.cfm`](seeds.cfm) is a **first-class ~30s beat** after the first Post
+scaffold + migrate — not an afterthought. Copy it to `app/db/seeds.cfm` and
+run `wheels seed` so `/posts` has two rows without typing through the form.
+
+```bash
+mkdir -p app/db
+cp docs/presentations/cfug-2026-09-15/demo-app/seeds.cfm app/db/seeds.cfm
+wheels seed
+```
+
+Why a prepared file instead of a generator:
+
+- LuCLI has **no** `wheels generate seed` (`Unknown generator type: seed`).
+- `wheels generate snippets seed-data` writes Role/Setting stubs under
+  `app/snippets/` — wrong models for this talk, plus a copy step.
+- Two `seedOnce()` calls on `Post` have no auth coupling (no `User`, no
+  `passwordDigest`).
+- `wheels seed` needs the server already running (true after Act 1).
+
+If the copy path is awkward on stage, paste the eight lines from `seeds.cfm`
+into `app/db/seeds.cfm` instead.

--- a/docs/presentations/cfug-2026-09-15/demo-app/seeds.cfm
+++ b/docs/presentations/cfug-2026-09-15/demo-app/seeds.cfm
@@ -1,0 +1,16 @@
+<!--- app/db/seeds.cfm — two posts for the CFUG live build.
+     Drop this file in place after the Post scaffold + migrate, then `wheels seed`.
+     LuCLI has no `wheels generate seed`; write this file (or copy it) yourself. --->
+<cfscript>
+
+seedOnce(modelName="Post", uniqueProperties="title", properties={
+	title: "Hello Mid-Michigan",
+	body: "A first post from wheels seed — no form-filling required."
+});
+
+seedOnce(modelName="Post", uniqueProperties="title", properties={
+	title: "Convention over configuration",
+	body: "Post maps to posts, Posts.cfc, and /posts. The naming is the wiring."
+});
+
+</cfscript>

--- a/docs/presentations/cfug-2026-09-15/demo.md
+++ b/docs/presentations/cfug-2026-09-15/demo.md
@@ -10,12 +10,19 @@ feature tour, the 4.1 release story, and the close) are slides and terminal
 snippets, not more live typing. In a 1.5-hour meeting that leaves ~30 minutes
 for announcements and Q&A.
 
+Rehearsed against **Wheels 4.1.0-snapshot / upcoming 4.1**. 4.1 is what we're
+shipping; the cut is held to absorb polish and the release blog is postponed
+to ~September 17. Treat this build as 4.1.
+
 ## Prerequisites
 
-- Wheels CLI 4.x (`wheels --version`) — Homebrew/Scoop/apt. Java 21.
+- Wheels CLI 4.1.0-snapshot (`wheels --version`) — Homebrew/Scoop/apt. Java 21.
 - A clean shell. No prior app state.
 - Optional but recommended: run the build once the day before so the Lucee
   server JARs and the SQLite JDBC driver are cached (first boot is the slow one).
+- The two-post seed file at [`demo-app/seeds.cfm`](demo-app/seeds.cfm) — copy
+  it into the new app after the first migrate (LuCLI has no
+  `wheels generate seed`).
 
 > The rehearsal checklist is at the bottom — read it before the talk.
 
@@ -29,36 +36,56 @@ cd blog
 wheels start
 ```
 
-Open the printed URL. **Point at the status line** on the welcome page:
-`Wheels <version> · <engine> · <database> · <environment>`.
+Open the printed URL. **Point at the welcome sentence**:
+
+> Your Wheels … application is running on Lucee with blog (development).
+
+That's version, engine, datasource, and environment — a prose sentence, not
+a `Wheels · engine · db · env` status chip.
 
 **Say:** "That's the whole stack — a running app with zero config. No
 `Application.cfc` hand-editing, no wiring, no XML. It's already up."
 
 > Gotcha: `wheels new` may ask for the app name if you omit it; pass it as the
 > positional arg as above. If `wheels start` picks a port you don't like,
-> stop and restart with `--port`.
+> stop and restart with `--port`. If a leftover server name collides
+> (registered to a different path), `wheels start --force`.
 
 ---
 
-## Act 2 — scaffold + migrate (≈4 min)
+## Act 2 — scaffold + migrate + seed (≈4 min)
 
 ```bash
 wheels generate scaffold Post title:string body:text
 wheels migrate latest
 ```
 
-Reload. Create a post, list it, edit it, delete it — all live.
+Drop the prepared two-post seed into place, then seed. LuCLI has no
+`wheels generate seed` — `wheels generate snippets seed-data` writes
+Role/Setting stubs under `app/snippets/`, which is the wrong content
+for this talk.
 
-**Open one generated file** (`app/models/Post.cfc`, `app/controllers/PostsController.cfc`)
+```bash
+mkdir -p app/db
+# from the talk checkout, or paste the 8 lines from demo-app/seeds.cfm
+cp /path/to/docs/presentations/cfug-2026-09-15/demo-app/seeds.cfm app/db/seeds.cfm
+wheels seed
+```
+
+Reload `/posts`. Two posts are on screen — no form-filling. Click through
+show / edit / delete on one of them if you want the CRUD click-tour;
+the seed already proved the list.
+
+**Open one generated file** (`app/models/Post.cfc`, `app/controllers/Posts.cfc`)
 to make the point that it's **real code you own**, not a black box.
 
 **Say:** "One command produced the model, the migration, the controller, the
-views, the tests, and the route. In Rails this is the `generate scaffold`
-moment — same idea, same payoff."
+views, the tests, and the route. `wheels seed` put content on the page.
+In Rails this is the `generate scaffold` moment — same idea, same payoff."
 
 > Gotcha: the scaffold also drops a `.resources("posts")` line into
 > `config/routes.cfm` automatically. Mention that you didn't touch routing yet.
+> `wheels seed` needs the server already running (it is, from Act 1).
 
 ---
 
@@ -90,7 +117,7 @@ component extends="Model" {
 }
 ```
 
-Show: create a post, add comments, show `post.comments` in the view. Then
+Show: open a seeded post, add comments, show `post.comments` in the view. Then
 submit an empty comment and **let the validation error render**.
 
 **Say:** "No foreign-key config. `belongsTo("post")` figures out `postId` from
@@ -100,6 +127,10 @@ the configuration."
 > Gotcha: if you want nested URLs (`/posts/1/comments`), that's the callback
 > syntax in routes — `.resources(name="posts", callback=function(map){ map.resources("comments"); })`.
 > Skip it live unless time allows; flat routes keep the demo moving.
+> After model edits, hard-reload with
+> `?reload=true&password=<WHEELS_RELOAD_PASSWORD>` from `.env` — bare
+> `?reload=true` is a silent no-op when a reload password is set (and
+> `wheels new` always sets one).
 
 ---
 
@@ -117,13 +148,21 @@ mapper()
 .end();
 ```
 
-In **`app/controllers/PostsController.cfc`**, delete the `findByKey` +
-not-found guard from `show()` — with binding, the record is loaded for you
-and a missing `:key` returns a 404 before the action runs.
+In **`app/controllers/Posts.cfc`**, replace `findByKey` in `show()` with
+`params.post`. Scaffolded `show()` is only the finder — there is **no**
+`IsObject` / not-found guard to delete.
+
+```cfm
+function show() {
+    post = params.post;
+}
+```
+
+A missing `:key` 404s in the dispatcher before the action runs.
 
 **Say:** "With `binding=true`, the dispatcher loads `params.post` before the
-action. No `findByKey`, no `IsObject` guard. And `bindBy="slug"` swaps the
-segment to any column for pretty URLs."
+action. No `findByKey`. And `bindBy="slug"` swaps the segment to any column
+for pretty URLs."
 
 ### 4b — one-command auth
 
@@ -133,18 +172,25 @@ wheels migrate latest
 ```
 
 Reload and show registration + login + logout, all generated. **Point at the
-`passwordHash` column** and say the magic words: *bcrypt, per-user salt in the
-hash, constant-time verify.*
+`passwordDigest` column** and say: *PBKDF2-HMAC-SHA256 via the
+`passwordHasher` service — per-user salt in the hash, constant-time verify.*
 
-### 4c — the CLI quick hits (30s each, pick two)
+Do **not** call this bcrypt. `bcryptHash()` / `bcryptVerify()` /
+`bcryptNeedsRehash()` are a separate 4.1 helper set (Part 4 slides) — they
+are not what `generate auth` writes.
+
+### 4c — coverage + the debug bar (the reliable wow)
 
 ```bash
-wheels migrate diff          # what would migrations say?
 wheels coverage --top=5      # change-risk ranking
 ```
 
-Plus: the **debug bar** in dev (request timing, params, queries, the new
-complexity panel).
+Then the **debug bar** in the browser: request timing, params, queries, the
+complexity panel. That's the tooling beat.
+
+`wheels migrate diff` is 4.1 polish (preview what AutoMigrator would say).
+Do **not** promise a live crash-free demo of it — mention it only as
+"shipping / coming polish" if someone asks.
 
 ---
 
@@ -154,8 +200,8 @@ One slide, then Q&A:
 
 > **Convention over configuration — but you own every line it generates.**
 
-Point to `guides.wheels.dev`, `blog.wheels.dev` (the 4.1 series), and
-`github.com/wheels-dev/wheels`.
+Point to `guides.wheels.dev`, `blog.wheels.dev` (the 4.1 series; the
+release post is ~September 17), and `github.com/wheels-dev/wheels`.
 
 **Say:** "Come build something with it — and when it breaks, file the issue.
 That's how 4.1 got its security pass: real apps in the wild."
@@ -166,12 +212,15 @@ That's how 4.1 got its security pass: real apps in the wild."
 
 - [ ] Run the full build once the day before (warms the server + JDBC cache).
 - [ ] Time each act; trim Act 4c if you're over 20 minutes.
-- [ ] Confirm `wheels generate auth` runs against the **released** 4.1.0 CLI
-      (not a checkout) — the demo targets shipped software.
+- [ ] Confirm `wheels generate auth` against the **4.1.0-snapshot** CLI
+      you'll use on stage — this talk is the upcoming 4.1 surface, not 4.0.x.
+- [ ] Have `demo-app/seeds.cfm` ready to copy (or the 8 lines on a sticky).
 - [ ] Have a fallback if the venue Wi-Fi blocks Maven/CFPM downloads — pre-cache
       by running the build once online beforehand.
 - [ ] Keep a clean `blog/` dir in a side terminal; if you fat-finger a step,
       `cd .. && rm -rf blog && wheels new blog` resets you in ~10 seconds.
+      Then `wheels start --force` if the old `blog` server name is still
+      registered.
 
 ## If it goes sideways
 
@@ -179,6 +228,8 @@ That's how 4.1 got its security pass: real apps in the wild."
 |---|---|
 | `wheels start` hangs on first boot | It's downloading engine JARs — wait, or restart. |
 | Port already in use | `wheels start --port 8090` |
+| Server name registered to another path | `wheels start --force` |
 | Migration says "already applied" | `wheels migrate down` then `wheels migrate latest`, or just roll forward. |
+| `wheels seed` refuses | Server must be running and bound to this project (`wheels start`). Confirm `app/db/seeds.cfm` exists. |
 | Auth generator warns about existing `User` | You already have a User model — scaffold used `User`, pick a different model name with `--model=`. |
-| Live edit didn't take effect | Hard reload (`?reload=true`) or restart the server — Adobe caches compiled CFCs. |
+| Live edit didn't take effect | Hard reload: `?reload=true&password=<WHEELS_RELOAD_PASSWORD>` from `.env`. Bare `?reload=true` is refused when a password is set. |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Aligns the September 15 Mid-Michigan CFUG deck and live-build runbook with a rehearsal on Wheels 4.1.0-snapshot / upcoming 4.1. Docs only — no framework code.

## Seed decision: **in** (first-class ~30s beat)

After the first Post scaffold + `wheels migrate latest`, copy `demo-app/seeds.cfm` to `app/db/seeds.cfm` and run `wheels seed`. Two posts appear on `/posts` without typing through the form.

Why this is clean enough to keep in the script:

- No auth coupling — seeds only `Post` (`title` / `body`).
- Server is already up from Act 1 (`wheels seed` requires that).
- LuCLI has **no** `wheels generate seed`. `wheels generate snippets seed-data` writes Role/Setting stubs under `app/snippets/`, which is the wrong content and an extra copy step. A prepared 8-line file is the honest path.

If the copy path is awkward on stage, paste the eight lines instead. Documented in `demo-app/README.md`.

## Rehearsal corrections

1. Welcome status is a prose sentence (`Your Wheels … application is running on Lucee with blog (development).`), not a `Wheels · engine · db · env` chip.
2. Controllers are `Posts.cfc` / `Comments.cfc`, not `*Controller.cfc`.
3. Scaffolded `show()` is only `findByKey` — replace with `params.post`; missing key → 404 via binding. No `IsObject` guard to delete.
4. Hard reload is `?reload=true&password=<WHEELS_RELOAD_PASSWORD>` from `.env`.
5. Auth column is `passwordDigest`; hashing is PBKDF2-HMAC-SHA256. `bcryptHash()` / `bcryptVerify()` stay a separate 4.1 helper set.
6. `wheels start --force` when a leftover server name collides.
7. Act 4c wow is `wheels coverage --top=5` + the debug bar. `migrate diff` is mentioned only as shipping polish — not a promised live demo.
8. Release wording: “4.1 is what we’re shipping / this build is 4.1.” Do not claim “4.1.0 shipped September 10.” Peter held the cut; blog postponed to ~September 17.

## Files

- `docs/presentations/cfug-2026-09-15/deck.md`
- `docs/presentations/cfug-2026-09-15/demo.md`
- `docs/presentations/cfug-2026-09-15/demo-app/` (`README.md`, `seeds.cfm`, `Post.cfc`, `Comment.cfc`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae14cf38-d307-4758-b6a8-3dfa8e27a0c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae14cf38-d307-4758-b6a8-3dfa8e27a0c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

