### PR TITLE
fix(cli): make `wheels docs fetch` actually work

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,6 +314,28 @@ jobs:
           ./tools/build/scripts/build-core.sh "${{ env.WHEELS_VERSION }}" "${{ env.BRANCH }}" "${{ github.run_number }}" "${{ env.WHEELS_PRERELEASE }}"
           ./tools/build/scripts/build-starterApp.sh "${{ env.WHEELS_VERSION }}"
 
+      # The offline docs bundle: the prebuilt Astro/Starlight guides and API
+      # reference that `wheels docs fetch` downloads and the Homebrew formula
+      # stages. Built here so it lands on the SAME release tag as the core and
+      # module zips — that is what both consumers resolve against.
+      - name: Setup Node for Docs Bundle
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Build Docs Bundle
+        run: |
+          cd web && pnpm install --frozen-lockfile && cd ..
+          ./tools/build/scripts/build-docs.sh "${{ env.WHEELS_VERSION }}"
+          cd "artifacts/wheels/${{ env.WHEELS_VERSION }}"
+          md5sum wheels-docs-${{ env.WHEELS_VERSION }}.zip > wheels-docs-${{ env.WHEELS_VERSION }}.zip.md5 || md5 -r wheels-docs-${{ env.WHEELS_VERSION }}.zip > wheels-docs-${{ env.WHEELS_VERSION }}.zip.md5
+          sha512sum wheels-docs-${{ env.WHEELS_VERSION }}.zip > wheels-docs-${{ env.WHEELS_VERSION }}.zip.sha512 || shasum -a 512 wheels-docs-${{ env.WHEELS_VERSION }}.zip > wheels-docs-${{ env.WHEELS_VERSION }}.zip.sha512
+
       - name: Build Wheels Module Tarball
         env:
           MODULE_VERSION: ${{ env.WHEELS_VERSION }}
@@ -498,6 +520,9 @@ jobs:
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-core-*.zip
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-core-*.zip.md5
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-core-*.zip.sha512
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-docs-*.zip
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-docs-*.zip.md5
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-docs-*.zip.sha512
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-starter-app-*.zip
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-starter-app-*.zip.md5
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-starter-app-*.zip.sha512
@@ -554,6 +579,9 @@ jobs:
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-core-*.zip
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-core-*.zip.md5
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-core-*.zip.sha512
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-docs-*.zip
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-docs-*.zip.md5
+              artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-docs-*.zip.sha512
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-starter-app-*.zip
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-starter-app-*.zip.md5
               artifacts/wheels/${{ env.WHEELS_VERSION }}/wheels-starter-app-*.zip.sha512

--- a/changelog.d/docs-fetch-publish.fixed.md
+++ b/changelog.d/docs-fetch-publish.fixed.md
@@ -1,0 +1,3 @@
+- Fixed `wheels docs fetch` failing with `Can't cast Complex Object Type [URL scope] to String`: the download URL was held in a variable named `url`, which shadows CFML's reserved URL scope, so the HTTP client received the scope struct instead of the string
+- Fixed `wheels docs fetch --force` being silently ignored — the flag was read from a helper that inspected `docsFetch()`'s own (empty) arguments scope rather than the parsed argv
+- Fixed the offline docs bundle never being published: `wheels docs fetch` and the Homebrew formula both resolve `wheels-docs-<version>.zip` from the release tag, but no workflow built it, so the download always 404'd. `release.yml` now builds the bundle and attaches it alongside the core and module zips

