### PR TITLE
fix: stop leaking allowExplicitTimestamps into JSON + exact SQLite decimals

### DIFF
--- a/changelog.d/allow-explicit-timestamps-json-leak.fixed.md
+++ b/changelog.d/allow-explicit-timestamps-json-leak.fixed.md
@@ -1,0 +1,1 @@
+- `model(...).new()`, `.create()`, and `.update()` no longer leak the internal `allowExplicitTimestamps` write-path control flag into `properties()` and `SerializeJSON` output — the flag is now stored in the private `variables` scope and only consulted when stamping `createdAt`/`updatedAt`, so API payloads no longer include an `allowExplicitTimestamps` key

--- a/changelog.d/sqlite-decimal-precision.fixed.md
+++ b/changelog.d/sqlite-decimal-precision.fixed.md
@@ -1,0 +1,1 @@
+- SQLite `decimal` columns now use `NUMERIC` instead of `REAL` storage, so a generated `price:decimal` column binds through `cf_sql_decimal` (BigDecimal) and round-trips values exactly — `149.99` reads back as `149.99` rather than `149.990005493164` (32-bit float noise)

--- a/vendor/wheels/databaseAdapters/SQLite/SQLiteMigrator.cfc
+++ b/vendor/wheels/databaseAdapters/SQLite/SQLiteMigrator.cfc
@@ -7,7 +7,13 @@ component extends="wheels.databaseAdapters.Abstract" {
 	variables.sqlTypes['boolean'] = { name = 'INTEGER' }; // SQLite has no real BOOLEAN type
 	variables.sqlTypes['date'] = { name = 'TEXT' };
 	variables.sqlTypes['datetime'] = { name = 'TEXT' };
-	variables.sqlTypes['decimal'] = { name = 'REAL' };
+	// NUMERIC keeps the declared type distinct from REAL so the model layer binds
+	// decimal values via cf_sql_decimal (BigDecimal) instead of cf_sql_float.
+	// REAL is SQLite's 8-byte floating point storage: Lucee binds it as a 32-bit
+	// float and 149.99 round-trips as 149.990005493164. NUMERIC affinity still
+	// stores non-integer values as a double internally, but the JDBC driver reads
+	// it back as an exact BigDecimal, so `price:decimal` round-trips 149.99.
+	variables.sqlTypes['decimal'] = { name = 'NUMERIC' };
 	variables.sqlTypes['float'] = { name = 'REAL' };
 	variables.sqlTypes['integer'] = { name = 'INTEGER' };
 	variables.sqlTypes['string'] = { name = 'TEXT', limit = 255 };

--- a/vendor/wheels/model/create.cfm
+++ b/vendor/wheels/model/create.cfm
@@ -27,7 +27,7 @@
 		$args(name = "create", args = arguments);
 		$setProperties(
 			argumentCollection = arguments,
-			filterList = "properties,parameterize,reload,validate,transaction,callbacks",
+			filterList = "properties,parameterize,reload,validate,transaction,callbacks,allowExplicitTimestamps",
 			setOnModel = false
 		);
 		local.rv = new (argumentCollection = arguments);
@@ -60,10 +60,11 @@
 	) {
 		arguments.properties = $setProperties(
 			argumentCollection = arguments,
-			filterList = "properties,reload,transaction,callbacks",
+			filterList = "properties,reload,transaction,callbacks,allowExplicitTimestamps",
 			setOnModel = false
 		);
 		local.rv = $createInstance(callbacks = arguments.callbacks, persisted = false, properties = arguments.properties);
+		local.rv.$setAllowExplicitTimestamps(arguments.allowExplicitTimestamps);
 		local.rv.$setDefaultValues();
 		return local.rv;
 	}

--- a/vendor/wheels/model/miscellaneous.cfm
+++ b/vendor/wheels/model/miscellaneous.cfm
@@ -445,9 +445,15 @@
 			local.settingName = "timeStampOnUpdateProperty";
 		}
 		// Allow explicit assignment of the timestamp property if allowExplicitTimestamps is true.
+		// The flag is stored in the private `variables` scope (set by
+		// new()/create()/update() via $setAllowExplicitTimestamps) so it is NOT
+		// serialized into JSON; the `this` check remains for direct
+		// setProperties(allowExplicitTimestamps=...) calls.
 		if (
-			StructKeyExists(this, "allowExplicitTimestamps")
-			&& this.allowExplicitTimestamps
+			(
+				(StructKeyExists(variables, "$allowExplicitTimestamps") && variables.$allowExplicitTimestamps)
+				|| (StructKeyExists(this, "allowExplicitTimestamps") && this.allowExplicitTimestamps)
+			)
 			&& StructKeyExists(this, $get(local.settingName))
 			&& Len(this[$get(local.settingName)])
 		) {
@@ -455,5 +461,16 @@
 			return;
 		}
 		$timestampProperty(property = variables.wheels.class[local.settingName]);
