### PR TITLE
fix(cli): reload the isolated test app before `wheels test`

### DIFF
--- a/changelog.d/wheels-test-reloads-test-app.fixed.md
+++ b/changelog.d/wheels-test-reloads-test-app.fixed.md
@@ -1,0 +1,1 @@
+- `wheels test` now reloads the isolated `_wheelsTest` application before an app-test run, so resources scaffolded after the first test run — e.g. `wheels generate api-resource` adding an `/api` namespace, a model, and its routes — are visible to the specs instead of erroring with "Could not find the `apiProducts` route" against a stale cached route table (RETEST-2461 B)

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -7009,6 +7009,19 @@ component extends="modules.BaseModule" {
 			out("Scope: #filter#", "cyan");
 		}
 
+		// Reload the isolated `_wheelsTest` application scope before an app
+		// test run (RETEST-2461 B): specs execute in a separate CFML
+		// application scope (suffix `_wheelsTest`, #3374) whose routes and
+		// model config are cached from its first boot. Anything scaffolded
+		// after that first run — e.g. `api-resource`'s `/api` routes and
+		// model config — stays invisible to the runner because `wheels reload`
+		// only restarts the live scope. Restart the test scope here so the
+		// suite reflects the code on disk. Core tests keep their own runner
+		// and reload semantics, so this is app-mode only.
+		if (!coreTests) {
+			$reloadTestApplication(serverPort, testPath);
+		}
+
 		// Struct (not a bare local) so the catch-block write persists on
 		// BoxLang — local assignments inside catch are discarded there
 		// (CLAUDE.md cross-engine invariant 11). result/specsFailedToLoad
