### PR TITLE
fix(cli): migrate diff never interpolates nested column structs

### DIFF
--- a/changelog.d/migrate-diff-struct-cast.fixed.md
+++ b/changelog.d/migrate-diff-struct-cast.fixed.md
@@ -1,0 +1,1 @@
+- `wheels migrate diff` no longer crashes with `Can't cast Complex Object Type [Struct] to String` when rendering a generate-auth User table — nested `changeColumns.from`/`to` structs and other non-scalar diff fields are printed by name/type instead of interpolated wholesale

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -5509,42 +5509,115 @@ component extends="modules.BaseModule" {
 	}
 
 	/**
+	 * Coerce a diff-payload field to a printable string.
+	 *
+	 * AutoMigrator entries are structs (`{name, type, from, to, …}`).
+	 * Interpolating one (`"#col#"` / `"#suggestion.from#"` when `from` is
+	 * itself a struct) throws `Can't cast Complex Object Type [Struct] to
+	 * String` — the generate-auth User table hits this via nested
+	 * `changeColumns.from` / `.to`. Prefer scalar `name` / `from` / `to` /
+	 * `type` when present. Public for specs.
+	 */
+	public string function $stringifyDiffValue(required any value, fallback = "") {
+		if (isSimpleValue(arguments.value)) {
+			return toString(arguments.value);
+		}
+		if (isStruct(arguments.value)) {
+			var preferred = ["name", "from", "to", "type"];
+			for (var key in preferred) {
+				if (structKeyExists(arguments.value, key) && isSimpleValue(arguments.value[key])) {
+					return toString(arguments.value[key]);
+				}
+			}
+		}
+		return arguments.fallback;
+	}
+
+	/**
+	 * Read a changeColumn `from` / `to` node. AutoMigrator emits
+	 * `{type, size, scale, nullable}`; rename/suggest emit a bare name
+	 * string. Never interpolates the struct itself.
+	 */
+	public string function $diffTypeLabel(required any node, fallback = "?") {
+		if (isStruct(arguments.node) && structKeyExists(arguments.node, "type") && isSimpleValue(arguments.node.type)) {
+			return toString(arguments.node.type);
+		}
+		if (isSimpleValue(arguments.node) && len(toString(arguments.node))) {
+			return toString(arguments.node);
+		}
+		return arguments.fallback;
+	}
+
+	/**
 	 * Render a diff bridge response. Human-readable column listing per
 	 * model, with a trailer when previewing.
+	 *
+	 * Public for specs. Every printed field is forced through
+	 * `$stringifyDiffValue` / `$diffTypeLabel` so a struct in any array
+	 * (add/remove/change/rename/suggest/unmapped, or nested from/to)
+	 * cannot hit the Struct-to-String cast.
 	 */
