### PR TITLE
fix: address CFUG demo dry-run findings

### DIFF
--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -254,8 +254,10 @@ component extends="modules.BaseModule" {
 	public struct function mcpToolSpecs() {
 		return {
 			"analyze" = analyzeArgSpec().toInputSchema(),
+			"create"  = createArgSpec().toInputSchema(),
 			"destroy" = destroyArgSpec().toInputSchema(),
 			"doctor"  = verboseFlagSpec().toInputSchema(),
+			"generate" = generateArgSpec().toInputSchema(),
 			"migrate" = migrateArgSpec().toInputSchema(),
 			"notes"   = notesArgSpec().toInputSchema(),
 			"seed"    = seedArgSpec().toInputSchema(),
@@ -324,6 +326,20 @@ component extends="modules.BaseModule" {
 			.positional(name = "type", default = "", description = "What to remove: resource, model, controller, or view")
 			.positional(name = "name", default = "", description = "Name of the artifact to remove")
 			.flag(name = "force", default = false, description = "Skip the confirmation prompt");
+	}
+
+	private any function generateArgSpec() {
+		return new services.ArgSpec()
+			.positional(name = "type", required = true, description = "What to generate: model, controller, view, scaffold, migration, api-resource, route, test, property, helper, policy, snippets, admin, auth, or app")
+			.positional(name = "name", description = "Artifact name (model/controller/resource name, or the app name for `generate app`)")
+			.positional(name = "attributes", description = "Column definitions for model/scaffold (space- or comma-delimited name:type pairs, e.g. 'title:string body:text')")
+			.flag(name = "dry-run", default = false, description = "Print the would-be paths and write nothing");
+	}
+
+	private any function createArgSpec() {
+		return new services.ArgSpec()
+			.positional(name = "type", required = true, description = "What to create: app")
+			.positional(name = "name", required = true, description = "Application name");
 	}
 
 	private any function verboseFlagSpec() {
@@ -588,6 +604,31 @@ component extends="modules.BaseModule" {
 
 		var type = cleaned[1];
 		var remaining = arrayLen(cleaned) > 1 ? cleaned.slice(2) : [];
+
+		// MCP and structured callers pass {"type": "...", "name": "...",
+		// "attributes": "..."} which toArgv() re-emits as --type=... --name=...
+		// --attributes=... — normalize those named prefixes back to positional
+		// form so `wheels generate scaffold Post title:string` behaves the same
+		// from a shell or an MCP tool call.
+		if (left(type, 7) == "--type=") {
+			type = mid(type, 8, len(type));
+		}
+		var normalized = [];
+		for (var i = 1; i <= arrayLen(remaining); i++) {
+			var r = remaining[i];
+			if (left(r, 7) == "--name=") {
+				arrayAppend(normalized, mid(r, 8, len(r)));
+			} else if (left(r, 12) == "--attributes=") {
+				// Attributes arrive as one space/comma-delimited string — split
+				// into the individual name:type tokens the generators expect.
+				for (var token in reMatch("[^\s,]+", mid(r, 13, len(r)))) {
+					arrayAppend(normalized, token);
+				}
+			} else {
+				arrayAppend(normalized, r);
+			}
+		}
+		remaining = normalized;
 
 		var result = $generateDispatch(type, remaining);
 
@@ -1563,6 +1604,23 @@ component extends="modules.BaseModule" {
 
 		var type = lCase(args[1]);
 		var remaining = args.len() > 1 ? args.slice(2) : [];
+
+		// Normalize the named --type=/--name= prefixes that MCP callers
+		// produce (toArgv re-emits {"type":"app","name":"myapp"} as
+		// --type=app --name=myapp) back to positional form.
+		if (left(type, 7) == "--type=") {
+			type = lCase(mid(type, 8, len(type)));
+		}
+		var normalizedRemaining = [];
+		for (var i = 1; i <= arrayLen(remaining); i++) {
+			var r = remaining[i];
+			if (left(r, 7) == "--name=") {
+				arrayAppend(normalizedRemaining, mid(r, 8, len(r)));
+			} else {
+				arrayAppend(normalizedRemaining, r);
+			}
+		}
+		remaining = normalizedRemaining;
 
 		switch (type) {
 			case "app":

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -1344,7 +1344,19 @@ component extends="modules.BaseModule" {
 		var cmdArgs = ["start"];
 		cmdArgs.append(passThrough, true);
 
-		executeCommand("server", cmdArgs, variables.projectRoot);
+		try {
+			executeCommand("server", cmdArgs, variables.projectRoot);
+		} catch (any startErr) {
+			// A failed LuCLI server start can leave a half-written
+			// registration in ~/.wheels/servers/<name>; the next start then
+			// refuses with "registered to a different project" and needs a
+			// manual --force. Wipe the dead registration so a retry starts
+			// clean.
+			try {
+				registry.clean(serverName);
+			} catch (any cleanupErr) {}
+			rethrow;
+		}
 
 		// Post-stage. If the express dir didn't exist at pre-stage time
 		// (very first LuCLI run on a fresh VM), the start command above just

--- a/cli/lucli/services/CodeGen.cfc
+++ b/cli/lucli/services/CodeGen.cfc
@@ -84,7 +84,10 @@ component {
 				arrayAppend(extraLines, "validatesFormatOf(property=""#prop.name#"", type=""URL"");");
 			}
 			if (isStringLikeLengthLimit(prop, propType)) {
-				arrayAppend(extraLines, "validatesLengthOf(property=""#prop.name#"", maximum=#prop.limit#);");
+				// allowBlank=true so an empty value only surfaces the
+				// validatesPresenceOf "can't be empty" error instead of also
+				// triggering a confusing "is the wrong length" duplicate.
+				arrayAppend(extraLines, "validatesLengthOf(property=""#prop.name#"", maximum=#prop.limit#, allowBlank=true);");
 			}
 		}
 

--- a/cli/lucli/services/Doctor.cfc
+++ b/cli/lucli/services/Doctor.cfc
@@ -434,7 +434,11 @@ component {
 	 */
 	private void function checkRawParamsMassAssignment(required struct results) {
 		var scanDirs = ["app/controllers", "app/models"];
-		var massAssignmentPattern = "\b(create|update|updateAll|new|save|findByKey)\s*\(\s*params\.";
+		// `findByKey` is deliberately excluded: it reads a single scalar primary
+		// key from params to look up a record and writes nothing to the model,
+		// so it is not a mass-assignment vector (the generated CRUD scaffolds
+		// call findByKey(params.key) in show/edit/update/delete).
+		var massAssignmentPattern = "\b(create|update|updateAll|new|save)\s*\(\s*params\.";
 		for (var scanDir in scanDirs) {
 			var absDir = variables.projectRoot & "/" & scanDir;
 			if (!directoryExists(absDir)) continue;

--- a/cli/lucli/services/Stats.cfc
+++ b/cli/lucli/services/Stats.cfc
@@ -187,7 +187,12 @@ component {
 			}
 			if (inBlockComment) {
 				comments++;
-				if (findNoCase("--->", trimmed)) {
+				// A block comment may be CFML (<!--- … --->) or JS-style
+				// (/* … */). Close on either marker; previously only "--->" was
+				// checked, so a multi-line /** doc comment never reset the flag
+				// and every following line (the actual cfscript code) was
+				// counted as a comment.
+				if (findNoCase("--->", trimmed) || find("*/", trimmed)) {
 					inBlockComment = false;
 				}
 				continue;

--- a/cli/lucli/services/Templates.cfc
+++ b/cli/lucli/services/Templates.cfc
@@ -538,21 +538,21 @@ component {
 						);
 						break;
 					case "date":
-						fieldCode = $scaffoldFieldCall(
+						fieldCode = $scaffoldDateFieldCall(
 							helperName = "dateSelect",
 							fieldName = fieldName,
 							fieldLabel = fieldLabel
 						);
 						break;
 					case "datetime": case "timestamp":
-						fieldCode = $scaffoldFieldCall(
+						fieldCode = $scaffoldDateFieldCall(
 							helperName = "dateTimeSelect",
 							fieldName = fieldName,
 							fieldLabel = fieldLabel
 						);
 						break;
 					case "time":
-						fieldCode = $scaffoldFieldCall(
+						fieldCode = $scaffoldDateFieldCall(
 							helperName = "timeSelect",
 							fieldName = fieldName,
 							fieldLabel = fieldLabel
@@ -620,6 +620,26 @@ component {
 		}
 		call &= ')##';
 		return '<div class="field">' & chr(10) & call & chr(10) & '</div>';
+	}
+
+	/**
+	 * One scaffolded date/time field: a single <label> above the composite
+	 * control, WITHOUT labelPlacement/includeErrorMessage on the helper. The
+	 * dateSelect/dateTimeSelect/timeSelect helpers render a sub-select per
+	 * component (3 for date, 6 for datetime), so passing label/error through
+	 * them repeated the label and validation message once per sub-select
+	 * (#3553). The top-level errorMessagesFor() still shows the error once.
+	 */
+	private string function $scaffoldDateFieldCall(
+		required string helperName,
+		required string fieldName,
+		required string fieldLabel
+	) {
+		var call = '##' & arguments.helperName & '(objectName="|ObjectNameSingular|", property="' & arguments.fieldName & '")##';
+		return '<div class="field">' & chr(10)
+			& '<label>' & arguments.fieldLabel & '</label>' & chr(10)
+			& call & chr(10)
+			& '</div>';
 	}
 
 	/**

--- a/cli/lucli/services/coverage/CoverageService.cfc
+++ b/cli/lucli/services/coverage/CoverageService.cfc
@@ -165,6 +165,10 @@ component output="false" {
 		}
 		local.pct = local.total ? Round(100 * local.covered / local.total) : 0;
 		arrayAppend(local.lines, "Function coverage: " & local.covered & "/" & local.total & " files (" & local.pct & "%) - " & arguments.instrumented & " counters instrumented" & (Len(arguments.suiteStatus) ? "; suite HTTP " & arguments.suiteStatus : ""));
+		if (Len(arguments.suiteStatus) && arguments.suiteStatus != "200") {
+			arrayAppend(local.lines, "");
+			arrayAppend(local.lines, "WARNING: the test suite did not pass (suite HTTP " & arguments.suiteStatus & "). Coverage numbers are incomplete and the CRAP ranking below understates change risk — fix the failing specs, then re-run `wheels coverage`.");
+		}
 		arrayAppend(local.lines, "");
 		arrayAppend(local.lines, "Top CRAP (change risk = complexity^2 x (1 - coverage)^3 + complexity):");
 		arrayAppend(local.lines, "  CRAP   comp  cov  file");

--- a/cli/lucli/templates/app/tests/populate.cfm
+++ b/cli/lucli/templates/app/tests/populate.cfm
@@ -4,25 +4,27 @@
 
     `wheels test` runs against the `<appname>_test` datasource (a
     separate SQLite file from your dev DB) so chapter-6-style manual
-    signups in development don't bleed into chapter-7 specs. The first
-    time the test DB is empty (no migrator-versions table), the
-    framework includes this file from app-runner.cfm to apply your
-    migrations.
+    signups in development don't bleed into chapter-7 specs. The framework
+    includes this file from app-runner.cfm before every test run to apply
+    your pending migrations (migrateToLatest() is a no-op when already
+    current).
 
     Customise this file when you need test-specific seed data — model
     fixtures, baseline users, anything that should exist before EVERY
     test run. Keep it minimal; most specs should set up their own state
-    via beforeEach/it blocks rather than relying on global fixtures.
+    via beforeEach/it blocks rather than relying on global fixtures. Any
+    seed data you add here runs on every test run, so it must be
+    idempotent.
 
     The framework only includes this file when:
     - the request was made with ?useTestDB=true (set automatically by
       `wheels test`; opt out with --no-test-db)
     - a `<dataSourceName>_test` datasource is registered (created
       automatically by `wheels new` when you accept the SQLite default)
-    - the test DB has no migrator-versions table
 
-    On second and subsequent runs the test DB schema persists, so this
-    file is skipped. Delete `db/test.sqlite` to force a fresh schema.
+    To force a fresh schema, stop the server first (`wheels stop`) and then
+    delete `db/test.sqlite` — deleting it while the server is running causes
+    SQLITE_READONLY_DBMOVED on every query.
 --->
 <cfscript>
     // Run all pending migrations against the active datasource —
@@ -35,10 +37,9 @@
         // UDFs), so surface it loudly through app-runner's populate-500 path.
         local.migrateResult = application.wheels.migrator.migrateToLatest();
         if (FindNoCase("Error migrating", local.migrateResult ?: "")) {
-            // Drop the versions table so the NEXT run re-enters populate and
-            // fails loudly again (app-runner only includes populate.cfm when the
-            // table is absent) — otherwise one failure leaves a silently
-            // half-migrated schema. Fix the migration, then just re-run.
+            // Drop the versions table so the NEXT run re-attempts the failing
+            // migration and fails loudly again — otherwise one failure leaves a
+            // silently half-migrated schema. Fix the migration, then just re-run.
             // Note: `DROP TABLE IF EXISTS` is unsupported on Oracle < 23c, so
             // the self-healing re-entry loop only latches for one run there;
             // the loud-failure Throw below still fires on the first failure.

--- a/cli/lucli/templates/auth/view-passwords-edit.txt
+++ b/cli/lucli/templates/auth/view-passwords-edit.txt
@@ -5,7 +5,6 @@
 
 <h1>Choose a new password</h1>
 
-#flashMessages()#
 <cfif IsObject({{modelVar}})>
 	#errorMessagesFor("{{modelVar}}")#
 </cfif>

--- a/cli/lucli/templates/auth/view-passwords-new.txt
+++ b/cli/lucli/templates/auth/view-passwords-new.txt
@@ -5,8 +5,6 @@
 
 <h1>Forgot your password?</h1>
 
-#flashMessages()#
-
 <p>Enter your email address and we'll send you a link to reset it.</p>
 
 #startFormTag(route="passwords")#

--- a/cli/lucli/templates/auth/view-registrations-new.txt
+++ b/cli/lucli/templates/auth/view-registrations-new.txt
@@ -5,7 +5,6 @@
 
 <h1>Create your account</h1>
 
-#flashMessages()#
 #errorMessagesFor("{{modelVar}}")#
 
 #startFormTag(route="registrations")#

--- a/cli/lucli/templates/auth/view-sessions-new.txt
+++ b/cli/lucli/templates/auth/view-sessions-new.txt
@@ -5,8 +5,6 @@
 
 <h1>Log in</h1>
 
-#flashMessages()#
-
 #startFormTag(route="session")#
 	<div>
 		#emailFieldTag(name="email", label="Email", value=params.email)#

--- a/cli/lucli/tests/specs/commands/McpToolSpecsSpec.cfc
+++ b/cli/lucli/tests/specs/commands/McpToolSpecsSpec.cfc
@@ -32,7 +32,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 			it("returns a populated object schema for every ArgSpec-backed tool", () => {
 				var specs = probe.mcpToolSpecs();
 				expect(specs).toBeStruct();
-				for (var toolName in ["test", "seed", "analyze", "destroy", "notes", "upgrade", "doctor", "stats"]) {
+				for (var toolName in ["test", "seed", "analyze", "destroy", "notes", "upgrade", "doctor", "stats", "generate", "create"]) {
 					expect(specs).toHaveKey(toolName, "Expected an inputSchema entry for the `#toolName#` tool.");
 					expect(specs[toolName].type).toBe("object");
 					expect(structCount(specs[toolName].properties)).toBeGT(

--- a/cli/lucli/tests/specs/services/CodeGenSpec.cfc
+++ b/cli/lucli/tests/specs/services/CodeGenSpec.cfc
@@ -245,7 +245,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					);
 					var content = fileRead(tempRoot & "/app/models/SizedTitle.cfc");
 					expect(content).toInclude('validatesPresenceOf("title")');
-					expect(content).toInclude('validatesLengthOf(property="title", maximum=50)');
+					expect(content).toInclude('validatesLengthOf(property="title", maximum=50, allowBlank=true)');
 				});
 
 				it("does not invent a length validation for a bare string", () => {
@@ -271,9 +271,9 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					);
 					var content = fileRead(tempRoot & "/app/models/SizedMisc.cfc");
 					expect(content).toInclude('validatesPresenceOf("sku,body,blob")');
-					expect(content).toInclude('validatesLengthOf(property="sku", maximum=80)');
-					expect(content).toInclude('validatesLengthOf(property="body", maximum=1000)');
-					expect(content).toInclude('validatesLengthOf(property="blob", maximum=4096)');
+					expect(content).toInclude('validatesLengthOf(property="sku", maximum=80, allowBlank=true)');
+					expect(content).toInclude('validatesLengthOf(property="body", maximum=1000, allowBlank=true)');
+					expect(content).toInclude('validatesLengthOf(property="blob", maximum=4096, allowBlank=true)');
 				});
 
 				it("skips length validation for integer limits and decimal precision", () => {
@@ -302,7 +302,7 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					var content = fileRead(tempRoot & "/app/models/MixedValidations.cfc");
 					expect(content).toInclude('validatesPresenceOf("title,email")');
 					expect(content).toInclude('validatesFormatOf(property="email", type="email")');
-					expect(content).toInclude('validatesLengthOf(property="title", maximum=50)');
+					expect(content).toInclude('validatesLengthOf(property="title", maximum=50, allowBlank=true)');
 					expect(content).toInclude(chr(9) & chr(9) & "validatesLengthOf");
 					expect(content).notToInclude(chr(10) & "validatesLengthOf");
 				});

--- a/vendor/wheels/Seeder.cfc
+++ b/vendor/wheels/Seeder.cfc
@@ -551,8 +551,11 @@ component output="false" extends="wheels.Global" {
 	 * the if-chain. Returns {handled: true/false, value: ...}.
 	 */
 	public struct function $generateTestDataByType(required string propertyType, required string name, required numeric index) {
-		// Boolean fields
-		if (arguments.propertyType == "boolean" || FindNoCase("active", arguments.name) || FindNoCase("enabled", arguments.name) || FindNoCase("published", arguments.name)) {
+		// Type-first: an explicit column type wins over name heuristics, so a
+		// `publishedAt:datetime` field gets a date instead of matching the
+		// "published" boolean name heuristic (the old order substring-matched
+		// "published" inside "publishedAt" and returned true/false).
+		if (arguments.propertyType == "boolean") {
 			return {handled = true, value = (arguments.index mod 2) == 1};
 		}
 
@@ -571,12 +574,28 @@ component output="false" extends="wheels.Global" {
 		}
 
 		// Date fields
-		if (arguments.propertyType == "date" || arguments.propertyType == "datetime" || FindNoCase("date", arguments.name) || FindNoCase("birthday", arguments.name) || FindNoCase("dob", arguments.name)) {
+		if (arguments.propertyType == "date" || arguments.propertyType == "datetime") {
+			return {handled = true, value = DateAdd("d", -arguments.index, Now())};
+		}
+
+		// Text fields
+		if (arguments.propertyType == "text") {
+			return {handled = true, value = "This is test content #arguments.index#. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."};
+		}
+
+		// Name heuristics — only for string/unknown types, so they never
+		// override an explicit column type. "published" is an exact match so it
+		// doesn't swallow a datetime-typed "publishedAt".
+		if (FindNoCase("active", arguments.name) || FindNoCase("enabled", arguments.name) || arguments.name == "published") {
+			return {handled = true, value = (arguments.index mod 2) == 1};
+		}
+
+		if (FindNoCase("date", arguments.name) || FindNoCase("birthday", arguments.name) || FindNoCase("dob", arguments.name) || FindNoCase("publishedat", arguments.name) || FindNoCase("publishedon", arguments.name)) {
 			return {handled = true, value = DateAdd("d", -arguments.index, Now())};
 		}
 
 		// Text/description fields
-		if (arguments.propertyType == "text" || FindNoCase("description", arguments.name) || FindNoCase("content", arguments.name) || FindNoCase("body", arguments.name)) {
+		if (FindNoCase("description", arguments.name) || FindNoCase("content", arguments.name) || FindNoCase("body", arguments.name)) {
 			return {handled = true, value = "This is test content #arguments.index#. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."};
 		}
 

--- a/vendor/wheels/tests/app-runner.cfm
+++ b/vendor/wheels/tests/app-runner.cfm
@@ -87,21 +87,19 @@
                 }
             }
 
-            // If the test database has no migrator-versions table, include
-            // the user's tests/populate.cfm to bootstrap schema. Skip
-            // silently when the file doesn't exist (advanced users with
+            // Always include the user's tests/populate.cfm before specs run so
+            // pending migrations reach the test DB on every run
+            // (migrateToLatest() is a no-op when already current) — gating on
+            // "no migrator-versions table" meant migrations added after the
+            // first run never reached db/test.sqlite and their specs failed
+            // with "table could not be found". Seed data added to
+            // populate.cfm must be idempotent: it runs before every test run.
+            // Skip silently when the file doesn't exist (advanced users with
             // their own setup).
             local.populatePath = ExpandPath("/tests/populate.cfm");
             if (local.swappedDataSource && FileExists(local.populatePath)) {
                 try {
-                    local.dbinfo = application.wo.$dbinfo(
-                        datasource = local.targetDataSource,
-                        type = "tables"
-                    );
-                    local.tableList = ValueList(local.dbinfo.table_name);
-                    if (!FindNoCase(application.wheels.migratorTableName, local.tableList)) {
-                        include "/tests/populate.cfm";
-                    }
+                    include "/tests/populate.cfm";
                 } catch (any populateErr) {
                     // Surface populate.cfm errors as JSON; don't silently
                     // run specs against an empty test DB.

--- a/vendor/wheels/tests/specs/seederSpec.cfc
+++ b/vendor/wheels/tests/specs/seederSpec.cfc
@@ -624,8 +624,11 @@ component extends="wheels.WheelsTest" {
 					expect(seeder.$generateTestData(propertyName = "flag", propertyType = "boolean", index = 2)).toBeFalse();
 					expect(seeder.$generateTestData(propertyName = "isActive", propertyType = "string", index = 1)).toBeTrue();
 					expect(seeder.$generateTestData(propertyName = "enabled", propertyType = "string", index = 2)).toBeFalse();
-					// publishedAt matches "published" before the later date-name branch.
-					expect(seeder.$generateTestData(propertyName = "publishedAt", propertyType = "string", index = 1)).toBeTrue();
+					// bare "published" is boolean; "publishedAt" is date-like. The
+					// type-first reorder stops the "published" substring from
+					// swallowing "publishedAt" into a boolean (#3552).
+					expect(seeder.$generateTestData(propertyName = "published", propertyType = "string", index = 1)).toBeTrue();
+					expect(IsDate(seeder.$generateTestData(propertyName = "publishedAt", propertyType = "string", index = 1))).toBeTrue();
 				});
 
 				it("S10: integer / numeric type — age, price, quantity, and default", () => {


### PR DESCRIPTION
## Summary

Fixes the demo-blocking and visibly-broken bugs found while dry-running the Mid-Michigan CFUG talk (Sept 15). Validated with `bash tools/test-cli-local.sh` (strict).

## Fixed

- **MCP `generate`/`create`** — now advertise populated `inputSchema` (via new `generateArgSpec()`/\`createArgSpec()\`) and normalize the `--type=`/`--name=`/`--attributes=` prefixes MCP callers produce, so an agent can scaffold over MCP instead of hitting `Unknown generator type: --type=scaffold`.
- **Test DB migrations** — `app-runner.cfm` now includes `tests/populate.cfm` (which runs `migrateToLatest()`) on every run, so migrations added after the first run reach `db/test.sqlite`.
- **`wheels stats` LOC** — a multi-line `/** ... */` doc comment no longer swallows the whole file (the JS-style `*/` closer now resets the block-comment flag).
- **`wheels doctor`** — `findByKey(params.key)` is no longer flagged as raw mass assignment.
- **Seeder** — `publishedAt:datetime` now generates a date instead of a boolean (explicit column type wins over name heuristics).
- **Scaffold form** — date/datetime/time fields emit one label without `includeErrorMessage`, so the label/error no longer repeat per sub-select.
- **Scaffold models** — `validatesLengthOf(..., allowBlank=true)` so an empty value only surfaces the presence error.
- **Generated auth views** — no longer duplicate the layout's `flashMessages()`.
- **`wheels coverage`** — warns clearly when the suite failed instead of only printing `suite HTTP 417`.
- **`wheels start`** — cleans up the server registration on a failed start so the next start doesn't refuse with `registered to a different project`.

## Still open (not fixed here)

- **First-run CRUD spec failure** (`no property with name [BODY] found in [boolean]`) — this is a subtle first-request model-metadata bootstrap issue that needs deeper investigation. Tracked separately.
- **Debug-bar Code Complexity panel** literal interpolation on a fresh app — pre-existing cross-engine `cfoutput`/\`cfinclude` quirk; needs a targeted repro.
- **`db reset`** does migrate+seed (never drops) — docs are accurate in the guides; the demo run-sheet wording should say \`wheels stop && rm db/*.sqlite && wheels start\` for a clean slate.