### PR TITLE
fix(tools): verify test-server ownership and actually stop it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ artifacts/
 
 # Offline docs bundle the CLI mirrors into the webroot of any app it runs in
 public/wheels-docs/
+
+# Test-server JVM pid recorded by tools/test-cli-local.sh
+.wheels-test-server.pid

--- a/tools/test-cli-local.sh
+++ b/tools/test-cli-local.sh
@@ -31,20 +31,74 @@ if [ -z "${JAVA_HOME:-}" ]; then
   fi
 fi
 
+# ── Server ownership helpers ────────────────────────
+#
+# The CLI records which project a server belongs to in
+# ~/.wheels/servers/<name>/.project-path, and its JVM as "<pid>:<port>" in
+# server.pid. Both are authoritative; probing the port is not, because any
+# HTTP responder there will answer — including a completely different app.
+project_server_dir() {
+  local d real
+  for d in "$HOME"/.wheels/servers/*/; do
+    [ -f "${d}.project-path" ] || continue
+    real="$(cd "$(cat "${d}.project-path")" 2>/dev/null && pwd -P)" || continue
+    if [ "$real" = "$(cd "$PROJECT_ROOT" && pwd -P)" ]; then
+      printf '%s\n' "${d%/}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+listener_pid() {
+  lsof -ti :"$1" -sTCP:LISTEN 2>/dev/null | head -1
+}
+
 # ── Lifecycle ───────────────────────────────────────
 cleanup() {
   if [ "${STARTED_SERVER:-false}" = "true" ]; then
     echo "Stopping test server..."
-    kill "$SERVER_PID" 2>/dev/null || true
-    lucli server stop 2>/dev/null || true
+    ( cd "$PROJECT_ROOT" && lucli server stop >/dev/null 2>&1 ) || true
+    # `kill $SERVER_PID` only kills the launcher: the JVM survives it and keeps
+    # holding the port, so whichever project wants that port next silently gets
+    # THIS app's responses. Kill the JVM the registry recorded, then wait for
+    # the port to actually come free.
+    local jvm
+    jvm="$(cut -d: -f1 "$PROJECT_ROOT/.wheels-test-server.pid" 2>/dev/null || true)"
+    if [ -n "$jvm" ]; then
+      kill "$jvm" 2>/dev/null || true
+      for _ in $(seq 1 20); do
+        kill -0 "$jvm" 2>/dev/null || break
+        sleep 0.5
+      done
+      kill -9 "$jvm" 2>/dev/null || true
+    fi
+    rm -f "$PROJECT_ROOT/.wheels-test-server.pid"
   fi
 }
 trap cleanup EXIT
 
 # ── Start server if not already running ─────────────
 STARTED_SERVER=false
-if curl -s -o /dev/null --connect-timeout 2 --max-time 3 "http://localhost:${PORT}/" 2>/dev/null; then
-  echo "Using existing server on port ${PORT}"
+EXISTING_PID="$(listener_pid "$PORT" || true)"
+if [ -n "$EXISTING_PID" ]; then
+  OWN_DIR="$(project_server_dir || true)"
+  OWN_PID=""
+  if [ -n "$OWN_DIR" ] && [ -f "$OWN_DIR/server.pid" ]; then
+    OWN_PID="$(cut -d: -f1 "$OWN_DIR/server.pid" 2>/dev/null || true)"
+  fi
+  if [ -z "$OWN_PID" ] || [ "$OWN_PID" != "$EXISTING_PID" ]; then
+    echo "::error::Port ${PORT} is held by PID ${EXISTING_PID}, which is not this project's server." >&2
+    echo "  Refusing to run — testing a foreign server reports results for the wrong app." >&2
+    if [ -n "$OWN_DIR" ]; then
+      echo "  This project's registered server: $(basename "$OWN_DIR")" >&2
+    else
+      echo "  This project has no registered server." >&2
+    fi
+    echo "  Fix: stop PID ${EXISTING_PID}, or re-run with PORT=<free port>." >&2
+    exit 1
+  fi
+  echo "Using existing server on port ${PORT} (PID ${EXISTING_PID}, this project)"
 else
   echo "Starting LuCLI server on port ${PORT}..."
 
@@ -99,6 +153,13 @@ else
     start_lucli
     echo "Waiting for server after JDBC install..."
     wait_for_server
+  fi
+
+  # Record the JVM (not the launcher) so cleanup can stop what actually holds
+  # the port. The registry writes "<pid>:<port>" once the server is up.
+  OWN_DIR="$(project_server_dir || true)"
+  if [ -n "$OWN_DIR" ] && [ -f "$OWN_DIR/server.pid" ]; then
+    cp "$OWN_DIR/server.pid" "$PROJECT_ROOT/.wheels-test-server.pid"
   fi
 fi
 

--- a/tools/test-local.sh
+++ b/tools/test-local.sh
@@ -68,6 +68,29 @@ if grep -q '{project}' lucee.json 2>/dev/null; then
   RESTORED_LUCEE_JSON=true
 fi
 
+# ── Server ownership helpers ────────────────────────
+#
+# The CLI records which project a server belongs to in
+# ~/.wheels/servers/<name>/.project-path, and its JVM as "<pid>:<port>" in
+# server.pid. Both are authoritative; probing the port is not, because any
+# HTTP responder there will answer — including a completely different app.
+project_server_dir() {
+  local d real
+  for d in "$HOME"/.wheels/servers/*/; do
+    [ -f "${d}.project-path" ] || continue
+    real="$(cd "$(cat "${d}.project-path")" 2>/dev/null && pwd -P)" || continue
+    if [ "$real" = "$(cd "$PROJECT_ROOT" && pwd -P)" ]; then
+      printf '%s\n' "${d%/}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+listener_pid() {
+  lsof -ti :"$1" -sTCP:LISTEN 2>/dev/null | head -1
+}
+
 cleanup() {
   # Restore original lucee.json if we modified it
   if [ "${RESTORED_LUCEE_JSON:-false}" = "true" ] && [ -f lucee.json.bak ]; then
@@ -76,16 +99,47 @@ cleanup() {
   # Kill server if we started it
   if [ "${STARTED_SERVER:-false}" = "true" ]; then
     echo "Stopping test server..."
-    kill "$SERVER_PID" 2>/dev/null || true
-    wheels server stop 2>/dev/null || true
+    ( cd "$PROJECT_ROOT" && wheels server stop >/dev/null 2>&1 ) || true
+    # `kill $SERVER_PID` only kills the launcher: the JVM survives it and keeps
+    # holding the port, so whichever project wants that port next silently gets
+    # THIS app's responses. Kill the JVM the registry recorded, then wait for
+    # the port to actually come free.
+    local jvm
+    jvm="$(cut -d: -f1 "$PROJECT_ROOT/.wheels-test-server.pid" 2>/dev/null || true)"
+    if [ -n "$jvm" ]; then
+      kill "$jvm" 2>/dev/null || true
+      for _ in $(seq 1 20); do
+        kill -0 "$jvm" 2>/dev/null || break
+        sleep 0.5
+      done
+      kill -9 "$jvm" 2>/dev/null || true
+    fi
+    rm -f "$PROJECT_ROOT/.wheels-test-server.pid"
   fi
 }
 trap cleanup EXIT
 
 # ── Start server if not already running ─────────────
 STARTED_SERVER=false
-if curl -s -o /dev/null --connect-timeout 2 --max-time 3 "http://localhost:${PORT}/" 2>/dev/null; then
-  echo "Using existing server on port ${PORT}"
+EXISTING_PID="$(listener_pid "$PORT" || true)"
+if [ -n "$EXISTING_PID" ]; then
+  OWN_DIR="$(project_server_dir || true)"
+  OWN_PID=""
+  if [ -n "$OWN_DIR" ] && [ -f "$OWN_DIR/server.pid" ]; then
+    OWN_PID="$(cut -d: -f1 "$OWN_DIR/server.pid" 2>/dev/null || true)"
+  fi
+  if [ -z "$OWN_PID" ] || [ "$OWN_PID" != "$EXISTING_PID" ]; then
+    echo "::error::Port ${PORT} is held by PID ${EXISTING_PID}, which is not this project's server." >&2
+    echo "  Refusing to run — testing a foreign server reports results for the wrong app." >&2
+    if [ -n "$OWN_DIR" ]; then
+      echo "  This project's registered server: $(basename "$OWN_DIR")" >&2
+    else
+      echo "  This project has no registered server." >&2
+    fi
+    echo "  Fix: stop PID ${EXISTING_PID}, or re-run with PORT=<free port>." >&2
+    exit 1
+  fi
+  echo "Using existing server on port ${PORT} (PID ${EXISTING_PID}, this project)"
 else
   echo "Starting Wheels CLI server on port ${PORT}..."
 
@@ -117,6 +171,13 @@ else
     fi
     sleep 2
   done
+
+  # Record the JVM (not the launcher) so cleanup can stop what actually holds
+  # the port. The registry writes "<pid>:<port>" once the server is up.
+  OWN_DIR="$(project_server_dir || true)"
+  if [ -n "$OWN_DIR" ] && [ -f "$OWN_DIR/server.pid" ]; then
+    cp "$OWN_DIR/server.pid" "$PROJECT_ROOT/.wheels-test-server.pid"
+  fi
 fi
 
 # ── Warm up Wheels ──────────────────────────────────


### PR DESCRIPTION
Fixes two defects in `tools/test-local.sh` and `tools/test-cli-local.sh` that together made a green suite meaningless — and that cost real debugging time this week when a leftover test server answered a dev URL and made a correct app look broken.

## 1. Any HTTP responder on the port was trusted

Both scripts probed the port and, on *any* response, printed `Using existing server on port N` and ran the suite against whatever answered:

```bash
if curl -s -o /dev/null ... "http://localhost:${PORT}/"; then
  echo "Using existing server on port ${PORT}"     # ← no ownership check
```

Point them at a port held by an unrelated app and they report **that app's** results. A run that looks like a pass while testing the wrong code, with no warning.

Ownership now comes from the CLI's own registry, which is authoritative:

- `~/.wheels/servers/<name>/.project-path` — the owning project root
- `~/.wheels/servers/<name>/server.pid` — `<pid>:<port>`

If the listener's PID isn't this project's server, the script fails loudly with the PID, this project's registered server, and the fix. Paths compare via `pwd -P`, because macOS `/tmp` is a symlink to `/private/tmp`.

## 2. Cleanup killed the launcher, not the server

```bash
kill "$SERVER_PID"        # the `wheels server run` wrapper, not the JVM
wheels server stop        # no --name → prints usage, does nothing non-interactively
```

The JVM survived, kept holding the port, and the next project to want it silently got the **previous app's** responses. Cleanup now stops the server from the project root, kills the JVM the registry recorded, waits for it to exit (then SIGKILL), and removes the recorded pid file.

## Reproduced both, with a real collision

Another app holding 8080:

| | |
|---|---|
| before | `Using existing server on port 8080` → suite ran against the **foreign** app; port still busy after exit |
| after | `::error::Port 8080 is held by PID 56122, which is not this project's server.` (exit 1) |

Happy path re-verified with the port free: **1346 pass**, matching the 4 pre-existing `DbCommandSpec` failures, **0 errors** — and 8080 **free immediately after the script exits**, pid file removed. An app that previously could not restart (because the port stayed squatted) now starts cleanly.

## Note on risk

No test covers these scripts — they're bash, not TestBox. The verification above is behavioural and is the evidence for this change; both scripts pass `bash -n`. I deliberately did not add a shell-test harness in this PR.