-	private void function $renderDiffResult(required struct parsed, required boolean write) {
+	public void function $renderDiffResult(required struct parsed, required boolean write) {
 		var isSingle = structKeyExists(arguments.parsed, "model");
 		var diffs = isSingle ? { "": arguments.parsed.model } : (arguments.parsed.models ?: {});
+		if (!isStruct(diffs)) {
+			diffs = {};
+		}
 
 		var anyOutput = false;
 		for (var modelKey in diffs) {
 			var diff = diffs[modelKey];
-			var heading = structKeyExists(diff, "modelName") ? diff.modelName : modelKey;
+			if (!isStruct(diff)) {
+				continue;
+			}
+			var heading = $stringifyDiffValue(
+				structKeyExists(diff, "modelName") ? diff.modelName : modelKey,
+				isSimpleValue(modelKey) ? toString(modelKey) : "model"
+			);
 			out("");
-			out("--- #heading# ---", "bold");
+			out("--- " & heading & " ---", "bold");
 
-			for (var col in (diff.addColumns ?: [])) {
-				out("  + add    #col.name# (#col.type#)", "green");
+			for (var col in $diffColumnArray(diff, "addColumns")) {
+				if (isStruct(col)) {
+					out(
+						"  + add    " & $stringifyDiffValue(col.name ?: "")
+							& " (" & $stringifyDiffValue(col.type ?: "") & ")",
+						"green"
+					);
+				} else {
+					out("  + add    " & $stringifyDiffValue(col), "green");
+				}
 				anyOutput = true;
 			}
-			for (var col in (diff.removeColumns ?: [])) {
-				out("  - remove #col.name#", "red");
-				out("      (if this is a rename, use --rename #col.name#:newName)", "yellow");
+			for (var col in $diffColumnArray(diff, "removeColumns")) {
+				var removed = isStruct(col)
+					? $stringifyDiffValue(col.name ?: "")
+					: $stringifyDiffValue(col);
+				out("  - remove " & removed, "red");
+				out("      (if this is a rename, use --rename " & removed & ":newName)", "yellow");
 				anyOutput = true;
 			}
-			for (var col in (diff.changeColumns ?: [])) {
-				out("  ~ change #col.name# (#col.from.type# -> #col.to.type#)", "yellow");
+			for (var col in $diffColumnArray(diff, "changeColumns")) {
+				// Nested from/to are structs — extract .type; never "#col.from#".
+				var changeName = isStruct(col) ? $stringifyDiffValue(col.name ?: "") : $stringifyDiffValue(col);
+				var fromType = isStruct(col) ? $diffTypeLabel(col.from ?: {}) : "?";
+				var toType = isStruct(col) ? $diffTypeLabel(col.to ?: {}) : "?";
+				out("  ~ change " & changeName & " (" & fromType & " -> " & toType & ")", "yellow");
 				anyOutput = true;
 			}
-			for (var col in (diff.renameColumns ?: [])) {
-				out("  ~ rename #col.from# -> #col.to#", "yellow");
+			for (var col in $diffColumnArray(diff, "renameColumns")) {
+				var renameFrom = isStruct(col) ? $stringifyDiffValue(col.from ?: "?") : $stringifyDiffValue(col);
+				var renameTo = isStruct(col) ? $stringifyDiffValue(col.to ?: "?") : "?";
+				out("  ~ rename " & renameFrom & " -> " & renameTo, "yellow");
 				anyOutput = true;
 			}
-			for (var suggestion in (diff.suggestedRenames ?: [])) {
-				var sugOld = suggestion.from ?: "?";
-				var sugNew = suggestion.to ?: "?";
-				var sugConf = suggestion.confidence ?: "";
-				out("  ? suggest #sugOld# -> #sugNew# (#sugConf#)", "cyan");
+			for (var suggestion in $diffColumnArray(diff, "suggestedRenames")) {
+				// Elvis (`from ?: "?"`) returns a struct when `from` is nested
+				// (changeColumn-shaped). Force both sides through stringify.
+				var sugOld = isStruct(suggestion) ? $stringifyDiffValue(suggestion.from ?: "?", "?") : $stringifyDiffValue(suggestion, "?");
+				var sugNew = isStruct(suggestion) ? $stringifyDiffValue(suggestion.to ?: "?", "?") : "?";
+				var sugConf = isStruct(suggestion) ? $stringifyDiffValue(suggestion.confidence ?: "", "") : "";
+				out("  ? suggest " & sugOld & " -> " & sugNew & " (" & sugConf & ")", "cyan");
 				anyOutput = true;
 			}
 		}
@@ -5560,6 +5633,16 @@ component extends="modules.BaseModule" {
 			out("");
 			out("Migration file(s) written.", "green");
 		}
+	}
+
+	/**
+	 * Safe array read for a diff key. Missing / non-array keys become [].
+	 */
+	private array function $diffColumnArray(required struct diff, required string key) {
+		if (!structKeyExists(arguments.diff, arguments.key) || !isArray(arguments.diff[arguments.key])) {
+			return [];
+		}
+		return arguments.diff[arguments.key];
 	}
 
 	// ── Seed Execution ──────────────────────────────

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -5552,87 +5552,179 @@ component extends="modules.BaseModule" {
 	 * Render a diff bridge response. Human-readable column listing per
 	 * model, with a trailer when previewing.
 	 *
-	 * Public for specs. Every printed field is forced through
-	 * `$stringifyDiffValue` / `$diffTypeLabel` so a struct in any array
-	 * (add/remove/change/rename/suggest/unmapped, or nested from/to)
-	 * cannot hit the Struct-to-String cast.
+	 * Public for specs. Per-array printers keep this orchestrator under
+	 * the complexity gate; they still force every field through
+	 * `$stringifyDiffValue` / `$diffTypeLabel` so a struct cannot hit
+	 * the Struct-to-String cast.
 	 */
 	public void function $renderDiffResult(required struct parsed, required boolean write) {
-		var isSingle = structKeyExists(arguments.parsed, "model");
-		var diffs = isSingle ? { "": arguments.parsed.model } : (arguments.parsed.models ?: {});
-		if (!isStruct(diffs)) {
-			diffs = {};
-		}
-
+		var diffs = $diffResultModels(arguments.parsed);
 		var anyOutput = false;
 		for (var modelKey in diffs) {
 			var diff = diffs[modelKey];
 			if (!isStruct(diff)) {
 				continue;
 			}
-			var heading = $stringifyDiffValue(
-				structKeyExists(diff, "modelName") ? diff.modelName : modelKey,
-				isSimpleValue(modelKey) ? toString(modelKey) : "model"
-			);
-			out("");
-			out("--- " & heading & " ---", "bold");
-
-			for (var col in $diffColumnArray(diff, "addColumns")) {
-				if (isStruct(col)) {
-					out(
-						"  + add    " & $stringifyDiffValue(col.name ?: "")
-							& " (" & $stringifyDiffValue(col.type ?: "") & ")",
-						"green"
-					);
-				} else {
-					out("  + add    " & $stringifyDiffValue(col), "green");
-				}
+			$renderDiffModelHeading(diff, modelKey);
+			if ($renderDiffAddColumns(diff)) {
 				anyOutput = true;
 			}
-			for (var col in $diffColumnArray(diff, "removeColumns")) {
-				var removed = isStruct(col)
-					? $stringifyDiffValue(col.name ?: "")
-					: $stringifyDiffValue(col);
-				out("  - remove " & removed, "red");
-				out("      (if this is a rename, use --rename " & removed & ":newName)", "yellow");
+			if ($renderDiffRemoveColumns(diff)) {
 				anyOutput = true;
 			}
-			for (var col in $diffColumnArray(diff, "changeColumns")) {
-				// Nested from/to are structs — extract .type; never "#col.from#".
-				var changeName = isStruct(col) ? $stringifyDiffValue(col.name ?: "") : $stringifyDiffValue(col);
-				var fromType = isStruct(col) ? $diffTypeLabel(col.from ?: {}) : "?";
-				var toType = isStruct(col) ? $diffTypeLabel(col.to ?: {}) : "?";
-				out("  ~ change " & changeName & " (" & fromType & " -> " & toType & ")", "yellow");
+			if ($renderDiffChangeColumns(diff)) {
 				anyOutput = true;
 			}
-			for (var col in $diffColumnArray(diff, "renameColumns")) {
-				var renameFrom = isStruct(col) ? $stringifyDiffValue(col.from ?: "?") : $stringifyDiffValue(col);
-				var renameTo = isStruct(col) ? $stringifyDiffValue(col.to ?: "?") : "?";
-				out("  ~ rename " & renameFrom & " -> " & renameTo, "yellow");
+			if ($renderDiffRenameColumns(diff)) {
 				anyOutput = true;
 			}
-			for (var suggestion in $diffColumnArray(diff, "suggestedRenames")) {
-				// Elvis (`from ?: "?"`) returns a struct when `from` is nested
-				// (changeColumn-shaped). Force both sides through stringify.
-				var sugOld = isStruct(suggestion) ? $stringifyDiffValue(suggestion.from ?: "?", "?") : $stringifyDiffValue(suggestion, "?");
-				var sugNew = isStruct(suggestion) ? $stringifyDiffValue(suggestion.to ?: "?", "?") : "?";
-				var sugConf = isStruct(suggestion) ? $stringifyDiffValue(suggestion.confidence ?: "", "") : "";
-				out("  ? suggest " & sugOld & " -> " & sugNew & " (" & sugConf & ")", "cyan");
+			if ($renderDiffSuggestedRenames(diff)) {
 				anyOutput = true;
 			}
 		}
+		$renderDiffFooter(anyOutput, arguments.write);
+	}
 
-		if (!anyOutput) {
+	/**
+	 * Single-model envelope is `parsed.model`; diffAll is `parsed.models`.
+	 */
+	public struct function $diffResultModels(required struct parsed) {
+		if (structKeyExists(arguments.parsed, "model")) {
+			return { "": arguments.parsed.model };
+		}
+		if (structKeyExists(arguments.parsed, "models") && isStruct(arguments.parsed.models)) {
+			return arguments.parsed.models;
+		}
+		return {};
+	}
+
+	public void function $renderDiffModelHeading(required struct diff, required any modelKey) {
+		var raw = arguments.modelKey;
+		if (structKeyExists(arguments.diff, "modelName")) {
+			raw = arguments.diff.modelName;
+		}
+		var fallback = "model";
+		if (isSimpleValue(arguments.modelKey)) {
+			fallback = toString(arguments.modelKey);
+		}
+		out("");
+		out("--- " & $stringifyDiffValue(raw, fallback) & " ---", "bold");
+	}
+
+	public boolean function $renderDiffAddColumns(required struct diff) {
+		var printed = false;
+		for (var col in $diffColumnArray(arguments.diff, "addColumns")) {
+			if (isStruct(col)) {
+				out(
+					"  + add    " & $diffStructField(col, "name")
+						& " (" & $diffStructField(col, "type") & ")",
+					"green"
+				);
+			} else {
+				out("  + add    " & $stringifyDiffValue(col), "green");
+			}
+			printed = true;
+		}
+		return printed;
+	}
+
+	public boolean function $renderDiffRemoveColumns(required struct diff) {
+		var printed = false;
+		for (var col in $diffColumnArray(arguments.diff, "removeColumns")) {
+			var removed = $diffStructField(col, "name");
+			out("  - remove " & removed, "red");
+			out("      (if this is a rename, use --rename " & removed & ":newName)", "yellow");
+			printed = true;
+		}
+		return printed;
+	}
+
+	public boolean function $renderDiffChangeColumns(required struct diff) {
+		var printed = false;
+		for (var col in $diffColumnArray(arguments.diff, "changeColumns")) {
+			// Nested from/to are structs — extract .type; never stringify from/to.
+			out(
+				"  ~ change " & $diffStructField(col, "name")
+					& " (" & $diffStructType(col, "from")
+					& " -> " & $diffStructType(col, "to") & ")",
+				"yellow"
+			);
+			printed = true;
+		}
+		return printed;
+	}
+
+	public boolean function $renderDiffRenameColumns(required struct diff) {
+		var printed = false;
+		for (var col in $diffColumnArray(arguments.diff, "renameColumns")) {
+			if (isStruct(col)) {
+				out(
+					"  ~ rename " & $diffStructField(col, "from", "?")
+						& " -> " & $diffStructField(col, "to", "?"),
+					"yellow"
+				);
+			} else {
+				out("  ~ rename " & $stringifyDiffValue(col) & " -> ?", "yellow");
+			}
+			printed = true;
+		}
+		return printed;
+	}
+
+	public boolean function $renderDiffSuggestedRenames(required struct diff) {
+		var printed = false;
+		for (var suggestion in $diffColumnArray(arguments.diff, "suggestedRenames")) {
+			// Elvis (`from ?: "?"`) returns a struct when `from` is nested.
+			if (isStruct(suggestion)) {
+				out(
+					"  ? suggest " & $diffStructField(suggestion, "from", "?")
+						& " -> " & $diffStructField(suggestion, "to", "?")
+						& " (" & $diffStructField(suggestion, "confidence") & ")",
+					"cyan"
+				);
+			} else {
+				out("  ? suggest " & $stringifyDiffValue(suggestion, "?") & " -> ? ()", "cyan");
+			}
+			printed = true;
+		}
+		return printed;
+	}
+
+	public void function $renderDiffFooter(required boolean anyOutput, required boolean write) {
+		if (!arguments.anyOutput) {
 			out("No differences found — models and database are in sync.", "green");
 		}
-
-		if (!arguments.write) {
-			out("");
-			out("Preview only — pass --write to commit the migration file(s).", "yellow");
-		} else {
-			out("");
+		out("");
+		if (arguments.write) {
 			out("Migration file(s) written.", "green");
+		} else {
+			out("Preview only — pass --write to commit the migration file(s).", "yellow");
 		}
+	}
+
+	/**
+	 * Read a named field from a column struct, or stringify a bare value.
+	 * Avoids Elvis (`?:`) at the call site — `?` counts as a complexity
+	 * decision and is what pushed `$renderDiffResult` over the gate.
+	 */
+	public string function $diffStructField(required any col, required string field, fallback = "") {
+		if (!isStruct(arguments.col)) {
+			return $stringifyDiffValue(arguments.col, arguments.fallback);
+		}
+		if (!structKeyExists(arguments.col, arguments.field)) {
+			return arguments.fallback;
+		}
+		return $stringifyDiffValue(arguments.col[arguments.field], arguments.fallback);
+	}
+
+	public string function $diffStructType(required any col, required string field, fallback = "?") {
+		if (!isStruct(arguments.col)) {
+			return arguments.fallback;
+		}
+		if (!structKeyExists(arguments.col, arguments.field)) {
+			return arguments.fallback;
+		}
+		return $diffTypeLabel(arguments.col[arguments.field], arguments.fallback);
 	}
 
 	/**

--- a/cli/lucli/tests/specs/commands/MigrateDiffRenderSpec.cfc
+++ b/cli/lucli/tests/specs/commands/MigrateDiffRenderSpec.cfc
@@ -1,0 +1,212 @@
+/**
+ * Regression coverage for `$renderDiffResult()` — the CLI printer for
+ * `wheels migrate diff`.
+ *
+ * AutoMigrator returns add/remove/change/rename/suggest entries as
+ * structs. Interpolating those structs (or nested `from`/`to` on
+ * changeColumns) throws `Can't cast Complex Object Type [Struct] to
+ * String`. The generate-auth User table is the live case: after
+ * `wheels generate auth` + migrate on SQLite, User is a wall of
+ * `changeColumns` whose `from`/`to` are `{type, size, scale, nullable}`.
+ *
+ * These specs feed that payload (and the other struct-shaped arrays)
+ * through the renderer with no running app server.
+ */
+component extends="wheels.wheelstest.system.BaseSpec" {
+
+	function beforeAll() {
+		variables.testHelper = new cli.lucli.tests.TestHelper();
+		variables.tempRoot = testHelper.scaffoldTempProject(expandPath("/"));
+		directoryCreate(tempRoot & "/vendor/wheels", true, true);
+	}
+
+	function afterAll() {
+		testHelper.cleanupTempProject(variables.tempRoot);
+	}
+
+	function run() {
+
+		describe("$renderDiffResult — generate-auth User payload", () => {
+
+			it("prints User changeColumns without casting nested from/to structs", () => {
+				// Shape AutoMigrator.diff("User") returns after `generate auth`
+				// on SQLite: every string/datetime column is TEXT in the DB
+				// (mapped to `text`) and cf_sql_varchar/`datetime` on the
+				// model (mapped to `string`/`datetime`). #3565 tracks the
+				// spurious type noise; this spec only pins the Struct cast.
+				var parsed = {
+					success: true,
+					models: {
+						User: $userShapedDiff()
+					}
+				};
+				var cap = $newCapture();
+				cap.$renderDiffResult(parsed, false);
+				var output = cap.capturedOutput();
+
+				expect(output).toInclude("--- User ---");
+				expect(output).toInclude("  ~ change email (text -> string)");
+				expect(output).toInclude("  ~ change passworddigest (text -> string)");
+				expect(output).toInclude("  ~ change resettokendigest (text -> string)");
+				expect(output).toInclude("  ~ change resettokenexpiresat (text -> datetime)");
+				expect(output).toInclude("Preview only");
+			});
+
+			it("prints the same User payload from the single-model envelope", () => {
+				var parsed = {
+					success: true,
+					model: $userShapedDiff()
+				};
+				var cap = $newCapture();
+				cap.$renderDiffResult(parsed, false);
+				expect(cap.capturedOutput()).toInclude("--- User ---");
+				expect(cap.capturedOutput()).toInclude("  ~ change email (text -> string)");
+			});
+
+		});
+
+		describe("$renderDiffResult — remaining struct arrays", () => {
+
+			it("renders add/remove/rename/suggest from named fields, not the raw struct", () => {
+				var parsed = {
+					success: true,
+					models: {
+						User: {
+							modelName: "User",
+							tableName: "users",
+							addColumns: [{name: "apiTokenDigest", type: "string", nullable: true, "default": ""}],
+							removeColumns: [{name: "legacy_flag", type: "string"}],
+							changeColumns: [],
+							renameColumns: [{from: "full_name", to: "fullName", type: "string", source: "hint"}],
+							suggestedRenames: [{
+								from: "email_addr",
+								to: "emailAddress",
+								type: "string",
+								confidence: 0.85,
+								ambiguous: false
+							}],
+							unmappedColumns: [{name: "legacy_flag", type: "string"}]
+						}
+					}
+				};
+				var cap = $newCapture();
+				cap.$renderDiffResult(parsed, false);
+				var output = cap.capturedOutput();
+
+				expect(output).toInclude("  + add    apiTokenDigest (string)");
+				expect(output).toInclude("  - remove legacy_flag");
+				expect(output).toInclude("--rename legacy_flag:newName");
+				expect(output).toInclude("  ~ rename full_name -> fullName");
+				expect(output).toInclude("  ? suggest email_addr -> emailAddress (0.85)");
+			});
+
+			it("does not crash when rename/suggest from/to are accidentally structs", () => {
+				// Edge case: a changeColumn-shaped node lands in rename or
+				// suggest (or Elvis returns the nested struct). The old
+				// `#col.from#` / `suggestion.from ?: "?"` path cast-crashed.
+				var parsed = {
+					success: true,
+					model: {
+						modelName: "User",
+						addColumns: [],
+						removeColumns: [],
+						changeColumns: [],
+						renameColumns: [{
+							from: {type: "text", size: 255, nullable: false},
+							to: {type: "string", size: 255, nullable: false}
+						}],
+						suggestedRenames: [{
+							from: {type: "text"},
+							to: {name: "emailAddress", type: "string"},
+							confidence: {value: 0.9}
+						}]
+					}
+				};
+				var cap = $newCapture();
+				cap.$renderDiffResult(parsed, true);
+				var output = cap.capturedOutput();
+
+				expect(output).toInclude("--- User ---");
+				expect(output).toInclude("  ~ rename");
+				expect(output).toInclude("  ? suggest");
+				expect(output).toInclude("Migration file(s) written.");
+			});
+
+			it("reports an in-sync payload without walking any column arrays", () => {
+				var parsed = {
+					success: true,
+					models: {
+						User: {
+							modelName: "User",
+							addColumns: [],
+							removeColumns: [],
+							changeColumns: [],
+							renameColumns: [],
+							suggestedRenames: []
+						}
+					}
+				};
+				var cap = $newCapture();
+				cap.$renderDiffResult(parsed, false);
+				expect(cap.capturedOutput()).toInclude("No differences found");
+			});
+
+		});
+
+		describe("$stringifyDiffValue / $diffTypeLabel", () => {
+
+			it("prefers a scalar name on a column struct and never stringifies the struct", () => {
+				var cap = $newCapture();
+				expect(cap.$stringifyDiffValue({name: "email", type: "string"})).toBe("email");
+				expect(cap.$stringifyDiffValue("passwordDigest")).toBe("passwordDigest");
+				expect(cap.$stringifyDiffValue({foo: {bar: 1}}, "?")).toBe("?");
+			});
+
+			it("reads type from a nested changeColumn from/to struct", () => {
+				var cap = $newCapture();
+				expect(cap.$diffTypeLabel({type: "text", size: 255, scale: 0, nullable: false})).toBe("text");
+				expect(cap.$diffTypeLabel("string")).toBe("string");
+				expect(cap.$diffTypeLabel({})).toBe("?");
+			});
+
+		});
+
+	}
+
+	private any function $newCapture() {
+		return new cli.lucli.tests._fixtures.commands.ModuleOutputCapture(cwd = variables.tempRoot);
+	}
+
+	/**
+	 * User-shaped AutoMigrator payload after `generate auth` + migrate on
+	 * SQLite. Mirrors cli/lucli/templates/auth/migration.txt columns.
+	 */
+	private struct function $userShapedDiff() {
+		return {
+			modelName: "User",
+			tableName: "users",
+			addColumns: [],
+			removeColumns: [],
+			changeColumns: [
+				$change("email", "text", "string"),
+				$change("passworddigest", "text", "string"),
+				$change("resettokendigest", "text", "string"),
+				$change("resettokenexpiresat", "text", "datetime"),
+				$change("createdat", "text", "datetime"),
+				$change("updatedat", "text", "datetime")
+			],
+			renameColumns: [],
+			suggestedRenames: [],
+			unmappedColumns: []
+		};
+	}
+
+	private struct function $change(required string name, required string fromType, required string toType) {
+		return {
+			name: arguments.name,
+			from: {type: arguments.fromType, size: 255, scale: 0, nullable: false},
+			to: {type: arguments.toType, size: 255, scale: "", nullable: false}
+		};
+	}
+
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`wheels migrate diff` still crashed with `Can't cast Complex Object Type [Struct] to String` under `--- User ---` on a typical CFUG demo app after `generate auth`.

[#3563](https://github.com/wheels-dev/wheels/pull/3563) stopped interpolating the top-level column struct (`#col#` → `#col.name#` / `#col.from.type#`). That was not enough:

- **`changeColumns.from` / `.to` are themselves structs** (`{type, size, scale, nullable}`). `#col.from.type#` is the happy path, but `#col.from#` (rename) and `suggestion.from ?: "?"` (Elvis returns the struct when `from` is nested) still stringify a struct.
- The generate-auth **User** table is the live case: after `wheels generate auth` + migrate on SQLite, User is a wall of `changeColumns` with nested `from`/`to` (the #3565 `text → string` noise). Interpolating any of those structs dies under `--- User ---`.

This PR forces every printed field through `$stringifyDiffValue` / `$diffTypeLabel` (concatenation of scalars only — never `#struct#` / `#struct.from#`) and adds a User-shaped renderer regression spec that would have caught the cast.

SQLite `text → string` noise is **not** fixed here — that remains #3565.

## Complexity

The first revision put all the Struct-safe branches in `$renderDiffResult` (complexity **36**, loc=77). The complexity analyzer treats Elvis `?:` as a decision, which is what blew the gate.

`$renderDiffResult` is now an orchestrator (**8** / loc=27). Per-array printers:

| Function | Complexity |
|---|---|
| `$renderDiffResult` | 8 |
| `$renderDiffAddColumns` | 3 |
| `$renderDiffRemoveColumns` | 2 |
| `$renderDiffChangeColumns` | 2 |
| `$renderDiffRenameColumns` | 3 |
| `$renderDiffSuggestedRenames` | 3 |

Local gate: `python3 tools/code-quality/cfml-complexity.py cli/lucli --gate 30 --baseline tools/code-quality/baseline-cli.json` → **PASS**.

## Related Issue

Follow-up to #3563. Related noise: #3565 (left open).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Documentation update
- [x] Refactoring

## Feature Completeness Checklist

- [x] **DCO sign-off**
- [x] **Tests** -- `MigrateDiffRenderSpec` 7/7 after the split
- [ ] **Framework Docs** -- n/a
- [ ] **AI Reference Docs** -- n/a
- [ ] **CLAUDE.md** -- n/a
- [x] **Changelog fragment** -- `changelog.d/migrate-diff-struct-cast.fixed.md`
- [x] **Test runner passes** -- `bash tools/test-cli-local.sh`: MigrateDiffRenderSpec 7/7. Complexity gate PASS.

## What was still casting

| Site | Payload | Old interpolation |
|---|---|---|
| `changeColumns` | `{name, from: {type, size, …}, to: {type, …}}` | `#col.from.type#` / `#col.from#` |
| `renameColumns` | `{from, to}` or a changeColumn-shaped node | `#col.from#` / `#col.to#` |
| `suggestedRenames` | `{from, to, confidence}` or nested `from`/`to` | `suggestion.from ?: "?"` then `#sugOld#` |
| `addColumns` / `removeColumns` | `{name, type}` | `#col.name#` / `#col.type#` if either key is a struct |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02d564bd-5bc1-4917-8fba-3bbec81e0d5e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02d564bd-5bc1-4917-8fba-3bbec81e0d5e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

