### PR TITLE
fix(docs): repair absolute metadata URLs in the local docs bundle

### DIFF
--- a/changelog.d/docs-bundle-canonical.fixed.md
+++ b/changelog.d/docs-bundle-canonical.fixed.md
@@ -1,0 +1,1 @@
+- Fixed the local docs bundle advertising URLs that do not exist: building with a mount `base` made Astro emit `https://guides.wheels.dev/wheels-docs/guides/v4-0-0/` as the canonical link, `og:url` and sitemap entry, because it concatenates `site` with the local base. The bundle build now strips the mount prefix from those absolute URLs so they describe the real page

--- a/tools/build/scripts/build-docs.sh
+++ b/tools/build/scripts/build-docs.sh
@@ -74,6 +74,26 @@ echo "  building api -> /wheels-docs/api/"
 rm -rf "${WEB_DIR}/sites/api/dist" "${WEB_DIR}/sites/api/.astro"
 (cd "${WEB_DIR}" && WHEELS_DOCS_BASE=/wheels-docs/api/ pnpm --filter @wheels-dev/site-api build)
 
+# ── Repair absolute URLs in metadata ───────────────────────────────────────
+# Astro builds canonical / og:url / the sitemap from `site`, but the local
+# bundle also sets `base`, so they come out as
+# https://guides.wheels.dev/wheels-docs/guides/v4-0-0/ — a URL that does not
+# exist on the live site. Nothing fetches these, but they should still describe
+# the real page, so strip the local mount prefix back off.
+echo "  repairing canonical/sitemap URLs"
+for pair in "guides:guides.wheels.dev" "api:api.wheels.dev"; do
+	site="${pair%%:*}"
+	domain="${pair##*:}"
+	# HTML: canonical, og:url, and any other absolute link into the mount
+	find "${WEB_DIR}/sites/${site}/dist" -name "*.html" -print0 \
+		| xargs -0 sed -i.bak -e "s|https://${domain}/wheels-docs/${site}/|https://${domain}/|g"
+	# Sitemaps
+	find "${WEB_DIR}/sites/${site}/dist" -name "*.xml" -print0 \
+		| xargs -0 sed -i.bak -e "s|https://${domain}/wheels-docs/${site}/|https://${domain}/|g"
+	# sed -i.bak leaves backups behind; drop them
+	find "${WEB_DIR}/sites/${site}/dist" -name "*.bak" -delete
+done
+
 # ── Stage ──────────────────────────────────────────────────────────────────
 rm -rf "${STAGE_DIR}"
 mkdir -p "${STAGE_DIR}/guides" "${STAGE_DIR}/api"


### PR DESCRIPTION
## What

The local docs bundle shipped absolute URLs that do not exist. Building with a mount `base` made Astro concatenate `site` with it:

```html
<link rel="canonical" href="https://guides.wheels.dev/wheels-docs/guides/v4-0-0/">
<meta property="og:url" content="https://guides.wheels.dev/wheels-docs/guides/v4-0-0/">
```

…and the same for every sitemap entry.

Nothing fetches these, so **offline reading was never affected** — I found it while validating and it is cosmetic. But the bundle should still describe the real page, and a wrong canonical is exactly the kind of thing that sits unnoticed until someone crawls the bundle.

## Fix

`build-docs.sh` now strips the mount prefix from absolute URLs after the Astro build, for both sites, across `.html` and `.xml`.

## Verified

| | before | after |
|---|---|---|
| guides canonical | `https://guides.wheels.dev/wheels-docs/guides/v4-0-0/` | `https://guides.wheels.dev/v4-0-0/` |
| api canonical | `https://api.wheels.dev/wheels-docs/api/v4-0-0/` | `https://api.wheels.dev/v4-0-0/` |
| `og:url` | mount-prefixed | real URL |
| sitemap `<loc>` | mount-prefixed | `https://guides.wheels.dev/` |

And the parts that must **not** change did not:

- absolute URLs into the mount remaining anywhere: **0**
- relative `/wheels-docs/…` asset and nav paths: **1,167,431**, all intact — including `/wheels-docs/guides/_astro/*.css` and sidebar links

`bash -n` clean. This is a build-script change only, so no framework behaviour is touched.