+	}
+
+	/**
+	 * Internal function. Record the `allowExplicitTimestamps` control flag in
+	 * the private `variables` scope instead of `this`, so the flag is honored by
+	 * `$stampTimestampProperty` but never leaks into `properties()` /
+	 * SerializeJSON output (it is a write-path control flag, not a model
+	 * attribute).
+	 */
+	public void function $setAllowExplicitTimestamps(required boolean value) {
+		variables.$allowExplicitTimestamps = arguments.value;
 	}
 </cfscript>

--- a/vendor/wheels/model/update.cfm
+++ b/vendor/wheels/model/update.cfm
@@ -244,8 +244,9 @@
 		$args(name = "update", args = arguments);
 		$setProperties(
 			argumentCollection = arguments,
-			filterList = "properties,parameterize,reload,validate,transaction,callbacks"
+			filterList = "properties,parameterize,reload,validate,transaction,callbacks,allowExplicitTimestamps"
 		);
+		$setAllowExplicitTimestamps(arguments.allowExplicitTimestamps);
 		return save(
 			callbacks = arguments.callbacks,
 			parameterize = arguments.parameterize,

--- a/vendor/wheels/tests/populate.cfm
+++ b/vendor/wheels/tests/populate.cfm
@@ -25,6 +25,7 @@
 <cfset local.textColumnType = "text">
 <cfset local.intColumnType = "int">
 <cfset local.floatColumnType = "float">
+<cfset local.decimalColumnType = "decimal(10,2)">
 <cfset local.identityColumnType = "">
 <cfset local.bitColumnType = "bit">
 <cfset local.bitColumnDefault = 0>
@@ -62,6 +63,7 @@
 	<cfset local.bitColumnType      = "NUMBER(1)">
 	<cfset local.bitColumnDefault   = "0">
 	<cfset local.intColumnType = "NUMBER(10)">
+	<cfset local.decimalColumnType = "NUMBER(10,2)">
 	<cfset local.textColumnType = "VARCHAR2(255)">
 	<cfset local.dateTimeDefault = "TIMESTAMP '2000-01-01 18:26:08.490'">
 	<cfset local.charType = "VARCHAR2(9)">
@@ -73,6 +75,7 @@
 	<cfset local.textColumnType = "TEXT">
 	<cfset local.intColumnType = "INTEGER">
 	<cfset local.floatColumnType = "REAL">
+	<cfset local.decimalColumnType = "NUMERIC(10,2)">
 	<cfset local.bitColumnType = "INTEGER">
 	<cfset local.bitColumnDefault = 0>
 	<cfset local.charType = "TEXT">
@@ -316,6 +319,7 @@ CREATE TABLE c_o_r_e_sqltypes
 	,binaryType #local.binaryColumnType# NULL
 	,dateTimeType #local.datetimeColumnType# DEFAULT #PreserveSingleQuotes(local.dateTimeDefault)# NOT NULL
 	,floatType #local.floatColumnType# DEFAULT 1.25 NULL
+	,decimalType #local.decimalColumnType# DEFAULT 1.25 NULL
 	,intType #local.intColumnType# DEFAULT 1 NOT NULL
 	,stringType char(4) DEFAULT 'blah' NOT NULL
 	,stringVariableType varchar(80) NOT NULL
@@ -702,7 +706,7 @@ FROM c_o_r_e_users u INNER JOIN c_o_r_e_galleries g ON u.id = g.userid
 </cfloop>
 
 <!--- sqltype --->
-<cfset model("sqltype").create(stringVariableType = "tony", textType = "blah blah blah blah")>
+<cfset model("sqltype").create(stringVariableType = "tony", textType = "blah blah blah blah", decimalType = 149.99)>
 
 <!--- assign posts for multiple join test --->
 <cfset local.andy.update(favouritePostId = 1, leastFavouritePostId = 2)>

--- a/vendor/wheels/tests/specs/database/SQLiteDecimalSpec.cfc
+++ b/vendor/wheels/tests/specs/database/SQLiteDecimalSpec.cfc
@@ -1,0 +1,50 @@
+component extends="wheels.WheelsTest" {
+
+	function run() {
+
+		g = application.wo;
+
+		describe("SQLite decimal storage", () => {
+
+			// Guard: the NUMERIC-vs-REAL bind path is SQLite-specific. Other
+			// adapters have a native DECIMAL/NUMERIC type and bind via
+			// setBigDecimal directly, so they don't share this bug surface.
+			var migration = CreateObject("component", "wheels.migrator.Migration").init();
+			if (migration.adapter.adapterName() != "SQLite") return;
+
+			it("round-trips 149.99 exactly through the model create/find path", () => {
+				transaction action="begin" {
+					var rec = g.model("sqltype").create(
+						stringVariableType = "decimal-roundtrip",
+						textType = "precision check",
+						decimalType = 149.99,
+						transaction = "none"
+					);
+
+					var found = g.model("sqltype").findByKey(rec.id);
+					expect(found.decimalType).toBe(149.99);
+
+					transaction action="rollback";
+				}
+			});
+
+			it("does not bind decimal values through the 32-bit float path", () => {
+				transaction action="begin" {
+					var rec = g.model("sqltype").create(
+						stringVariableType = "decimal-bind",
+						textType = "precision check",
+						decimalType = 149.99,
+						transaction = "none"
+					);
+
+					// The old REAL mapping read back 149.990005493164 (32-bit
+					// float noise). Guard the exact value, not a fuzzy compare.
+					var found = g.model("sqltype").findByKey(rec.id);
+					expect(ToString(found.decimalType)).notToBe("149.990005493164");
+
+					transaction action="rollback";
+				}
+			});
+		});
+	}
+}

--- a/vendor/wheels/tests/specs/migrator/helperFunctions.cfm
+++ b/vendor/wheels/tests/specs/migrator/helperFunctions.cfm
@@ -157,7 +157,7 @@
 			case "PostgreSQL":
 				return "NUMERIC";
 			case "SQLite":
-				return "REAL";
+				return "NUMERIC";
 			default:
 				return "`adddecimal()` not supported for " & migration.adapter.adapterName();
 		}

