### PR TITLE
fix: create belongsTo parent in scaffold specs + normalize SQLite TEXT affinity

### DIFF
--- a/cli/lucli/services/CodeGen.cfc
+++ b/cli/lucli/services/CodeGen.cfc
@@ -303,6 +303,7 @@ component {
 		required string name,
 		array properties = [],
 		string modelName = "",
+		string belongsTo = "",
 		boolean force = false
 	) {
 		var meta = $testFileMeta(arguments.type, arguments.name);
@@ -326,7 +327,8 @@ component {
 			testName = testName,
 			targetName = meta.targetName,
 			modelName = arguments.modelName,
-			properties = arguments.properties
+			properties = arguments.properties,
+			belongsTo = arguments.belongsTo
 		);
 
 		var result = variables.templateService.generateFromTemplate(
@@ -411,7 +413,8 @@ component {
 		required string testName,
 		required string targetName,
 		string modelName = "",
-		array properties = []
+		array properties = [],
+		string belongsTo = ""
 	) {
 		var resolvedModel = len(arguments.modelName) ? arguments.modelName : arguments.targetName;
 		var controllerName = arguments.targetName;
@@ -443,7 +446,17 @@ component {
 		context["pluralLower"] = pluralLower;
 		context["collectionRoute"] = "api" & variables.helpers.capitalize(pluralLower);
 		context["memberRoute"] = "api" & variables.helpers.capitalize(modelNameLower);
-		context["validAttributes"] = $buildValidAttributesLiteral(arguments.properties);
+
+		// belongsTo-aware: the child's FK must reference a real parent, but the
+		// generated spec hard-coded `<name>_id: 1`. The controller eager-loads the
+		// parent via findByKey(include="<name>"), which inner-joins — so a child
+		// with no parent yet came back false and the first `wheels test` run
+		// failed the show/edit/update/delete specs. Create each parent in
+		// beforeEach (validation skipped: the generator can't know the parent's
+		// required fields) and reference its id for the FK.
+		var belongsToInfo = $belongsToInfo(arguments.belongsTo, arguments.properties);
+		context["belongsToSetup"] = $belongsToSetupLines(belongsToInfo);
+		context["validAttributes"] = $buildValidAttributesLiteral(arguments.properties, belongsToInfo);
 		context["validationExamples"] = $buildValidationExamples(resolvedModel, arguments.properties);
 		context["timestamp"] = dateTimeFormat(now(), "yyyy-mm-dd HH:nn:ss");
 		return context;
@@ -456,15 +469,69 @@ component {
 	 * are a boolean equality expression, not a keyed entry — create() then
 	 * receives a boolean and Wheels looks up TITLE on it.
 	 */
-	private string function $buildValidAttributesLiteral(required array properties) {
+	private string function $buildValidAttributesLiteral(required array properties, array belongsToInfo = []) {
 		if (!arrayLen(arguments.properties)) {
 			return "{}";
 		}
 		var parts = [];
 		for (var prop in arguments.properties) {
-			arrayAppend(parts, '"' & prop.name & '": ' & $samplePropertyLiteral(prop));
+			var literal = $samplePropertyLiteral(prop);
+			// Replace a belongsTo FK sample value with the created parent's id.
+			for (var info in arguments.belongsToInfo) {
+				if (prop.name == info.fkColumn) {
+					literal = "variables." & info.parentVar & ".id";
+					break;
+				}
+			}
+			arrayAppend(parts, '"' & prop.name & '": ' & literal);
 		}
 		return "{" & arrayToList(parts, ", ") & "}";
+	}
+
+	/**
+	 * Map each belongsTo parent to its parent model, variable name, and the
+	 * foreign-key column in the child's properties (matching either `_id` or
+	 * `Id` convention). Empty when there are no belongsTo associations.
+	 */
+	private array function $belongsToInfo(required string belongsTo, required array properties) {
+		var result = [];
+		if (!len(arguments.belongsTo)) {
+			return result;
+		}
+		for (var parent in listToArray(arguments.belongsTo)) {
+			var parentVar = lCase(trim(parent));
+			var parentModel = variables.helpers.capitalize(parentVar);
+			var fkColumn = "";
+			for (var prop in arguments.properties) {
+				var propName = lCase(prop.name);
+				if (propName == parentVar & "_id" || propName == parentVar & "id") {
+					fkColumn = prop.name;
+					break;
+				}
+			}
+			if (len(fkColumn)) {
+				arrayAppend(result, {parentVar = parentVar, parentModel = parentModel, fkColumn = fkColumn});
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * beforeEach lines that persist each belongsTo parent with validation
+	 * skipped (the generator can't know the parent's required fields). Joined
+	 * with a newline + 4 tabs so the template's `{{belongsToSetup}}` placeholder
+	 * (already indented under beforeEach) lines up with the sibling statements.
+	 */
+	private string function $belongsToSetupLines(required array belongsToInfo) {
+		if (!arrayLen(arguments.belongsToInfo)) {
+			return "";
+		}
+		var lines = [];
+		for (var info in arguments.belongsToInfo) {
+			arrayAppend(lines, 'variables.' & info.parentVar & ' = model("' & info.parentModel & '").new();');
+			arrayAppend(lines, 'variables.' & info.parentVar & '.save(validate = false);');
+		}
+		return arrayToList(lines, chr(10) & chr(9) & chr(9) & chr(9) & chr(9));
 	}
 
 	/**

--- a/cli/lucli/services/Scaffold.cfc
+++ b/cli/lucli/services/Scaffold.cfc
@@ -169,6 +169,7 @@ component {
 					name = pluralName,
 					properties = props,
 					modelName = arguments.name,
+					belongsTo = arguments.belongsTo,
 					force = arguments.force
 				);
 				if (ctrlTestResult.success) {

--- a/cli/lucli/templates/codegen/tests/controller.txt
+++ b/cli/lucli/templates/codegen/tests/controller.txt
@@ -16,6 +16,7 @@ component extends="wheels.WheelsTest" {
 		describe("{{targetName}} controller", () => {
 
 			beforeEach(() => {
+				{{belongsToSetup}}
 				variables.{{modelNameLower}} = model("{{modelName}}").create(properties = {{validAttributes}});
 			});
 

--- a/cli/lucli/tests/specs/services/ScaffoldSpec.cfc
+++ b/cli/lucli/tests/specs/services/ScaffoldSpec.cfc
@@ -618,6 +618,25 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 					expect(content).notToInclude('findByKey(params.key, include=');
 				});
 
+				it("creates the belongsTo parent in the controller spec beforeEach so the FK is valid", () => {
+					// The controller eager-loads the parent via include= (an inner
+					// join); the generated spec used to hard-code <name>_id: 1, so on
+					// a fresh test DB (child specs run before the parent specs) the
+					// first `wheels test` returned false from findByKey(include=...) and
+					// broke show/edit/update/delete. The spec now persists the parent
+					// (validation skipped) and references its id for the FK.
+					scaffold.generateScaffold(
+						name = "Review",
+						properties = [{name: "body", type: "text"}],
+						belongsTo = "Author",
+						force = true
+					);
+					var spec = fileRead(tempRoot & "/tests/specs/controllers/ReviewsControllerSpec.cfc");
+					expect(spec).toInclude('variables.author = model("Author").new();');
+					expect(spec).toInclude('variables.author.save(validate = false);');
+					expect(spec).toInclude('variables.author.id');
+				});
+
 				it("emits <name>_id FK column when useUnderscoreReferenceColumns=true", () => {
 					// `wheels new` apps opt into underscore reference columns; the
 					// scaffold's belongsTo FK column must match what t.references()

--- a/vendor/wheels/migrator/AutoMigrator.cfc
+++ b/vendor/wheels/migrator/AutoMigrator.cfc
@@ -123,6 +123,16 @@ component extends="wheels.migrator.Base" {
 				local.expectedMigType = $cfSqlTypeToMigrationType(local.expected.type);
 				local.actualMigType = $dbTypeToMigrationType(local.actual.typeName);
 
+				// SQLite's type affinity collapses VARCHAR/DATETIME/DATE/BOOLEAN
+				// to a single TEXT storage class, so the schema probe reports
+				// "text" where the model declared "string" (and similarly for
+				// the INTEGER/REAL affinities). Normalize the affinity-equivalent
+				// pairs so `migrate diff` doesn't emit spurious `text -> string`
+				// changes on a schema that is already in sync.
+				if ($getDBType() == "sqlite" && local.actualMigType == "text" && ListFindNoCase("string,text,datetime,date,time,boolean", local.expectedMigType)) {
+					local.actualMigType = local.expectedMigType;
+				}
+
 				local.typeChanged = (local.expectedMigType != local.actualMigType && local.actualMigType != "unknown");
 				local.sizeChanged = (
 					Len(ToString(local.expected.size))


### PR DESCRIPTION
## Summary

Two demo-blocking bugs found while running the MMCFUG talk's 8 beats on a cold server (snapshot 2461):

## 1. First `wheels test` failed the Comment CRUD specs

The scaffold's CRUD controller eager-loads the parent via `findByKey(include="<name>")`, which **inner-joins**. The generated controller spec hard-coded the FK (`post_id: 1`), so on a fresh test DB the child specs ran before the parent specs and the record came back `false` from the inner join — breaking show/edit/update/delete with `there is no property with name [BODY] found in [boolean]`.

**Fix:** the generated `beforeEach` now persists each `belongsTo` parent with validation skipped (the generator can't know the parent's required fields) and references its id for the FK. Verified: first run went from 23 passed/4 errors → **35 passed**.

## 2. `wheels migrate diff` emitted spurious `text -> string` changes

SQLite's type affinity stores `VARCHAR`/\`DATETIME`/\`DATE`/\`BOOLEAN` as `TEXT`, so the probe reported `text` where the model declared `string`, flagging phantom changes on an in-sync schema.

**Fix:** `AutoMigrator.diff()` normalizes SQLite's TEXT affinity against string-like model types. Verified: `migrate diff` now reports **"No differences found"**.

## Validation

- `bash tools/test-cli-local.sh` (strict) — **1309 pass, 0 fail, 0 error** (added a ScaffoldSpec assertion).
- `bash tools/test-local.sh migrator` — **292 passed**.

## Still open (separate, not fixed here)

- API JSON leaks `allowExplicitTimestamps: false` and `149.99` reads back as `149.990005493164` on SQLite (decimal precision) — tracked in the CFUG bug list as #14.
- The deck's Beat 7 curl omits `sku`, so the POST returns 422 (the generated model requires sku presence) — deck/run-sheet needs the `sku` field added.