@@ -9011,6 +9024,43 @@ component extends="modules.BaseModule" {
 	public string function $buildTestRunnerPath(boolean coreTests = false, string basePath = "") {
 		var prefix = $normalizeBasePath(arguments.basePath);
 		return prefix & (arguments.coreTests ? "/wheels/core/tests" : "/wheels/app/tests");
+	}
+
+	/**
+	 * Restart the isolated `_wheelsTest` application scope before an app test
+	 * run. See runTests() for the why (RETEST-2461 B).
+	 *
+	 * Hitting the test-runner path with `?reload=true&password=...` routes the
+	 * request to the `_wheelsTest` scope (the path matches testcontext.cfm's
+	 * `/wheels/app/tests` haystack) and the framework's reload gate calls
+	 * applicationStop() there, then `location()`-redirects — so a successful
+	 * restart answers HTTP 302 and the next suite request boots the scope fresh.
+	 *
+	 * Best-effort: when no reload password is configured the gate fails closed
+	 * and the warm (possibly stale) scope is reused. We surface a note but never
+	 * block the run on a reload.
+	 *
+	 * Public ONLY so TestCommandSpec can unit-test the 302-vs-fallthrough
+	 * contract against a stub server (same carve-out as $evaluateReloadResponse).
+	 */
+	public boolean function $reloadTestApplication(required numeric serverPort, required string testPath) {
+		var password = detectReloadPassword();
+		if (!len(password)) {
+			return false;
+		}
+		var reloadUrl = "#$serverUrlBase(serverPort)##testPath#?reload=true&password=#urlEncodedFormat(password)#";
+		var reloadState = { statusCode = 0 };
+		try {
+			reloadState = makeHttpRequestWithStatus(reloadUrl, false);
+		} catch (any e) {
+			out("Note: could not reload the isolated test application (#e.message#).", "yellow");
+			return false;
+		}
+		if (reloadState.statusCode == 302) {
+			return true;
+		}
+		out("Note: the isolated test application was not reloaded (HTTP #reloadState.statusCode#); the run may use cached routes.", "yellow");
+		return false;
 	}
 
 	/**

--- a/cli/lucli/tests/specs/commands/TestCommandSpec.cfc
+++ b/cli/lucli/tests/specs/commands/TestCommandSpec.cfc
@@ -342,6 +342,52 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 
 		});
 
+		describe("$reloadTestApplication (RETEST-2461 B)", () => {
+
+			it("is invoked by runTests for app-mode runs, never core", () => {
+				var moduleSource = fileRead(expandPath("/cli/lucli/Module.cfc"));
+				// The call site is gated on !coreTests so core matrix runs keep
+				// their own runner/reload semantics.
+				expect(moduleSource).toInclude("if (!coreTests) {");
+				expect(moduleSource).toInclude("$reloadTestApplication(serverPort, testPath);");
+			});
+
+			it("returns true and treats the reload redirect (302) as a successful restart", () => {
+				var sandbox = $scaffold(envBody = "WHEELS_RELOAD_PASSWORD=secret");
+				var stubServer = new cli.lucli.tests.StubHttpServer(302);
+				var localMod = new cli.lucli.Module(cwd = sandbox);
+				try {
+					expect(localMod.$reloadTestApplication(stubServer.getPort(), "/wheels/app/tests")).toBeTrue();
+				} finally {
+					stubServer.stop();
+					$tearDown(sandbox);
+				}
+			});
+
+			it("returns false when the reload gate falls through (200 = wrong/missing password)", () => {
+				var sandbox = $scaffold(envBody = "WHEELS_RELOAD_PASSWORD=secret");
+				var stubServer = new cli.lucli.tests.StubHttpServer(200);
+				var localMod = new cli.lucli.Module(cwd = sandbox);
+				try {
+					expect(localMod.$reloadTestApplication(stubServer.getPort(), "/wheels/app/tests")).toBeFalse();
+				} finally {
+					stubServer.stop();
+					$tearDown(sandbox);
+				}
+			});
+
+			it("skips the reload and returns false when no reload password is configured", () => {
+				var sandbox = $scaffold();
+				var localMod = new cli.lucli.Module(cwd = sandbox);
+				try {
+					expect(localMod.$reloadTestApplication(1, "/wheels/app/tests")).toBeFalse();
+				} finally {
+					$tearDown(sandbox);
+				}
+			});
+
+		});
+
 		describe("$resolveTestBasePath (issue 3026)", () => {
 
 			it("returns empty when no flag, env, or subpath setting is present", () => {


### PR DESCRIPTION
Fixes the RETEST-2461 B runbook caveat: after `wheels generate api-resource`, `wheels test` errored because the isolated `_wheelsTest` application scope had cached its routes/model config before the new resource existed.

## Root cause

App specs run in a separate CFML application scope (`_wheelsTest`, #3374) so the live `application.wheels` is never mutated. That scope caches routes and model config from its first boot. `wheels reload` only restarts the live scope, so anything scaffolded after the first test run was invisible to the runner — `ApiProductsControllerSpec` errored with "Could not find the `apiProducts` route" and `ProductSpec` saw a model with no validations.

## Change

`runTests()` now restarts the `_wheelsTest` scope before an app-test run by hitting the test-runner path with `?reload=true&password=...`. That path routes the request to the test scope (testcontext.cfm matches `/wheels/app/tests`), and the framework's reload gate calls `applicationStop()` there then 302-redirects — so the next suite request boots the scope fresh against the code on disk.

- App-mode only; `--core` keeps its own runner/reload semantics.
- Best-effort: no configured reload password → gate fails closed, warm scope reused, a note is printed.
- New `$reloadTestApplication()` helper (public for specs, like `$evaluateReloadResponse`).

## Verification

- Live: on a Beat-1-through-7 demo app, `wheels test` after `api-resource` now reports **36 passed, 0 failed, 0 errors** (was 29 passed / 2 failed / 5 errors).
- CLI suite: **1313 pass, 0 fail, 0 error** (strict), including 4 new tests for the reload helper (302 → restart, 200 → fall-through, no password → skip, plus a source-scan that `runTests` calls it for app mode).