### PR TITLE
fix(cli): top-align scaffold action rows; Delete no longer floats 4px high

### DIFF
--- a/changelog.d/action-row-alignment.fixed.md
+++ b/changelog.d/action-row-alignment.fixed.md
@@ -1,0 +1,1 @@
+- Scaffolded action rows are top-aligned and the Delete button sits flush with its siblings. `buttonTo` wraps its button in a `<form>`, and simple.css's bottom margin on that nested button made the form taller than the neighbouring links — under `align-items: center` Delete floated 4px above Edit and "← all"

--- a/cli/lucli/templates/app/public/stylesheets/wheels.css
+++ b/cli/lucli/templates/app/public/stylesheets/wheels.css
@@ -190,14 +190,22 @@ form label > input[type="radio"] {
  * `.button` class so links and form buttons read alike — before this, Edit and
  * "all posts" were plain links next to a Delete button. `buttonTo` needs its
  * class passed as `inputClass` because it wraps a nested <button>.
+ *
+ * Top-aligned on purpose. `buttonTo` renders a <form>, so the flex item is
+ * the form and the visible button sits one level down. simple.css gives that
+ * nested button `margin-bottom: 8px`, which made the form 8px taller than the
+ * sibling links; `align-items: center` then floated the Delete button 4px
+ * above Edit and "all posts". Zeroing the nested margin fixes the height, and
+ * `flex-start` means a future height difference can't re-centre the row.
  */
 .wheels-actions {
 	display: flex;
 	flex-wrap: wrap;
-	align-items: center;
+	align-items: flex-start;
 	gap: 0.5rem;
 }
 
-.wheels-actions > * {
+.wheels-actions > *,
+.wheels-actions > form > .button {
 	margin-bottom: 0;
 }

--- a/cli/lucli/tests/specs/commands/NewCommandTemplateSpec.cfc
+++ b/cli/lucli/tests/specs/commands/NewCommandTemplateSpec.cfc
@@ -108,6 +108,12 @@ component extends="wheels.wheelstest.system.BaseSpec" {
 				// the buttons sit flush against each other with no gap.
 				expect(css).toInclude(".wheels-actions");
 				expect(css).toInclude("display: flex");
+				// Top-aligned, and the button nested inside buttonTo's <form>
+				// loses simple.css's 8px bottom margin. With `center` and that
+				// margin intact, the form was 8px taller than the sibling links
+				// and Delete floated 4px above Edit and "all posts".
+				expect(css).toInclude("align-items: flex-start");
+				expect(css).toInclude(".wheels-actions > form > .button");
 
 				var layout = fileRead(templateRoot & "app/views/layout.cfm");
 				expect(layout).toInclude('styleSheetLinkTag(sources="simple,wheels")');


### PR DESCRIPTION
The Delete button in a scaffolded action row sat a few pixels above **Edit** and **← all posts**. Cause confirmed by measurement, not guessed.

## Why

`buttonTo` renders a `<form>`, so in the flex row the **form** is the flex item and the visible button sits one level down. simple.css gives that nested button `margin-bottom: 8px`, which the existing `.wheels-actions > *` reset could not reach — it stops at the form. So the form was 8px taller than the sibling `<a>` links, and `align-items: center` floated its button up by half the difference.

| | top | bottom | inner margin-bottom |
|---|---|---|---|
| Edit (`<a>`) | 299.9 | 342.3 | 0 |
| **Delete** (`<form>` → `<button>`) | **295.9** | 338.3 | **8px** |
| ← all posts (`<a>`) | 299.9 | 342.3 | 0 |

Exactly **4px**.

## Fix

Two changes, each sufficient alone, both kept:

- `.wheels-actions > form > .button { margin-bottom: 0 }` — equalises height
- `align-items: flex-start` — top-justifies, so a future height difference can't re-centre the row

After: all three at top **295.9** / bottom **338.3**.

CLI suite: **1357 pass**, the 4 pre-existing `DbCommandSpec` failures, 0 errors.