--- a/vendor/wheels/tests/specs/model/propertiesSpec.cfc
+++ b/vendor/wheels/tests/specs/model/propertiesSpec.cfc
@@ -351,7 +351,9 @@ component extends="wheels.WheelsTest" {
 
 				_properties = author.properties()
 				actual = ListSort(StructKeyList(_properties), "text")
-				expected = "allowExplicitTimestamps,firstName,lastName"
+				// allowExplicitTimestamps is a write-path control flag stored in the
+				// private variables scope — it must not surface as a property.
+				expected = "firstName,lastName"
 
 				expect(actual).toBe(expected)
 				expect(author.firstName).toBe("Foo")
@@ -383,7 +385,9 @@ component extends="wheels.WheelsTest" {
 
 				_properties = author.properties(returnIncluded = false)
 				actual = ListSort(StructKeyList(_properties), "text")
-				expected = "allowExplicitTimestamps,firstName,lastName"
+				// allowExplicitTimestamps is a write-path control flag stored in the
+				// private variables scope — it must not surface as a property.
+				expected = "firstName,lastName"
 
 				expect(actual).toBe(expected)
 			})


### PR DESCRIPTION
Two CFUG demo dry-run fixes found while rehearsing the 8-beat build:

## 1. `allowExplicitTimestamps` leaks into JSON output

`new()`/`create()`/`update()` stored the write-path control flag on the public `this` scope, so `SerializeJSON(component)` — which serializes `this`, not `variables` — surfaced an `allowExplicitTimestamps` key in every API payload built from a model instance.

The flag now lives in the private `variables` scope via `$setAllowExplicitTimestamps()` and is only read by `$stampTimestampProperty()` when deciding whether to honor an explicitly assigned `createdAt`/`updatedAt`. A `this` fallback remains for direct `setProperties(allowExplicitTimestamps=...)` calls.

## 2. SQLite `decimal` columns lose precision

SQLite's `decimal` mapped to `REAL`, and Lucee binds `REAL` via a 32-bit float, so `price:decimal` round-tripped `149.99` as `149.990005493164`. `NUMERIC` keeps the declared type distinct from `REAL`, so the model binds via `cf_sql_decimal` (BigDecimal) and non-integer values read back exactly.

Both fixes are covered by specs (`propertiesSpec`, new `SQLiteDecimalSpec`) and the full Lucee 7 + SQLite suite passes (5627).