### PR TITLE
fix(cli): ship the 404 guard in the app-side scaffold template too

### DIFF
--- a/cli/lucli/templates/app/app/snippets/CRUDContent.txt
+++ b/cli/lucli/templates/app/app/snippets/CRUDContent.txt
@@ -8,6 +8,17 @@
 	 */
 	function config() {
 		super.config();
+		// 404 rather than a 500 when the key matches nothing. findByKey returns a
+		// non-object for BOTH a missing key and a soft-deleted row, and the
+		// actions below then operate on that empty value — `post.title` in the
+		// view, or `.update()` here, throws.
+		//
+		// A BEFORE filter that deliberately does NOT assign the record: the
+		// actions keep their conventional single-finder body, which the
+		// `--belongsTo` parent wiring depends on — it only rewrites `show()`
+		// when the finder is the whole body, and skips a customized one.
+		// Loading twice is cheap and keeps that contract intact.
+		filters(through="requireRecord", only="show,edit,update,delete");
 	}
 
 	/**
@@ -79,6 +90,23 @@
 		|ObjectNameSingular|.delete();
 		flashInsert(success="|ObjectNameSingularC| was deleted successfully.");
 		redirectTo(route="|ObjectNamePlural|");
+	}
+
+	/**
+	* Guard: abort with a 404 when the key matches no record.
+	*
+	* The message is a plain string on purpose. The scaffold's parent wiring
+	* scans this file with ScaffoldSource, which refuses interpolated strings
+	* (`##...##`) wholesale — a single `##params.key##` here would silently turn
+	* off `include=` wiring for every `--belongsTo` child of this model.
+	**/
+	private function requireRecord() {
+		if (!IsObject(model("|ObjectNameSingularC|").findByKey(key=params.key))) {
+			Throw(
+				type = "Wheels.RecordNotFound",
+				message = "|ObjectNameSingularC| not found for the requested key."
+			);
+		}
 	}
 
 }

--- a/cli/lucli/tests/specs/commands/NewCommandTemplateSpec.cfc
+++ b/cli/lucli/tests/specs/commands/NewCommandTemplateSpec.cfc
@@ -129,6 +129,25 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 				expect(fileExists(templateRoot & "tests/specs/models/.gitkeep")).toBeTrue();
 			});
 
+			it("ships app/snippets/CRUDContent.txt identical to the bundled codegen template", () => {
+				// `wheels new` copies every codegen template into the app's
+				// app/snippets/, and Templates.cfc resolves THOSE first — they
+				// shadow the bundled copy. So a fix to templates/codegen/
+				// CRUDContent.txt is invisible to every freshly generated app
+				// unless the snippet copy moves with it. That is exactly how the
+				// 404 guard shipped in a release and then failed to appear in a
+				// stock `wheels new` app: the two files had silently diverged.
+				//
+				// Only this pair is pinned. Two other twins differ on purpose
+				// (the app copies read the reload password from .env), so a
+				// blanket "all snippets match codegen" rule would be wrong.
+				var bundled = fileRead(expandPath("/cli/lucli/templates/codegen/CRUDContent.txt"));
+				var shipped = fileRead(templateRoot & "app/snippets/CRUDContent.txt");
+				expect(compare(shipped, bundled)).toBe(0);
+				// And the shipped copy must actually carry the guard.
+				expect(shipped).toInclude('filters(through="requireRecord"');
+			});
+
 		});
 
 	}


### PR DESCRIPTION
#3607 added the `requireRecord` filter to `templates/codegen/CRUDContent.txt` and was verified on a generated app — but a **stock** `wheels new` app never got it.

## Why

`wheels new` copies every codegen template into the app's `app/snippets/`, and `Templates.cfc` resolves those **first** — they shadow the bundled copy. So the fix landed in the bundled template while the app-shipped twin silently overrode it with the old, guard-less body.

Release 2487 carried the fix. A fresh app generated *from* 2487 did not. My earlier verification had hand-written the rendered template into the controller, which is exactly why it looked fixed.

## The fix

The snippet copy is now byte-identical to the bundled one. Confirmed on a **genuinely stock** app — fresh `wheels new`, real scaffold, soft-deleted through the real delete action, zero edits:

| request | result |
|---|---|
| `/posts/10` (soft-deleted) | **404** |
| `/posts/99999` | **404** |
| `/posts/10/edit` | **404** |
| `/posts/1` | 200 |

## Pinning it

A new spec asserts the pair is identical. **Only this pair.** Two other snippet twins differ on purpose (the app copies read the reload password from `.env`), so a blanket "all snippets match codegen" rule would be wrong. 11 of 13 twins were already identical; this was the one that drifted.

CLI suite: **1357 pass**, the 4 pre-existing `DbCommandSpec` failures, **0 errors**.
