### PR TITLE
docs(presentations): correct the demo runbook against the current CLI

### DIFF
--- a/docs/presentations/cfug-2026-09-15/demo.md
+++ b/docs/presentations/cfug-2026-09-15/demo.md
@@ -36,15 +36,19 @@ cd blog
 wheels start
 ```
 
-Open the printed URL. **Point at the welcome sentence**:
-
-> Your Wheels … application is running on Lucee with blog (development).
-
-That's version, engine, datasource, and environment — a prose sentence, not
-a `Wheels · engine · db · env` status chip.
+Open the printed URL. **Point at the starter page**: the Wheels wordmark, the
+**The details** block (Wheels version, engine, datasource, environment), and
+the two cards.
 
 **Say:** "That's the whole stack — a running app with zero config. No
 `Application.cfc` hand-editing, no wiring, no XML. It's already up."
+
+> Gotcha: this page used to be a single prose sentence
+> ("Your Wheels … application is running on Lucee with blog (development)").
+> It now renders the environment as a labelled **The details** list with the
+> real brand mark, and offers **Guides** and **API docs** as cards that open in
+> a new tab. Point at the list, not a sentence. `deck.md` still quotes the old
+> prose wording — fix that slide before the talk.
 
 > Gotcha: `wheels new` may ask for the app name if you omit it; pass it as the
 > positional arg as above. If `wheels start` picks a port you don't like,
@@ -91,36 +95,47 @@ In Rails this is the `generate scaffold` moment — same idea, same payoff."
 
 ## Act 3 — associations + validation (≈4 min)
 
+Pass the association to the scaffold so the CLI wires **both** models and the
+parent's UI for you:
+
 ```bash
-wheels generate scaffold Comment postId:integer author:string body:text
+wheels generate scaffold Comment body:text --belongsTo=post
 wheels migrate latest
 ```
 
-Edit **`app/models/Post.cfc`** — add the association in `config()`:
+That single flag does four things the runbook used to ask you to hand-edit:
 
-```cfm
-component extends="Model" {
-    function config() {
-        hasMany(name="comments", dependent="delete");
-    }
-}
-```
+| File | Change |
+|---|---|
+| `app/models/Comment.cfc` | `belongsTo(name="post")` |
+| `app/models/Post.cfc` | `hasMany(name="comments")` |
+| `app/controllers/Posts.cfc` | `show()` gains `include="comments"` |
+| `app/views/posts/show.cfm` | a related-comments block, with an empty state |
 
-Edit **`app/models/Comment.cfc`**:
+The comment form also gets a **Post** dropdown instead of a bare `postId`
+number field. Reload `/posts/1` and the **Comments** section is already there.
+
+> Gotcha: scaffolding `Comment postId:integer` instead (the old instruction)
+> wires **nothing** — you get no `hasMany`, no `include=`, no comments section
+> on the post page, and a raw integer field in the form. Verified both ways;
+> use `--belongsTo=post`.
+
+Add the validation by hand — that's the one edit worth doing live, because it
+shows the generated model is plain code you own:
 
 ```cfm
 component extends="Model" {
     function config() {
         belongsTo(name="post");
-        validatesPresenceOf("author,body");
+        validatesPresenceOf("body");
     }
 }
 ```
 
-Show: open a seeded post, add comments, show `post.comments` in the view. Then
+Show: open a seeded post, add comments, show them listed on the post. Then
 submit an empty comment and **let the validation error render**.
 
-**Say:** "No foreign-key config. `belongsTo("post")` figures out `postId` from
+**Say:** "No foreign-key config. `belongsTo("post")` figures out `post_id` from
 the schema. `Post` ↔ `posts`, `Comment` ↔ `comments` — the convention *is*
 the configuration."
 
@@ -159,6 +174,30 @@ function show() {
 ```
 
 A missing `:key` 404s in the dispatcher before the action runs.
+
+> **Gotcha — this one bites.** `params.post` carries **no** eager-loaded
+> associations, and the generated related-comments block renders from the array
+> that `include="comments"` populates. So after this edit the post page shows
+> **"No comments yet"** even though the comments exist. Verified.
+>
+> Three ways through it:
+>
+> 1. **Demo binding on `/comments` instead** — the comments resource has no
+>    related block, so nothing regresses. The cleanest option.
+> 2. **Keep the comments visible** by re-adding the association to the action:
+>    ```cfm
+>    function show() {
+>        post = params.post;
+>        post.comments = model("Comment").findAll(where="post_id=#post.id#");
+>    }
+>    ```
+>    Costs you the "no `findByKey`" line for that one action.
+> 3. Do Act 3 last, or accept the empty state and say so — it is a real
+>    consequence of binding, not a bug you introduced.
+>
+> The underlying wart is that `include=` yields an **array** on the parent while
+> a lazy `post.comments()` call yields a **query**, so a generated block can
+> only serve one shape. Worth its own issue.
 
 **Say:** "With `binding=true`, the dispatcher loads `params.post` before the
 action. No `findByKey`. And `bindBy="slug"` swaps the segment to any column


### PR DESCRIPTION
Rehearsed the runbook end to end against **4.1.0-snapshot.2481** and fixed what no longer matches.

## Act 1 — the welcome sentence is gone

The starter page now renders the environment as a labelled **The details** list with the brand mark, plus **Guides** / **API docs** cards. There is no prose sentence to point at. `deck.md` still quotes the old wording — flagged inline.

## Act 3 — one flag replaces four hand-edits

The runbook scaffolded `Comment postId:integer` then asked for four manual edits. `--belongsTo=post` does all four:

| File | Change |
|---|---|
| `Comment.cfc` | `belongsTo(name="post")` |
| `Post.cfc` | `hasMany(name="comments")` |
| `Posts.cfc` | `show()` gains `include="comments"` |
| `posts/show.cfm` | related-comments block + empty state |

**Verified both ways.** With `postId:integer` you get no `hasMany`, no `include=`, no comments section, and a raw integer field instead of a Post dropdown. With `--belongsTo=post` the comment form gains a Post picker and the post page lists comments — confirmed by adding a comment in the browser and seeing it render.

## Act 4a — a gotcha that would have bitten on stage

Route model binding drops the eager `include`, so the comments section falls back to **"No comments yet"** even though the comments exist. Reproduced. The runbook now warns about it and gives three ways through; option 2 (re-assigning the association in the action) was verified to render the comment.

## The underlying wart

`include=` yields an **array** on the parent while a lazy `post.comments()` call yields a **query**. A generated block can only serve one shape.

**I tried to fix that and backed it out.** The shape-tolerant version broke `ScaffoldSpec` at suite level — suite `Failed`, 0 specs enumerated, deterministic (1345/5 vs a 1346/4 baseline, confirmed by stashing and re-running) — and I could not verify it through the generator itself, because the installed CLI renders from its own template copy rather than the checkout's. Shipping an unverified framework change to make a demo note unnecessary is the wrong trade. It needs its own PR with its own evidence.