--- a/cli/lucli/Module.cfc
+++ b/cli/lucli/Module.cfc
@@ -1105,9 +1105,19 @@ component extends="modules.BaseModule" {
 	public string function docs() {
 		var args = new services.ArgSpec().toArgv(structuredArgs(arguments));
 		var action = arrayLen(args) ? lCase(args[1]) : "fetch";
+		// Resolve --force HERE, in the command that actually receives the parsed
+		// argv. docsFetch() takes no arguments, so a helper reading its
+		// `arguments` scope always saw an empty struct and the flag was
+		// silently ignored.
+		var force = false;
+		for (var a in args) {
+			if (lCase(a) == "--force") {
+				force = true;
+			}
+		}
 		switch (action) {
 			case "fetch":
-				return docsFetch();
+				return docsFetch(force = force);
 			case "status":
 				return docsStatus();
 			default:
@@ -1123,7 +1133,7 @@ component extends="modules.BaseModule" {
 	 * (the Homebrew formula's wrapper does essentially the same thing on
 	 * install/upgrade).
 	 */
-	private string function docsFetch() {
+	private string function docsFetch(boolean force = false) {
 		var version = $docsFrameworkVersion();
 		if (!len(version)) {
 			out("Could not determine the framework version — is this a Wheels project?", "red");
@@ -1135,22 +1145,24 @@ component extends="modules.BaseModule" {
 			return "";
 		}
 		var target = home & "/docs/" & version;
-		var force = $docsHasForceFlag();
 
-		if (directoryExists(target) && !force) {
+		if (directoryExists(target) && !arguments.force) {
 			out("Documentation for #version# is already installed.", "green");
 			out("  #target#");
 			out("  Re-run with --force to replace it.");
 			return "";
 		}
 
-		var url = $docsBundleUrl(version);
+		// Not `url` — a variable named after a reserved CFML scope shadows it,
+		// and the download then receives the URL scope struct instead of the
+		// string ("Can't cast Complex Object Type [URL scope] to String").
+		var bundleUrl = $docsBundleUrl(version);
 		var tmp = getTempDirectory() & "wheels-docs-#version#.zip";
 		out("Fetching docs for #version#...");
-		out("  #url#");
+		out("  #bundleUrl#");
 
 		try {
-			new services.packages.HttpClient(timeoutSeconds = 300).download(url, tmp);
+			new services.packages.HttpClient(timeoutSeconds = 300).download(bundleUrl, tmp);
 		} catch (any e) {
 			out("Download failed: #e.message#", "red");
 			out("  A release without a docs asset will 404 here — the bundle is built by");
@@ -1323,15 +1335,6 @@ component extends="modules.BaseModule" {
 		return "https://github.com/wheels-dev/#repo#/releases/download/v#arguments.version#/wheels-docs-#arguments.version#.zip";
 	}
 
-	private boolean function $docsHasForceFlag() {
-		var args = new services.ArgSpec().toArgv(structuredArgs(arguments));
-		for (var a in args) {
-			if (lCase(a) == "--force") {
-				return true;
-			}
-		}
-		return false;
-	}
 
 	// ─────────────────────────────────────────────────
 	//  reload — Reload application


### PR DESCRIPTION
## Why

Validating the merged feature end-to-end — update the CLI, `wheels new`, test the guides and API — failed. Three defects, all of which had to be fixed before `wheels docs fetch` could ever succeed.

## 1. `Can't cast Complex Object Type [URL scope] to String`

```cfc
var url = $docsBundleUrl(version);          // shadows CFML's URL scope
new services.packages.HttpClient(...).download(url, tmp);
```

A local named `url` shadows the reserved URL scope, so `HttpClient` received the scope struct rather than the string. This is **anti-pattern #11 in CLAUDE.md** — "never use a reserved scope name as a parameter, local var, or function argument name". Renamed to `bundleUrl`.

## 2. `--force` was silently ignored

`$docsHasForceFlag()` inspected its **own** `arguments` scope, but `docsFetch()` takes no arguments — so it always saw an empty struct and returned false. The flag is now resolved in `docs()`, which does receive the parsed argv, and passed down as `docsFetch(force = ...)`.

## 3. The bundle was never published

The real blocker, and the one that made the feature non-functional as shipped: both `wheels docs fetch` and the Homebrew resource resolve `wheels-docs-<version>.zip` from the release tag, but **no workflow built it**. The 2470 snapshot's asset list confirms it — core, module, starter-app, base-template, deb/rpm, but no docs bundle.

`release.yml` now sets up Node + pnpm, runs `tools/build/scripts/build-docs.sh`, generates md5/sha512, and attaches all three to **both** the stable and snapshot release asset lists. Verified the YAML parses and that the globs are present in both lists.

## Verification against a freshly scaffolded app

`wheels new valapp` → `4.1.0-snapshot.2470`, then:

| Check | Result |
|---|---|
| app starts and serves | 200 |
| `/wheels-docs/guides/`, `/wheels-docs/guides/v4-0-0/basics/migrations/` | 200, real Starlight pages |
| `/wheels-docs/api/`, `/wheels-docs/api/v4-0-0/model-class/findall/` | 200 |
| `_astro/*.css`, `pagefind.js`, `favicon.svg` | 200 with correct MIME |
| `/wheels/api?format=json&type=core` | 200, `functions` + `sections` present |
| `wheels docs status` | reports the installed bundle |
| `wheels docs fetch --force` | reaches the download and reports the 404 with the correct URL |

The last row is the expected state until a release carrying the asset is cut — the URL it prints is exactly what the new `release.yml` step will attach.

## Note on the app-startup failure

I could not reproduce an app failing to start. A fresh app started and served first time here. The most likely cause on your machine is a **stale server holding port 8080** or a stale registration, both of which I hit repeatedly during this work:

- `wheels start` fails with *"Server name 'X' is registered to a different project"* — `wheels start --force` clears it
- `tools/test-local.sh` leaves its own server on 8080, so a later app's `start` reports success while the wrong app answers

Worth checking `lsof -ti :8080` before retrying.

## Verification

- `bash tools/test-local.sh` — **5637 passed**
- `bash tools/test-cli-local.sh` — **1300 pass, 4 fail, 2 error**, identical to the `develop` baseline
